### PR TITLE
Add Supabase keep-alive timer to prevent free tier inactivity pause

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -191,7 +191,12 @@ funzioni prima di toccare la produzione.
   Clausole vessatorie nel form di registrazione allineate alla struttura ToS v01.
   Procedure di aggiornamento documentate in CLAUDE.md.
 
-**Test effettivi (v0.9.1 in corso):** 7 unit aggiunti (export-actions) → **708 unit** + 8 E2E;
+- ✅ Supabase keep-alive timer: `startSupabaseKeepAlive()` in `instrumentation.ts` (root) —
+  `setInterval` ogni 5gg (< soglia 7gg free tier), query `profiles LIMIT 1` via admin client,
+  `.unref()` per graceful shutdown. Export aggiunti per testabilità. 10 unit test aggiunti.
+  TODO: rimuovere quando si passa a Supabase Pro.
+
+**Test effettivi (v0.9.1 in corso):** 17 unit aggiunti (7 export-actions + 10 keep-alive) → **718 unit** + 8 E2E;
 ~10 E2E attesi a completamento checkpoint
 
 ---

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -4,9 +4,9 @@ import { logger } from "@/lib/logger";
 // Supabase free tier pausa i progetti dopo 7 giorni senza query al DB.
 // Questo interval esegue una query lightweight ogni 5 giorni per prevenire la pausa.
 // TODO: rimuovere quando si passa a Supabase Pro.
-const KEEP_ALIVE_INTERVAL_MS = 5 * 24 * 60 * 60 * 1000; // 5 giorni
+export const KEEP_ALIVE_INTERVAL_MS = 5 * 24 * 60 * 60 * 1000; // 5 giorni
 
-function startSupabaseKeepAlive() {
+export function startSupabaseKeepAlive() {
   const interval: ReturnType<typeof setInterval> = setInterval(async () => {
     try {
       const { createAdminSupabaseClient } =

--- a/tests/unit/instrumentation-keep-alive.test.ts
+++ b/tests/unit/instrumentation-keep-alive.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  KEEP_ALIVE_INTERVAL_MS,
+  startSupabaseKeepAlive,
+  register,
+} from "../../instrumentation";
+
+const { mockCreateAdminSupabaseClient, mockLoggerInfo, mockLoggerWarn } =
+  vi.hoisted(() => ({
+    mockCreateAdminSupabaseClient: vi.fn(),
+    mockLoggerInfo: vi.fn(),
+    mockLoggerWarn: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminSupabaseClient: mockCreateAdminSupabaseClient,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: mockLoggerInfo, warn: mockLoggerWarn },
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureRequestError: vi.fn(),
+}));
+
+vi.mock("../../sentry.server.config", () => ({}));
+vi.mock("../../sentry.edge.config", () => ({}));
+
+describe("KEEP_ALIVE_INTERVAL_MS", () => {
+  it("vale esattamente 5 giorni in millisecondi", () => {
+    expect(KEEP_ALIVE_INTERVAL_MS).toBe(5 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe("startSupabaseKeepAlive()", () => {
+  let capturedCallback: (() => Promise<void>) | undefined;
+  let mockUnref: ReturnType<typeof vi.fn>;
+  let mockLimit: ReturnType<typeof vi.fn>;
+  let mockSelect: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockUnref = vi.fn();
+    const mockTimer = { unref: mockUnref } as unknown as ReturnType<
+      typeof setInterval
+    >;
+    vi.spyOn(global, "setInterval").mockImplementation((callback) => {
+      capturedCallback = callback as () => Promise<void>;
+      return mockTimer;
+    });
+
+    mockLimit = vi.fn().mockResolvedValue({ data: [], error: null });
+    mockSelect = vi.fn(() => ({ limit: mockLimit }));
+    mockFrom = vi.fn(() => ({ select: mockSelect }));
+    mockCreateAdminSupabaseClient.mockReturnValue({ from: mockFrom });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    capturedCallback = undefined;
+  });
+
+  it("chiama setInterval con l'intervallo corretto (5 giorni)", () => {
+    startSupabaseKeepAlive();
+    expect(global.setInterval).toHaveBeenCalledWith(
+      expect.any(Function),
+      KEEP_ALIVE_INTERVAL_MS,
+    );
+  });
+
+  it("chiama .unref() sull'interval per non bloccare lo shutdown", () => {
+    startSupabaseKeepAlive();
+    expect(mockUnref).toHaveBeenCalled();
+  });
+
+  it("non chiama il DB prima che scatti il timer", () => {
+    startSupabaseKeepAlive();
+    expect(mockCreateAdminSupabaseClient).not.toHaveBeenCalled();
+  });
+
+  it("chiama profiles.select(id).limit(1) quando il callback scatta", async () => {
+    startSupabaseKeepAlive();
+    await capturedCallback!();
+
+    expect(mockCreateAdminSupabaseClient).toHaveBeenCalledOnce();
+    expect(mockFrom).toHaveBeenCalledWith("profiles");
+    expect(mockSelect).toHaveBeenCalledWith("id");
+    expect(mockLimit).toHaveBeenCalledWith(1);
+  });
+
+  it("logga info dopo una query riuscita", async () => {
+    startSupabaseKeepAlive();
+    await capturedCallback!();
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      "Supabase keep-alive ping eseguito",
+    );
+  });
+
+  it("logga warn senza lanciare eccezioni in caso di errore del client", async () => {
+    const error = new Error("DB unavailable");
+    mockCreateAdminSupabaseClient.mockImplementation(() => {
+      throw error;
+    });
+    startSupabaseKeepAlive();
+    await capturedCallback!();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      { err: error },
+      "Supabase keep-alive ping fallito",
+    );
+    expect(mockLoggerInfo).not.toHaveBeenCalled();
+  });
+
+  it("il callback può essere eseguito più volte (timer periodico)", async () => {
+    startSupabaseKeepAlive();
+    await capturedCallback!();
+    await capturedCallback!();
+
+    expect(mockCreateAdminSupabaseClient).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("register()", () => {
+  let originalNextRuntime: string | undefined;
+  let mockUnref: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalNextRuntime = process.env.NEXT_RUNTIME;
+    mockUnref = vi.fn();
+    const mockTimer = { unref: mockUnref } as unknown as ReturnType<
+      typeof setInterval
+    >;
+    vi.spyOn(global, "setInterval").mockReturnValue(mockTimer);
+  });
+
+  afterEach(() => {
+    if (originalNextRuntime === undefined) {
+      delete process.env.NEXT_RUNTIME;
+    } else {
+      process.env.NEXT_RUNTIME = originalNextRuntime;
+    }
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("avvia il keep-alive quando NEXT_RUNTIME=nodejs", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+
+    await register();
+
+    expect(global.setInterval).toHaveBeenCalledWith(
+      expect.any(Function),
+      KEEP_ALIVE_INTERVAL_MS,
+    );
+  });
+
+  it("non avvia il keep-alive quando NEXT_RUNTIME=edge", async () => {
+    process.env.NEXT_RUNTIME = "edge";
+
+    await register();
+
+    expect(global.setInterval).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Implements a periodic keep-alive mechanism for Supabase free tier to prevent automatic project suspension after 7 days of inactivity. The solution executes a lightweight database query every 5 days to maintain activity status.

## Key Changes
- **Export keep-alive utilities** from `instrumentation.ts` for testability:
  - `KEEP_ALIVE_INTERVAL_MS`: 5-day interval constant (5 × 24 × 60 × 60 × 1000 ms)
  - `startSupabaseKeepAlive()`: Initializes periodic keep-alive timer
  
- **Implementation details**:
  - Uses `setInterval()` to execute a minimal query (`SELECT id FROM profiles LIMIT 1`) via admin client every 5 days
  - Calls `.unref()` on the interval to prevent blocking graceful shutdown
  - Graceful error handling with warning logs on query failures
  - Conditional activation in `register()` only when `NEXT_RUNTIME=nodejs` (not on Edge Runtime)

- **Comprehensive test coverage**: 10 new unit tests covering:
  - Interval timing validation
  - Timer initialization and unref behavior
  - Database query execution and chaining
  - Success/error logging
  - Periodic callback execution
  - Runtime environment detection

## Notes
- Marked with TODO comment for removal when upgrading to Supabase Pro tier
- Threshold of 5 days chosen to stay safely below the 7-day free tier suspension limit

https://claude.ai/code/session_01CeyyqBGmdV1oFmHwE1Yar1