### PR TITLE
fix(marketing): aggiorna prezzi FAQ e rimuove voce self-hosted ridondante

### DIFF
--- a/src/components/marketing/faq-items.ts
+++ b/src/components/marketing/faq-items.ts
@@ -27,11 +27,6 @@ export const faqItems = [
   {
     question: "Quanto costa?",
     answer:
-      "Starter a €5,99/mese (o €29,99/anno) e Pro a €8,99/mese (o €49,99/anno). Entrambi includono 30 giorni di prova gratuita, senza inserire alcun metodo di pagamento. Se non scegli un piano alla scadenza, l'account passa in sola lettura: vedi lo storico scontrini ma non puoi emetterne di nuovi.",
-  },
-  {
-    question: "Posso installarlo da solo sul mio server?",
-    answer:
-      "Sì. ScontrinoZero è open source e puoi installarlo sul tuo server gratuitamente, senza limiti e senza abbonamento. Le credenziali Fisconline rimangono sul tuo server e non transitano da nessun servizio esterno.",
+      "Starter a €4,99/mese (o €29,99/anno) e Pro a €8,99/mese (o €49,99/anno). Entrambi includono 30 giorni di prova gratuita, senza inserire alcun metodo di pagamento. Se non scegli un piano alla scadenza, l'account passa in sola lettura: vedi lo storico scontrini ma non puoi emetterne di nuovi.",
   },
 ] as const;


### PR DESCRIPTION
## Summary

- Corretto prezzo Starter nella FAQ "Quanto costa?" da €5,99 a **€4,99/mese** (allineato alla tabella prezzi)
- Rimossa FAQ "Posso installarlo da solo sul mio server?" — ridondante con la sezione open source già presente nella landing page

## Test plan

- [ ] Verificare che la sezione FAQ mostri 6 voci (non 7)
- [ ] Verificare che il prezzo Starter nella FAQ sia €4,99/mese
- [ ] Verificare che il prezzo annuale (€29,99) sia invariato

🤖 Generated with [Claude Code](https://claude.com/claude-code)