### PR TITLE
Add Info section to footer navigation

### DIFF
--- a/src/components/marketing/footer.tsx
+++ b/src/components/marketing/footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   return (
     <footer className="border-border/50 border-t">
       <div className="mx-auto max-w-5xl px-4 py-12">
-        <div className="grid gap-8 md:grid-cols-2">
+        <div className="grid gap-8 md:grid-cols-3">
           <div>
             <div className="flex items-center gap-2">
               <ReceiptEuro className="text-primary h-5 w-5" />
@@ -15,6 +15,36 @@ export function Footer() {
             <p className="text-muted-foreground mt-2 text-sm">
               Il registratore di cassa virtuale per micro-attività italiane.
             </p>
+          </div>
+
+          <div>
+            <h3 className="mb-3 text-sm font-semibold">Info</h3>
+            <ul className="text-muted-foreground space-y-2 text-sm">
+              <li>
+                <Link
+                  href="/#funzionalita"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Funzionalità
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/#prezzi"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Prezzi
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/#faq"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Domande Frequenti
+                </Link>
+              </li>
+            </ul>
           </div>
 
           <div>


### PR DESCRIPTION
## Summary
Updated the footer component to include a new "Info" section with links to key page sections, improving navigation and site discoverability.

## Changes
- Changed footer grid layout from 2 columns to 3 columns (`md:grid-cols-2` → `md:grid-cols-3`)
- Added new "Info" section with three navigation links:
  - Funzionalità (Features)
  - Prezzi (Pricing)
  - Domande Frequenti (FAQ)
- Links use anchor navigation to page sections and include hover state styling for better UX

## Implementation Details
- The new section follows the existing footer styling patterns with consistent typography and spacing
- Links use smooth color transitions on hover (`transition-colors`) for visual feedback
- All links are internal anchor links using the `#` hash navigation pattern

https://claude.ai/code/session_01K2BU7NBTSYa8p9tLCrjAbj