### PR TITLE
feat(cassa): persisti carrello in sessionStorage tra navigazioni

### DIFF
--- a/src/hooks/use-cassa.test.ts
+++ b/src/hooks/use-cassa.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal("crypto", {
 
 beforeEach(() => {
   uuidCounter = 0;
+  sessionStorage.clear();
 });
 
 describe("useCassa", () => {
@@ -275,5 +276,124 @@ describe("useCassa", () => {
     });
 
     expect(result.current.total).toBe(0);
+  });
+
+  it("persiste le righe in sessionStorage dopo addLine", async () => {
+    const { result } = renderHook(() => useCassa());
+
+    act(() => {
+      result.current.addLine({
+        description: "Caffè",
+        quantity: 1,
+        grossUnitPrice: 1.2,
+        vatCode: "22",
+      });
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem("cassa_cart") ?? "{}");
+    expect(stored.lines).toHaveLength(1);
+    expect(stored.lines[0].description).toBe("Caffè");
+  });
+
+  it("aggiorna sessionStorage dopo removeLine", () => {
+    const { result } = renderHook(() => useCassa());
+
+    act(() => {
+      result.current.addLine({
+        description: "A",
+        quantity: 1,
+        grossUnitPrice: 1,
+        vatCode: "22",
+      });
+      result.current.addLine({
+        description: "B",
+        quantity: 1,
+        grossUnitPrice: 2,
+        vatCode: "22",
+      });
+    });
+    const firstId = result.current.lines[0].id;
+
+    act(() => {
+      result.current.removeLine(firstId);
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem("cassa_cart") ?? "{}");
+    expect(stored.lines).toHaveLength(1);
+    expect(stored.lines[0].description).toBe("B");
+  });
+
+  it("clearCart svuota le righe in sessionStorage", () => {
+    const { result } = renderHook(() => useCassa());
+
+    act(() => {
+      result.current.addLine({
+        description: "A",
+        quantity: 1,
+        grossUnitPrice: 1,
+        vatCode: "22",
+      });
+    });
+
+    act(() => {
+      result.current.clearCart();
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem("cassa_cart") ?? "{}");
+    expect(stored.lines).toEqual([]);
+  });
+
+  it("carica lines da sessionStorage all'inizializzazione", () => {
+    sessionStorage.setItem(
+      "cassa_cart",
+      JSON.stringify({
+        lines: [
+          {
+            id: "stored-uuid-1",
+            description: "Prodotto salvato",
+            quantity: 2,
+            grossUnitPrice: 5,
+            vatCode: "22",
+          },
+        ],
+        paymentMethod: "PC",
+      }),
+    );
+
+    const { result } = renderHook(() => useCassa());
+
+    expect(result.current.lines).toHaveLength(1);
+    expect(result.current.lines[0].description).toBe("Prodotto salvato");
+  });
+
+  it("carica paymentMethod da sessionStorage all'inizializzazione", () => {
+    sessionStorage.setItem(
+      "cassa_cart",
+      JSON.stringify({ lines: [], paymentMethod: "PE" }),
+    );
+
+    const { result } = renderHook(() => useCassa());
+
+    expect(result.current.paymentMethod).toBe("PE");
+  });
+
+  it("sessionStorage corrotto → inizia con carrello vuoto", () => {
+    sessionStorage.setItem("cassa_cart", "not-valid-json{{{");
+
+    const { result } = renderHook(() => useCassa());
+
+    expect(result.current.lines).toEqual([]);
+    expect(result.current.paymentMethod).toBe("PC");
+  });
+
+  it("persiste paymentMethod in sessionStorage dopo setPaymentMethod", () => {
+    const { result } = renderHook(() => useCassa());
+
+    act(() => {
+      result.current.setPaymentMethod("PE");
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem("cassa_cart") ?? "{}");
+    expect(stored.paymentMethod).toBe("PE");
   });
 });

--- a/src/hooks/use-cassa.ts
+++ b/src/hooks/use-cassa.ts
@@ -1,7 +1,28 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { CartLine, PaymentMethod, VatCode } from "@/types/cassa";
+
+const SESSION_KEY = "cassa_cart";
+
+interface SessionData {
+  lines: CartLine[];
+  paymentMethod: PaymentMethod;
+}
+
+interface CartState extends SessionData {
+  isHydrated: boolean;
+}
+
+function readFromSession(): SessionData {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return { lines: [], paymentMethod: "PC" };
+    return JSON.parse(raw) as SessionData;
+  } catch {
+    return { lines: [], paymentMethod: "PC" };
+  }
+}
 
 interface AddLineInput {
   description: string;
@@ -22,27 +43,58 @@ interface UseCassaReturn {
 }
 
 export function useCassa(): UseCassaReturn {
-  const [lines, setLines] = useState<CartLine[]>([]);
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("PC");
+  const [{ lines, paymentMethod, isHydrated }, setCartState] =
+    useState<CartState>({
+      lines: [],
+      paymentMethod: "PC",
+      isHydrated: false,
+    });
+
+  // Idrata da sessionStorage dopo il mount (evita hydration mismatch SSR/client).
+  // sessionStorage è una API browser non disponibile lato server: il lazy initializer causerebbe
+  // hydration mismatch, quindi l'idratazione post-mount via useEffect è il pattern corretto.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration da sessionStorage post-mount; pattern necessario per evitare SSR/client mismatch
+    setCartState({ ...readFromSession(), isHydrated: true });
+  }, []);
+
+  // Sincronizza su sessionStorage ad ogni cambiamento (solo dopo l'idratazione)
+  useEffect(() => {
+    if (!isHydrated) return;
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ lines, paymentMethod }),
+    );
+  }, [lines, paymentMethod, isHydrated]);
 
   const addLine = useCallback((input: AddLineInput) => {
     const newLine: CartLine = {
       id: crypto.randomUUID(),
       ...input,
     };
-    setLines((prev) => [...prev, newLine]);
+    setCartState((prev) => ({ ...prev, lines: [...prev.lines, newLine] }));
   }, []);
 
   const updateLine = useCallback((id: string, input: AddLineInput) => {
-    setLines((prev) => prev.map((l) => (l.id === id ? { ...l, ...input } : l)));
+    setCartState((prev) => ({
+      ...prev,
+      lines: prev.lines.map((l) => (l.id === id ? { ...l, ...input } : l)),
+    }));
   }, []);
 
   const removeLine = useCallback((id: string) => {
-    setLines((prev) => prev.filter((l) => l.id !== id));
+    setCartState((prev) => ({
+      ...prev,
+      lines: prev.lines.filter((l) => l.id !== id),
+    }));
   }, []);
 
   const clearCart = useCallback(() => {
-    setLines([]);
+    setCartState((prev) => ({ ...prev, lines: [] }));
+  }, []);
+
+  const setPaymentMethod = useCallback((method: PaymentMethod) => {
+    setCartState((prev) => ({ ...prev, paymentMethod: method }));
   }, []);
 
   const total = useMemo(


### PR DESCRIPTION
## Summary

- Il carrello si svuotava navigando tra i tab del dashboard (Cassa → Storico → Cassa): lo stato viveva solo in `useState` e veniva distrutto al dismount del componente
- Aggiunta persistenza su `sessionStorage`: il carrello sopravvive a navigazioni e refresh, si svuota automaticamente alla chiusura del tab — ciclo di vita ideale per una transazione POS in corso
- L'idratazione avviene in un `useEffect` post-mount (con un singolo `eslint-disable` documentato) per evitare l'hydration mismatch SSR/client: il lazy initializer di `useState` girerebbe anche lato server dove `sessionStorage` non esiste

## Dettagli tecnici

- `lines` + `paymentMethod` + `isHydrated` unificati in un singolo `CartState` per ridurre i `setState` nell'effect a uno solo
- Effect di idratazione (deps `[]`): legge da `sessionStorage` post-mount
- Effect di sync (deps `[lines, paymentMethod, isHydrated]`): scrive su `sessionStorage` solo dopo idratazione (guard `isHydrated`)

## Test plan

- [x] 22/22 test verdi (7 nuovi test per la persistenza su sessionStorage)
- [x] Nessun errore ESLint / Prettier
- [x] Nessun hydration error in console
- [x] Carrello ripristinato dopo navigazione Cassa → Storico → Cassa
- [x] Carrello ripristinato dopo refresh pagina
- [x] `clearCart` (emissione scontrino) svuota correttamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)