### PR TITLE
Remove deprecated FormEvent import, use inline type

### DIFF
--- a/src/components/marketing/waitlist-form.tsx
+++ b/src/components/marketing/waitlist-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ArrowRight, Check, Loader2 } from "lucide-react";
@@ -12,7 +12,7 @@ export function WaitlistForm() {
   >("idle");
   const [message, setMessage] = useState("");
 
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: { preventDefault: () => void }) {
     e.preventDefault();
     if (!email) return;
 


### PR DESCRIPTION
FormEvent is deprecated in React 19 types. Since we only call preventDefault(), use a minimal structural type instead.

https://claude.ai/code/session_01AL6Dv6uPpx9HV59VjQV2az