### PR TITLE
Add Supabase keep-alive mechanism to prevent project pause

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,8 +1,33 @@
 import * as Sentry from "@sentry/nextjs";
+import { logger } from "@/lib/logger";
+
+// Supabase free tier pausa i progetti dopo 7 giorni senza query al DB.
+// Questo interval esegue una query lightweight ogni 5 giorni per prevenire la pausa.
+// TODO: rimuovere quando si passa a Supabase Pro.
+const KEEP_ALIVE_INTERVAL_MS = 5 * 24 * 60 * 60 * 1000; // 5 giorni
+
+function startSupabaseKeepAlive() {
+  const interval: ReturnType<typeof setInterval> = setInterval(async () => {
+    try {
+      const { createAdminSupabaseClient } = await import(
+        "@/lib/supabase/admin"
+      );
+      const supabase = createAdminSupabaseClient();
+      await supabase.from("profiles").select("id").limit(1);
+      logger.info("Supabase keep-alive ping eseguito");
+    } catch (err) {
+      logger.warn({ err }, "Supabase keep-alive ping fallito");
+    }
+  }, KEEP_ALIVE_INTERVAL_MS);
+
+  // .unref() evita che l'interval blocchi lo shutdown del processo Node.js
+  interval.unref();
+}
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./sentry.server.config");
+    startSupabaseKeepAlive();
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {


### PR DESCRIPTION
## Summary
Implements an automatic keep-alive mechanism for Supabase to prevent the free tier from pausing projects due to inactivity. The solution executes a lightweight database query every 5 days to maintain project activity status.

## Key Changes
- Added `startSupabaseKeepAlive()` function that runs a periodic lightweight query against the `profiles` table
- Configured interval to execute every 5 days (before Supabase's 7-day inactivity threshold)
- Integrated keep-alive startup into the Node.js runtime initialization in the `register()` function
- Added proper error handling with logging for both successful pings and failures
- Used `.unref()` on the interval to prevent blocking Node.js process shutdown

## Implementation Details
- The keep-alive query is intentionally minimal (`select("id").limit(1)`) to minimize resource usage
- Supabase admin client is dynamically imported within the interval callback to avoid unnecessary module loading at startup
- Logging integration provides visibility into keep-alive execution and any failures
- Includes a TODO comment noting this workaround should be removed when upgrading to Supabase Pro tier

https://claude.ai/code/session_0172tnUxg7TdjGGNFsDFtJQy