### PR TITLE
docs: documenta strategia security audit e aggiunge task audit-ci in …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,11 @@ Fasi:
   - Free tier generoso per repo privati (2.000 minuti/mese)
 - **Smart skip**: i workflow analizzano il diff e saltano se non ci sono file rilevanti
   (risparmio minuti CI su modifiche a soli `.md`, `static/`, etc.)
+- **Security audit**: attualmente `npm audit --audit-level=high` (blocca solo high/critical).
+  Prima di v1.0.0 va portato a `moderate` usando `audit-ci` con un file di allowlist
+  per le eccezioni documentate (es. esbuild in drizzle-kit è devDependency il cui
+  vettore d'attacco è irrilevante in CI). Le low non si auditano: rapporto segnale/rumore
+  pessimo senza benefici reali.
 - **Pipeline CI** (su push/PR verso main):
   1. Lint (ESLint) + type-check (`tsc --noEmit`)
   2. Test con coverage (Vitest → lcov)

--- a/PLAN.md
+++ b/PLAN.md
@@ -131,6 +131,8 @@ funzioni prima di toccare la produzione.
   - upgrade Free → Starter (Stripe test mode)
   - reset password via Resend
 - ⬜ Lighthouse audit: landing ≥90 mobile, dashboard ≥80 mobile
+- ⬜ Security audit: portare CI a `--audit-level=moderate` con `audit-ci` + allowlist
+  documentata per le eccezioni approvate (es. esbuild in drizzle-kit devDependency)
 - ⬜ SonarCloud quality gate verde, zero issue Blocker/Critical
 - ⬜ Smoke test su ambiente test con `ADE_MODE=mock`
 - ⬜ Verificare che tutte le variabili d'ambiente `.env.example` siano aggiornate


### PR DESCRIPTION
…v0.9.1

- CLAUDE.md: aggiunta nota su --audit-level (high → moderate con audit-ci prima di v1.0.0) e spiegazione sulla gestione delle eccezioni in allowlist
- PLAN.md: aggiunto task esplicito in v0.9.1 per portare CI a moderate con audit-ci + allowlist documentata

https://claude.ai/code/session_01GEkHt1vEBprDN857VugGFy