### PR TITLE
Replace Receipt icon with ReceiptEuro across marketing components

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -11,7 +11,7 @@ import { WaitlistForm } from "@/components/marketing/waitlist-form";
 import { FaqSection } from "@/components/marketing/faq-section";
 import {
   Smartphone,
-  Receipt,
+  ReceiptEuro,
   Clock,
   BarChart3,
   Shield,
@@ -133,7 +133,7 @@ export default function Home() {
           <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {[
               {
-                icon: Receipt,
+                icon: ReceiptEuro,
                 title: "Scontrino in 5 secondi",
                 description:
                   "Inserisci l'importo, conferma, fatto. La trasmissione all'Agenzia delle Entrate avviene in automatico.",

--- a/src/components/marketing/footer.tsx
+++ b/src/components/marketing/footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Receipt } from "lucide-react";
+import { ReceiptEuro } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 
 export function Footer() {
@@ -9,7 +9,7 @@ export function Footer() {
         <div className="grid gap-8 md:grid-cols-3">
           <div>
             <div className="flex items-center gap-2">
-              <Receipt className="text-primary h-5 w-5" />
+              <ReceiptEuro className="text-primary h-5 w-5" />
               <span className="text-lg font-bold">ScontrinoZero</span>
             </div>
             <p className="text-muted-foreground mt-2 text-sm">

--- a/src/components/marketing/header.tsx
+++ b/src/components/marketing/header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Receipt } from "lucide-react";
+import { ReceiptEuro } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function Header() {
@@ -7,7 +7,7 @@ export function Header() {
     <header className="border-border/50 sticky top-0 z-50 border-b bg-white/80 backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
         <Link href="/" className="flex items-center gap-2">
-          <Receipt className="text-primary h-5 w-5" />
+          <ReceiptEuro className="text-primary h-5 w-5" />
           <span className="text-lg font-bold">ScontrinoZero</span>
         </Link>
 


### PR DESCRIPTION
## Summary
Updated the icon used in the marketing pages and components from `Receipt` to `ReceiptEuro` from the lucide-react icon library. This change provides a more contextually appropriate icon for the ScontrinoZero application, which deals with financial receipts and transactions.

## Changes Made
- Updated the home page (`src/app/(marketing)/page.tsx`) to import and use `ReceiptEuro` instead of `Receipt` in the features section
- Updated the header component (`src/components/marketing/header.tsx`) to use `ReceiptEuro` for the logo icon
- Updated the footer component (`src/components/marketing/footer.tsx`) to use `ReceiptEuro` for the logo icon

## Implementation Details
All three instances of the `Receipt` icon have been consistently replaced with `ReceiptEuro` across the marketing UI. The icon maintains the same styling and sizing (h-5 w-5, text-primary class) as the original implementation, ensuring visual consistency throughout the application.

https://claude.ai/code/session_01TrnYSGdPupgT3rJbB75XS6