### PR TITLE
ci: skip heavy jobs on lockfile-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      lockfile: ${{ steps.filter.outputs.lockfile }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -28,7 +29,6 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'package.json'
-              - 'package-lock.json'
               - 'tsconfig.json'
               - 'next.config.ts'
               - 'vitest.config.ts'
@@ -37,9 +37,26 @@ jobs:
               - 'src/**'
               - 'e2e/**'
               - 'package.json'
-              - 'package-lock.json'
               - 'next.config.ts'
               - 'playwright.config.ts'
+            lockfile:
+              - 'package-lock.json'
+
+  # Audit dipendenze — gira anche su modifiche al solo lockfile
+  audit:
+    needs: changes
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.lockfile == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Security audit
+        run: npm audit --audit-level=high
 
   # Parallel checks — lint, type-check e test girano in contemporanea
   lint:
@@ -54,8 +71,6 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Security audit
-        run: npm audit --audit-level=high
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
Extracted package-lock.json into a dedicated `lockfile` filter. Added a standalone `audit` job that runs whenever src or lockfile changes. Removed package-lock.json from `src` and `e2e` filters so a lockfile-only commit (e.g. npm version drift) no longer triggers lint/type-check/test/ build/sonar/e2e — only the security audit runs.

https://claude.ai/code/session_013jR8J8bZksRMxpUue7jQ9U