### PR TITLE
Add landing page with marketing route group, waitlist, and pricing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,15 +32,16 @@ Setup iniziale del progetto, tooling e infrastruttura.
 
 Sito vetrina per raccogliere email e iniziare a costruire un'audience prima del lancio.
 
-- ⬜ Design landing page mobile-first (hero, problema, soluzione, come funziona, pricing preview, CTA)
-- ⬜ Implementare route group `(marketing)` con layout dedicato
-- ⬜ Pagina `/` — hero + value proposition
-- ⬜ Pagina `/prezzi` — tabella comparativa 3 piani (preview, senza Stripe ancora)
-- ⬜ Pagina `/funzionalita` — feature principali con icone
-- ⬜ Componente waitlist: input email + submit (salvare su Supabase, tabella `waitlist`)
+- ✅ Design landing page mobile-first (hero, problema, soluzione, come funziona, pricing preview, CTA)
+- ✅ Implementare route group `(marketing)` con layout dedicato
+- ✅ Pagina `/` — hero + value proposition
+- ✅ Pagina `/prezzi` — tabella comparativa 3 piani + confronto competitor
+- ✅ Pagina `/funzionalita` — 12 feature con icone Lucide
+- ✅ Componente waitlist: input email + submit (API + tabella `waitlist` su Supabase)
+- ✅ SEO: metadata, Open Graph, title template
 - ⬜ Email di conferma iscrizione (Resend)
-- ⬜ SEO: metadata, Open Graph, JSON-LD structured data
 - ⬜ Sitemap (`next-sitemap`)
+- ⬜ JSON-LD structured data
 - ⬜ Setup Umami analytics (self-hosted su VPS)
 - ⬜ Privacy Policy + Cookie Policy (pagine statiche)
 - ⬜ Deploy landing page su `scontrinozero.it`

--- a/src/app/(marketing)/funzionalita/page.tsx
+++ b/src/app/(marketing)/funzionalita/page.tsx
@@ -1,0 +1,151 @@
+import type { Metadata } from "next";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { WaitlistForm } from "@/components/marketing/waitlist-form";
+import {
+  Smartphone,
+  Zap,
+  Shield,
+  Receipt,
+  Clock,
+  BarChart3,
+  Share2,
+  Wifi,
+  Github,
+  CreditCard,
+  FileText,
+  Users,
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Funzionalità — ScontrinoZero",
+  description:
+    "Emissione scontrini, trasmissione AdE, chiusura giornaliera, dashboard, PWA mobile-first. Tutto dal tuo smartphone.",
+};
+
+const features = [
+  {
+    icon: Receipt,
+    title: "Emissione scontrini",
+    description:
+      "Tastierino numerico rapido, selezione aliquota IVA (4%, 5%, 10%, 22%, esente), metodo di pagamento (contanti, elettronico, misto).",
+  },
+  {
+    icon: Zap,
+    title: "Trasmissione istantanea",
+    description:
+      "Lo scontrino appare emesso subito grazie all'Optimistic UI. La trasmissione all'Agenzia delle Entrate avviene in background.",
+  },
+  {
+    icon: Clock,
+    title: "Chiusura giornaliera",
+    description:
+      "Chiusura automatica (o manuale) dei corrispettivi a fine giornata. Nessun obbligo di ricordarti.",
+  },
+  {
+    icon: BarChart3,
+    title: "Dashboard",
+    description:
+      "Monitora il totale giornaliero, il conteggio scontrini, e consulta lo storico con filtri per data.",
+  },
+  {
+    icon: Smartphone,
+    title: "PWA mobile-first",
+    description:
+      "Installabile come app dal browser, senza passare dagli store. Funziona su qualsiasi smartphone.",
+  },
+  {
+    icon: Share2,
+    title: "Condivisione scontrini",
+    description:
+      "Invia lo scontrino al cliente via QR code, email o link condivisibile (WhatsApp, SMS).",
+  },
+  {
+    icon: Shield,
+    title: "Credenziali cifrate",
+    description:
+      "Le credenziali Fisconline sono cifrate at-rest (AES-256). Mai visibili in chiaro, mai condivise.",
+  },
+  {
+    icon: CreditCard,
+    title: "Codice lotteria",
+    description:
+      "Supporto per il codice lotteria scontrini: il cliente lo inserisce e viene trasmesso con il documento.",
+  },
+  {
+    icon: FileText,
+    title: "Annullamento e reso",
+    description:
+      "Annulla uno scontrino emesso per errore. Il reso viene trasmesso correttamente all'AdE.",
+  },
+  {
+    icon: Users,
+    title: "Multi-dispositivo",
+    description:
+      "Usa ScontrinoZero da più dispositivi con lo stesso account. Perfetto se hai dipendenti.",
+  },
+  {
+    icon: Wifi,
+    title: "Funziona offline",
+    description:
+      "L'interfaccia è sempre disponibile grazie al service worker. Gli scontrini vengono sincronizzati quando torni online.",
+  },
+  {
+    icon: Github,
+    title: "Open source",
+    description:
+      "Codice sorgente aperto e verificabile. Self-hosting gratuito per sempre con O'Saasy License.",
+  },
+];
+
+export default function FunzionalitaPage() {
+  return (
+    <>
+      <section className="px-4 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="text-center text-3xl font-extrabold md:text-4xl">
+            Tutto dal tuo smartphone
+          </h1>
+          <p className="text-muted-foreground mx-auto mt-4 max-w-lg text-center">
+            ScontrinoZero sostituisce il registratore telematico con un&apos;app
+            web moderna, veloce e sicura.
+          </p>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {features.map((feature) => (
+              <Card key={feature.title} className="border-border/50">
+                <CardHeader className="pb-2">
+                  <feature.icon className="text-primary h-5 w-5" />
+                  <CardTitle className="text-base">{feature.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="leading-relaxed">
+                    {feature.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-muted/50 px-4 py-16">
+        <div className="mx-auto max-w-xl text-center">
+          <h2 className="text-xl font-bold">Vuoi essere tra i primi?</h2>
+          <p className="text-muted-foreground mt-2 text-sm">
+            Iscriviti e ti avvisiamo al lancio.
+          </p>
+          <div className="mt-4 flex justify-center">
+            <WaitlistForm />
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,0 +1,16 @@
+import { Header } from "@/components/marketing/header";
+import { Footer } from "@/components/marketing/footer";
+
+export default function MarketingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,0 +1,334 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { WaitlistForm } from "@/components/marketing/waitlist-form";
+import {
+  Smartphone,
+  Zap,
+  Shield,
+  Receipt,
+  Clock,
+  BarChart3,
+  ArrowRight,
+  Check,
+  Github,
+} from "lucide-react";
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="px-4 py-20 md:py-32">
+        <div className="mx-auto max-w-3xl text-center">
+          <Badge variant="secondary" className="mb-4">
+            Presto disponibile
+          </Badge>
+          <h1 className="text-4xl font-extrabold tracking-tight md:text-5xl lg:text-6xl">
+            Lo scontrino elettronico
+            <br />
+            <span className="text-primary">dal tuo smartphone</span>
+          </h1>
+          <p className="text-muted-foreground mx-auto mt-6 max-w-xl text-lg">
+            Emetti scontrini e trasmetti i corrispettivi all&apos;Agenzia delle
+            Entrate senza registratore telematico. Il più economico sul mercato.
+          </p>
+          <div className="mt-8 flex flex-col items-center gap-4">
+            <WaitlistForm />
+            <p className="text-muted-foreground text-xs">
+              Niente spam. Ti avvisiamo solo al lancio.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Problem → Solution */}
+      <section className="bg-muted/50 px-4 py-20">
+        <div className="mx-auto max-w-5xl">
+          <div className="grid gap-12 md:grid-cols-2">
+            <div>
+              <h2 className="text-2xl font-bold">Il problema</h2>
+              <p className="text-muted-foreground mt-4 leading-relaxed">
+                I registratori telematici costano centinaia di euro, hanno
+                canoni annuali di manutenzione, e sono obbligatori per legge.
+                <br />
+                <br />
+                Per un ambulante, un artigiano o una micro-attività, è un costo
+                sproporzionato.
+              </p>
+            </div>
+            <div>
+              <h2 className="text-2xl font-bold">La soluzione</h2>
+              <p className="text-muted-foreground mt-4 leading-relaxed">
+                L&apos;Agenzia delle Entrate offre la procedura{" "}
+                <strong>&quot;Documento Commerciale Online&quot;</strong> che
+                permette di emettere scontrini senza registratore fisico.
+                <br />
+                <br />
+                ScontrinoZero la rende <strong>semplice e veloce</strong>, dal
+                tuo smartphone.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="px-4 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold">Come funziona</h2>
+          <p className="text-muted-foreground mx-auto mt-2 max-w-lg text-center">
+            Tre passi per emettere il tuo primo scontrino elettronico.
+          </p>
+
+          <div className="mt-12 grid gap-8 md:grid-cols-3">
+            {[
+              {
+                step: "1",
+                title: "Registrati",
+                description:
+                  "Crea un account e collega le tue credenziali Fisconline.",
+                icon: Shield,
+              },
+              {
+                step: "2",
+                title: "Emetti lo scontrino",
+                description:
+                  "Inserisci l'importo, scegli l'aliquota IVA e il metodo di pagamento.",
+                icon: Receipt,
+              },
+              {
+                step: "3",
+                title: "Trasmissione automatica",
+                description:
+                  "ScontrinoZero trasmette i corrispettivi all'AdE in automatico.",
+                icon: Zap,
+              },
+            ].map((item) => (
+              <div key={item.step} className="text-center">
+                <div className="bg-primary/10 text-primary mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+                  <item.icon className="h-6 w-6" />
+                </div>
+                <h3 className="mt-4 font-semibold">{item.title}</h3>
+                <p className="text-muted-foreground mt-2 text-sm">
+                  {item.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="bg-muted/50 px-4 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold">
+            Tutto quello che ti serve
+          </h2>
+          <p className="text-muted-foreground mx-auto mt-2 max-w-lg text-center">
+            Progettato per micro-attività che vogliono semplicità e risparmio.
+          </p>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {[
+              {
+                icon: Smartphone,
+                title: "Mobile-first",
+                description:
+                  "Installabile come app sul tuo smartphone. Nessun hardware aggiuntivo.",
+              },
+              {
+                icon: Zap,
+                title: "Istantaneo",
+                description:
+                  "Lo scontrino appare emesso subito. La trasmissione avviene in background.",
+              },
+              {
+                icon: Clock,
+                title: "Chiusura automatica",
+                description:
+                  "Chiusura giornaliera dei corrispettivi senza pensieri.",
+              },
+              {
+                icon: BarChart3,
+                title: "Dashboard",
+                description:
+                  "Monitora vendite, totali giornalieri e storico scontrini.",
+              },
+              {
+                icon: Shield,
+                title: "Sicuro",
+                description:
+                  "Le tue credenziali Fisconline sono cifrate e mai condivise con terzi.",
+              },
+              {
+                icon: Github,
+                title: "Open source",
+                description:
+                  "Codice aperto, verificabile. Self-hosting gratuito per sempre.",
+              },
+            ].map((feature) => (
+              <Card key={feature.title} className="border-border/50">
+                <CardHeader className="pb-2">
+                  <feature.icon className="text-primary h-5 w-5" />
+                  <CardTitle className="text-base">{feature.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription>{feature.description}</CardDescription>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing preview */}
+      <section className="px-4 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold">
+            Il più economico del mercato
+          </h2>
+          <p className="text-muted-foreground mx-auto mt-2 max-w-lg text-center">
+            Nessun canone nascosto. Nessun hardware. Prezzi chiari.
+          </p>
+
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {[
+              {
+                name: "Free",
+                price: "€0",
+                period: "per sempre",
+                description: "Per provare senza impegno",
+                features: [
+                  "10 scontrini / mese",
+                  "1 dispositivo",
+                  "Storico scontrini",
+                ],
+                cta: "Inizia gratis",
+                highlighted: false,
+              },
+              {
+                name: "Starter",
+                price: "~€2",
+                period: "/ mese",
+                description: "Per ambulanti e micro-attività",
+                features: [
+                  "Scontrini illimitati",
+                  "1 dispositivo",
+                  "Chiusura giornaliera",
+                  "Supporto email",
+                ],
+                cta: "Scegli Starter",
+                highlighted: true,
+              },
+              {
+                name: "Pro",
+                price: "~€4",
+                period: "/ mese",
+                description: "Per attività regolari",
+                features: [
+                  "Scontrini illimitati",
+                  "Multi-dispositivo",
+                  "Dashboard avanzata",
+                  "Export dati",
+                  "Supporto prioritario",
+                ],
+                cta: "Scegli Pro",
+                highlighted: false,
+              },
+            ].map((plan) => (
+              <Card
+                key={plan.name}
+                className={
+                  plan.highlighted
+                    ? "border-primary shadow-sm"
+                    : "border-border/50"
+                }
+              >
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">{plan.name}</CardTitle>
+                    {plan.highlighted && (
+                      <Badge variant="secondary">Consigliato</Badge>
+                    )}
+                  </div>
+                  <div className="mt-2">
+                    <span className="text-3xl font-extrabold">
+                      {plan.price}
+                    </span>
+                    <span className="text-muted-foreground text-sm">
+                      {" "}
+                      {plan.period}
+                    </span>
+                  </div>
+                  <CardDescription>{plan.description}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2 text-sm">
+                    {plan.features.map((f) => (
+                      <li key={f} className="flex items-center gap-2">
+                        <Check className="text-primary h-4 w-4 shrink-0" />
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <p className="text-muted-foreground mt-6 text-center text-sm">
+            Prezzi finali definiti al lancio. Self-hosting{" "}
+            <Link href="/prezzi" className="text-primary underline">
+              sempre gratuito
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      {/* Waitlist CTA */}
+      <section id="waitlist" className="bg-muted/50 px-4 py-20">
+        <div className="mx-auto max-w-xl text-center">
+          <h2 className="text-2xl font-bold">Non perderti il lancio</h2>
+          <p className="text-muted-foreground mt-2">
+            Iscriviti alla lista d&apos;attesa per essere tra i primi a provare
+            ScontrinoZero.
+          </p>
+          <div className="mt-6 flex justify-center">
+            <WaitlistForm />
+          </div>
+        </div>
+      </section>
+
+      {/* Self-hosting callout */}
+      <section className="px-4 py-16">
+        <div className="mx-auto max-w-3xl text-center">
+          <h3 className="text-lg font-semibold">Preferisci il self-hosting?</h3>
+          <p className="text-muted-foreground mt-2 text-sm">
+            ScontrinoZero è open source. Scarica il codice, installa sul tuo
+            server e usalo gratis per sempre. Le tue credenziali restano a casa
+            tua.
+          </p>
+          <Button variant="outline" size="sm" className="mt-4" asChild>
+            <a
+              href="https://github.com/dstmrk/scontrinozero"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Github className="h-4 w-4" />
+              Vedi su GitHub
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </Button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/(marketing)/prezzi/page.tsx
+++ b/src/app/(marketing)/prezzi/page.tsx
@@ -1,0 +1,221 @@
+import type { Metadata } from "next";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { WaitlistForm } from "@/components/marketing/waitlist-form";
+import { Check, Server } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Prezzi — ScontrinoZero",
+  description:
+    "Il registratore di cassa virtuale più economico. Da €0/mese. Self-hosting gratuito per sempre.",
+};
+
+const plans = [
+  {
+    name: "Free",
+    price: "€0",
+    period: "per sempre",
+    description: "Per provare senza impegno",
+    features: [
+      "10 scontrini / mese",
+      "1 dispositivo",
+      "Storico scontrini",
+      "Chiusura giornaliera",
+    ],
+    highlighted: false,
+  },
+  {
+    name: "Starter",
+    price: "~€2",
+    period: "/ mese",
+    description: "Per ambulanti e micro-attività",
+    features: [
+      "Scontrini illimitati",
+      "1 dispositivo",
+      "Chiusura giornaliera",
+      "Storico completo",
+      "Supporto email",
+    ],
+    highlighted: true,
+  },
+  {
+    name: "Pro",
+    price: "~€4",
+    period: "/ mese",
+    description: "Per attività regolari",
+    features: [
+      "Scontrini illimitati",
+      "Multi-dispositivo",
+      "Dashboard avanzata",
+      "Export CSV / Excel",
+      "Supporto prioritario",
+    ],
+    highlighted: false,
+  },
+];
+
+const competitors = [
+  { name: "Billy", price: "€70/anno", perMonth: "~€6/mese" },
+  { name: "Scontrina", price: "€80/anno", perMonth: "~€7/mese" },
+  { name: "MyCassa", price: "€49/anno", perMonth: "~€4/mese" },
+  { name: "Scontrinare", price: "€30/anno", perMonth: "~€2.5/mese" },
+  {
+    name: "ScontrinoZero",
+    price: "da €0/anno",
+    perMonth: "da €0/mese",
+    highlighted: true,
+  },
+];
+
+export default function PrezziPage() {
+  return (
+    <>
+      <section className="px-4 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="text-center text-3xl font-extrabold md:text-4xl">
+            Prezzi chiari, nessuna sorpresa
+          </h1>
+          <p className="text-muted-foreground mx-auto mt-4 max-w-lg text-center">
+            Tutti i piani includono la trasmissione all&apos;Agenzia delle
+            Entrate. Nessun costo per scontrino. Nessun hardware.
+          </p>
+
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {plans.map((plan) => (
+              <Card
+                key={plan.name}
+                className={
+                  plan.highlighted
+                    ? "border-primary shadow-sm"
+                    : "border-border/50"
+                }
+              >
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">{plan.name}</CardTitle>
+                    {plan.highlighted && (
+                      <Badge variant="secondary">Consigliato</Badge>
+                    )}
+                  </div>
+                  <div className="mt-2">
+                    <span className="text-3xl font-extrabold">
+                      {plan.price}
+                    </span>
+                    <span className="text-muted-foreground text-sm">
+                      {" "}
+                      {plan.period}
+                    </span>
+                  </div>
+                  <CardDescription>{plan.description}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2 text-sm">
+                    {plan.features.map((f) => (
+                      <li key={f} className="flex items-center gap-2">
+                        <Check className="text-primary h-4 w-4 shrink-0" />
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <p className="text-muted-foreground mt-6 text-center text-sm">
+            Prezzi finali definiti al lancio. Sconto per pagamento annuale.
+          </p>
+        </div>
+      </section>
+
+      {/* Competitor comparison */}
+      <section className="bg-muted/50 px-4 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-center text-2xl font-bold">
+            Confronto con i competitor
+          </h2>
+          <p className="text-muted-foreground mt-2 text-center text-sm">
+            Quanto costa un registratore di cassa virtuale in Italia?
+          </p>
+
+          <div className="mt-8 overflow-hidden rounded-lg border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-white">
+                  <th className="px-4 py-3 text-left font-medium">Servizio</th>
+                  <th className="px-4 py-3 text-left font-medium">
+                    Prezzo annuale
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium">Al mese</th>
+                </tr>
+              </thead>
+              <tbody>
+                {competitors.map((c) => (
+                  <tr
+                    key={c.name}
+                    className={`border-b ${c.highlighted ? "bg-primary/5 font-semibold" : "bg-white"}`}
+                  >
+                    <td className="px-4 py-3">
+                      {c.name}
+                      {c.highlighted && (
+                        <Badge variant="secondary" className="ml-2">
+                          Noi
+                        </Badge>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">{c.price}</td>
+                    <td className="px-4 py-3">{c.perMonth}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Self-hosting */}
+      <section className="px-4 py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <Server className="text-primary mx-auto h-10 w-10" />
+          <h2 className="mt-4 text-2xl font-bold">Self-hosting gratuito</h2>
+          <p className="text-muted-foreground mt-4 leading-relaxed">
+            ScontrinoZero è open source. Installa il software sul tuo server e
+            usalo gratis per sempre, senza limiti. Le tue credenziali Fisconline
+            restano sul tuo server, nessun dato transita da terzi.
+          </p>
+          <Button variant="outline" className="mt-6" asChild>
+            <a
+              href="https://github.com/dstmrk/scontrinozero"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Guida all&apos;installazione
+            </a>
+          </Button>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-muted/50 px-4 py-16">
+        <div className="mx-auto max-w-xl text-center">
+          <h2 className="text-xl font-bold">
+            Iscriviti alla lista d&apos;attesa
+          </h2>
+          <p className="text-muted-foreground mt-2 text-sm">
+            Sarai tra i primi a provarlo.
+          </p>
+          <div className="mt-4 flex justify-center">
+            <WaitlistForm />
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { waitlist } from "@/db/schema";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { email } = await request.json();
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json(
+        { error: "Email obbligatoria." },
+        { status: 400 },
+      );
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json({ error: "Email non valida." }, { status: 400 });
+    }
+
+    await db
+      .insert(waitlist)
+      .values({ email: email.toLowerCase().trim() })
+      .onConflictDoNothing();
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json(
+      { error: "Errore interno. Riprova più tardi." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,9 +24,27 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "ScontrinoZero",
+  title: {
+    default: "ScontrinoZero — Scontrini elettronici dal tuo smartphone",
+    template: "%s | ScontrinoZero",
+  },
   description:
-    "Registratore di cassa virtuale. Emetti scontrini elettronici dal tuo smartphone.",
+    "Registratore di cassa virtuale per micro-attività. Emetti scontrini elettronici e trasmetti i corrispettivi all'Agenzia delle Entrate senza registratore telematico. Il più economico del mercato.",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL ?? "https://scontrinozero.it",
+  ),
+  openGraph: {
+    type: "website",
+    locale: "it_IT",
+    siteName: "ScontrinoZero",
+    title: "ScontrinoZero — Scontrini elettronici dal tuo smartphone",
+    description:
+      "Emetti scontrini elettronici e trasmetti i corrispettivi all'AdE senza registratore telematico. Da €0/mese.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-primary text-2xl font-bold">ScontrinoZero</h1>
-    </main>
-  );
-}

--- a/src/components/marketing/footer.tsx
+++ b/src/components/marketing/footer.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { Receipt } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+
+export function Footer() {
+  return (
+    <footer className="border-border/50 border-t">
+      <div className="mx-auto max-w-5xl px-4 py-12">
+        <div className="grid gap-8 md:grid-cols-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <Receipt className="text-primary h-5 w-5" />
+              <span className="text-lg font-bold">ScontrinoZero</span>
+            </div>
+            <p className="text-muted-foreground mt-2 text-sm">
+              Il registratore di cassa virtuale per micro-attività italiane.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="mb-3 text-sm font-semibold">Prodotto</h3>
+            <ul className="text-muted-foreground space-y-2 text-sm">
+              <li>
+                <Link
+                  href="/funzionalita"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Funzionalità
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/prezzi"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Prezzi
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="mb-3 text-sm font-semibold">Legale</h3>
+            <ul className="text-muted-foreground space-y-2 text-sm">
+              <li>
+                <Link
+                  href="/privacy"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/termini"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Termini di Servizio
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <Separator className="my-8" />
+
+        <div className="text-muted-foreground flex flex-col items-center justify-between gap-4 text-xs sm:flex-row">
+          <p>&copy; {new Date().getFullYear()} ScontrinoZero</p>
+          <p>
+            Open source con{" "}
+            <a
+              href="https://github.com/dstmrk/scontrinozero"
+              className="hover:text-foreground underline transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              O&apos;Saasy License
+            </a>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/marketing/header.tsx
+++ b/src/components/marketing/header.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { Receipt } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function Header() {
+  return (
+    <header className="border-border/50 sticky top-0 z-50 border-b bg-white/80 backdrop-blur-sm">
+      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+        <Link href="/" className="flex items-center gap-2">
+          <Receipt className="text-primary h-5 w-5" />
+          <span className="text-lg font-bold">ScontrinoZero</span>
+        </Link>
+
+        <nav className="hidden items-center gap-6 text-sm md:flex">
+          <Link
+            href="/funzionalita"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Funzionalità
+          </Link>
+          <Link
+            href="/prezzi"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Prezzi
+          </Link>
+        </nav>
+
+        <Button size="sm" asChild>
+          <a href="#waitlist">Lista d&apos;attesa</a>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/marketing/waitlist-form.tsx
+++ b/src/components/marketing/waitlist-form.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowRight, Check, Loader2 } from "lucide-react";
+
+export function WaitlistForm() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+  const [message, setMessage] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+
+    setStatus("loading");
+
+    try {
+      const res = await fetch("/api/waitlist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+        setMessage("Iscritto! Ti avviseremo al lancio.");
+        setEmail("");
+      } else {
+        const data = await res.json();
+        setStatus("error");
+        setMessage(data.error || "Qualcosa è andato storto.");
+      }
+    } catch {
+      setStatus("error");
+      setMessage("Errore di connessione. Riprova.");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="flex items-center gap-2 text-sm font-medium text-emerald-600">
+        <Check className="h-4 w-4" />
+        {message}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full max-w-sm gap-2">
+      <Input
+        type="email"
+        placeholder="La tua email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        disabled={status === "loading"}
+      />
+      <Button type="submit" disabled={status === "loading"}>
+        {status === "loading" ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <>
+            Iscriviti
+            <ArrowRight className="h-4 w-4" />
+          </>
+        )}
+      </Button>
+      {status === "error" && <p className="text-xs text-red-500">{message}</p>}
+    </form>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        destructive:
+          "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "ring-foreground/10 bg-card text-card-foreground group/card flex flex-col gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "bg-muted/50 flex items-center rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 file:text-foreground placeholder:text-muted-foreground h-8 w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import { Separator as SeparatorPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from "./profiles";
 export * from "./businesses";
+export * from "./waitlist";
 export * from "./relations";

--- a/src/db/schema/waitlist.ts
+++ b/src/db/schema/waitlist.ts
@@ -1,0 +1,15 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+export const waitlist = pgTable("waitlist", {
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  email: text("email").notNull().unique(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type InsertWaitlist = typeof waitlist.$inferInsert;
+export type SelectWaitlist = typeof waitlist.$inferSelect;

--- a/supabase/migrations/0001_nosy_unus.sql
+++ b/supabase/migrations/0001_nosy_unus.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "waitlist" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "waitlist_email_unique" UNIQUE("email")
+);

--- a/supabase/migrations/meta/0001_snapshot.json
+++ b/supabase/migrations/meta/0001_snapshot.json
@@ -1,0 +1,220 @@
+{
+  "id": "3c6892d8-be04-46b7-ace4-af9608f94ca1",
+  "prevId": "89ddb1b4-db2d-4979-b8a1-6ef8fa7e8817",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_auth_user_id_unique": {
+          "name": "profiles_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.businesses": {
+      "name": "businesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_code": {
+          "name": "activity_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_regime": {
+          "name": "tax_regime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "businesses_profile_id_profiles_id_fk": {
+          "name": "businesses_profile_id_profiles_id_fk",
+          "tableFrom": "businesses",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770727604737,
       "tag": "0000_wooden_lady_ursula",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1770734168024,
+      "tag": "0001_nosy_unus",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Phase 1 — Landing page + waitlist:
- (marketing) route group with header, footer, and dedicated layout
- Home page: hero, problem/solution, how it works, features grid, pricing preview (3 plans), waitlist CTA, self-hosting callout
- /prezzi: detailed pricing cards, competitor comparison table, self-hosting section
- /funzionalita: 12 feature cards with Lucide icons
- Waitlist form component (client-side, optimistic UX)
- POST /api/waitlist endpoint with email validation and upsert
- Waitlist DB schema + migration (0001_nosy_unus.sql)
- SEO: Open Graph metadata, title template, metadataBase
- shadcn/ui components: button, card, input, badge, separator

https://claude.ai/code/session_01AL6Dv6uPpx9HV59VjQV2az