### PR TITLE
Add terms of service acceptance requirement to registration

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -26,10 +26,12 @@ export default function RegisterPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<{
     email?: string;
     password?: string;
     confirmPassword?: string;
+    terms?: string;
   }>({});
   const [serverError, setServerError] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
@@ -45,6 +47,9 @@ export default function RegisterPage() {
     if (!confirmPassword) errors.confirmPassword = ERR_CONFIRM_REQUIRED;
     else if (password !== confirmPassword)
       errors.confirmPassword = ERR_CONFIRM_MISMATCH;
+    if (!termsAccepted)
+      errors.terms =
+        "Devi accettare i Termini di servizio e la Privacy Policy.";
 
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors);
@@ -60,6 +65,7 @@ export default function RegisterPage() {
     formData.set("email", email);
     formData.set("password", password);
     formData.set("confirmPassword", confirmPassword);
+    formData.set("termsAccepted", "true");
 
     const result = await signUp(formData);
     setIsPending(false);
@@ -123,6 +129,45 @@ export default function RegisterPage() {
               <p className="text-destructive text-xs">
                 {fieldErrors.confirmPassword}
               </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <div className="flex items-start gap-2">
+              <input
+                id="termsAccepted"
+                type="checkbox"
+                checked={termsAccepted}
+                onChange={(e) => setTermsAccepted(e.target.checked)}
+                className="accent-primary mt-0.5 h-4 w-4 shrink-0 cursor-pointer"
+              />
+              <label
+                htmlFor="termsAccepted"
+                className="cursor-pointer text-sm leading-snug select-none"
+              >
+                Ho letto e accetto i{" "}
+                <Link
+                  href="/termini"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Termini di servizio
+                </Link>{" "}
+                e la{" "}
+                <Link
+                  href="/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Privacy Policy
+                </Link>
+                .
+              </label>
+            </div>
+            {fieldErrors.terms && (
+              <p className="text-destructive text-xs">{fieldErrors.terms}</p>
             )}
           </div>
 

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -128,6 +128,21 @@ describe("auth-actions", () => {
       expect(result).toEqual({ error: "Le password non coincidono." });
     });
 
+    it("returns error when terms are not accepted", async () => {
+      const { signUp } = await import("./auth-actions");
+      const result = await signUp(
+        formData({
+          email: "test@example.com",
+          password: "Secure#99x",
+          confirmPassword: "Secure#99x",
+          // termsAccepted omitted
+        }),
+      );
+      expect(result).toEqual({
+        error: "Devi accettare i Termini di servizio e la Privacy Policy.",
+      });
+    });
+
     it("creates user and profile then redirects on success", async () => {
       mockSignUp.mockResolvedValue({
         data: { user: { id: "user-123" } },
@@ -142,6 +157,7 @@ describe("auth-actions", () => {
             email: "test@example.com",
             password: "Secure#99x",
             confirmPassword: "Secure#99x",
+            termsAccepted: "true",
           }),
         );
         expect.fail("Expected redirect");
@@ -171,6 +187,7 @@ describe("auth-actions", () => {
           email: "test@example.com",
           password: "Secure#99x",
           confirmPassword: "Secure#99x",
+          termsAccepted: "true",
         }),
       );
       expect(result).toEqual({ error: "Registrazione fallita. Riprova." });
@@ -185,6 +202,7 @@ describe("auth-actions", () => {
           email: "test@example.com",
           password: "Secure#99x",
           confirmPassword: "Secure#99x",
+          termsAccepted: "true",
         }),
       );
       expect(result.error).toContain("Troppi tentativi");
@@ -207,6 +225,7 @@ describe("auth-actions", () => {
             email: "test@example.com",
             password: "Secure#99x",
             confirmPassword: "Secure#99x",
+            termsAccepted: "true",
           }),
         );
         expect.fail("Expected redirect");

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -43,6 +43,7 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
   const confirmPassword = formData.get("confirmPassword") as string;
+  const termsAccepted = formData.get("termsAccepted");
 
   if (!email || !isValidEmail(email)) {
     return { error: "Email non valida." };
@@ -55,6 +56,11 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
   }
   if (password !== confirmPassword) {
     return { error: "Le password non coincidono." };
+  }
+  if (termsAccepted !== "true") {
+    return {
+      error: "Devi accettare i Termini di servizio e la Privacy Policy.",
+    };
   }
 
   const ip = await getClientIp();


### PR DESCRIPTION
## Summary
This PR adds a mandatory terms of service and privacy policy acceptance requirement to the user registration flow. Users must now explicitly accept both documents before they can create an account.

## Key Changes
- **Frontend (Register Page)**
  - Added `termsAccepted` state to track checkbox status
  - Added terms field to validation error handling
  - Implemented checkbox UI with links to `/termini` and `/privacy` pages
  - Display validation error message when terms are not accepted
  - Include `termsAccepted` in form submission

- **Backend (Auth Actions)**
  - Added server-side validation to ensure `termsAccepted` is set to `"true"`
  - Return appropriate error message if terms are not accepted
  - Validation occurs before rate limiting and database operations

- **Tests**
  - Added test case verifying error is returned when terms are not accepted
  - Updated existing test cases to include `termsAccepted: "true"` in form data

## Implementation Details
- The checkbox is positioned with proper accessibility (linked label, proper spacing)
- Terms links open in new tabs with security attributes (`noopener noreferrer`)
- Validation happens on both client and server side for security
- Error message is consistent across frontend and backend: "Devi accettare i Termini di servizio e la Privacy Policy."
- The implementation follows the existing pattern used for other form fields (email, password, confirmPassword)

https://claude.ai/code/session_01TyG3HmrDEU3GEycA3rTDcy