### PR TITLE
build: pin ESLint to latest 9.x

### DIFF
--- a/MERGE_CHECK.md
+++ b/MERGE_CHECK.md
@@ -1,0 +1,35 @@
+# Merge verification report
+
+Date: 2026-02-10
+
+## What was checked
+
+- Git working tree status
+- Remaining merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+- Main quality gates:
+  - `npm run type-check`
+  - `npm test`
+  - `npm run build`
+  - `npm run lint`
+
+## Results
+
+- ✅ Working tree is clean.
+- ✅ No merge conflict markers were found.
+- ✅ Type checking passed.
+- ✅ Tests passed.
+- ✅ Production build passed.
+- ⚠️ Linting failed due to an ESLint major-version mismatch.
+
+## Linting issue details
+
+`npm run lint` fails with:
+
+- `ESLint: 10.0.0`
+- `TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function`
+
+This is consistent with a dependency compatibility issue between `eslint@10` and some Next.js ESLint plugin dependencies that currently expect ESLint 9 APIs.
+
+## Suggested fix
+
+Pin ESLint to 9.x (for example `^9.39.0`) and regenerate lockfile in an environment that can fetch dependencies.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "^0.31.9",
-    "eslint": "^10",
+    "eslint": "^9.39.2",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",


### PR DESCRIPTION
### Motivation
- Fix a linting failure caused by an incompatible `eslint@10` API used by some Next.js ESLint plugin dependencies by reverting to the latest 9.x line.

### Description
- Updated `devDependencies.eslint` in `package.json` from `^10` to `^9.39.2` to restore compatibility with the project's ESLint plugin stack.
- Added `MERGE_CHECK.md` with a merge verification report and the linting incompatibility details.
- Ensured the codebase still passes type checking and unit tests after the change.

### Testing
- Ran `npm run type-check` and it completed successfully. ✅
- Ran `npm test` (Vitest) and all tests passed. ✅
- Ran `npm run lint` and it failed because the installed `node_modules` still contain `eslint@10`, producing `TypeError: Error while loading rule 'react/display-name'` due to API mismatch. ❌
- Attempted to regenerate the lockfile with `npm install --package-lock-only` but the environment returned `403 Forbidden` from the npm registry so `node_modules` could not be updated; dependency pin is in place and running `npm install` in a registry-enabled environment should fix the lockfile and resolve linting failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b2ed0437c83258a3b7b10d486f7ba)