### PR TITLE
fix: add missing migrations to Drizzle journal and make them idempotent

### DIFF
--- a/supabase/migrations/0001_rls_policies.sql
+++ b/supabase/migrations/0001_rls_policies.sql
@@ -8,21 +8,25 @@
 -- Supabase REST API using the NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (anon key).
 -- Since that key is embedded in the client bundle, these policies ensure that even
 -- if someone calls the Supabase API directly, they can only access their own data.
+--
+-- All statements are idempotent: safe to run on both fresh and existing databases.
 
--- Enable RLS on all user-data tables
-ALTER TABLE "profiles" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "businesses" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "ade_credentials" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "commercial_documents" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "commercial_document_lines" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "catalog_items" ENABLE ROW LEVEL SECURITY;
+-- Enable RLS on all user-data tables (idempotent)
+ALTER TABLE "profiles" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "businesses" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "ade_credentials" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "commercial_documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "commercial_document_lines" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "catalog_items" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 
 -- profiles: each user can only access their own profile row
+DROP POLICY IF EXISTS "profiles_own" ON "profiles";--> statement-breakpoint
 CREATE POLICY "profiles_own" ON "profiles"
   FOR ALL
-  USING (auth_user_id = auth.uid());
+  USING (auth_user_id = auth.uid());--> statement-breakpoint
 
 -- businesses: accessible only to the user who owns the linked profile
+DROP POLICY IF EXISTS "businesses_own" ON "businesses";--> statement-breakpoint
 CREATE POLICY "businesses_own" ON "businesses"
   FOR ALL
   USING (
@@ -31,9 +35,10 @@ CREATE POLICY "businesses_own" ON "businesses"
       WHERE profiles.id = businesses.profile_id
         AND profiles.auth_user_id = auth.uid()
     )
-  );
+  );--> statement-breakpoint
 
 -- ade_credentials: accessible only through the owning business
+DROP POLICY IF EXISTS "ade_credentials_own" ON "ade_credentials";--> statement-breakpoint
 CREATE POLICY "ade_credentials_own" ON "ade_credentials"
   FOR ALL
   USING (
@@ -43,9 +48,10 @@ CREATE POLICY "ade_credentials_own" ON "ade_credentials"
       WHERE businesses.id = ade_credentials.business_id
         AND profiles.auth_user_id = auth.uid()
     )
-  );
+  );--> statement-breakpoint
 
 -- commercial_documents: accessible only through the owning business
+DROP POLICY IF EXISTS "commercial_documents_own" ON "commercial_documents";--> statement-breakpoint
 CREATE POLICY "commercial_documents_own" ON "commercial_documents"
   FOR ALL
   USING (
@@ -55,9 +61,10 @@ CREATE POLICY "commercial_documents_own" ON "commercial_documents"
       WHERE businesses.id = commercial_documents.business_id
         AND profiles.auth_user_id = auth.uid()
     )
-  );
+  );--> statement-breakpoint
 
 -- commercial_document_lines: accessible only through the owning document → business
+DROP POLICY IF EXISTS "commercial_document_lines_own" ON "commercial_document_lines";--> statement-breakpoint
 CREATE POLICY "commercial_document_lines_own" ON "commercial_document_lines"
   FOR ALL
   USING (
@@ -68,9 +75,10 @@ CREATE POLICY "commercial_document_lines_own" ON "commercial_document_lines"
       WHERE commercial_documents.id = commercial_document_lines.document_id
         AND profiles.auth_user_id = auth.uid()
     )
-  );
+  );--> statement-breakpoint
 
 -- catalog_items: accessible only through the owning business
+DROP POLICY IF EXISTS "catalog_items_own" ON "catalog_items";--> statement-breakpoint
 CREATE POLICY "catalog_items_own" ON "catalog_items"
   FOR ALL
   USING (

--- a/supabase/migrations/0002_terms_acceptance.sql
+++ b/supabase/migrations/0002_terms_acceptance.sql
@@ -1,3 +1,3 @@
 ALTER TABLE "profiles"
-  ADD COLUMN "terms_accepted_at" timestamp with time zone,
-  ADD COLUMN "terms_version"     text;
+  ADD COLUMN IF NOT EXISTS "terms_accepted_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "terms_version"     text;

--- a/supabase/migrations/0003_fix_fk_constraint_name.sql
+++ b/supabase/migrations/0003_fix_fk_constraint_name.sql
@@ -1,6 +1,14 @@
 -- Fix FK constraint name that exceeded PostgreSQL's 63-character identifier limit.
 -- The original name "commercial_document_lines_document_id_commercial_documents_id_fk" (64 chars)
 -- was silently truncated by PostgreSQL to 63 chars on creation.
-ALTER TABLE "commercial_document_lines"
-  RENAME CONSTRAINT "commercial_document_lines_document_id_commercial_documents_id_f"
-  TO "cd_lines_document_id_fk";
+-- Idempotent: only renames if the truncated name still exists.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'commercial_document_lines_document_id_commercial_documents_id_f'
+  ) THEN
+    ALTER TABLE "commercial_document_lines"
+      RENAME CONSTRAINT "commercial_document_lines_document_id_commercial_documents_id_f"
+      TO "cd_lines_document_id_fk";
+  END IF;
+END $$;

--- a/supabase/migrations/0004_stripe_subscription.sql
+++ b/supabase/migrations/0004_stripe_subscription.sql
@@ -1,21 +1,22 @@
 -- v0.9.0: Stripe payments — aggiunge colonne billing su profiles e crea tabella subscriptions
+-- All statements are idempotent: safe to run on both fresh and existing databases.
 
 -- -----------------------------------------------------------------------
 -- profiles: nuove colonne billing
 -- -----------------------------------------------------------------------
 
 ALTER TABLE "profiles"
-  ADD COLUMN "plan"             text        NOT NULL DEFAULT 'trial',
-  ADD COLUMN "trial_started_at" timestamptz          DEFAULT NOW(),
-  ADD COLUMN "plan_expires_at"  timestamptz,
+  ADD COLUMN IF NOT EXISTS "plan"             text        NOT NULL DEFAULT 'trial',
+  ADD COLUMN IF NOT EXISTS "trial_started_at" timestamptz          DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS "plan_expires_at"  timestamptz,
   -- Anti-abuso trial: stessa P.IVA non può aprire più trial
-  ADD COLUMN "partita_iva"      text        UNIQUE;
+  ADD COLUMN IF NOT EXISTS "partita_iva"      text        UNIQUE;--> statement-breakpoint
 
 -- -----------------------------------------------------------------------
 -- subscriptions: record Stripe (1:1 con auth.users)
 -- -----------------------------------------------------------------------
 
-CREATE TABLE "subscriptions" (
+CREATE TABLE IF NOT EXISTS "subscriptions" (
   "id"                     uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   "user_id"                uuid        NOT NULL UNIQUE
                              CONSTRAINT subscriptions_user_id_fk
@@ -28,14 +29,15 @@ CREATE TABLE "subscriptions" (
   "interval"               text,
   "created_at"             timestamptz NOT NULL DEFAULT NOW(),
   "updated_at"             timestamptz NOT NULL DEFAULT NOW()
-);
+);--> statement-breakpoint
 
 -- -----------------------------------------------------------------------
 -- RLS: subscriptions
 -- -----------------------------------------------------------------------
 
-ALTER TABLE "subscriptions" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "subscriptions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 
+DROP POLICY IF EXISTS "subscriptions_own" ON "subscriptions";--> statement-breakpoint
 CREATE POLICY "subscriptions_own" ON "subscriptions"
   FOR ALL
   USING (user_id = auth.uid());

--- a/supabase/migrations/0005_add_missing_indexes.sql
+++ b/supabase/migrations/0005_add_missing_indexes.sql
@@ -5,8 +5,8 @@
 --   1. idx_businesses_profile_id: query di ownership check e onboarding status
 --   2. idx_commercial_document_lines_document_id: inArray queries in searchReceipts/exportUserData
 
-CREATE INDEX "idx_businesses_profile_id"
-  ON "businesses" USING btree ("profile_id");
+CREATE INDEX IF NOT EXISTS "idx_businesses_profile_id"
+  ON "businesses" USING btree ("profile_id");--> statement-breakpoint
 
-CREATE INDEX "idx_commercial_document_lines_document_id"
+CREATE INDEX IF NOT EXISTS "idx_commercial_document_lines_document_id"
   ON "commercial_document_lines" USING btree ("document_id");

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -8,6 +8,41 @@
       "when": 1772398479211,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1772398479212,
+      "tag": "0001_rls_policies",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772398479213,
+      "tag": "0002_terms_acceptance",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772398479214,
+      "tag": "0003_fix_fk_constraint_name",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772398479215,
+      "tag": "0004_stripe_subscription",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772398479216,
+      "tag": "0005_add_missing_indexes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Migrations `0001`–`0005` existed on filesystem but were absent from `_journal.json`, so `npm run db:migrate` only ever applied `0000_initial` on fresh databases — resulting in tables with no RLS, no policies, and missing columns/tables
- Added all 5 missing entries to `_journal.json` so `db:migrate` applies the full migration sequence
- Made every migration idempotent (`IF NOT EXISTS`, `DROP POLICY IF EXISTS`, conditional `DO` block for constraint rename) so existing test/prod databases can safely run `db:migrate` without errors

## Test plan

- [ ] On a fresh Supabase project, run `npm run db:migrate` and verify:
  - All tables have RLS enabled (`SELECT tablename, rowsecurity FROM pg_tables WHERE schemaname = 'public'`)
  - All policies exist (`SELECT tablename, policyname FROM pg_policies WHERE schemaname = 'public'`)
  - `profiles` has columns: `terms_accepted_at`, `plan`, `trial_started_at`, `plan_expires_at`, `partita_iva`
  - Table `subscriptions` exists with policy `subscriptions_own`
  - Indexes `idx_businesses_profile_id` and `idx_commercial_document_lines_document_id` exist
- [ ] On an existing DB (test/prod), run `npm run db:migrate` and verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)