### PR TITLE
fix(stripe): handle SCA/3DS, add subscription metadata, harden webhoo…

### DIFF
--- a/src/app/api/stripe/checkout/route.test.ts
+++ b/src/app/api/stripe/checkout/route.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetAuthenticatedUser,
+  mockRateLimiterCheck,
+  mockSelect,
+  mockInsert,
+  mockUpdate,
+  mockCustomerCreate,
+  mockSessionCreate,
+  mockIsValidPriceId,
+} = vi.hoisted(() => ({
+  mockGetAuthenticatedUser: vi.fn(),
+  mockRateLimiterCheck: vi.fn(),
+  mockSelect: vi.fn(),
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockCustomerCreate: vi.fn(),
+  mockSessionCreate: vi.fn(),
+  mockIsValidPriceId: vi.fn(),
+}));
+
+vi.mock("@/lib/server-auth", () => ({
+  getAuthenticatedUser: mockGetAuthenticatedUser,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockRateLimiterCheck };
+  }),
+}));
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+  }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  subscriptions: "subscriptions-table",
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn().mockReturnValue({
+    customers: { create: mockCustomerCreate },
+    checkout: { sessions: { create: mockSessionCreate } },
+  }),
+  isValidPriceId: mockIsValidPriceId,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSelectBuilder(result: unknown[]) {
+  const builder = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn().mockResolvedValue(result),
+  };
+  builder.from.mockReturnValue(builder);
+  builder.where.mockReturnValue(builder);
+  return builder;
+}
+
+function makeInsertBuilder() {
+  const builder = { values: vi.fn().mockResolvedValue(undefined) };
+  return builder;
+}
+
+function makeRequest(body: object) {
+  return new Request("http://localhost/api/stripe/checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+import { POST } from "./route";
+
+describe("POST /api/stripe/checkout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimiterCheck.mockReturnValue({ success: true });
+    mockIsValidPriceId.mockReturnValue(true);
+    mockSessionCreate.mockResolvedValue({
+      url: "https://checkout.stripe.com/session",
+    });
+  });
+
+  it("restituisce 401 se non autenticato", async () => {
+    mockGetAuthenticatedUser.mockRejectedValue(new Error("unauth"));
+    const res = await POST(makeRequest({ priceId: "price_123" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("restituisce 429 se rate limit superato", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockRateLimiterCheck.mockReturnValue({ success: false });
+    const res = await POST(makeRequest({ priceId: "price_123" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("restituisce 400 se body non è JSON valido", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    const req = new Request("http://localhost/api/stripe/checkout", {
+      method: "POST",
+      body: "non-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("restituisce 400 se priceId non è valido", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockIsValidPriceId.mockReturnValue(false);
+    const res = await POST(makeRequest({ priceId: "price_invalid" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("usa il customer esistente se già in DB", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([{ stripeCustomerId: "cus_existing" }]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(200);
+    expect(mockCustomerCreate).not.toHaveBeenCalled();
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_existing" }),
+    );
+  });
+
+  it("crea un nuovo customer Stripe se non esiste", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockCustomerCreate.mockResolvedValue({ id: "cus_new" });
+    mockInsert.mockReturnValue(makeInsertBuilder());
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(200);
+    expect(mockCustomerCreate).toHaveBeenCalledWith({ email: "a@b.it" });
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_new" }),
+    );
+  });
+
+  it("restituisce l'URL della checkout session", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([{ stripeCustomerId: "cus_existing" }]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_starter" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe("https://checkout.stripe.com/session");
+  });
+
+  it("passa subscription_data.metadata con userId alla checkout session", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-42",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([{ stripeCustomerId: "cus_existing" }]),
+    );
+
+    await POST(makeRequest({ priceId: "price_pro" }));
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscription_data: {
+          metadata: { userId: "user-42" },
+        },
+      }),
+    );
+  });
+});

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -75,6 +75,9 @@ export async function POST(req: Request): Promise<Response> {
     customer: stripeCustomerId,
     line_items: [{ price: priceId, quantity: 1 }],
     mode: "subscription",
+    subscription_data: {
+      metadata: { userId: user.id },
+    },
     success_url: `${appUrl}/dashboard/settings?success=1`,
     cancel_url: `${appUrl}/dashboard/settings?canceled=1`,
   });

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -1,0 +1,298 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockConstructEvent,
+  mockSubscriptionsRetrieve,
+  mockUpdate,
+  mockSelect,
+  mockPlanFromPriceId,
+  mockIntervalFromPriceId,
+  mockLoggerError,
+  mockLoggerWarn,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockSelect: vi.fn(),
+  mockPlanFromPriceId: vi.fn(),
+  mockIntervalFromPriceId: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn().mockReturnValue({
+    webhooks: { constructEvent: mockConstructEvent },
+    subscriptions: { retrieve: mockSubscriptionsRetrieve },
+  }),
+  planFromPriceId: mockPlanFromPriceId,
+  intervalFromPriceId: mockIntervalFromPriceId,
+}));
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({ update: mockUpdate, select: mockSelect }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  subscriptions: "subscriptions-table",
+  profiles: "profiles-table",
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: mockLoggerError, warn: mockLoggerWarn },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Builder helpers
+// ---------------------------------------------------------------------------
+
+function makeUpdateBuilder() {
+  const builder = {
+    set: vi.fn(),
+    where: vi.fn().mockResolvedValue(undefined),
+  };
+  builder.set.mockReturnValue(builder);
+  return builder;
+}
+
+function makeSelectBuilder(result: unknown[]) {
+  const builder = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn().mockResolvedValue(result),
+  };
+  builder.from.mockReturnValue(builder);
+  builder.where.mockReturnValue(builder);
+  return builder;
+}
+
+function makeRequest(body = "{}", signature = "sig_test") {
+  return new Request("http://localhost/api/stripe/webhook", {
+    method: "POST",
+    body,
+    headers: { "stripe-signature": signature },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+import { POST } from "./route";
+
+describe("POST /api/stripe/webhook — request validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  it("restituisce 400 se manca l'header stripe-signature", async () => {
+    const req = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: "{}",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("restituisce 500 se STRIPE_WEBHOOK_SECRET non è configurato", async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+
+  it("restituisce 400 se la firma non è valida", async () => {
+    mockConstructEvent.mockImplementation(() => {
+      throw new Error("Invalid signature");
+    });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid signature.");
+    expect(mockLoggerWarn).toHaveBeenCalled();
+  });
+
+  it("restituisce 200 { received: true } per eventi sconosciuti", async () => {
+    mockConstructEvent.mockReturnValue({
+      type: "some.unknown.event",
+      data: { object: {} },
+    });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.received).toBe(true);
+  });
+});
+
+describe("POST /api/stripe/webhook — invoice.payment_action_required", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  it("imposta status a 'incomplete' quando subscriptionId è presente", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue({
+      type: "invoice.payment_action_required",
+      data: {
+        object: {
+          parent: {
+            subscription_details: { subscription: "sub_incomplete_123" },
+          },
+          period_end: 0,
+        },
+      },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith("subscriptions-table");
+    expect(updateBuilder.set).toHaveBeenCalledWith({ status: "incomplete" });
+  });
+
+  it("ignora l'evento se subscriptionId è assente", async () => {
+    mockConstructEvent.mockReturnValue({
+      type: "invoice.payment_action_required",
+      data: { object: { parent: null } },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/stripe/webhook — invoice.payment_failed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  it("imposta status a 'past_due'", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue({
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          parent: {
+            subscription_details: { subscription: "sub_pastdue_123" },
+          },
+        },
+      },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).toHaveBeenCalledWith({ status: "past_due" });
+  });
+});
+
+describe("POST /api/stripe/webhook — customer.subscription.deleted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  it("imposta status a 'canceled' e declassa il profilo a 'trial'", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+    mockSelect.mockReturnValue(makeSelectBuilder([{ userId: "user-abc" }]));
+
+    mockConstructEvent.mockReturnValue({
+      type: "customer.subscription.deleted",
+      data: { object: { id: "sub_deleted_123", customer: "cus_123" } },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    // First update: subscription → canceled
+    expect(updateBuilder.set).toHaveBeenCalledWith({ status: "canceled" });
+    // Second update: profile → trial
+    expect(updateBuilder.set).toHaveBeenCalledWith({ plan: "trial" });
+  });
+
+  it("non aggiorna il profilo se la subscription non ha userId nel DB", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+
+    mockConstructEvent.mockReturnValue({
+      type: "customer.subscription.deleted",
+      data: { object: { id: "sub_deleted_456", customer: "cus_456" } },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).toHaveBeenCalledTimes(1);
+    expect(updateBuilder.set).toHaveBeenCalledWith({ status: "canceled" });
+  });
+});
+
+describe("POST /api/stripe/webhook — checkout.session.completed type guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  it("ignora la sessione se subscription non è una stringa", async () => {
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          subscription: null,
+          customer: "cus_123",
+        },
+      },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled();
+  });
+
+  it("recupera la subscription se subscription è una stringa", async () => {
+    const fakeSub = {
+      id: "sub_123",
+      status: "active",
+      customer: "cus_123",
+      items: {
+        data: [{ price: { id: "price_pro" }, current_period_end: 9999 }],
+      },
+    };
+    mockSubscriptionsRetrieve.mockResolvedValue(fakeSub);
+    mockPlanFromPriceId.mockReturnValue("pro");
+    mockIntervalFromPriceId.mockReturnValue("month");
+
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          subscription: "sub_123",
+          customer: "cus_123",
+        },
+      },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(mockSubscriptionsRetrieve).toHaveBeenCalledWith("sub_123");
+  });
+});

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -56,13 +56,13 @@ async function handleEvent(event: Stripe.Event, stripe: Stripe): Promise<void> {
   switch (event.type) {
     case "checkout.session.completed": {
       const session = event.data.object as Stripe.Checkout.Session;
-      if (!session.subscription || !session.customer) break;
+      if (typeof session.subscription !== "string" || !session.customer) break;
 
       // Retrieve full subscription object for price/interval data
       const stripeSub = await stripe.subscriptions.retrieve(
-        session.subscription as string,
+        session.subscription,
       );
-      await upsertSubscriptionData(db, session.customer as string, stripeSub);
+      await syncSubscriptionData(db, session.customer as string, stripeSub);
       break;
     }
 
@@ -82,7 +82,21 @@ async function handleEvent(event: Stripe.Event, stripe: Stripe): Promise<void> {
 
     case "customer.subscription.updated": {
       const sub = event.data.object as Stripe.Subscription;
-      await upsertSubscriptionData(db, sub.customer as string, sub);
+      await syncSubscriptionData(db, sub.customer as string, sub);
+      break;
+    }
+
+    case "invoice.payment_action_required": {
+      const invoice = event.data.object as Stripe.Invoice;
+      const subscriptionId = invoice.parent?.subscription_details?.subscription;
+      if (!subscriptionId) break;
+
+      await db
+        .update(subscriptions)
+        .set({ status: "incomplete" })
+        .where(
+          eq(subscriptions.stripeSubscriptionId, subscriptionId as string),
+        );
       break;
     }
 
@@ -133,10 +147,9 @@ async function handleEvent(event: Stripe.Event, stripe: Stripe): Promise<void> {
 }
 
 /**
- * Upsert subscription data into DB and sync the user's plan on profiles.
+ * Sync subscription data into DB and update the user's plan on profiles.
  */
-
-async function upsertSubscriptionData(
+async function syncSubscriptionData(
   db: ReturnType<typeof getDb>,
   stripeCustomerId: string,
   stripeSub: Stripe.Subscription,


### PR DESCRIPTION
…k types

- Handle invoice.payment_action_required: set subscription status to "incomplete" when SCA/3DS authentication is required on renewal (relevant for EU/Italy PSD2 compliance)
- Add subscription_data.metadata (userId) to checkout session for traceability in Stripe Dashboard
- Replace `session.subscription as string` cast with explicit type guard (typeof !== "string") in checkout.session.completed handler
- Rename upsertSubscriptionData → syncSubscriptionData to accurately reflect UPDATE-only semantics
- Add webhook/route.test.ts (11 tests) and checkout/route.test.ts (8 tests)