### PR TITLE
Fix FAQ accordion spacing and move FAQ above Open Source section

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -22,39 +22,6 @@ import {
   Building,
 } from "lucide-react";
 
-const faqItems = [
-  {
-    question: "Serve per forza un registratore telematico fisico?",
-    answer:
-      "No. ScontrinoZero nasce proprio per aiutarti a emettere documento commerciale e trasmettere i corrispettivi senza cassa fisica, usando i canali previsti dall'Agenzia delle Entrate.",
-  },
-  {
-    question: "A chi è adatto ScontrinoZero?",
-    answer:
-      "È pensato per ambulanti, artigiani, professionisti e micro-attività che vogliono una soluzione semplice, economica e utilizzabile direttamente da smartphone o PC.",
-  },
-  {
-    question: "Le credenziali Fisconline sono al sicuro?",
-    answer:
-      "Sì. Le credenziali vengono protette con misure di sicurezza dedicate e usate solo per le operazioni necessarie all'erogazione del servizio richiesto da te.",
-  },
-  {
-    question: "Quanto costa?",
-    answer:
-      "La beta è gratuita. Al termine della fase beta comunicheremo i piani in modo trasparente, con opzioni adatte sia a chi parte da zero sia a chi ha volumi più alti.",
-  },
-  {
-    question: "Posso provarlo prima del lancio ufficiale?",
-    answer:
-      "Sì. Iscrivendoti alla lista d'attesa puoi accedere in anteprima e ricevere aggiornamenti sulle nuove funzionalità.",
-  },
-  {
-    question: "È disponibile anche in versione self-hosted?",
-    answer:
-      "Sì. Il progetto è open source: puoi installarlo sul tuo server e mantenere il pieno controllo della tua infrastruttura.",
-  },
-];
-
 export default function Home() {
   return (
     <>
@@ -284,6 +251,20 @@ export default function Home() {
         </div>
       </section>
 
+      {/* FAQ */}
+      <section id="faq" className="bg-muted/50 px-4 py-20">
+        <div className="mx-auto max-w-3xl">
+          <Badge variant="secondary" className="mx-auto mb-4 block w-fit">
+            Supporto
+          </Badge>
+          <h2 className="text-center text-2xl font-bold">Domande Frequenti</h2>
+          <p className="text-muted-foreground mx-auto mt-2 max-w-2xl text-center">
+            Le risposte rapide ai dubbi più comuni su ScontrinoZero.
+          </p>
+          <FaqSection />
+        </div>
+      </section>
+
       {/* Open source */}
       <section className="px-4 py-16">
         <div className="mx-auto max-w-3xl text-center">
@@ -310,20 +291,6 @@ export default function Home() {
               <ArrowRight className="h-4 w-4" />
             </a>
           </Button>
-        </div>
-      </section>
-
-      {/* FAQ */}
-      <section id="faq" className="bg-muted/50 px-4 py-20">
-        <div className="mx-auto max-w-3xl">
-          <Badge variant="secondary" className="mx-auto mb-4 block w-fit">
-            Supporto
-          </Badge>
-          <h2 className="text-center text-2xl font-bold">Domande Frequenti</h2>
-          <p className="text-muted-foreground mx-auto mt-2 max-w-2xl text-center">
-            Le risposte rapide ai dubbi più comuni su ScontrinoZero.
-          </p>
-          <FaqSection />
         </div>
       </section>
     </>

--- a/src/components/marketing/faq-section.tsx
+++ b/src/components/marketing/faq-section.tsx
@@ -67,7 +67,7 @@ export function FaqSection() {
               onClick={() => setOpenIndex(isOpen ? null : index)}
               aria-expanded={isOpen}
             >
-              <CardHeader className="flex flex-row items-center justify-between gap-4 pb-3">
+              <CardHeader className="flex flex-row items-center justify-between gap-4 pb-0">
                 <CardTitle className="text-base">{item.question}</CardTitle>
                 <ChevronDown
                   className={`text-muted-foreground h-5 w-5 shrink-0 transition-transform duration-300 ${
@@ -85,7 +85,7 @@ export function FaqSection() {
               }`}
             >
               <div className="overflow-hidden">
-                <CardContent className="pt-0">
+                <CardContent className="pt-3">
                   <CardDescription className="text-sm leading-relaxed">
                     {item.answer}
                   </CardDescription>


### PR DESCRIPTION
### Motivation
- The closed FAQ accordion had unwanted vertical space between the question and the hidden answer, which should only appear when an item is expanded.
- The FAQ section should appear earlier in the landing page flow, before the "Codice aperto, verificabile" (Open source) block for better information order.

### Description
- Adjusted FAQ card header and content padding in `src/components/marketing/faq-section.tsx` by changing `pb-3` to `pb-0` on the header and `pt-0` to `pt-3` on the content so spacing appears only when expanded.
- Moved the FAQ section above the Open Source section in `src/app/(marketing)/page.tsx` to change the landing page order.
- Removed the now-unused `faqItems` constant from `src/app/(marketing)/page.tsx` to clean up dead code.

### Testing
- Ran linter with `npm run lint -- --max-warnings=0 src/components/marketing/faq-section.tsx src/app/(marketing)/page.tsx` and it completed successfully.
- Executed a Playwright script that navigated to the local dev server and captured a screenshot of the updated FAQ section, which ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699835c6554883259b6e4a14696c4e6e)