### PR TITLE
docs: aggiorna PLAN.md e ROADMAP.md con ricevuta HTML pubblica

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,8 +138,9 @@ Piano dettagliato con test e review checkpoint: vedi [`PLAN.md`](./PLAN.md)
 - ✅ Server actions + optimistic UI (TanStack Query) — `emitReceipt`, `useMutation`, idempotency
 - ✅ Storico scontrini (filtri data/stato, dialog dettaglio, righe cliccabili)
 - ✅ Annullamento scontrino (void, dialog 3-state con conferma)
-- ✅ PDF "Invia ricevuta" (API route + PDFKit, bottone in cassa e storico) — **359 unit + 8 E2E test**
+- ✅ PDF "Invia ricevuta" (API route + PDFKit, auth+ownership) — **359 unit + 8 E2E test**
 - ✅ **4F**: UI polish — cassa (importo vuoto placeholder, "Continua", ReceiptEuro), storico (paginazione 10/pag, bottoni annullo invertiti), registrazione (confirmPassword, isStrongPassword) — **370 unit + 8 E2E test**
+- ✅ **Ricevuta HTML pubblica** — link `/r/[id]` condivisibile (UUID come token opaco); pagina HTML mobile-first; Web Share API + fallback clipboard; PDF scaricabile senza auth; helper condivisi `fetchPublicReceipt` (UUID guard) + `generatePdfResponse` — **422 unit + 8 E2E test**
 - 🔵 **4G**: Catalogo prodotti + navigazione mobile-first (bottom nav bar, home → Catalogo)
 - ⬜ **4H**: Onboarding refactor (firstName/lastName, rimuovi P.IVA/CF → da AdE, CAP 5 cifre, nazione IT fissa, preferredVatCode)
 - ⬜ Dashboard base: totale giornaliero, conteggio (dopo 4G)


### PR DESCRIPTION
- Conteggio test aggiornato: 370 → 422 unit test
- 4D+: pagina /r/[id], share-button, PDF pubblico, fetchPublicReceipt, generatePdfResponse — 52 nuovi test documentati
- Tabella cumulativa PLAN.md aggiornata con riga 4D+

https://claude.ai/code/session_01GviZkWjVnrSoAvWZS3SBQs