### PR TITLE
Add rate limiting to Stripe checkout and improve env validation

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -3,6 +3,13 @@ import { getDb } from "@/db";
 import { subscriptions } from "@/db/schema";
 import { getAuthenticatedUser } from "@/lib/server-auth";
 import { getStripe, isValidPriceId } from "@/lib/stripe";
+import { RateLimiter } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+const checkoutLimiter = new RateLimiter({
+  maxRequests: 10,
+  windowMs: 60 * 60 * 1000, // 1 hour
+});
 
 export async function POST(req: Request): Promise<Response> {
   // ── Auth ──────────────────────────────────────────────────────────────────
@@ -11,6 +18,16 @@ export async function POST(req: Request): Promise<Response> {
     user = await getAuthenticatedUser();
   } catch {
     return Response.json({ error: "Non autenticato." }, { status: 401 });
+  }
+
+  // ── Rate limit ────────────────────────────────────────────────────────────
+  const rateLimitResult = checkoutLimiter.check(`checkout:${user.id}`);
+  if (!rateLimitResult.success) {
+    logger.warn({ userId: user.id }, "Stripe checkout rate limit exceeded");
+    return Response.json(
+      { error: "Troppe richieste. Riprova tra qualche ora." },
+      { status: 429 },
+    );
   }
 
   // ── Validate body ─────────────────────────────────────────────────────────

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -10,28 +10,32 @@ import { type NextRequest, NextResponse } from "next/server";
 export function createMiddlewareSupabaseClient(request: NextRequest) {
   let response = NextResponse.next({ request });
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "",
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          // Set cookies on the request (so downstream reads see them)
-          for (const { name, value } of cookiesToSet) {
-            request.cookies.set(name, value);
-          }
-          // Create a new response to carry the updated cookies
-          response = NextResponse.next({ request });
-          for (const { name, value, options } of cookiesToSet) {
-            response.cookies.set(name, value, options);
-          }
-        },
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY are required",
+    );
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        // Set cookies on the request (so downstream reads see them)
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        // Create a new response to carry the updated cookies
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
       },
     },
-  );
+  });
 
   return { supabase, response: () => response };
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -8,26 +8,30 @@ import { cookies } from "next/headers";
 export async function createServerSupabaseClient() {
   const cookieStore = await cookies();
 
-  return _createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "",
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll(cookiesToSet) {
-          for (const { name, value, options } of cookiesToSet) {
-            try {
-              cookieStore.set(name, value, options);
-            } catch {
-              // `setAll` may be called from a Server Component where cookies
-              // cannot be set. This is expected — the middleware will handle
-              // refreshing the session cookie.
-            }
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY are required",
+    );
+  }
+
+  return _createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value, options } of cookiesToSet) {
+          try {
+            cookieStore.set(name, value, options);
+          } catch {
+            // `setAll` may be called from a Server Component where cookies
+            // cannot be set. This is expected — the middleware will handle
+            // refreshing the session cookie.
           }
-        },
+        }
       },
     },
-  );
+  });
 }

--- a/tests/unit/api-stripe-checkout.test.ts
+++ b/tests/unit/api-stripe-checkout.test.ts
@@ -16,6 +16,7 @@ const {
   mockInsert,
   mockCustomerCreate,
   mockSessionCreate,
+  mockRateLimiterCheck,
 } = vi.hoisted(() => ({
   mockGetAuthenticatedUser: vi.fn(),
   mockIsValidPriceId: vi.fn(),
@@ -29,6 +30,13 @@ const {
   mockInsert: vi.fn(),
   mockCustomerCreate: vi.fn(),
   mockSessionCreate: vi.fn(),
+  mockRateLimiterCheck: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockRateLimiterCheck };
+  }),
 }));
 
 vi.mock("@/lib/server-auth", () => ({
@@ -65,6 +73,12 @@ function makeRequest(body: unknown): Request {
 describe("POST /api/stripe/checkout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    mockRateLimiterCheck.mockReturnValue({
+      success: true,
+      remaining: 9,
+      resetAt: Date.now() + 3_600_000,
+    });
 
     mockGetAuthenticatedUser.mockResolvedValue({
       id: "user-123",
@@ -163,5 +177,35 @@ describe("POST /api/stripe/checkout", () => {
       | Record<string, unknown>
       | undefined;
     expect(subscriptionData?.trial_period_days).toBeUndefined();
+  });
+
+  it("returns 429 when rate limit is exceeded", async () => {
+    mockRateLimiterCheck.mockReturnValue({
+      success: false,
+      remaining: 0,
+      resetAt: Date.now() + 3_600_000,
+    });
+    const response = await POST(
+      makeRequest({ priceId: "price_starter_monthly" }),
+    );
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it("checks rate limit with per-user key", async () => {
+    await POST(makeRequest({ priceId: "price_starter_monthly" }));
+    expect(mockRateLimiterCheck).toHaveBeenCalledWith("checkout:user-123");
+  });
+
+  it("does not call Stripe when rate limit is exceeded", async () => {
+    mockRateLimiterCheck.mockReturnValue({
+      success: false,
+      remaining: 0,
+      resetAt: Date.now() + 3_600_000,
+    });
+    await POST(makeRequest({ priceId: "price_starter_monthly" }));
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+    expect(mockCustomerCreate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
This PR adds rate limiting to the Stripe checkout endpoint and improves environment variable validation across Supabase client initialization.

## Key Changes
- **Rate Limiting**: Implemented per-user rate limiting on the Stripe checkout endpoint (10 requests per hour) to prevent abuse
  - Returns 429 status code when limit is exceeded
  - Uses user ID as the rate limit key for per-user tracking
  - Logs warnings when rate limit is exceeded
  
- **Environment Variable Validation**: Replaced silent fallbacks (`?? ""`) with explicit validation in Supabase client initialization
  - Added validation in `createMiddlewareSupabaseClient()` 
  - Added validation in `createServerSupabaseClient()`
  - Throws descriptive error if required Supabase environment variables are missing
  
- **Test Coverage**: Added comprehensive tests for rate limiting behavior
  - Tests for 429 response when rate limit exceeded
  - Tests for per-user rate limit key usage
  - Tests to ensure Stripe API calls are skipped when rate limited
  - Setup mock for rate limiter in test suite

## Implementation Details
- Rate limiter is instantiated once at module level for the checkout route
- Rate limit check happens after authentication but before any Stripe API calls
- Environment variable validation happens at client creation time, failing fast if configuration is incomplete

https://claude.ai/code/session_01GhMHecZYcxjadCCjYZRDgn