### PR TITLE
docs: update PLAN.md and CLAUDE.md with recent Stripe additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,8 @@ export async function myAction(input: MyInput): Promise<MyResult> {
 - `emit:<userId>` — `emitReceipt` → 30/ora (operazione frequente)
 - `void:<userId>` — `voidReceipt` → 10/ora (operazione rara e irreversibile)
 - `pdf:<ip>` — PDF pubblico → 60/ora (per-IP, non autenticato)
+- `checkout:<userId>` — `POST /api/stripe/checkout` → 10/ora
+- `portal:<userId>` — `GET|POST /api/stripe/portal` → 10/ora
 - Auth actions — 5/15min per-IP (in `src/server/auth-actions.ts`)
 
 ### Checklist pre-PR

--- a/PLAN.md
+++ b/PLAN.md
@@ -136,12 +136,17 @@ altrimenti sola lettura (storico visibile, emissione bloccata).
   (Stripe SDK v20.4.1, API version 2026-02-25.clover)
 - ✅ `src/lib/plans.ts` — `getPlan()`, `isTrialExpired()`, `canEmit()`, `canUsePro()`, `canAddCatalogItem()`
 - ✅ `POST /api/stripe/checkout` — crea Checkout Session; trial gestito internamente (no trial Stripe)
-- ✅ `POST /api/stripe/webhook` — gestisce 4 eventi Stripe:
-  `checkout.session.completed`, `invoice.paid`, `customer.subscription.updated`, `customer.subscription.deleted`
+- ✅ `POST /api/stripe/webhook` — gestisce 5 eventi Stripe:
+  `checkout.session.completed`, `invoice.paid`, `invoice.payment_failed`,
+  `customer.subscription.updated`, `customer.subscription.deleted`
+- ✅ `GET /api/stripe/portal` — redirect al portale Stripe (per link anchor)
+- ✅ `POST /api/stripe/portal` — restituisce `{ url }` JSON (per chiamate JS)
+- ✅ Rate limiting: `checkout:<userId>` 10/ora, `portal:<userId>` 10/ora
 - ✅ Feature gate catalogo: max 5 prodotti per trial/Starter in `addCatalogItem`
 - ✅ `TrialExpiringEmail` template (scheduler post-lancio)
-- ✅ `/dashboard/abbonamento` — badge piano corrente, card piani con CTA Stripe Checkout,
-  link Stripe Customer Portal per utenti abbonati
+- ✅ `/dashboard/abbonamento` → spostato in `/dashboard/settings`:
+  badge piano corrente, toggle mensile/annuale (default annuale),
+  card piani con CTA Stripe Checkout, link Customer Portal per utenti abbonati
 - ✅ Aggiornato bottom-nav (5 voci) e desktop nav con "Abbonamento"
 - ✅ `.env.example` aggiornato con tutte le variabili Stripe
 


### PR DESCRIPTION
PLAN.md v0.9.0:
- webhook: 5 eventi (aggiunto invoice.payment_failed)
- GET/POST /api/stripe/portal con comportamento distinto
- rate limiting su checkout e portal (10/ora per-user)
- UI abbonamento spostata in settings, toggle mensile/annuale

CLAUDE.md:
- soglie consolidate: checkout:<userId> e portal:<userId> 10/ora

https://claude.ai/code/session_01YXPAXp18ijkGNdE4UZ1Bgp