### PR TITLE
Add /help route as marketing-only with redirect from app domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.0",

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -195,6 +195,38 @@ describe("proxy", () => {
       expect(response.status).toBe(200);
     });
 
+    it("allows /help on marketing domain (marketing-only route)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/help", "scontrinozero.it"),
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("allows /help/api on marketing domain (help subroute)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/help/api", "scontrinozero.it"),
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("redirects /help on app domain to marketing domain", async () => {
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/help", "app.scontrinozero.it"),
+      );
+      expect(response.status).toBe(307);
+      const location = new URL(response.headers.get("location")!);
+      expect(location.hostname).toBe("scontrinozero.it");
+      expect(location.pathname).toBe("/help");
+    });
+
     it("redirects /dashboard on marketing domain to app domain", async () => {
       const { proxy } = await import("./proxy");
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,12 @@ const PROTECTED_PREFIXES = ["/dashboard", "/onboarding"];
 const AUTH_ONLY_PATHS = ["/login", "/register", "/reset-password"];
 
 /** Routes served exclusively on the marketing domain */
-const MARKETING_ONLY_ROUTES = ["/privacy", "/termini", "/cookie-policy"];
+const MARKETING_ONLY_ROUTES = [
+  "/privacy",
+  "/termini",
+  "/cookie-policy",
+  "/help",
+];
 
 /**
  * Redirects based on hostname to enforce domain separation.


### PR DESCRIPTION
## Summary
This PR adds the `/help` route as a marketing-only route and implements proper domain routing to redirect help requests from the app domain to the marketing domain.

## Key Changes
- Added `/help` to the `MARKETING_ONLY_ROUTES` list to serve it exclusively on the marketing domain
- Added test coverage for:
  - `/help` access on marketing domain (returns 200)
  - `/help/api` subroute access on marketing domain (returns 200)
  - `/help` access on app domain (redirects with 307 status to marketing domain)

## Implementation Details
- The `/help` route now follows the same domain separation pattern as other marketing-only routes like `/privacy`, `/termini`, and `/cookie-policy`
- Requests to `/help` on the app domain (e.g., `app.scontrinozero.it/help`) are redirected with a 307 status code to the marketing domain (e.g., `scontrinozero.it/help`)
- Subroutes under `/help` (e.g., `/help/api`) are also accessible on the marketing domain

https://claude.ai/code/session_01V77VEZTEfBcBWvXuqxVtU9