### PR TITLE
feat(supabase): template HTML brandizzato per email conferma signup

### DIFF
--- a/supabase/templates/confirm-signup.html
+++ b/supabase/templates/confirm-signup.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Conferma il tuo account ScontrinoZero</title>
+  </head>
+  <body
+    style="
+      background-color: #f9fafb;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+    "
+  >
+    <table
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      style="background-color: #f9fafb; padding: 40px 16px"
+    >
+      <tr>
+        <td align="center">
+          <table
+            width="560"
+            cellpadding="0"
+            cellspacing="0"
+            style="
+              background-color: #ffffff;
+              border-radius: 8px;
+              max-width: 560px;
+              width: 100%;
+              overflow: hidden;
+            "
+          >
+            <!-- Header -->
+            <tr>
+              <td
+                style="
+                  background-color: #0d9488;
+                  border-radius: 8px 8px 0 0;
+                  padding: 24px 32px;
+                "
+              >
+                <p
+                  style="
+                    font-size: 22px;
+                    font-weight: 700;
+                    color: #ffffff;
+                    margin: 0;
+                    letter-spacing: -0.3px;
+                  "
+                >
+                  ScontrinoZero
+                </p>
+                <p
+                  style="font-size: 13px; color: #ccfbf1; margin: 4px 0 0"
+                >
+                  Registratore di cassa virtuale
+                </p>
+              </td>
+            </tr>
+
+            <!-- Body -->
+            <tr>
+              <td style="padding: 32px">
+                <h2
+                  style="
+                    font-size: 20px;
+                    font-weight: 600;
+                    color: #111827;
+                    margin: 0 0 12px;
+                  "
+                >
+                  Conferma il tuo account
+                </h2>
+                <p
+                  style="
+                    font-size: 15px;
+                    line-height: 24px;
+                    color: #374151;
+                    margin: 12px 0;
+                  "
+                >
+                  Benvenuto in ScontrinoZero! Clicca sul pulsante qui sotto per
+                  confermare il tuo indirizzo email e attivare l&apos;account.
+                </p>
+                <p style="margin: 20px 0 8px">
+                  <a
+                    href="{{ .ConfirmationURL }}"
+                    style="
+                      background-color: #0d9488;
+                      border-radius: 6px;
+                      color: #ffffff;
+                      font-size: 15px;
+                      font-weight: 600;
+                      padding: 12px 24px;
+                      text-decoration: none;
+                      display: inline-block;
+                    "
+                  >
+                    Conferma email
+                  </a>
+                </p>
+                <p
+                  style="
+                    font-size: 13px;
+                    line-height: 20px;
+                    color: #6b7280;
+                    margin: 16px 0 0;
+                  "
+                >
+                  Se non hai creato un account su ScontrinoZero, ignora questa
+                  email.
+                </p>
+              </td>
+            </tr>
+
+            <!-- Footer -->
+            <tr>
+              <td
+                style="
+                  border-top: 1px solid #e5e7eb;
+                  padding: 16px 32px;
+                  text-align: center;
+                "
+              >
+                <p
+                  style="
+                    font-size: 12px;
+                    color: #9ca3af;
+                    margin: 0;
+                  "
+                >
+                  ScontrinoZero &middot; scontrinozero.it
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Aggiunge supabase/templates/confirm-signup.html con lo stesso stile delle email Resend (header teal, bottone teal, testo in italiano). Da incollare in Supabase Dashboard > Authentication > Email Templates > Confirm signup.

https://claude.ai/code/session_0163CDoCLrtFQ2FNa2f5rSgx