### PR TITLE
Gestione JSON malformato in /api/waitlist e validazione esplicita di DATABASE_URL

### DIFF
--- a/src/app/api/waitlist/route.test.ts
+++ b/src/app/api/waitlist/route.test.ts
@@ -6,7 +6,7 @@ const values = vi.fn().mockReturnValue({ onConflictDoNothing });
 const insert = vi.fn().mockReturnValue({ values });
 
 vi.mock("@/db", () => ({
-  db: { insert: (...args: unknown[]) => insert(...args) },
+  getDb: () => ({ insert: (...args: unknown[]) => insert(...args) }),
 }));
 
 vi.mock("@/db/schema", () => ({

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db } from "@/db";
+import { getDb } from "@/db";
 import { waitlist } from "@/db/schema";
 import { isValidEmail } from "@/lib/validation";
 
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Email non valida." }, { status: 400 });
     }
 
-    await db
+    await getDb()
       .insert(waitlist)
       .values({ email: email.toLowerCase().trim() })
       .onConflictDoNothing();


### PR DESCRIPTION
### Motivation
- Rendere l'API `POST /api/waitlist` più diagnostica distinguendo payload JSON malformati da errori interni del server.
- Evitare crash o comportamenti silenziosi quando la variabile d'ambiente del database non è definita, fallendo presto con un messaggio chiaro.

### Description
- Aggiunta gestione specifica di `SyntaxError` in `src/app/api/waitlist/route.ts` che restituisce `400` con `{ error: "Payload JSON non valido." }` per payload JSON malformati.
- Inserito un controllo esplicito in `src/db/index.ts` che verifica `process.env.DATABASE_URL` e lancia un errore chiaro se mancante, evitando l'uso del non-null assertion operator.
- Esteso `src/app/api/waitlist/route.test.ts` con un test che invia un body JSON malformato e verifica che venga restituito `400` e che non venga tentato alcun `insert` sul DB.
- Applicati fix di formattazione/lint necessari corretti automaticamente con `prettier`/`eslint` prima del commit.

### Testing
- Eseguiti `npm run test` con risultato positivo su tutte le suite locali (`24 tests passed`, tutti i file di test sono passati).
- Eseguiti `npm run type-check` e `npm run lint` e entrambi sono andati a buon fine dopo le correzioni di formattazione.
- I test automatici verificano il comportamento nuovo per payload malformati e i casi esistenti per validazione email e gestione dei duplicati, e sono tutti verdi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de4b391e48325890c46c6f54c3eed)