### PR TITLE
feat: run DB migrations automatically on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,11 @@ ENV SENTRY_PROJECT=$SENTRY_PROJECT
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
+RUN npx esbuild scripts/migrate.ts \
+    --bundle \
+    --platform=node \
+    --outfile=.next/standalone/migrate.js
+
 # =============================================================================
 # Stage 3: Production
 # =============================================================================
@@ -57,4 +62,4 @@ ENV HOSTNAME="0.0.0.0"
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
 
-CMD ["node", "server.js"]
+CMD ["sh", "-c", "node migrate.js && exec node server.js"]

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,28 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+import path from "path";
+
+async function runMigrations() {
+  const connectionString =
+    process.env.DATABASE_URL_DIRECT ?? process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL_DIRECT or DATABASE_URL must be set");
+  }
+
+  const sql = postgres(connectionString, { max: 1 });
+  const db = drizzle(sql);
+
+  const migrationsFolder = path.join(process.cwd(), "supabase", "migrations");
+
+  console.log("Running DB migrations...");
+  await migrate(db, { migrationsFolder });
+  console.log("Migrations completed successfully.");
+
+  await sql.end();
+}
+
+runMigrations().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Aggiunge `scripts/migrate.ts`: usa l'API programmatica di Drizzle ORM (`drizzle-orm/postgres-js/migrator`) per applicare le migrazioni pendenti prima dell'avvio dell'app
- Modifica il `Dockerfile`: esbuild bundla lo script in `.next/standalone/migrate.js` durante la build; il CMD del container diventa `node migrate.js && exec node server.js`
- Se le migrazioni falliscono il container abortisce (exit 1) invece di avviarsi con uno schema obsoleto — il `restart: always` in docker-compose fa ripartire il container automaticamente

## Motivazione

Al deploy di una nuova versione era necessario ricordarsi manualmente di eseguire le migrazioni prima di avviare l'app. Questo rende il container autonomo e fail-safe.

## Test plan

- [ ] Build Docker locale: `docker build -t scontrinozero-test .` — verificare che esbuild bundli `migrate.js` senza errori
- [ ] Avvio con env: `docker run --env-file .env -p 3000:3000 scontrinozero-test` — verificare nei log `"Running DB migrations..."` → `"Migrations completed successfully."` → avvio Next.js
- [ ] Simulare migrazione fallita (DB URL errato) — verificare che il container non parta

🤖 Generated with [Claude Code](https://claude.com/claude-code)