### PR TITLE
Add Docker Compose deployment configuration with Cloudflare Tunnel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
     outputs:
       environment: ${{ steps.env.outputs.environment }}
-      image_tag: ${{ steps.meta.outputs.tags }}
+      image_version: ${{ steps.meta.outputs.version }}
 
     steps:
       - uses: actions/checkout@v6
@@ -70,14 +70,20 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     environment: ${{ needs.build-and-push.outputs.environment }}
+    permissions:
+      packages: read
 
     steps:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_VERSION: ${{ needs.build-and-push.outputs.image_version }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GHCR_TOKEN,APP_VERSION
           script: |
             ENV=${{ needs.build-and-push.outputs.environment }}
             if [ "$ENV" = "test" ]; then
@@ -85,5 +91,6 @@ jobs:
             else
               cd /opt/scontrinozero
             fi
-            docker compose pull app
-            docker compose up -d
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            APP_VERSION=$APP_VERSION docker compose -f docker-compose.deploy.yml pull app
+            APP_VERSION=$APP_VERSION docker compose -f docker-compose.deploy.yml up -d

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,35 @@
+services:
+  app:
+    image: ghcr.io/dstmrk/scontrinozero:${APP_VERSION}
+    container_name: scontrinozero
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: scontrinozero-tunnel
+    restart: unless-stopped
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      app:
+        condition: service_healthy
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.local-test.yml
+++ b/docker-compose.local-test.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    image: ghcr.io/dstmrk/scontrinozero:${APP_VERSION:-latest}
+    container_name: scontrinozero-local-test
+    env_file: .env
+    ports:
+      - "3000:3000"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary
This PR introduces production-ready Docker Compose configurations for deployment and local testing, along with updates to the GitHub Actions deployment workflow to support containerized deployments with proper authentication and health checks.

## Key Changes

- **Added `docker-compose.deploy.yml`**: Production deployment configuration featuring:
  - Main application service with health checks via HTTP endpoint
  - Cloudflare Tunnel integration for secure external access
  - Service dependency management (tunnel waits for app to be healthy)
  - JSON file logging with rotation (10m max size, 3 file limit)
  - Configurable app version via environment variable

- **Added `docker-compose.local-test.yml`**: Local testing configuration with simplified setup for development and CI testing

- **Updated GitHub Actions deployment workflow**:
  - Changed output from `image_tag` to `image_version` for consistency
  - Added GHCR authentication via GitHub token before pulling images
  - Implemented environment variable passing (APP_VERSION, GHCR_TOKEN) to deployment script
  - Updated docker compose commands to use the new `docker-compose.deploy.yml` file
  - Added `packages: read` permission for GHCR access
  - Explicit APP_VERSION substitution in compose commands

## Notable Implementation Details

- Health checks are configured with a 40-second start period to allow app initialization
- Cloudflare Tunnel depends on the app service being healthy before starting
- Both test and production environments are supported via conditional path logic in the deployment script
- Docker login is performed before pulling to ensure authenticated access to private GHCR images

https://claude.ai/code/session_01SVuZ4GJmBJ4NiMNmFHppky