### PR TITLE
fix(sonar): risolvi 5 code smell "Ambiguous spacing" in termini/v01

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,10 @@ Stesso progetto Next.js, non un sito separato:
   1. Creare `src/app/(marketing)/termini/vXX/page.tsx` con il nuovo testo
   2. Aggiornare il redirect in `src/app/(marketing)/termini/page.tsx` → `/termini/vXX`
   3. Aggiornare `CURRENT_TERMS_VERSION = "vXX"` in `src/server/auth-actions.ts`
+  4. Aggiornare il testo del **secondo flag** (clausole vessatorie art. 1341 c.c.) in
+     `src/app/(auth)/register/page.tsx` — i numeri di paragrafo devono rispecchiare
+     la struttura della nuova versione (§ limitazione responsabilità, § no rimborso,
+     § sospensione unilaterale, § foro esclusivo)
 
 ## Decisioni architetturali
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -184,7 +184,9 @@ funzioni prima di toccare la produzione.
 - ⬜ SonarCloud quality gate verde, zero issue Blocker/Critical
 - ⬜ Smoke test su ambiente test con `ADE_MODE=mock`
 - ⬜ Verificare che tutte le variabili d'ambiente `.env.example` siano aggiornate
-- ⬜ Aggiornare Privacy Policy/ToS se necessario dopo test legale
+- ✅ Aggiornare Privacy Policy/ToS: clausole vessatorie nel form di registrazione
+  allineate alla struttura v01 (§9 limitazione responsabilità, §10 no rimborso,
+  §11 sospensione, §16 foro Torino). Procedure aggiornata in CLAUDE.md.
 
 **Test attesi:** ~5 unit (export dati) + ~10 E2E → totale ~**519 unit + 19 E2E**
 

--- a/src/app/(marketing)/termini/v01/page.tsx
+++ b/src/app/(marketing)/termini/v01/page.tsx
@@ -106,7 +106,7 @@ export default function TerminiV01Page() {
               >
                 info@scontrinozero.it
               </a>
-              .
+              {"."}
             </p>
           </section>
 
@@ -136,7 +136,7 @@ export default function TerminiV01Page() {
                 solo titolare e responsabile dell&apos;utilizzo delle proprie
                 credenziali AdE
               </strong>
-              . ScontrinoZero agisce come mero esecutore tecnico delle
+              {". "}ScontrinoZero agisce come mero esecutore tecnico delle
               istruzioni impartite dall&apos;utente. Qualsiasi trasmissione
               effettuata tramite le credenziali dell&apos;utente è da
               considerarsi compiuta dall&apos;utente stesso.
@@ -265,7 +265,7 @@ export default function TerminiV01Page() {
                 dall&apos;utente nei 12 mesi precedenti l&apos;evento che ha
                 generato il danno
               </strong>
-              .
+              {"."}
             </p>
             <p className="text-muted-foreground mt-2">
               Resta esclusivamente in capo all&apos;utente la responsabilità di
@@ -431,7 +431,7 @@ export default function TerminiV01Page() {
               >
                 ec.europa.eu/consumers/odr
               </a>
-              .
+              {"."}
             </p>
           </section>
 
@@ -445,7 +445,7 @@ export default function TerminiV01Page() {
               >
                 info@scontrinozero.it
               </a>
-              .
+              {"."}
             </p>
           </section>
         </div>


### PR DESCRIPTION
Converte text node JSX ambigui (`. ` dopo </a> e </strong>) in espressioni esplicite {"."}  / {". "} — elimina 5 Major code smell SonarCloud nella pagina /termini/v01.

chore(docs): aggiungi step 4 alla procedura di aggiornamento ToS in CLAUDE.md (aggiornare flag clausole vessatorie nel form di registrazione) e segna item v0.9.1 come completato in PLAN.md.

https://claude.ai/code/session_01KT7SU4VcUncoqN1tgg3wxp