### PR TITLE
Persist email on failed login attempt

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -33,6 +33,7 @@ export default function LoginPage() {
               placeholder="mario@esempio.it"
               required
               autoComplete="email"
+              defaultValue={state?.email}
             />
           </div>
           <div className="space-y-2">

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -462,7 +462,10 @@ describe("auth-actions", () => {
       const result = await signIn(
         formData({ email: "test@example.com", password: "wrongpass" }),
       );
-      expect(result).toEqual({ error: "Email o password non corretti." });
+      expect(result).toEqual({
+        error: "Email o password non corretti.",
+        email: "test@example.com",
+      });
     });
   });
 

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -23,6 +23,7 @@ const authLimiter = new RateLimiter({
 
 export type AuthActionResult = {
   error?: string;
+  email?: string;
 };
 
 async function getClientIp(): Promise<string> {
@@ -137,7 +138,7 @@ export async function signIn(formData: FormData): Promise<AuthActionResult> {
 
   if (error) {
     logger.warn("signIn failed");
-    return { error: "Email o password non corretti." };
+    return { error: "Email o password non corretti.", email };
   }
 
   redirect("/dashboard");


### PR DESCRIPTION
## Summary
This change improves the login experience by persisting the user's email address when authentication fails, allowing them to correct only their password without re-entering their email.

## Key Changes
- Updated `AuthActionResult` type to include an optional `email` field
- Modified `signIn` action to return the email address along with error messages on failed authentication
- Updated the login form to populate the email input with the previously entered email using `defaultValue`
- Updated corresponding test to verify the email is returned in the error response

## Implementation Details
When a sign-in attempt fails due to incorrect credentials, the server now returns both the error message and the email that was submitted. The login page then uses this email to pre-fill the email input field, reducing friction for users who need to retry with a corrected password.

https://claude.ai/code/session_012aRADPh5cCcbMUYYzd7A3g