### PR TITLE
docs: allinea la specifica API documento commerciale ai file C#

### DIFF
--- a/docs/documento-commerciale-api-json.md
+++ b/docs/documento-commerciale-api-json.md
@@ -1,53 +1,71 @@
 # Definizione API JSON per Documento Commerciale (caso ScontrinoZero)
 
-Questo documento aggiorna la proposta API JSON usando i file caricati nel repository (`vendita.har`, `annullo.har`) come sorgente reale del tracciato verso AdE.
-
-> Nota operativa: in questa working copy non sono presenti file `.cs` e non è stato possibile fare pull/fetch da `main` verso GitHub (errore rete `CONNECT tunnel failed, response 403`). Le regole sotto sono quindi basate su HAR + codice JS embedded nei HAR.
+Questo documento aggiorna la proposta API JSON usando sia i tracciati reali (`vendita.har`, `annullo.har`) sia i file C# aggiunti nel repository (`DC.cs`, `Send.cs`, `Esiti.cs`) come riferimento operativo del flusso verso AdE.
 
 ## Fonti analizzate
 
 - `vendita.har`: invio documento commerciale di vendita.
 - `annullo.har`: invio documento di annullo.
+- `DC.cs`: modello payload JSON, enum/codifiche e serializzazione decimali.
+- `Send.cs`: sequenza di autenticazione/sessione e invio POST all'endpoint documenti.
+- `Esiti.cs`: shape della risposta AdE mappata lato client.
 
-Dai tracciati risulta un solo endpoint POST usato dall'applicativo AdE:
+Endpoint finale di invio confermato:
 
-- `POST https://ivaservizi.agenziaentrate.gov.it/ser/api/documenti/v1/doc/documenti/`
-- `Content-Type: application/json;charset=UTF-8`
+- `POST https://ivaservizi.agenziaentrate.gov.it/ser/api/documenti/v1/doc/documenti/` (nel codice viene aggiunto `?v=<unix_ms>`)
+- `Content-Type: application/json`
 
-Inoltre, dai payload osservati:
+Inoltre dai payload/modelli risulta:
 
-- `datiTrasmissione.formato` è `DCW10`.
-- `cedentePrestatore.multiAttivita` e `cedentePrestatore.multiSede` risultano array (vuoti nei casi campione).
-- su `documentoCommerciale.vendita[].tipo` compaiono almeno i codici `PC`, `PE`, `TR`, `NR_EF`, `NR_PS`, `NR_CS`.
-
----
-
-## 1) Correzioni/aggiunte principali emerse dall'analisi
-
-Rispetto alla bozza precedente, ci sono 4 punti importanti da fissare nel contratto API di ScontrinoZero:
-
-1. **Per annullo NON va inviato `vendita[]`** nel `documentoCommerciale`.
-2. **Per annullo è presente `idtrx` a livello root**, valorizzato con l'id transazione del documento originale.
-3. **Per annullo dentro `elementiContabili[]` compare `idElementoContabile` valorizzato** (id riga originale), non vuoto.
-4. I campi importo nel payload AdE sono spesso serializzati come **stringhe decimali** (es. `"2.01000000"`, `"1.00"`), quindi l'adapter deve controllare formattazione e scala.
-5. In entrambi i casi analizzati, le righe usano la stessa shape (`elementiContabili[]`); cambia il fatto che in annullo `idElementoContabile` è valorizzato con id riga originale.
+- `datiTrasmissione.formato` = `DCW10`.
+- `flagIdentificativiModificati` presente a livello root.
+- `cedentePrestatore` contiene `identificativiFiscali` + `altriDatiIdentificativi`.
+- su `documentoCommerciale.vendita[].tipo` compaiono almeno `PC`, `PE`, `TR`, `NR_EF`, `NR_PS`, `NR_CS`.
+- serializzazione importi come stringa con due decimali (converter custom in C#).
 
 ---
 
-## 2) Architettura consigliata per il nostro caso
+## 1) Correzioni/aggiunte principali emerse dall'analisi C#
 
-Per ScontrinoZero conviene mantenere due livelli:
+Rispetto alla bozza precedente, ci sono punti da fissare nel contratto API + adapter:
+
+1. **Annullo senza `vendita[]`** nel `documentoCommerciale`.
+2. **Annullo con `idtrx` a livello root** valorizzato con id transazione originale.
+3. **Annullo con `elementiContabili[].idElementoContabile` valorizzato** (riferimento riga originale).
+4. **Importi serializzati come stringhe decimali a 2 cifre** (`N2`, cultura invariant), non numeri JSON puri.
+5. In C# `NullValueHandling.Ignore`: i campi null non vengono inviati. L'adapter deve quindi evitare di forzare proprietà non necessarie.
+6. Il modello C# include campi aggiuntivi in `cedentePrestatore.altriDatiIdentificativi`:
+   - `modificati`
+   - `defAliquotaIVA`
+   - `nuovoUtente`
+7. Nel `documentoCommerciale` sono previsti anche:
+   - `progressivoCollegato`
+   - `importoTotaleIva`
+   - `scontoTotaleLordo`
+   - `totaleImponibile`
+   - `ammontareComplessivo`
+   - `totaleNonRiscosso`
+   - `scontoAbbuono`
+   - `importoDetraibileDeducibile`
+
+---
+
+## 2) Architettura consigliata per ScontrinoZero
+
+Mantenere due livelli:
 
 1. **Public API ScontrinoZero** (stabile, semplice, business-oriented).
-2. **Adapter AdE** (mappa Public DTO -> payload AdE osservato nei HAR).
+2. **Adapter AdE** (mappa Public DTO -> payload AdE `DCW10` aderente ai tracciati/C#).
 
-### Flusso
+### Flusso tecnico suggerito
 
 1. Client chiama API ScontrinoZero.
 2. Backend valida e calcola i totali.
-3. Adapter costruisce payload AdE (formato `DCW10`).
-4. Backend invia POST ad AdE.
-5. Backend salva request/response raw e restituisce risposta normalizzata al client.
+3. Adapter costruisce payload AdE con formattazione importi stringa `N2`.
+4. Backend invia POST ad AdE su endpoint documenti.
+5. Backend salva request/response raw e restituisce risposta normalizzata.
+
+Nota: il client C# esegue anche una pipeline di autenticazione/sessione (`portale` + scelta utenza + verifica adesione) prima dell'invio JSON. Per noi conviene astrarla nel provider AdE, separata dal mapping business.
 
 ---
 
@@ -187,17 +205,19 @@ Solo annullo:
 - `issuer.vatNumber` -> `cedentePrestatore.identificativiFiscali.partitaIva`
 - `issuer.taxCode` -> `cedentePrestatore.identificativiFiscali.codiceFiscale`
 - Dati anagrafici/indirizzo -> `cedentePrestatore.altriDatiIdentificativi.*`
+- Campo opzionale/configurabile lato adapter: `defAliquotaIVA`
 
 ## 4.3 Documento vendita
 
 - `document.date` -> `documentoCommerciale.dataOra` in formato `dd/MM/yyyy`.
-- `document.customerTaxCode` -> `cfCessionarioCommittente` (stringa vuota se assente).
+- `document.customerTaxCode` -> `cfCessionarioCommittente` (se supportato dal tracciato corrente).
 - `document.isGiftDocument` -> `flagDocCommPerRegalo`.
 - `document.lines[]` -> `elementiContabili[]`.
 - `document.payments[]` -> `vendita[]`.
-- Totali calcolati server-side e serializzati in stringa decimale con scala coerente con AdE.
+- `document.globalDiscount` -> `scontoAbbuono`.
+- `document.deductibleAmount` -> `importoDetraibileDeducibile`.
 
-Shape minima riga AdE (`elementiContabili[]`) rilevata nei tracciati:
+Campi riga rilevati nel modello C# (`elementiContabili[]`):
 
 - `idElementoContabile`
 - `descrizioneProdotto`
@@ -230,13 +250,33 @@ Dentro `documentoCommerciale`:
 
 Inoltre:
 
-- non inviare `vendita[]` nell'annullo;
-- popolare `elementiContabili[].idElementoContabile` con gli id riga originali quando disponibili.
-- mantenere `elementiContabili[]` con importi coerenti alla riga originaria (nei campioni sono presenti quantità/importi completi, non solo un riferimento).
+- non inviare `vendita[]`;
+- popolare `elementiContabili[].idElementoContabile` con gli id riga originali quando disponibili;
+- mantenere `elementiContabili[]` con importi coerenti alla riga originaria.
+
+## 4.5 Formattazione importi (obbligatoria nell'adapter)
+
+Dai converter C#:
+
+- decimal/float serializzati come stringa con 2 decimali (`"1.00"`, `"2.01"`);
+- separatore decimale `.`;
+- nessun separatore migliaia;
+- raccomandato standardizzare helper unico, es. `toAdeAmount(value: number): string`.
 
 ---
 
-## 5) Validazioni consigliate (nostre API)
+## 5) Codifiche IVA/Natura osservate nei file C#
+
+Nel modello `NaturaIVA` sono presenti i codici:
+
+- IVA ordinaria: `4`, `5`, `10`, `22`
+- Natura: `N1`, `N2`, `N3`, `N4`, `N5`, `N6`, `N7`
+
+Suggerimento: validare `vatCode` contro questa whitelist nel layer pubblico o adapter (in base al livello di rigidità desiderato).
+
+---
+
+## 6) Validazioni consigliate (nostre API)
 
 - `issuer.vatNumber`: 11 cifre.
 - `issuer.taxCode`: 16 caratteri (con gestione casi speciali).
@@ -245,12 +285,31 @@ Inoltre:
 - Somma pagamenti = totale documento (tolleranza 0.01).
 - `idempotencyKey` obbligatorio per endpoint POST.
 - `originalDocument.transactionId` e `originalDocument.documentProgressive` obbligatori per annullo.
-- `originalDocument.lineReferences[].adeLineId` obbligatorio se si annulla a livello riga (mapping su `idElementoContabile`).
+- `originalDocument.lineReferences[].adeLineId` obbligatorio se si annulla a livello riga.
 - Data input in ISO (`yyyy-MM-dd`), conversione a `dd/MM/yyyy` solo nell'adapter AdE.
+- Importi normalizzati prima dell'invio AdE in formato stringa a due decimali.
 
 ---
 
-## 6) Error model unico lato ScontrinoZero
+## 7) Error model unico lato ScontrinoZero
+
+Shape AdE confermato da `Esiti.cs`:
+
+```json
+{
+  "esito": true,
+  "idtrx": "151085589",
+  "progressivo": "DCW2026/5111-2188",
+  "errori": [
+    {
+      "codice": "...",
+      "descrizione": "..."
+    }
+  ]
+}
+```
+
+Errore normalizzato lato API pubblica:
 
 ```json
 {
@@ -274,7 +333,7 @@ Mappatura HTTP:
 
 ---
 
-## 7) Persistenza minima consigliata
+## 8) Persistenza minima consigliata
 
 Tabella `commercial_documents`:
 
@@ -304,7 +363,7 @@ Tabella `commercial_document_lines`:
 
 ---
 
-## 8) Checklist implementativa per ScontrinoZero
+## 9) Checklist implementativa per ScontrinoZero
 
 - [ ] DTO pubblici (`SaleRequest`, `VoidRequest`, `CommercialDocumentResponse`).
 - [ ] Validazione con schema condiviso (Zod o equivalente server).
@@ -313,16 +372,12 @@ Tabella `commercial_document_lines`:
 - [ ] Persistenza `ade_line_id` in vendita per annulli successivi.
 - [ ] Idempotenza per chiave + hash request.
 - [ ] Logging strutturato e redazione dati sensibili.
-- [ ] Appena disponibili i `.cs`: verifica completa enum/tipologie e campi opzionali per chiudere gap HAR-only.
+- [ ] Provider AdE separato per gestione sessione/autenticazione e invio.
 
 ---
 
-## 9) Payload AdE osservato nei file caricati
+## 10) Nota operativa su invio multiplo
 
-I tracciati confermano:
+Il metodo C# `SendDC` accetta `List<DC.RootObject>` e invia i documenti uno per volta nello stesso contesto di sessione, restituendo `List<Esiti.Esito>`.
 
-- risposta standard AdE: `{ "esito": true|false, "idtrx": "...", "progressivo": "...", "errori": [...] }`;
-- vendita con `documentoCommerciale.vendita[]`;
-- annullo con `idtrx` root + `resoAnnullo` e senza `vendita[]`.
-
-Questo è il comportamento da replicare nell'adapter, mantenendo però un contratto API pubblico più pulito e stabile per le app ScontrinoZero.
+Per ScontrinoZero è consigliato mantenere endpoint pubblici single-document (più semplici e idempotenti) ma prevedere internamente una pipeline batch-safe, in modo da poter riusare connessioni/sessione verso AdE.


### PR DESCRIPTION
### Motivation

- Integrare i file C# appena aggiunti nel repository per ricavare regole pratiche e dettagli di serializzazione/shape del payload AdE non visibili solo dai tracciati HAR.
- Aggiornare la specifica API pubblica e le raccomandazioni di mapping/adapter in modo da evitare ambiguità all'implementazione (annulli, formati importi, campi opzionali).

### Description

- Aggiornato `docs/documento-commerciale-api-json.md` per includere `DC.cs`, `Send.cs` e `Esiti.cs` come fonti e per confermare l'endpoint di invio `POST https://ivaservizi.agenziaentrate.gov.it/ser/api/documenti/v1/doc/documenti/?v=<unix_ms>` e `Content-Type: application/json`.
- Documentata la forma corretta di annullo lato AdE (assenza di `vendita[]`, presenza di `idtrx` a root e popolazione di `elementiContabili[].idElementoContabile`) e i campi aggiuntivi osservati nei modelli C# per `cedentePrestatore` e `documentoCommerciale`.
- Normalizzazione/formatting: specificata la serializzazione degli importi come stringhe con 2 decimali (cultura invariant, pattern `N2`) e il comportamento `NullValueHandling.Ignore` del serializer C# come vincolo per l'adapter.
- Aggiunte le codifiche IVA/Natura osservate (`4,5,10,22` e `N1..N7`), aggiornate le validazioni consigliate, il mapping Public API -> AdE e la checklist (incluso suggerimento di separare un provider AdE per sessione/autenticazione e nota su invio batch-safe).

### Testing

- Eseguito `git diff --check` che non ha segnalato errori e ha restituito esito positivo.
- I pre-commit hook (formattazione `prettier`) sono stati eseguiti automaticamente durante il commit e hanno completato con successo.
- La modifica è esclusivamente documentale e non modifica codice runtime, quindi non sono stati eseguiti test di integrazione sul runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dab3e37fc8325a318a6c5a1dab463)