### PR TITLE
feat: mostra sempre % come label IVA, 0% con descrizione per codici N

### DIFF
--- a/src/app/r/[documentId]/page.tsx
+++ b/src/app/r/[documentId]/page.tsx
@@ -34,12 +34,12 @@ const VAT_LABELS: Record<string, string> = {
   "5": "5%",
   "10": "10%",
   "22": "22%",
-  N1: "Esclusa",
-  N2: "Non sogg.",
-  N3: "Non imp.",
-  N4: "Esente",
-  N5: "Reg.marg.",
-  N6: "Non IVA",
+  N1: "0% – Art. 15",
+  N2: "0% – Non sogg.",
+  N3: "0% – Non imp.",
+  N4: "0% – Esente",
+  N5: "0% – Margine",
+  N6: "0% – Inv. cont.",
 };
 
 const PAYMENT_LABELS: Record<string, string> = {

--- a/src/components/cassa/vat-selector.test.tsx
+++ b/src/components/cassa/vat-selector.test.tsx
@@ -27,7 +27,7 @@ describe("VatSelector", () => {
 
   it("mostra la descrizione corretta per un codice natura", () => {
     render(<VatSelector value="N2" onChange={vi.fn()} />);
-    expect(screen.getByText("N2 – Non soggette")).toBeInTheDocument();
+    expect(screen.getByText("0% – Non soggette")).toBeInTheDocument();
   });
 
   it("aggiorna la descrizione al cambio di prop value", () => {
@@ -37,7 +37,7 @@ describe("VatSelector", () => {
 
     rerender(<VatSelector value="N4" onChange={vi.fn()} />);
 
-    expect(screen.getByText("N4 – Esenti")).toBeInTheDocument();
+    expect(screen.getByText("0% – Esente")).toBeInTheDocument();
   });
 
   it("il trigger ha role combobox (accessibilità Select)", () => {
@@ -50,7 +50,7 @@ describe("VatSelector", () => {
 
     fireEvent.click(screen.getByRole("combobox"));
 
-    // Le 10 aliquote: 4%, 5%, 10%, 22%, N1-N6
+    // Le 10 aliquote: 4%, 5%, 10%, 22%, 0% (N1-N6 con descrizione)
     expect(
       screen.getByRole("option", { name: "4% – Ridotta" }),
     ).toBeInTheDocument();
@@ -64,22 +64,22 @@ describe("VatSelector", () => {
       screen.getByRole("option", { name: "22% – Ordinaria" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "N1 – Escluse art. 15" }),
+      screen.getByRole("option", { name: "0% – Escluse art. 15" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "N2 – Non soggette" }),
+      screen.getByRole("option", { name: "0% – Non soggette" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "N3 – Non imponibili" }),
+      screen.getByRole("option", { name: "0% – Non imponibili" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "N4 – Esenti" }),
+      screen.getByRole("option", { name: "0% – Esente" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "N5 – Regime del margine" }),
+      screen.getByRole("option", { name: "0% – Regime del margine" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "N6 – Inv. contabile" }),
+      screen.getByRole("option", { name: "0% – Inv. contabile" }),
     ).toBeInTheDocument();
   });
 
@@ -93,12 +93,12 @@ describe("VatSelector", () => {
     expect(onChange).toHaveBeenCalledWith("10");
   });
 
-  it("chiama onChange con 'N2' quando si seleziona N2", () => {
+  it("chiama onChange con 'N2' quando si seleziona 0% – Non soggette", () => {
     const onChange = vi.fn();
     render(<VatSelector value="22" onChange={onChange} />);
 
     fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByRole("option", { name: "N2 – Non soggette" }));
+    fireEvent.click(screen.getByRole("option", { name: "0% – Non soggette" }));
 
     expect(onChange).toHaveBeenCalledWith("N2");
   });

--- a/src/components/storico/void-receipt-dialog.tsx
+++ b/src/components/storico/void-receipt-dialog.tsx
@@ -14,6 +14,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { voidReceipt } from "@/server/void-actions";
 import type { ReceiptListItem, VoidReceiptResult } from "@/types/storico";
+import { VAT_LABELS } from "@/types/cassa";
+import type { VatCode } from "@/types/cassa";
 
 interface VoidReceiptDialogProps {
   readonly receipt: ReceiptListItem;
@@ -35,8 +37,7 @@ function formatCurrency(amount: string): string {
 }
 
 function formatVat(vatCode: string): string {
-  if (vatCode.startsWith("N")) return vatCode;
-  return `${vatCode}% IVA`;
+  return VAT_LABELS[vatCode as VatCode] ?? vatCode;
 }
 
 /** Tre stati del dialog:

--- a/src/lib/pdf/generate-sale-receipt.ts
+++ b/src/lib/pdf/generate-sale-receipt.ts
@@ -33,12 +33,12 @@ const VAT_LABELS: Record<string, string> = {
   "5": "5%",
   "10": "10%",
   "22": "22%",
-  N1: "Esclusa",
-  N2: "Non sogg.",
-  N3: "Non imp.",
-  N4: "Esente",
-  N5: "Reg.marg.",
-  N6: "Non IVA",
+  N1: "0% – Art. 15",
+  N2: "0% – Non sogg.",
+  N3: "0% – Non imp.",
+  N4: "0% – Esente",
+  N5: "0% – Margine",
+  N6: "0% – Inv. cont.",
 };
 
 const PAYMENT_LABELS: Record<string, string> = {

--- a/src/types/cassa.ts
+++ b/src/types/cassa.ts
@@ -33,12 +33,12 @@ export const VAT_LABELS: Record<VatCode, string> = {
   "5": "5%",
   "10": "10%",
   "22": "22%",
-  N1: "N1",
-  N2: "N2",
-  N3: "N3",
-  N4: "N4",
-  N5: "N5",
-  N6: "N6",
+  N1: "0% – Art. 15",
+  N2: "0% – Non sogg.",
+  N3: "0% – Non imp.",
+  N4: "0% – Esente",
+  N5: "0% – Margine",
+  N6: "0% – Inv. cont.",
 };
 
 /** Descrizioni complete per il dropdown di selezione */
@@ -47,12 +47,12 @@ export const VAT_DESCRIPTIONS: Record<VatCode, string> = {
   "5": "5% – Ridotta",
   "10": "10% – Ridotta",
   "22": "22% – Ordinaria",
-  N1: "N1 – Escluse art. 15",
-  N2: "N2 – Non soggette",
-  N3: "N3 – Non imponibili",
-  N4: "N4 – Esenti",
-  N5: "N5 – Regime del margine",
-  N6: "N6 – Inv. contabile",
+  N1: "0% – Escluse art. 15",
+  N2: "0% – Non soggette",
+  N3: "0% – Non imponibili",
+  N4: "0% – Esente",
+  N5: "0% – Regime del margine",
+  N6: "0% – Inv. contabile",
 };
 
 /** Etichette UI per i metodi di pagamento */


### PR DESCRIPTION
I codici N1-N6 (esenti/non imponibili) vengono ora mostrati come "0% – [descrizione]" invece delle sigle tecniche, in tutti i punti dell'UI dove appare l'aliquota IVA:

- VAT_LABELS (badge compatti, catalogo, storico): "0% – Art. 15", "0% – Non sogg.", "0% – Non imp.", "0% – Esente", "0% – Margine", "0% – Inv. cont."
- VAT_DESCRIPTIONS (dropdown selezione): versioni estese senza sigla ("0% – Escluse art. 15", "0% – Non soggette", ecc.)
- Aggiornate le definizioni locali in receipt page e PDF
- void-receipt-dialog: formatVat() ora usa VAT_LABELS condiviso (rimosso suffisso " IVA" ridondante per i codici %)
- Test vat-selector aggiornati con le nuove label

https://claude.ai/code/session_012Dghj86gs2swHcavDGJxWP