### PR TITLE
Update receipt handling: replace daily closure with void receipt feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ Fasi:
 
 L'integrazione AdE usa un **pattern adapter/strategy**:
 
-- Interfaccia `AdeClient` con metodi: `submitReceipt()`, `closeDay()`, etc.
+- Interfaccia `AdeClient` con metodi: `submitSale()`, `submitVoid()`, etc.
 - `RealAdeClient` — invia davvero all'AdE (produzione)
 - `MockAdeClient` — esegue **tutta la logica** (validazione, formattazione,
   preparazione payload) ma si ferma prima dell'invio HTTP all'AdE, restituendo

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -14,7 +14,7 @@ import { PricingSection } from "@/components/marketing/pricing-section";
 import {
   Smartphone,
   ReceiptEuro,
-  Clock,
+  Undo2,
   BarChart3,
   Shield,
   CalendarRange,
@@ -105,7 +105,7 @@ export default function Home() {
                 step: "3",
                 title: "Tutto il resto è automatico",
                 description:
-                  "La trasmissione all'Agenzia delle Entrate e la chiusura giornaliera avvengono da sole.",
+                  "La trasmissione all'Agenzia delle Entrate è automatica ad ogni scontrino.",
               },
             ].map((item) => (
               <div key={item.step} className="text-center">
@@ -138,10 +138,10 @@ export default function Home() {
                   "Inserisci l'importo, conferma, fatto. La trasmissione all'Agenzia delle Entrate avviene in automatico.",
               },
               {
-                icon: Clock,
-                title: "Fine giornata senza pensieri",
+                icon: Undo2,
+                title: "Scontrino sbagliato? Annullalo.",
                 description:
-                  "La chiusura dei corrispettivi è automatica. Una cosa in meno a cui pensare a fine giornata.",
+                  "Hai inserito un importo errato? Annulla lo scontrino direttamente dall'app. L'AdE viene aggiornata in automatico.",
               },
               {
                 icon: BarChart3,

--- a/src/app/(marketing)/privacy/v01/page.tsx
+++ b/src/app/(marketing)/privacy/v01/page.tsx
@@ -254,7 +254,7 @@ export default function PrivacyV01Page() {
               <li>
                 Sono utilizzate esclusivamente per le operazioni telematiche
                 esplicitamente richieste dall&apos;utente (emissione documento,
-                annullo, chiusura giornaliera).
+                annullo).
               </li>
               <li>
                 L&apos;accesso è limitato ai soli processi tecnici strettamente


### PR DESCRIPTION
## Summary
This PR updates the marketing messaging and internal documentation to reflect a shift in the receipt handling workflow. Instead of emphasizing automatic daily closure of receipts, the focus is now on the ability to void/cancel individual receipts with automatic tax authority updates.

## Key Changes

- **Marketing page updates**: 
  - Changed step 3 description from "daily closure happens automatically" to "transmission to tax authority is automatic for each receipt"
  - Replaced "End of day without worries" feature card with "Wrong receipt? Cancel it" feature
  - Updated icon from `Clock` to `Undo2` to better represent the void receipt functionality
  - Added description explaining users can cancel incorrectly entered amounts directly from the app with automatic tax authority updates

- **Documentation updates**:
  - Updated `AdeClient` interface method names from `submitReceipt()`, `closeDay()` to `submitSale()`, `submitVoid()` to reflect the new receipt-by-receipt and void operations pattern

- **Privacy policy updates**:
  - Removed "daily closure" from the list of telematic operations that require user data
  - Kept "void/cancellation" as an explicit operation requiring user data

## Implementation Details
The changes indicate a shift from a batch-based daily closure model to a real-time, receipt-by-receipt submission model with support for individual receipt cancellations. This aligns the tax authority integration with modern POS workflows where each transaction is immediately transmitted rather than batched at day-end.

https://claude.ai/code/session_014cyZ2eDBdt1af7ykAVcpuP