### PR TITLE
Refactor CI/CD pipeline for parallel execution and better caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}
+      e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -26,69 +27,131 @@ jobs:
             src:
               - 'src/**'
               - 'tests/**'
-              - 'e2e/**'
               - 'package.json'
               - 'package-lock.json'
               - 'tsconfig.json'
               - 'next.config.ts'
               - 'vitest.config.ts'
-              - 'playwright.config.ts'
               - 'eslint.config.mjs'
+            e2e:
+              - 'src/**'
+              - 'e2e/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.ts'
+              - 'playwright.config.ts'
 
-  ci:
+  # Parallel checks — lint, type-check e test girano in contemporanea
+  lint:
     needs: changes
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Lint
         run: npm run lint
 
+  type-check:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
       - name: Type check
         run: npm run type-check
 
+  test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
       - name: Test with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 1
 
+  # SonarQube parte non appena i test finiscono, in parallelo con build
+  sonar:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Download coverage report
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-report
+          path: coverage/
       - name: SonarQube Cloud scan
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Build
-        run: npm run build
-
-  e2e:
-    needs: ci
+  # Build parte solo quando tutti e tre i check paralleli sono verdi
+  build:
+    needs: [lint, type-check, test]
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-
       - name: Install dependencies
         run: npm ci
+      - name: Build
+        run: npm run build
 
+  e2e:
+    needs: [build, changes]
+    if: needs.changes.outputs.e2e == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
-
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
       - name: Run E2E tests
         run: npm run test:e2e
-
       - name: Upload report
         uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
Restructured the GitHub Actions CI/CD workflow to enable parallel execution of independent checks, improve build efficiency, and optimize Playwright browser caching for E2E tests.

## Key Changes

- **Separated path filters**: Split the single `src` filter into two distinct filters (`src` and `e2e`) to independently trigger relevant jobs based on file changes
  - `src` filter: Triggers lint, type-check, and test jobs
  - `e2e` filter: Triggers E2E tests only when E2E-related files change

- **Parallelized CI checks**: Decomposed the monolithic `ci` job into three independent parallel jobs:
  - `lint`: Runs ESLint checks
  - `type-check`: Runs TypeScript type checking
  - `test`: Runs unit tests with coverage reporting

- **Optimized job dependencies**: 
  - `sonar` job now depends only on `test` (runs in parallel with `build`)
  - `build` job depends on all three parallel checks (`lint`, `type-check`, `test`)
  - `e2e` job depends on both `build` and `changes` filter outputs

- **Enhanced Playwright caching**: 
  - Added caching layer for Playwright browser binaries using `~/.cache/ms-playwright`
  - Conditional installation: only installs browsers if cache miss occurs
  - Installs system dependencies separately when using cached browsers

- **Improved artifact handling**: 
  - Coverage reports are now uploaded as artifacts from the `test` job
  - `sonar` job downloads coverage artifacts instead of generating them inline

## Benefits
- Faster feedback: Lint, type-check, and tests run concurrently instead of sequentially
- Reduced CI time: Playwright browser caching eliminates redundant installations
- Better resource utilization: E2E tests only run when E2E files actually change
- Cleaner workflow: Each job has a single, well-defined responsibility

https://claude.ai/code/session_019CwPvBRDXA2FNe8soQkmPP