### PR TITLE
Add API subdomain routing with rewrites and CORS headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,16 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react"],
   },
+  async rewrites() {
+    // Requests arriving at the API subdomain (api[-sandbox].scontrinozero.it) come in
+    // as /v1/... — rewrite to /api/v1/... where the actual route handlers live.
+    return [
+      {
+        source: "/v1/:path*",
+        destination: "/api/v1/:path*",
+      },
+    ];
+  },
   async headers() {
     // Restrict internal API routes to the app's own origin only.
     // NEXT_PUBLIC_APP_URL is set per-environment (e.g. http://localhost:3000 in dev,
@@ -43,6 +53,19 @@ const nextConfig: NextConfig = {
         // Placed after the generic rule so it overrides Access-Control-Allow-Origin
         // for /api/v1/* paths specifically.
         source: "/api/v1/:path*",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Access-Control-Allow-Methods", value: "GET, POST, OPTIONS" },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Content-Type, Authorization",
+          },
+        ],
+      },
+      {
+        // Incoming /v1/* requests (from the API subdomain, before rewrite) also need
+        // open CORS — Next.js header rules match the original path, not the rewritten one.
+        source: "/v1/:path*",
         headers: [
           { key: "Access-Control-Allow-Origin", value: "*" },
           { key: "Access-Control-Allow-Methods", value: "GET, POST, OPTIONS" },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -119,6 +119,6 @@ export const config = {
      * - monitoring (Sentry tunnel)
      * - Static assets (svg, png, jpg, etc.)
      */
-    "/((?!_next/static|_next/image|favicon\\.ico|sitemap\\.xml|robots\\.txt|api/health|api/v1|monitoring|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)", // NOSONAR — String.raw breaks Next.js static analysis of matcher config
+    "/((?!_next/static|_next/image|favicon\\.ico|sitemap\\.xml|robots\\.txt|api/health|api/v1|v1|monitoring|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)", // NOSONAR — String.raw breaks Next.js static analysis of matcher config
   ],
 };


### PR DESCRIPTION
## Summary
This PR adds support for routing requests from an API subdomain (api[-sandbox].scontrinozero.it) to the application's internal API routes. Requests arriving at the API subdomain are rewritten from `/v1/...` to `/api/v1/...` where the actual route handlers live, with appropriate CORS headers configured.

## Key Changes
- **URL Rewrites**: Added Next.js `rewrites()` configuration to map incoming `/v1/:path*` requests to `/api/v1/:path*`
- **CORS Headers**: Added header rules for `/v1/:path*` requests to allow cross-origin access with GET, POST, and OPTIONS methods, supporting Content-Type and Authorization headers
- **Middleware Matcher**: Updated the proxy middleware matcher in `src/proxy.ts` to exclude `/v1` routes from middleware processing (similar to existing `/api/v1` exclusion)

## Implementation Details
- The rewrite configuration handles requests arriving at the API subdomain before they reach the internal route handlers
- CORS headers are applied to the original `/v1/*` path since Next.js header rules match against the original request path, not the rewritten destination
- The middleware matcher update ensures that `/v1` requests bypass the proxy middleware, allowing them to be processed by Next.js route handlers directly

https://claude.ai/code/session_01E9NbCmZgdGAD2r94zHDMzJ