### PR TITLE
Exclude playwright.config.ts and e2e/ from Next.js build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e"]
 }


### PR DESCRIPTION
Next.js includes all TS files in the build by default. Playwright is a devDependency not installed in production, causing build failures.

https://claude.ai/code/session_01AL6Dv6uPpx9HV59VjQV2az