### PR TITLE
Restructure roadmap to semantic versioning (v0.7.0 → v1.0.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,18 +9,20 @@ all'Agenzia delle Entrate senza registratore telematico fisico, sfruttando la pr
 
 ## Roadmap e piano di sviluppo
 
-Il piano di sviluppo con fasi sequenziali, test attesi, checkpoint di review, riepilogo visuale
-e backlog è in **`PLAN.md`** (root del repo).
+Il piano di sviluppo — release semantiche, task per versione, storico fasi, test cumulativi —
+è in **`PLAN.md`** (root del repo).
 
-**Fase corrente:** Phase 4I ⬜ (dati_doc_commerciale AdE — `dati_doc_commerciale.har` disponibile)
+**Versione corrente:** v0.7.0 ⬜ (AdE fiscal data update — `updateFiscalData()`)
 
-**Approccio TDD:** Per ogni fase, scrivere i test PRIMA dell'implementazione.
+**Approccio TDD:** Per ogni release, scrivere i test PRIMA dell'implementazione.
 I test di validazione e degli endpoint usano `vi.mock` per isolare le dipendenze (Drizzle, etc.).
 
-**Sequenza fasi:** 0 ✅ → 1A ✅ → 2 ✅ (AdE spike) → 1B ✅ (landing) → 3A ✅ (security infra) →
-3B ✅ (auth) → 4A-4D ✅ (MVP core) → 4F ✅ (UI polish) → 4G ✅ (catalogo+nav) → 4H ✅ (onboarding refactor) →
-4J ✅ (SPID login) → 4I ⬜ (dati_doc_commerciale AdE) →
-5 (PWA) → 6 (stabilità) → 7 (Stripe) → 8 (lancio)
+**Release roadmap (pre-lancio):**
+v0.7.0 ⬜ → v0.8.0 ⬜ (Resend) → v0.8.1 ⬜ (landing) → v0.9.0 ⬜ (Stripe) → v0.9.1 ⬜ (E2E checkpoint) → **v1.0.0** ⬜ (lancio pubblico)
+
+**Post-lancio:** v1.1.0 (PWA) → v1.2.0 (annual billing) → v1.3.0 (receipt email) → v1.4.0+ (analytics, catalog sync, …)
+
+Storico fasi completate (0 → 4J): vedi PLAN.md § "Storico sviluppo".
 
 ## Principi di prodotto
 
@@ -560,17 +562,17 @@ scontrinozero/
 - [Effatta API (riferimento competitor)](https://effatta.it/scontrino-elettronico/)
 - [DataCash API (riferimento competitor)](https://datacash.it/api-developer/)
 
-## File HAR da analizzare (fasi future)
+## File HAR da analizzare
 
-Presenti nella root del repo, da analizzare prima delle relative fasi di sviluppo:
+Presenti nella root del repo, da analizzare prima delle relative release:
 
-| File                             | Feature                                            | Fase   |
-| -------------------------------- | -------------------------------------------------- | ------ |
-| `dati_doc_commerciale.har`       | Aggiornamento dati business su AdE post-onboarding | 4H     |
-| `aggiungi_prodotto_catalogo.har` | Aggiunta prodotto su rubrica AdE                   | 4G     |
-| `modifica_prodotto_catalogo.har` | Modifica prodotto su rubrica AdE                   | futuro |
-| `elimina_prodotto_catalogo.har`  | Eliminazione prodotto su rubrica AdE               | futuro |
-| `ricerca_prodotto_catalogo.har`  | Ricerca prodotto su rubrica AdE                    | 4G     |
-| `ricerca_documento.har`          | Ricerca documento su AdE                           | futuro |
-| `login_spid.har`                 | SPID login flow                                    | futuro |
-| `login_cie.har`                  | CIE login flow                                     | futuro |
+| File                             | Feature                                            | Versione   |
+| -------------------------------- | -------------------------------------------------- | ---------- |
+| `dati_doc_commerciale.har`       | Aggiornamento dati business su AdE post-onboarding | v0.7.0     |
+| `aggiungi_prodotto_catalogo.har` | Aggiunta prodotto su rubrica AdE                   | v1.5.0     |
+| `modifica_prodotto_catalogo.har` | Modifica prodotto su rubrica AdE                   | v1.5.0     |
+| `elimina_prodotto_catalogo.har`  | Eliminazione prodotto su rubrica AdE               | v1.5.0     |
+| `ricerca_prodotto_catalogo.har`  | Ricerca prodotto su rubrica AdE                    | v1.5.0     |
+| `ricerca_documento.har`          | Ricerca documento su AdE                           | v2.0.0+    |
+| `login_spid.har`                 | SPID login flow (analizzato e implementato)        | ✅ v0.x    |
+| `login_cie.har`                  | CIE login flow                                     | v1.8.0+    |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,484 +1,247 @@
 # ScontrinoZero — Piano di sviluppo
 
-## Contesto
+## Versione corrente: v0.7.0 ⬜
 
-Phase 0, 1A, 2A-2C, 1B (parziale), 3A, 3B, 4A, 4B, 4C, 4D, 4F, 4G, 4H, 4J completate. Il progetto ha 502 unit test + 8 E2E test.
-Modulo AdE completo (MockAdeClient + RealAdeClient) con 55 test dedicati.
-Phase 4J completata: SPID login (SAML2 HTTP POST Binding via Sogei broker, push 2FA polling, fallback gestori/me→dati/fiscali per SPID users, MockAdeClient.loginSpid(), SpidCredentials/SpidProvider types, AdeSpidTimeoutError).
-Infrastruttura sicurezza: logger (pino), rate limiting, encryption (AES-256-GCM), Sentry.
-Auth: Supabase Auth con middleware, onboarding wizard 3-step, credenziali AdE cifrate.
-Schema DB scontrini: tabelle `commercial_documents` + `commercial_document_lines` con migration.
-UI cassa mobile-first: tastierino numerico, selezione IVA, riepilogo scontrino.
-Code review completata: security fixes (IDOR, open redirect, redaction), React best practices.
-Phase 4C completata: server action `emitReceipt` + `useMutation` TanStack Query + schermate success/error nella cassa.
-Phase 4D completata: storico scontrini + annullamento + link HTML ricevuta pubblica (`/r/[id]`).
-Phase 4G completata: catalogo prodotti + bottom navigation bar mobile-first.
-HAR catalogo (aggiungi/modifica/elimina/ricerca_prodotto_catalogo.har) non letti — sync AdE catalogo rimandato post-MVP.
-Phase 4H completata: onboarding refactor (firstName/lastName separati, rimozione P.IVA/CF → recupero da AdE, indirizzo completo, CAP validato, nazione IT fissa, preferredVatCode, migration 0005). Bug fix code review: getFiscalData() ora chiamato prima di logout() per garantire sessione AdE attiva.
-Prossimo step: Phase 4I (`dati_doc_commerciale.har` disponibile).
+Il piano usa **release semantiche** (vx.y.z). La v1.0.0 è il lancio pubblico: prima di
+quella data nessun cliente paga, nessuno si aspetta stabilità di produzione.
+
+**Approccio TDD:** per ogni release, i test si scrivono _prima_ dell'implementazione.
 
 ---
 
-## Riepilogo visuale
+## Release pre-lancio → v1.0.0
 
-| Fase                          | Stato    | Note                                                                      |
-| ----------------------------- | -------- | ------------------------------------------------------------------------- |
-| 0 — Fondamenta                | ✅       | Next.js 16, shadcn/ui, CI/CD, Supabase, Drizzle                           |
-| 1A — Security fix + TDD       | ✅       | 23 unit test                                                              |
-| 2 — Integrazione AdE          | ✅       | MockAdeClient + RealAdeClient, 92 test                                    |
-| 1B — Landing page             | ✅ parz. | Privacy ✅, ToS ✅, Sitemap ✅ — JSON-LD/email/Umami ⬜                   |
-| 3A — Fondamenta sicurezza     | ✅       | Sentry, pino, rate limiting, AES-256-GCM                                  |
-| 3B — Auth + onboarding        | ✅       | Supabase Auth, wizard 3-step, credenziali cifrate                         |
-| 4A–4H — MVP core              | ✅       | Cassa, storico, PDF, catalogo, onboarding refactor — **469 unit + 8 E2E** |
-| 4J — SPID login               | ✅       | SAML2+push 2FA, fallback gestori/me→dati/fiscali — **502 unit + 8 E2E**   |
-| 4I — Dati doc commerciale AdE | ⬜       | `dati_doc_commerciale.har` disponibile                                    |
-| 5 — PWA                       | ⬜       | `@serwist/next`, manifest, install prompt                                 |
-| 6 — Stabilità + legale        | ⬜       | E2E suite completa, audit, doc legali                                     |
-| 7 — Stripe payments           | ⬜       | Billing, checkout, feature gating                                         |
-| 8 — Lancio                    | ⬜       | Deploy prod, waitlist, blog SEO                                           |
+| Versione    | Descrizione                 | Stato |
+| ----------- | --------------------------- | ----- |
+| **v0.7.0**  | AdE fiscal data update      | ⬜    |
+| **v0.8.0**  | Email transazionali (Resend)| ⬜    |
+| **v0.8.1**  | Landing completeness        | ⬜    |
+| **v0.9.0**  | Stripe payments             | ⬜    |
+| **v0.9.1**  | Stabilità + E2E checkpoint  | ⬜    |
+| **v1.0.0**  | Lancio pubblico             | ⬜    |
 
 ---
 
-## Sequenza
+### v0.7.0 — AdE fiscal data update ⬜
 
-### Phase 1A: Fix security + stabilire pattern di test ✅
+Aggiornamento dati cedente sul portale AdE dopo l'onboarding (indirizzo, nome attività).
+Dipende dall'analisi di `dati_doc_commerciale.har`.
 
-- ✅ `src/lib/validation.ts` — `isValidEmail()` lineare (no regex backtracking)
-- ✅ `src/lib/validation.test.ts` — 13 test TDD
-- ✅ `src/app/api/waitlist/route.test.ts` — 7 test con mock Drizzle
-- ✅ SonarCloud issues risolte (readonly props, deprecated icons/types, CSS)
-- **Risultato:** 23 test totali, SonarCloud quality gate verde
+**Task (TDD — test prima):**
 
----
+- ⬜ Analizzare `dati_doc_commerciale.har` → mappare endpoint + payload
+- ⬜ Aggiungere `updateFiscalData(data)` all'interfaccia `AdeClient` (`src/lib/ade/client.ts`)
+- ⬜ Implementare in `MockAdeClient` + `RealAdeClient`
+- ⬜ Server action `syncFiscalData` in `src/server/onboarding-actions.ts`
+- ⬜ Bottone "Sincronizza dati su AdE" in Settings (`src/app/dashboard/settings/page.tsx`)
+- ⬜ Test TDD: ~10 nuovi unit test
 
-### Phase 2: Integrazione AdE
-
-**2A: Ricerca e documentazione ✅**
-
-- ✅ Analizzati 17 file HAR (login, vendita, annullo, ricerca, rubrica, logout, full flow)
-- ✅ Analizzato codice C# di riferimento (Send.cs, DC.cs, Esiti.cs)
-- ✅ Creata specifica completa `docs/api-spec.md` (auth, endpoint, payload, mapping, validazioni, persistenza)
-- ✅ Flusso auth Fisconline mappato in 6 fasi (da Send.cs + login_fol.har)
-- ✅ Pulizia docs/: rimossi file C#, Swagger, HAR, PDF; resta solo api-spec.md
-
-**2B: Interface design + MockAdeClient (3-5 giorni) ✅**
-
-- Definire tipi TypeScript basati su `docs/api-spec.md` sez. 3-7:
-  - `src/lib/ade/types.ts` — payload AdE (vendita/annullo), risposta, codifiche IVA, pagamenti
-  - `src/lib/ade/public-types.ts` — DTO API pubblica (SaleRequest, VoidRequest, Response)
-- Definire interfaccia `AdeClient` in `src/lib/ade/client.ts`:
-  - `login(credentials)` → session
-  - `submitSale(payload)` → AdeResponse
-  - `submitVoid(payload)` → AdeResponse
-  - `getFiscalData()` → CedentePrestatore
-  - `getDocument(idtrx)` → DocumentDetail
-  - `downloadPdf(idtrx)` → Buffer
-  - `logout()` → void
-- Mapper: `src/lib/ade/mapper.ts`
-  - `mapSaleToAdePayload(sale, fiscalData)` → AdE JSON (sez. 9 api-spec.md)
-  - `mapVoidToAdePayload(void, fiscalData)` → AdE JSON
-  - `toAdeAmount(n)` → stringa 2 decimali
-  - `toAdeDate(iso)` → `dd/MM/yyyy`
-- Validazione Zod: `src/lib/ade/validation.ts` (sez. 10 api-spec.md)
-- TDD: test per MockAdeClient e mapper
-- Implementare `MockAdeClient` in `src/lib/ade/mock-client.ts`
-- Factory `createAdeClient(mode)` in `src/lib/ade/index.ts` controllata da `ADE_MODE`
-- **Test attesi:** 20-25 test (mapper, validazione, mock client, factory)
-- **Risultato:** 67 test (13 cookie-jar + 22 mapper + 19 validation + 13 mock-client)
-
-**2C: RealAdeClient proof of concept (5-10 giorni) ✅**
-
-- Implementare `RealAdeClient` in `src/lib/ade/real-client.ts`
-- Flusso auth Fisconline 6 fasi (sez. 1 api-spec.md):
-  1. GET `/portale/web/guest` — init cookie jar
-  2. POST `/portale/home?..._58_struts_action=...` — login (CF + pwd + PIN)
-  3. GET `/dp/api` — bootstrap
-  4. POST `/portale/scelta-utenza-lavoro?p_auth={token}` — seleziona P.IVA
-  5. GET `/ser/api/fatture/v1/ul/me/adesione/stato/` — ready probe
-  6. POST `/ser/api/documenti/v1/doc/documenti/` — invio
-- Gestire cookie jar, estrazione `p_auth` Liferay, redirect 302, login ok/fail
-- Headers necessari (sez. 2.4 api-spec.md)
-- Logout multi-step (sez. 1.6 api-spec.md)
-- **Test attesi:** 10-15 test (mock HTTP con `vi.mock`)
-- **Risultato:** 25 test (auth flow, submit, void, logout, error handling)
-
-**Decisione GO/NO-GO:** Se funziona, si prosegue. Se no, fallback su DataCash/Effatta API.
+**Test attesi:** ~10 unit → totale ~**479 unit + 8 E2E**
 
 ---
 
-### REVIEW CHECKPOINT 1 ✅
+### v0.8.0 — Email transazionali (Resend) ⬜
 
-- ✅ Integrazione AdE documentata e validata (direct HTTP, no fallback necessario)
-- ✅ Interface `AdeClient` definita e testata (6 metodi)
-- ✅ MockAdeClient funzionante con test completi (13 test)
-- ✅ RealAdeClient con 6-phase auth flow (25 test)
-- ✅ Coverage del modulo `ade/`: 92 test totali
+Integrazione Resend con template React Email per le email minime obbligatorie al lancio.
 
----
+**Task (TDD — test prima):**
 
-### Phase 1B: Completare landing page (3-5 giorni) — parzialmente ✅
+- ⬜ Installare `resend` + `@react-email/components`
+- ⬜ Template `WelcomeEmail` in `src/emails/welcome.tsx`
+- ⬜ Template `PasswordResetEmail` in `src/emails/password-reset.tsx`
+- ⬜ `src/lib/email.ts` — wrapper `sendEmail(to, template)` con Resend SDK
+- ⬜ Hook post-registrazione: inviare welcome email da `signUp` server action
+- ⬜ Override email password reset Supabase: usare Resend al posto del template Supabase default
+- ⬜ Test TDD per `sendEmail` (mock Resend SDK)
+- ⬜ Variabile d'ambiente: `RESEND_API_KEY`, `FROM_EMAIL`
 
-**Obiettivo:** Landing live su scontrinozero.it con tutti i requisiti legali e SEO.
+**Escluso da questa versione:** email con PDF scontrino al cliente → v1.3.0
 
-**Task completati:**
-
-1. ✅ Privacy Policy — `src/app/(marketing)/privacy/page.tsx`
-2. ✅ Termini di Servizio — `src/app/(marketing)/termini/page.tsx`
-3. ✅ Sitemap — `src/app/sitemap.ts` (3 test)
-4. ✅ robots.txt — `src/app/robots.ts` (2 test)
-5. ✅ Pricing → teaser beta con 3 piani
-6. ✅ E2E test landing aggiornati
-
-**Task rimandati (richiedono servizi esterni):**
-
-- ⬜ JSON-LD structured data — schema `SoftwareApplication` + `Organization`
-- ⬜ Email conferma waitlist — Resend + template React Email
-- ⬜ Setup Umami analytics su VPS
-- ⬜ Deploy produzione `scontrinozero.it` (tag `v0.1.0`)
-- ℹ️ Cookie Policy: non necessaria (solo cookie tecnici Supabase auth + Umami cookieless — nessun banner GDPR richiesto)
+**Test attesi:** ~10 unit → totale ~**489 unit + 8 E2E**
 
 ---
 
-### Phase 3A: Fondamenta sicurezza (5-7 giorni) ✅
+### v0.8.1 — Landing completeness ⬜
 
-**Rationale:** La Phase 3B e 4 gestiranno credenziali Fisconline. L'infrastruttura di sicurezza DEVE essere in piedi PRIMA di scrivere codice che tocca credenziali.
+La landing deve essere pronta per convertire visitatori in clienti paganti.
 
-1. ✅ **Sentry** — `@sentry/nextjs` v10, error tracking + performance, tunnelRoute `/monitoring`
-2. ✅ **Logging strutturato** — `pino`, logger in `src/lib/logger.ts`, redazione campi sensibili
-3. ✅ **Rate limiting** — `src/lib/rate-limit.ts`, in-memory con TTL, fixed window per key
-4. ✅ **Modulo encryption** — `src/lib/crypto.ts`, AES-256-GCM con `node:crypto`, supporto rotazione chiavi
+**Task:**
 
-**Test attesi:** ~20 test (crypto roundtrip, tamper detection, rate limit, logger)
-**Risultato:** 23 test (9 crypto + 7 rate-limit + 7 logger)
+- ⬜ Aggiornare sezione pricing con i piani reali (Free / Starter / Pro) e i prezzi definitivi
+- ⬜ Rimuovere qualsiasi menzione "beta" o "presto disponibile" dalla landing
+- ⬜ CTA principale → `/register` (non più waitlist)
+- ⬜ JSON-LD structured data (`SoftwareApplication` + `Organization`)
+- ⬜ Aggiornare Privacy Policy, ToS e Cookie Policy con prezzi Stripe reali e data corrente
+- ⬜ Verificare che la sitemap includa tutte le pagine marketing
 
----
-
-### Phase 3B: Autenticazione e onboarding ✅
-
-1. ✅ Supabase Auth — `@supabase/ssr`, client helpers in `src/lib/supabase/` (server, browser, middleware)
-2. ✅ Route group `(auth)` — login, register, reset-password, verify-email, callback
-3. ✅ Middleware Next.js — protezione `/dashboard/*`, `/onboarding/*`, redirect auth-only
-4. ✅ Onboarding wizard 3-step — dati attivita, credenziali Fisconline (cifrate AES-256-GCM), verifica AdE
-5. ✅ Dashboard shell — layout, home, settings (profilo + attivita + stato credenziali)
-6. ✅ Migrazione DB — tabella `ade_credentials` (1:1 con businesses, campi cifrati)
-7. ✅ Server actions auth — signUp, signIn, signInWithMagicLink, signOut, resetPassword
-8. ✅ Server actions onboarding — saveBusiness, saveAdeCredentials, verifyAdeCredentials, getOnboardingStatus
-9. ✅ Sitemap aggiornata (+login, +register), robots.txt con disallow dashboard/onboarding
-
-**Test attesi:** 15-25 unit → **Risultato:** 43 nuovi test (4 supabase + 11 middleware + 13 auth + 15 onboarding)
+**Test attesi:** ~5 unit (JSON-LD, sitemap) → totale ~**494 unit + 8 E2E**
 
 ---
 
-### REVIEW CHECKPOINT 2
+### v0.9.0 — Stripe payments ⬜
 
-- Auth flows funzionanti
-- Credenziali cifrate at-rest (verificare nel DB)
-- Rate limiting attivo
-- Sentry che cattura errori
-- SonarCloud verde
-- Coverage auth + crypto: target 85%+
+Integrazione completa Stripe Billing per i tre piani + feature gating.
 
----
+**Task (TDD — test prima):**
 
-### Phase 4: MVP core — emissione scontrini (3-4 settimane)
+- ⬜ Aggiungere tabella `subscriptions` al DB (`src/db/schema/subscriptions.ts`)
+  - `id`, `userId` (FK → auth.users), `stripeCustomerId`, `stripePriceId`,
+    `stripeSubscriptionId`, `status` (active/canceled/past_due/trialing), `currentPeriodEnd`
+- ⬜ Migration Supabase + RLS policy
+- ⬜ Installare `stripe` SDK
+- ⬜ `src/lib/stripe.ts` — client Stripe + prodotti/prezzi costanti
+- ⬜ API route `POST /api/stripe/checkout` — crea Stripe Checkout Session
+- ⬜ API route `POST /api/stripe/webhook` — gestisce eventi:
+  - `checkout.session.completed` → attiva subscription
+  - `invoice.paid` → rinnova `currentPeriodEnd`
+  - `customer.subscription.deleted` → cancella subscription
+- ⬜ Feature gate: `src/lib/subscription.ts` → `getPlan(userId)` → Free / Starter / Pro
+- ⬜ Limite Free tier: max 10 scontrini/mese — check in `emitReceipt` server action
+- ⬜ Pagina `/dashboard/abbonamento` — piano corrente, upgrade, gestione (Stripe Customer Portal)
+- ⬜ Variabili: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
 
-**4A:** Schema DB ✅ — `commercial_documents`, `commercial_document_lines`
+**Piani:**
 
-**4B:** UI cassa mobile-first ✅ — tastierino numerico, selezione IVA, metodo pagamento, riepilogo
+| Piano      | Prezzo mensile | Scontrini/mese | Dispositivi |
+| ---------- | -------------- | -------------- | ----------- |
+| Free       | €0             | 10             | 1           |
+| Starter    | ~€2-3          | Illimitati     | 1           |
+| Pro        | ~€4-5          | Illimitati     | Multi       |
 
-**4C:** Server actions + optimistic UI ✅ — `emitReceipt`, `useMutation` TanStack Query, idempotency, schermate success/error
+_I prezzi esatti si definiscono in Stripe prima del deploy._
 
-- `commercial_documents`: 12 col, enum `document_kind` (SALE/VOID), enum `document_status` (PENDING/ACCEPTED/VOID_ACCEPTED/REJECTED/ERROR), `idempotency_key` UNIQUE, payload AdE in jsonb, FK → businesses cascade
-- `commercial_document_lines`: 8 col, numeric con precision, `ade_line_id` per annulli parziali, FK → commercial_documents cascade
-- Nota: **`daily_closures` non esiste** — con Documento Commerciale Online ogni scontrino è inviato singolarmente all'AdE; non c'è chiusura giornaliera
-- Migration: `supabase/migrations/0003_colossal_jimmy_woo.sql`
-- Coverage: `src/db/schema/**` escluso da vitest + SonarCloud (callback lazy Drizzle non eseguibili a test-time; correttezza garantita da TypeScript + migration SQL)
-- **Risultato:** 214 unit test + 8 E2E, SonarCloud quality gate verde
-
-**4B:** UI cassa mobile-first — tastierino numerico, selezione IVA, pagamento, schermata riepilogo
-**4C:** Server actions + optimistic UI — TanStack Query, mutation, rollback automatico
-
-**4D: Storico scontrini + PDF + Annullamento ✅**
-
-- ✅ `src/server/void-actions.ts` — `searchReceipts` (filtri data/stato) + `voidReceipt` (idempotency key)
-- ✅ `src/types/storico.ts` — `ReceiptListItem`, `SearchReceiptsParams`, `VoidReceiptInput/Result`
-- ✅ `src/components/storico/storico-client.tsx` — lista con filtri Dal/Al/Stato, righe cliccabili, `›` hint
-- ✅ `src/components/storico/void-receipt-dialog.tsx` — dialog 3-state (`detail` / `confirmingVoid` / `voidSuccess`)
-- ✅ `src/lib/pdf/generate-sale-receipt.ts` — PDFKit, layout 58mm, altezza dinamica, IVA per aliquota
-- ✅ `src/app/api/documents/[documentId]/pdf/route.ts` — API route GET auth+ownership (download diretto)
-- ✅ `next.config.ts` — `serverExternalPackages: ["pdfkit"]` (fix AFM font path con Turbopack)
-- ✅ Pagina ricevuta HTML pubblica `src/app/r/[documentId]/page.tsx` — Server Component, no auth, UUID come token (122 bit, non indovinabile), guard regex prima della query DB
-- ✅ `src/app/r/[documentId]/share-button.tsx` — Web Share API con fallback clipboard, feedback "Link copiato!" 2s
-- ✅ `src/app/r/[documentId]/pdf/route.ts` — PDF pubblico (no auth), riusa `fetchPublicReceipt` + `generatePdfResponse`
-- ✅ `src/lib/receipts/fetch-public-receipt.ts` — helper condiviso con UUID regex guard (evita 500 da Postgres)
-- ✅ `src/lib/receipts/generate-pdf-response.ts` — helper PDF+Response condiviso tra route auth e pubblica
-- ✅ Bottone "Invia ricevuta" in `receipt-success.tsx` e `void-receipt-dialog.tsx` → condivide `/r/[id]`
-- **Risultato:** 422 unit + 8 E2E test
-
-**4F: UI polish + registrazione ✅**
-
-Cassa:
-
-- ✅ Importo iniziale vuoto (opacity-30 placeholder "€ 0,00" finché non si digita) — `src/components/cassa/cassa-client.tsx`
-- ⬜ Default aliquota IVA = `business.preferredVatCode` → fallback `"22"` — rimandato a Phase 4H (colonna non ancora in schema)
-- ✅ Bottone "Emetti" → "Continua" nel carrello — `src/components/cassa/cassa-client.tsx`
-- ✅ Icona `Receipt` (aveva `$`) → `ReceiptEuro` (ha `€`) — `src/components/cassa/receipt-summary.tsx`
-
-Storico:
-
-- ✅ Invertire ordine pulsanti nella conferma annullo: "Annulla scontrino" a sx, "Chiudi" a dx — `src/components/storico/void-receipt-dialog.tsx`
-- ✅ Paginazione: 10 elementi per pagina, Precedente/Successiva, reset su nuova ricerca — `src/components/storico/storico-client.tsx`
-
-Registrazione:
-
-- ✅ Rimosso campo `fullName`, aggiunto `confirmPassword` — `src/app/(auth)/register/page.tsx`
-- ✅ Validazione password forte (`isStrongPassword`): ≥8 char, maiusc, minusc, numero, speciale — `src/lib/validation.ts` + `auth-actions.ts` + hint UI
-- ⬜ Email di benvenuto branded — Resend (rimandato: da decidere se sostituire email Supabase auth o solo email business)
-- TODO futuro: Passkey support
-
-- **Risultato:** 370 unit + 8 E2E test (+11: 10 `isStrongPassword` validation, 1 `confirmPassword` signUp)
-
-**4G: Catalogo prodotti/servizi + navigazione mobile ✅**
-
-Navigazione:
-
-- ✅ Bottom navigation bar mobile-first (Catalogo, Cassa, Storico, Impostazioni) — `src/components/dashboard/bottom-nav.tsx` + `src/app/dashboard/layout.tsx`
-- ✅ Home `/dashboard` → Catalogo (non più welcome/metrics) — `src/app/dashboard/page.tsx`
-
-DB:
-
-- ✅ Nuova tabella `catalog_items` — `src/db/schema/catalog-items.ts`
-  - `id`, `businessId` (FK → businesses, cascade), `description` (NOT NULL), `defaultPrice` (numeric, nullable), `defaultVatCode` (text, nullable), `createdAt`, `updatedAt`
-- ✅ Migration `supabase/migrations/0004_catalog_items.sql`
-
-Server actions — `src/server/catalog-actions.ts`:
-
-- ✅ `getCatalogItems(businessId)` → lista prodotti (ordinata per descrizione, fail-safe)
-- ✅ `addCatalogItem(input)` → crea prodotto (validazione description + price + vatCode + ownership)
-- ✅ `deleteCatalogItem(itemId, businessId)` → elimina con ownership check (IDOR-safe)
-
-UI — `src/components/catalogo/`:
-
-- ✅ `catalogo-client.tsx` — lista card prodotti + bottone "+" + empty state
-- ✅ `add-item-dialog.tsx` — dialog aggiunta (description obbligatoria, price + vatCode opzionali)
-- ✅ Tap su prodotto → `/dashboard/cassa?description=...&price=...&vatCode=...` (query params)
-- ✅ Conferma eliminazione inline nella card (no AlertDialog)
-
-HAR catalogo non letti (non bloccanti, rimandati): `aggiungi_prodotto_catalogo.har`, `modifica_prodotto_catalogo.har`, `elimina_prodotto_catalogo.har`, `ricerca_prodotto_catalogo.har`
-
-- **Risultato:** 42 nuovi test (16 catalog-actions + 9 catalogo-client + 10 add-item-dialog + 7 bottom-nav) → **464 unit + 8 E2E test**
-
-TODO futuro: bordo colorato card, modifica prodotto, sync AdE catalogo (HAR da leggere), cleanup DB documenti vecchi (valutare limiti Supabase 500MB)
-
-**4H: Onboarding refactor ✅**
-
-Motivazione: P.IVA e CF sono già nelle credenziali AdE. Vanno recuperati automaticamente
-dopo la verifica, non digitati dall'utente.
-
-DB migrations:
-
-- ✅ `profiles`: aggiunti `first_name` (text, nullable), `last_name` (text, nullable); `full_name` → mantenuto per retrocompatibilità
-- ✅ `businesses`: `vat_number` → nullable (popolato da AdE); `business_name` → nullable; aggiunti `street_number` (text, nullable); `preferred_vat_code` (text, nullable)
-- ✅ Migration `supabase/migrations/0005_onboarding_refactor.sql` (generata con drizzle-kit)
-- ✅ `src/db/schema/catalog-items.ts` — aggiunto `index("idx_catalog_items_business_id")` per allineamento snapshot Drizzle
-
-Step 0 — nuovi campi (ordine form):
-
-- ✅ Nome attività (opzionale) — PRIMA di nome/cognome
-- ✅ Nome + Cognome (obbligatori, due campi separati) → salvati su `profiles`
-- ✅ Aliquota IVA prevalente (opzionale) — select con aliquote comuni
-- ✅ Indirizzo (obbligatorio), Numero civico (opzionale)
-- ✅ CAP (obbligatorio, validazione `/^\d{5}$/`)
-- ✅ Città (opzionale), Provincia (opzionale)
-- ✅ Nazione: hardcoded IT, campo hidden — non mostrata
-- ✅ RIMOSSI: P.IVA e Codice Fiscale
-
-Step 2 — dopo verifica riuscita:
-
-- ✅ Chiamare `getFiscalData()` (già in `AdeClient`) — **prima** di `logout()` per sessione attiva
-- ✅ Salvare `vatNumber` + `fiscalCode` su `businesses` dal risultato AdE
-- ✅ Non bloccante: se getFiscalData fallisce, verifica ha comunque successo
-- ✅ Fix code review: ordine corretto → login → getFiscalData → logout → markVerified
-
-Cassa:
-
-- ✅ Default aliquota IVA = `business.preferredVatCode` → fallback `"22"`
-
-Settings:
-
-- ✅ Mostra `firstName`/`lastName` (con fallback su `fullName`), indirizzo completo con `streetNumber`, `preferredVatCode`
-
-**Risultato:** 469 unit + 8 E2E test (+5 nuovi)
-
-**4I: Aggiornamento dati business su AdE ⬜** (attende `dati_doc_commerciale.har`)
-
-- ⬜ Analizzare `dati_doc_commerciale.har` → mappare endpoint + payload per aggiornamento dati cedente su AdE
-- ⬜ Aggiungere metodo `updateFiscalData(data)` all'interfaccia `AdeClient`
-- ⬜ Implementare in `RealAdeClient` + `MockAdeClient`
-- ⬜ Integrare nel flusso post-verifica o da Settings
-- Test TDD
-
-**4J: SPID login via AdE ⬜** (attende HAR SPID dall'utente)
-
-- ⬜ Analizzare HAR SPID login → mappare flusso HTTP (diverso da Fisconline)
-- ⬜ Aggiungere login SPID a `AdeClient` (strategy pattern o metodo separato)
-- ⬜ Aggiornare Step 1 onboarding: selezione metodo (Fisconline / SPID)
-- ⬜ Credenziali SPID cifrate (username + password, niente PIN)
-- ⬜ Investigare durata sessione SPID vs Fisconline
-- Test TDD
-
-TODO futuro: CIE (`login_cie.har`), persistenza sessione AdE per SPID (cookie jar cifrato in DB)
-
-**Nota persistenza sessione SPID**: SPID è stateless (SAML assertion monouso). Quello che persiste
-è la sessione Liferay dell'AdE (JSESSIONID, LFR_SESSION, DataPower token). Per evitare che l'utente
-SPID debba ri-approvare la push ogni poche ore: serializzare la CookieJar con `jar.serialize()`,
-cifrarla con AES-256-GCM, salvarla in DB per utente. Al prossimo request: caricarla e riusarla.
-Se AdE risponde 401 → re-auth SPID (richiede interazione utente → notifica app/email).
-La sessione ScontrinoZero (Supabase JWT) è invece indefinita (refresh token rotante in cookie).
-
-**Test attesi 4F-4J:** ~80 unit + 2-3 E2E
+**Test attesi:** ~20 unit + 1 E2E → totale ~**514 unit + 9 E2E**
 
 ---
 
-### REVIEW CHECKPOINT 3
+### v0.9.1 — Stabilità + E2E checkpoint ⬜
 
-- Flusso completo: register → onboard → emetti → storico → annulla → chiudi
-- Optimistic UI percepita come istantanea
-- Skeleton loading ovunque (zero schermi bianchi)
-- Mobile UX testata su telefono reale
-- Coverage: target 70%+ su codice non-UI
-- Lighthouse mobile: >90 landing, >80 dashboard
+Checkpoint obbligatorio: questa non è una feature release, ma una verifica che tutto
+funzioni prima di toccare la produzione.
 
----
+**Task:**
 
-### Phase 5: PWA e distribuzione (7-10 giorni)
+- ⬜ Suite E2E completa su `test.scontrinozero.it`:
+  - register → onboard → emetti scontrino (MockAdeClient) → storico → storno
+  - upgrade Free → Starter (Stripe test mode)
+  - reset password via Resend
+- ⬜ Lighthouse audit: landing ≥90 mobile, dashboard ≥80 mobile
+- ⬜ SonarCloud quality gate verde, zero issue Blocker/Critical
+- ⬜ Smoke test su ambiente test con `ADE_MODE=mock`
+- ⬜ Verificare che tutte le variabili d'ambiente `.env.example` siano aggiornate
+- ⬜ Aggiornare Privacy Policy/ToS se necessario dopo test legale
 
-- Service worker con `@serwist/next`
-- Manifest, install prompt
-- Condivisione scontrino: QR code, email, link WhatsApp/SMS
-- Ottimizzazione mobile: touch targets, viewport
-
-**Test attesi:** 10-15 unit + 2-3 E2E
-
----
-
-### Phase 6: Stabilita' e documenti legali (5-7 giorni)
-
-- Informativa trattamento dati credenziali Fisconline
-- Termini di Servizio
-- Condizioni di vendita
-- Suite E2E completa (tutti i flussi critici)
-- Audit error handling
-- Performance testing
-- ⬜ **Persistenza sessione AdE per SPID**: `jar.serialize()` → AES-256-GCM → DB;
-  ricaricamento al prossimo request; re-auth SPID on 401 con notifica utente
-
-**Test attesi:** 5-10 unit + 5-10 E2E
+**Test attesi:** ~10 nuovi E2E → totale ~**514 unit + 19 E2E**
 
 ---
 
-### REVIEW CHECKPOINT 4: Pre-pagamenti
+### v1.0.0 — Lancio pubblico ⬜
 
-- Pagine legali pubblicate
-- E2E suite verde e completa
-- Zero issue SonarCloud
-- Sentry dashboard pulita
-- Performance accettabile
+**Non è una release di sviluppo.** È il tag push che promuove il codice di v0.9.1 in
+produzione. Zero nuovi sviluppi — solo validazione finale.
 
----
+**Checklist pre-tag:**
 
-### Phase 7: Stripe payments (10-14 giorni)
-
-- Definire pricing finale 3 piani + free tier
-- Stripe Billing: checkout, webhook, customer portal
-- Feature gating middleware
-- Pagina prezzi con pulsanti acquisto
-- Email transazionali (conferma, rinnovo, scadenza)
-
-**Test attesi:** 15-20 unit + 2-3 E2E
+- ⬜ `package.json` version → `1.0.0`
+- ⬜ Rimuovere qualsiasi badge/label "beta" rimasto
+- ⬜ Deploy su `scontrinozero.it` via tag `v1.0.0`
+- ⬜ Verificare Stripe live mode (chiavi `sk_live_*`)
+- ⬜ Verificare Resend produzione
+- ⬜ Verificare `ADE_MODE=real` in produzione
+- ⬜ Sentry produzione che riceve eventi
+- ⬜ Email lancio alla waitlist
+- ⬜ Richiedere prime recensioni
 
 ---
 
-### Phase 8: Lancio (3-5 giorni)
+## Definizione v1.0.0: incluso / escluso
 
-- Deploy produzione finale
-- Email lancio alla waitlist
-- Richiedere recensioni
-- Blog/guide SEO
-- Documentazione self-hosting
+### IN v1.0.0
+
+- Emissione scontrino via `RealAdeClient` (Fisconline)
+- Auth: email/password + SPID
+- Onboarding wizard 3-step completo
+- Storico + storno + PDF + share link pubblico
+- Catalogo prodotti locale (CRUD)
+- Settings (dati business, credenziali AdE, sync AdE, piano corrente)
+- Stripe: Free + Starter + Pro (billing mensile)
+- Feature gate Free tier (10 scontrini/mese)
+- Welcome email + password reset email (Resend)
+- Landing con prezzi reali, senza "beta"
+- Privacy Policy, ToS, Cookie Policy aggiornate
+- Deploy Docker via tag `v1.0.0`
+
+### FUORI da v1.0.0 (vedi release post-lancio)
+
+| Feature                            | Versione    |
+| ---------------------------------- | ----------- |
+| PWA (installabile, offline shell)  | v1.1.0      |
+| Billing annuale                    | v1.2.0      |
+| Email scontrino al cliente         | v1.3.0      |
+| Dashboard analytics (grafici)      | v1.4.0      |
+| AdE catalog sync                   | v1.5.0      |
+| SPID session persistence (DB)      | v1.6.0      |
+| CSV import prodotti + barcode      | v1.7.0      |
+| Bluetooth print, Passkey, CIE      | v1.8.0+     |
+| API pubblica, multi-operatore      | v2.0.0+     |
+
+---
+
+## Release post-lancio (v1.x.y)
+
+| Versione    | Descrizione                                                              |
+| ----------- | ------------------------------------------------------------------------ |
+| **v1.1.0**  | PWA: `@serwist/next`, manifest, offline shell, install prompt             |
+| **v1.2.0**  | Billing annuale (2 mesi gratis), Stripe Customer Portal polished          |
+| **v1.3.0**  | Email scontrino al cliente (PDF allegato via Resend)                      |
+| **v1.4.0**  | Dashboard analytics: totale giornaliero, sparkline revenue, export CSV    |
+| **v1.5.0**  | Catalogo: modifica prodotto + sync AdE (HAR: aggiungi/modifica/elimina)   |
+| **v1.6.0**  | SPID session persistence: cookie jar cifrato nel DB, re-auth on 401       |
+| **v1.7.0**  | CSV import prodotti, barcode scanner (BarcodeDetector API), Umami analytics |
+| **v1.8.0+** | Bluetooth printing (58/80mm), Passkey, CIE login, codice lotteria         |
+| **v2.0.0+** | API pubblica, webhook, multi-operatore, integrazione e-commerce           |
+
+---
+
+## Storico sviluppo (fasi completate)
+
+| Fase                          | Stato | Test al completamento      | Note                                              |
+| ----------------------------- | ----- | -------------------------- | ------------------------------------------------- |
+| 0 — Fondamenta                | ✅    | —                          | Next.js 16, shadcn/ui, CI/CD, Supabase, Drizzle   |
+| 1A — Security fix + TDD       | ✅    | 23 unit                    | `isValidEmail`, waitlist API, SonarCloud verde     |
+| 2 — Integrazione AdE          | ✅    | 92 unit (55 AdE dedicati)  | MockAdeClient + RealAdeClient, 6-phase Fisconline  |
+| 1B — Landing page             | ✅    | 6 unit + 8 E2E             | Privacy ✅, ToS ✅, Sitemap ✅ — JSON-LD ⬜ (→ v0.8.1) |
+| 3A — Fondamenta sicurezza     | ✅    | 148 unit + 8 E2E           | Sentry, pino, rate limiting, AES-256-GCM           |
+| 3B — Auth + onboarding        | ✅    | 191 unit + 8 E2E           | Supabase Auth, wizard 3-step, credenziali cifrate  |
+| 4A — Schema DB scontrini      | ✅    | 214 unit + 8 E2E           | `commercial_documents` + `commercial_document_lines` |
+| 4B — UI cassa mobile-first    | ✅    | 305 unit + 8 E2E           | Tastierino, IVA, metodo pagamento, riepilogo        |
+| 4C — Server actions + UI      | ✅    | 319 unit + 8 E2E           | `emitReceipt`, TanStack Query, optimistic updates   |
+| 4D — Storico + storno + PDF   | ✅    | 422 unit + 8 E2E           | PDF pdfkit 58mm, share link pubblico, HTML receipt  |
+| 4F — UI polish + registrazione| ✅    | 370→422 unit + 8 E2E       | `isStrongPassword`, paginazione storico, UX fixes   |
+| 4G — Catalogo + nav mobile    | ✅    | 464 unit + 8 E2E           | `catalog_items`, CRUD, bottom-nav, tap→cassa        |
+| 4H — Onboarding refactor      | ✅    | 469 unit + 8 E2E           | firstName/lastName, P.IVA da AdE, CAP, migration    |
+| 4J — SPID login               | ✅    | 502 unit + 8 E2E           | SAML2 HTTP POST, push 2FA polling, MockAdeClient.loginSpid() |
 
 ---
 
 ## Riepilogo test cumulativi
 
-| Fase                          | Nuovi test  | Totale cumulativo    |
-| ----------------------------- | ----------- | -------------------- |
-| 1A (Security fix) ✅          | 23 (reali)  | 27 (23 unit + 4 E2E) |
-| 2A (AdE ricerca) ✅           | 0 (ricerca) | 27                   |
-| 2B-2C (AdE impl) ✅           | 92 (reali)  | 119                  |
-| 1B (Landing) ✅ parz.         | 6 (reali)   | 125 unit + 8 E2E     |
-| 3A (Security infra) ✅        | 23 (reali)  | 148 unit + 8 E2E     |
-| 3B (Auth) ✅                  | 43 (reali)  | 191 unit + 8 E2E     |
-| 4A (Schema DB) ✅             | 23 (reali)  | 214 unit + 8 E2E     |
-| 4B (UI cassa) ✅              | 91 (reali)  | 305 unit + 8 E2E     |
-| 4C (server action) ✅         | 14 (reali)  | 319 unit + 8 E2E     |
-| 4D (storico+annullo+PDF) ✅   | 40 (reali)  | 359 unit + 8 E2E     |
-| 4F (UI polish+reg) ✅         | 11 (reali)  | 370 unit + 8 E2E     |
-| 4D+ (ricevuta HTML pubbl.) ✅ | 52 (reali)  | 422 unit + 8 E2E     |
-| 4G (catalogo+nav) ✅          | 42 (reali)  | 464 unit + 8 E2E     |
-| 4H (onboarding refactor) ✅   | 5 (reali)   | 469 unit + 8 E2E     |
-| 4I (dati_doc_commerciale AdE) | ~10         | ~479                 |
-| 4J (SPID login)               | ~15         | ~494                 |
-| 5 (PWA)                       | ~13         | ~507                 |
-| 6 (Stabilita')                | ~15         | ~522                 |
-| 7 (Stripe)                    | ~20         | ~542                 |
-| **Lancio**                    |             | **~545+ test**       |
+| Versione    | Nuovi test (stimati) | Totale unit | Totale E2E |
+| ----------- | -------------------- | ----------- | ---------- |
+| (storico)   | —                    | 502         | 8          |
+| **v0.7.0**  | ~10                  | ~512        | 8          |
+| **v0.8.0**  | ~10                  | ~522        | 8          |
+| **v0.8.1**  | ~5                   | ~527        | 8          |
+| **v0.9.0**  | ~20                  | ~547        | 8          |
+| **v0.9.1**  | ~0 unit / ~10 E2E    | ~547        | ~18        |
+| **v1.0.0**  | 0 (solo tag)         | ~547        | ~18        |
 
 ---
 
-## Review checkpoint: cosa verificare
+## Principi del piano
 
-Ad ogni checkpoint:
-
-1. SonarCloud quality gate verde (zero nuovi bug, zero vulnerabilita')
-2. Coverage in crescita rispetto al checkpoint precedente
-3. Breve summary nella PR o nel ROADMAP.md
-4. Valutare se serve refactor prima di procedere
-
----
-
-## Prossimo passo immediato
-
-**Phase 4H completata.** Avviare **Phase 4J** (SPID login — `login_spid.har` disponibile).
-Poi **Phase 4I** (`dati_doc_commerciale.har` disponibile).
-
----
-
-## Backlog — Feature future (post-lancio)
-
-- ⬜ Import CSV/XLS prodotti
-- ⬜ Scanner barcode via fotocamera
-- ⬜ Stampa Bluetooth (58/80mm)
-- ⬜ Integrazione POS: SumUp, Nexi, Satispay
-- ⬜ Fatturazione elettronica (SDI)
-- ⬜ Dashboard avanzata: grafici, trend, export
-- ⬜ Dashboard base: totale giornaliero, conteggio (dopo 4G)
-- ⬜ Codice lotteria scontrini
-- ⬜ Multi-operatore: ruoli, log attività
-- ⬜ Integrazione e-commerce (WooCommerce, Shopify)
-- ⬜ Blog MDX per SEO organico
-- ⬜ Notifiche push (PWA)
-- ⬜ Modalità offline con coda di sincronizzazione
-- ⬜ API pubblica / webhook
-- ⬜ App Capacitor (feature native)
-- ⬜ CIE login (analizzare `login_cie.har`)
-- ⬜ Pre-sessione AdE al login per velocizzare emissione (Fisconline)
-- ⬜ Persistenza cookie jar AdE per sessioni SPID multi-giorno (Phase 6)
-- ⬜ Bordo colorato card catalogo
-- ⬜ Modifica prodotto a catalogo
-- ⬜ Sync AdE catalogo (HAR: `aggiungi/modifica/elimina/ricerca_prodotto_catalogo.har`)
-- ⬜ Cleanup automatico DB documenti vecchi (valutare policy + limiti Supabase 500MB)
-- ⬜ Passkey support (registrazione)
-- ⬜ Cambio password (impostazioni profilo)
-- ⬜ Invia scontrino via email (Resend) dallo storico
-- ⬜ Email di benvenuto branded (Resend)
+1. **Minimalismo**: ogni release include solo quello che sblocca la successiva o il lancio.
+2. **TDD**: i test si scrivono prima dell'implementazione. Ogni `it()` ha almeno un `expect()`.
+3. **v0.9.1 è un checkpoint**, non una feature release. Niente di nuovo finché non è verde.
+4. **v1.0.0 è solo un tag push**: se c'è ancora sviluppo da fare, siamo a v0.9.x.
+5. **Stripe prima di PWA**: meglio pochi utenti paganti che tanti utenti gratuiti non monetizzati.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,0 @@
-# ScontrinoZero — Roadmap
-
-> Il piano di sviluppo dettagliato (fasi, test, checkpoint di review, riepilogo visuale, backlog)
-> è stato consolidato in **[`PLAN.md`](./PLAN.md)**.


### PR DESCRIPTION
## Summary

Consolidated the development plan from phase-based sequencing to semantic versioning with clear release milestones. The roadmap now uses `vx.y.z` format with v1.0.0 as the public launch target, making it easier to track progress and communicate release scope to stakeholders.

## Key Changes

- **Replaced phase-based plan with release-based roadmap**: Phases 0–4J (completed) are now documented in a "Storico sviluppo" (development history) table; future work is organized as v0.7.0 → v1.0.0 (pre-launch) → v1.x.y (post-launch)

- **Defined pre-launch releases**:
  - **v0.7.0**: AdE fiscal data update (`updateFiscalData()`)
  - **v0.8.0**: Email transactional (Resend integration)
  - **v0.8.1**: Landing page completeness (pricing, JSON-LD, CTA)
  - **v0.9.0**: Stripe payments (Free/Starter/Pro tiers, feature gating)
  - **v0.9.1**: Stability checkpoint (E2E suite, Lighthouse audit, SonarCloud)
  - **v1.0.0**: Public launch (tag push only, no new development)

- **Clarified v1.0.0 scope**: Explicit "IN v1.0.0" and "FUORI da v1.0.0" sections listing what ships at launch vs. post-launch features (PWA, annual billing, receipt email, analytics, etc.)

- **Added post-launch roadmap**: v1.1.0–v2.0.0+ with feature descriptions (PWA, billing, email, analytics, catalog sync, SPID persistence, CSV import, Bluetooth print, public API)

- **Consolidated test tracking**: Cumulative test count table showing progression from current 502 unit + 8 E2E → ~547 unit + ~18 E2E at v1.0.0

- **Updated CLAUDE.md**: Reflected new versioning scheme and release roadmap in developer onboarding docs

- **Removed ROADMAP.md**: Consolidated into PLAN.md (single source of truth)

## Implementation Details

- Each pre-launch release includes TDD task lists with estimated test counts
- v0.9.1 is explicitly a **checkpoint**, not a feature release—no development proceeds until it's green
- v1.0.0 is a **tag push only**—if work remains, the version stays at v0.9.x
- Stripe prioritized before PWA to focus on monetization over distribution
- HAR file analysis tasks mapped to specific releases (e.g., `dati_doc_commerciale.har` → v0.7.0)

https://claude.ai/code/session_01Dyb3Wrp3QX2UDp4yAGWRMT