### PR TITLE
perf(db): add missing FK indexes, projected select, atomic receipt in…

### DIFF
--- a/src/db/schema/businesses.ts
+++ b/src/db/schema/businesses.ts
@@ -1,33 +1,37 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { profiles } from "./profiles";
 
-export const businesses = pgTable("businesses", {
-  id: uuid("id")
-    .primaryKey()
-    .default(sql`gen_random_uuid()`),
-  profileId: uuid("profile_id")
-    .notNull()
-    .references(() => profiles.id, { onDelete: "cascade" }),
-  businessName: text("business_name"),
-  vatNumber: text("vat_number"),
-  fiscalCode: text("fiscal_code"),
-  address: text("address"),
-  streetNumber: text("street_number"),
-  city: text("city"),
-  province: text("province"),
-  zipCode: text("zip_code"),
-  preferredVatCode: text("preferred_vat_code"),
-  activityCode: text("activity_code"),
-  taxRegime: text("tax_regime"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow()
-    .$onUpdate(() => new Date()),
-});
+export const businesses = pgTable(
+  "businesses",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    businessName: text("business_name"),
+    vatNumber: text("vat_number"),
+    fiscalCode: text("fiscal_code"),
+    address: text("address"),
+    streetNumber: text("street_number"),
+    city: text("city"),
+    province: text("province"),
+    zipCode: text("zip_code"),
+    preferredVatCode: text("preferred_vat_code"),
+    activityCode: text("activity_code"),
+    taxRegime: text("tax_regime"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index("idx_businesses_profile_id").on(table.profileId)],
+);
 
 export type InsertBusiness = typeof businesses.$inferInsert;
 export type SelectBusiness = typeof businesses.$inferSelect;

--- a/src/db/schema/commercial-document-lines.ts
+++ b/src/db/schema/commercial-document-lines.ts
@@ -1,5 +1,6 @@
 import {
   foreignKey,
+  index,
   integer,
   numeric,
   pgTable,
@@ -39,6 +40,7 @@ export const commercialDocumentLines = pgTable(
       columns: [table.documentId],
       foreignColumns: [commercialDocuments.id],
     }).onDelete("cascade"),
+    index("idx_commercial_document_lines_document_id").on(table.documentId),
   ],
 );
 

--- a/src/server/receipt-actions.test.ts
+++ b/src/server/receipt-actions.test.ts
@@ -41,11 +41,19 @@ const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
 const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
 const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
 
+const mockTransaction = vi
+  .fn()
+  .mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+    const tx = { select: mockSelect, insert: mockInsert, update: mockUpdate };
+    return callback(tx);
+  });
+
 vi.mock("@/db", () => ({
   getDb: vi.fn().mockReturnValue({
     select: mockSelect,
     insert: mockInsert,
     update: mockUpdate,
+    transaction: mockTransaction,
   }),
 }));
 
@@ -123,6 +131,18 @@ describe("receipt-actions", () => {
     mockGetAuthenticatedUser.mockResolvedValue(FAKE_USER);
     mockCheckBusinessOwnership.mockResolvedValue(null);
     mockFetchAdePrerequisites.mockResolvedValue(FAKE_PREREQUISITES);
+
+    // Restore transaction default implementation after clearAllMocks
+    mockTransaction.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          select: mockSelect,
+          insert: mockInsert,
+          update: mockUpdate,
+        };
+        return callback(tx);
+      },
+    );
 
     // DB: insert routing by table
     mockInsert.mockImplementation((table: unknown) => {
@@ -327,6 +347,13 @@ describe("receipt-actions", () => {
       const setArg = mockUpdateSet.mock.calls[0][0];
       expect(setArg.status).toBe("REJECTED");
       expect(setArg.adeResponse).toBeDefined();
+    });
+
+    it("insert is wrapped in a transaction (document + lines atomic)", async () => {
+      const { emitReceipt } = await import("./receipt-actions");
+      await emitReceipt(VALID_INPUT);
+
+      expect(mockTransaction).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/server/receipt-actions.ts
+++ b/src/server/receipt-actions.ts
@@ -60,21 +60,40 @@ export async function emitReceipt(
 
   const db = getDb();
 
-  // Insert commercial document (idempotent via unique idempotencyKey)
-  const [document] = await db
-    .insert(commercialDocuments)
-    .values({
-      businessId: input.businessId,
-      kind: "SALE",
-      idempotencyKey: input.idempotencyKey,
-      publicRequest: { paymentMethod: input.paymentMethod },
-      status: "PENDING",
-    })
-    .onConflictDoNothing()
-    .returning({ id: commercialDocuments.id });
+  // Insert document + lines atomically: if either fails, nothing is persisted
+  const txResult = await db.transaction(async (tx) => {
+    const [document] = await tx
+      .insert(commercialDocuments)
+      .values({
+        businessId: input.businessId,
+        kind: "SALE",
+        idempotencyKey: input.idempotencyKey,
+        publicRequest: { paymentMethod: input.paymentMethod },
+        status: "PENDING",
+      })
+      .onConflictDoNothing()
+      .returning({ id: commercialDocuments.id });
 
-  // Idempotency: a document with this key already exists
-  if (!document) {
+    // Idempotency: a document with this key already exists
+    if (!document) {
+      return { alreadyExists: true };
+    }
+
+    await tx.insert(commercialDocumentLines).values(
+      input.lines.map((line, index) => ({
+        documentId: document.id,
+        lineIndex: index,
+        description: line.description,
+        quantity: String(line.quantity),
+        grossUnitPrice: String(line.grossUnitPrice),
+        vatCode: line.vatCode,
+      })),
+    );
+
+    return { alreadyExists: false, id: document.id };
+  });
+
+  if (txResult.alreadyExists) {
     const [existing] = await db
       .select({
         id: commercialDocuments.id,
@@ -101,19 +120,11 @@ export async function emitReceipt(
     };
   }
 
-  const documentId = document.id;
-
-  // Insert all document lines
-  await db.insert(commercialDocumentLines).values(
-    input.lines.map((line, index) => ({
-      documentId,
-      lineIndex: index,
-      description: line.description,
-      quantity: String(line.quantity),
-      grossUnitPrice: String(line.grossUnitPrice),
-      vatCode: line.vatCode,
-    })),
-  );
+  const documentId = txResult.id;
+  if (!documentId) {
+    logger.error({}, "Transaction returned no document ID");
+    return { error: "Errore interno: impossibile creare il documento." };
+  }
 
   // Build sale document request (round to 2 decimal places to avoid float imprecision)
   const totalAmount =

--- a/src/server/storico-actions.ts
+++ b/src/server/storico-actions.ts
@@ -54,7 +54,14 @@ export async function searchReceipts(
   }
 
   const docs = await db
-    .select()
+    .select({
+      id: commercialDocuments.id,
+      kind: commercialDocuments.kind,
+      status: commercialDocuments.status,
+      adeProgressive: commercialDocuments.adeProgressive,
+      adeTransactionId: commercialDocuments.adeTransactionId,
+      createdAt: commercialDocuments.createdAt,
+    })
     .from(commercialDocuments)
     .where(and(...conditions))
     .orderBy(desc(commercialDocuments.createdAt));

--- a/supabase/migrations/0005_add_missing_indexes.sql
+++ b/supabase/migrations/0005_add_missing_indexes.sql
@@ -1,0 +1,12 @@
+-- v0.9.1: Indici mancanti su colonne FK
+--
+-- Postgres non crea automaticamente indici sulle colonne che referenziano (FK).
+-- Questi indici sono necessari per:
+--   1. idx_businesses_profile_id: query di ownership check e onboarding status
+--   2. idx_commercial_document_lines_document_id: inArray queries in searchReceipts/exportUserData
+
+CREATE INDEX "idx_businesses_profile_id"
+  ON "businesses" USING btree ("profile_id");
+
+CREATE INDEX "idx_commercial_document_lines_document_id"
+  ON "commercial_document_lines" USING btree ("document_id");


### PR DESCRIPTION
…sert

- Add idx_businesses_profile_id and idx_commercial_document_lines_document_id (migration 0005): FK columns without indexes cause seq scans on every ownership check and every storico/export query
- Replace SELECT * with projected columns in searchReceipts to avoid fetching large ade_request/ade_response JSONB payloads unnecessarily
- Wrap emitReceipt INSERT document + INSERT lines in db.transaction() for atomicity: a crash between the two inserts no longer leaves orphaned PENDING documents without lines
- Update receipt-actions mock to expose transaction and add coverage test