### PR TITLE
Add receipt lines and payment details to GET /v1/receipts/{id}

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,4 @@ a5a40835e95ef4240016a5fc5773f017461258e6:src/app/(marketing)/help/api/page.tsx:g
 7af6a44d0cac02543ab90fd96158544d6bc6251d:src/app/(marketing)/help/api/page.tsx:curl-auth-header:246
 7af6a44d0cac02543ab90fd96158544d6bc6251d:src/app/(marketing)/help/api/page.tsx:curl-auth-header:299
 7af6a44d0cac02543ab90fd96158544d6bc6251d:src/app/(marketing)/help/api/page.tsx:curl-auth-header:380
+018633dd87fd76911da874961a343d618972a90a:DEVELOPER.md:curl-auth-header:169

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -157,13 +157,48 @@ curl -X POST https://api.scontrinozero.it/v1/receipts \
 
 ```json
 {
-  "id": "uuid",
-  "status": "ACCEPTED",
+  "documentId": "uuid",
   "adeTransactionId": "151085589",
-  "adeProgressive": "DCW2026/5111-2188",
-  "createdAt": "2026-03-26T10:00:00Z"
+  "adeProgressive": "DCW2026/5111-2188"
 }
 ```
+
+**Esempio GET scontrino:**
+
+```bash
+curl https://api.scontrinozero.it/v1/receipts/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer szk_live_XXXX"
+```
+
+**Risposta GET (200):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "kind": "SALE",
+  "status": "ACCEPTED",
+  "idempotencyKey": "550e8400-e29b-41d4-a716-446655440000",
+  "adeTransactionId": "151085589",
+  "adeProgressive": "DCW2026/5111-2188",
+  "createdAt": "2026-03-26T10:00:00Z",
+  "paymentMethod": "PE",
+  "lotteryCode": "ABCD1234",
+  "voidedDocumentId": null,
+  "total": "16.00",
+  "lines": [
+    {
+      "description": "Pizza Margherita",
+      "quantity": "2.000",
+      "grossUnitPrice": "8.00",
+      "vatCode": "10"
+    }
+  ]
+}
+```
+
+> `voidedDocumentId` è valorizzato solo per documenti `kind: "VOID"` e contiene l'UUID del SALE annullato.
+> `lotteryCode` è `null` se non fornito o se il metodo di pagamento è `"PC"` (contanti).
+> `quantity` e `grossUnitPrice` sono stringhe con precisione fissa (3 e 2 decimali rispettivamente).
 
 **Errori standard:**
 

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -353,26 +353,79 @@ export default function ApiDocsPage() {
   "idempotencyKey": "550e8400-e29b-41d4-a716-446655440000",
   "adeTransactionId": "151085589",
   "adeProgressive": "DCW2026/5111-2188",
-  "createdAt": "2026-03-26T10:00:00.000Z"
+  "createdAt": "2026-03-26T10:00:00.000Z",
+  "paymentMethod": "PE",
+  "lotteryCode": "ABCD1234",
+  "voidedDocumentId": null,
+  "total": "18.50",
+  "lines": [
+    {
+      "description": "Pizza Margherita",
+      "quantity": "2.000",
+      "grossUnitPrice": "8.00",
+      "vatCode": "10"
+    },
+    {
+      "description": "Acqua naturale",
+      "quantity": "1.000",
+      "grossUnitPrice": "2.50",
+      "vatCode": "10"
+    }
+  ]
 }`}</code>
         </pre>
-        <p className="text-muted-foreground mt-3 text-xs">
-          {"Il campo "}
-          <code className="bg-muted rounded px-1 font-mono">kind</code>
-          {" può essere "}
-          <code className="bg-muted rounded px-1 font-mono">SALE</code>
-          {" o "}
-          <code className="bg-muted rounded px-1 font-mono">VOID</code>
-          {". Il campo "}
-          <code className="bg-muted rounded px-1 font-mono">status</code>
-          {" può essere "}
-          <code className="bg-muted rounded px-1 font-mono">ACCEPTED</code>
-          {", "}
-          <code className="bg-muted rounded px-1 font-mono">REJECTED</code>
-          {" o "}
-          <code className="bg-muted rounded px-1 font-mono">PENDING</code>
-          {"."}
-        </p>
+        <div className="text-muted-foreground mt-3 overflow-x-auto text-sm">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b">
+                <th className="py-2 pr-4 text-left text-xs font-semibold tracking-wide uppercase">
+                  Campo
+                </th>
+                <th className="py-2 text-left text-xs font-semibold tracking-wide uppercase">
+                  Descrizione
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {[
+                ["kind", "SALE (vendita) o VOID (annullo)."],
+                [
+                  "status",
+                  "ACCEPTED, VOID_ACCEPTED, REJECTED, ERROR o PENDING.",
+                ],
+                [
+                  "paymentMethod",
+                  "PC (contanti) o PE (carta/elettronico), così come inviato in emissione.",
+                ],
+                [
+                  "lotteryCode",
+                  "Codice lotteria scontrini, null se non fornito o se il metodo di pagamento è PC.",
+                ],
+                [
+                  "voidedDocumentId",
+                  "Presente solo per documenti VOID: UUID del SALE che è stato annullato.",
+                ],
+                [
+                  "total",
+                  'Totale calcolato dalle righe, con 2 decimali (es. "18.50").',
+                ],
+                [
+                  "lines[].quantity",
+                  'Stringa con 3 decimali fissi (es. "2.000").',
+                ],
+                [
+                  "lines[].grossUnitPrice",
+                  'Stringa con 2 decimali fissi (es. "8.00"), in euro.',
+                ],
+              ].map(([field, desc]) => (
+                <tr key={field} className="border-b last:border-0">
+                  <td className="py-2 pr-4 font-mono text-xs">{field}</td>
+                  <td className="py-2 text-xs">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
         {/* ─── POST /v1/receipts/{id}/void ─── */}
         <h3 className="mt-10 text-base font-semibold">

--- a/src/app/api/v1/receipts/[id]/route.test.ts
+++ b/src/app/api/v1/receipts/[id]/route.test.ts
@@ -72,8 +72,8 @@ const FAKE_DOC = {
   adeProgressive: "001",
   createdAt: new Date("2026-03-01T10:00:00Z"),
   publicRequest: { paymentMethod: "PC" },
-  lotteryCode: null,
-  voidedDocumentId: null,
+  lotteryCode: null as string | null,
+  voidedDocumentId: null as string | null,
 };
 
 const FAKE_LINE = {

--- a/src/app/api/v1/receipts/[id]/route.test.ts
+++ b/src/app/api/v1/receipts/[id]/route.test.ts
@@ -7,17 +7,23 @@ const {
   mockAuthenticateApiKey,
   mockIsApiKeyAuthError,
   mockCanUseApi,
-  mockSelectLimit,
-  mockSelectWhere,
-  mockSelectFrom,
+  mockSelectDocLimit,
+  mockSelectDocWhere,
+  mockSelectDocFrom,
+  mockSelectLinesOrderBy,
+  mockSelectLinesWhere,
+  mockSelectLinesFrom,
   mockSelect,
 } = vi.hoisted(() => ({
   mockAuthenticateApiKey: vi.fn(),
   mockIsApiKeyAuthError: vi.fn(),
   mockCanUseApi: vi.fn(),
-  mockSelectLimit: vi.fn(),
-  mockSelectWhere: vi.fn(),
-  mockSelectFrom: vi.fn(),
+  mockSelectDocLimit: vi.fn(),
+  mockSelectDocWhere: vi.fn(),
+  mockSelectDocFrom: vi.fn(),
+  mockSelectLinesOrderBy: vi.fn(),
+  mockSelectLinesWhere: vi.fn(),
+  mockSelectLinesFrom: vi.fn(),
   mockSelect: vi.fn(),
 }));
 
@@ -36,11 +42,13 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/db/schema", () => ({
   commercialDocuments: "commercial-documents-table",
+  commercialDocumentLines: "commercial-document-lines-table",
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((col, val) => ({ col, val })),
   and: vi.fn((...args) => args),
+  asc: vi.fn((col) => ({ col, direction: "asc" })),
 }));
 
 // --- Fixtures ---
@@ -63,6 +71,19 @@ const FAKE_DOC = {
   adeTransactionId: "trx-001",
   adeProgressive: "001",
   createdAt: new Date("2026-03-01T10:00:00Z"),
+  publicRequest: { paymentMethod: "PC" },
+  lotteryCode: null,
+  voidedDocumentId: null,
+};
+
+const FAKE_LINE = {
+  id: "line-uuid-1",
+  documentId: DOC_ID,
+  lineIndex: 0,
+  description: "Espresso",
+  quantity: "2.000",
+  grossUnitPrice: "1.50",
+  vatCode: "22",
 };
 
 function makeRequest() {
@@ -71,6 +92,20 @@ function makeRequest() {
 
 function makeParams(id = DOC_ID) {
   return { params: Promise.resolve({ id }) };
+}
+
+function setupDocMock(doc: typeof FAKE_DOC | null) {
+  mockSelect.mockReturnValueOnce({ from: mockSelectDocFrom });
+  mockSelectDocFrom.mockReturnValue({ where: mockSelectDocWhere });
+  mockSelectDocWhere.mockReturnValue({ limit: mockSelectDocLimit });
+  mockSelectDocLimit.mockResolvedValue(doc ? [doc] : []);
+}
+
+function setupLinesMock(lines: (typeof FAKE_LINE)[]) {
+  mockSelect.mockReturnValueOnce({ from: mockSelectLinesFrom });
+  mockSelectLinesFrom.mockReturnValue({ where: mockSelectLinesWhere });
+  mockSelectLinesWhere.mockReturnValue({ orderBy: mockSelectLinesOrderBy });
+  mockSelectLinesOrderBy.mockResolvedValue(lines);
 }
 
 // --- Tests ---
@@ -84,10 +119,8 @@ describe("GET /api/v1/receipts/[id]", () => {
     mockAuthenticateApiKey.mockResolvedValue(FAKE_AUTH);
     mockCanUseApi.mockReturnValue(true);
 
-    mockSelect.mockReturnValue({ from: mockSelectFrom });
-    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
-    mockSelectWhere.mockReturnValue({ limit: mockSelectLimit });
-    mockSelectLimit.mockResolvedValue([FAKE_DOC]);
+    setupDocMock(FAKE_DOC);
+    setupLinesMock([FAKE_LINE]);
   });
 
   it("ritorna 200 con i dati del documento", async () => {
@@ -96,6 +129,69 @@ describe("GET /api/v1/receipts/[id]", () => {
     const body = await res.json();
     expect(body.id).toBe(DOC_ID);
     expect(body.status).toBe("ACCEPTED");
+  });
+
+  it("ritorna lines con i campi corretti", async () => {
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.lines).toHaveLength(1);
+    expect(body.lines[0]).toEqual({
+      description: "Espresso",
+      quantity: "2.000",
+      grossUnitPrice: "1.50",
+      vatCode: "22",
+    });
+  });
+
+  it("ritorna total calcolato correttamente", async () => {
+    // 2.000 * 1.50 = 3.00
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe("3.00");
+  });
+
+  it("ritorna paymentMethod estratto da publicRequest", async () => {
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.paymentMethod).toBe("PC");
+  });
+
+  it("ritorna lotteryCode quando presente", async () => {
+    setupDocMock({ ...FAKE_DOC, lotteryCode: "ABCD1234" });
+    setupLinesMock([FAKE_LINE]);
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.lotteryCode).toBe("ABCD1234");
+  });
+
+  it("ritorna lotteryCode null quando assente", async () => {
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+    expect(body.lotteryCode).toBeNull();
+  });
+
+  it("ritorna voidedDocumentId per documenti VOID", async () => {
+    const voidedId = "00000000-0000-0000-0000-000000000001";
+    setupDocMock({ ...FAKE_DOC, kind: "VOID", voidedDocumentId: voidedId });
+    setupLinesMock([]);
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.voidedDocumentId).toBe(voidedId);
+    expect(body.kind).toBe("VOID");
+  });
+
+  it("ritorna total 0.00 quando non ci sono righe", async () => {
+    setupDocMock(FAKE_DOC);
+    setupLinesMock([]);
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+    expect(body.total).toBe("0.00");
+    expect(body.lines).toHaveLength(0);
   });
 
   it("ritorna 401 se API key non valida", async () => {
@@ -127,7 +223,11 @@ describe("GET /api/v1/receipts/[id]", () => {
   });
 
   it("ritorna 404 se documento non trovato (o appartiene ad altro business)", async () => {
-    mockSelectLimit.mockResolvedValue([]);
+    vi.clearAllMocks();
+    mockIsApiKeyAuthError.mockReturnValue(false);
+    mockAuthenticateApiKey.mockResolvedValue(FAKE_AUTH);
+    mockCanUseApi.mockReturnValue(true);
+    setupDocMock(null);
 
     const res = await GET(
       makeRequest(),

--- a/src/app/api/v1/receipts/[id]/route.ts
+++ b/src/app/api/v1/receipts/[id]/route.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { getDb } from "@/db";
-import { commercialDocuments } from "@/db/schema";
+import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
 import { isValidUuid } from "@/lib/uuid";
 import {
   requireBusinessApiAuth,
@@ -39,6 +39,9 @@ export async function GET(
       adeTransactionId: commercialDocuments.adeTransactionId,
       adeProgressive: commercialDocuments.adeProgressive,
       createdAt: commercialDocuments.createdAt,
+      lotteryCode: commercialDocuments.lotteryCode,
+      voidedDocumentId: commercialDocuments.voidedDocumentId,
+      publicRequest: commercialDocuments.publicRequest,
     })
     .from(commercialDocuments)
     .where(
@@ -55,5 +58,43 @@ export async function GET(
     );
   }
 
-  return withCors(Response.json(doc));
+  const lines = await db
+    .select()
+    .from(commercialDocumentLines)
+    .where(eq(commercialDocumentLines.documentId, doc.id))
+    .orderBy(asc(commercialDocumentLines.lineIndex));
+
+  const total =
+    Math.round(
+      lines.reduce(
+        (sum, l) =>
+          sum +
+          Number.parseFloat(l.grossUnitPrice) * Number.parseFloat(l.quantity),
+        0,
+      ) * 100,
+    ) / 100;
+
+  const pr = doc.publicRequest as { paymentMethod?: string } | null;
+
+  return withCors(
+    Response.json({
+      id: doc.id,
+      kind: doc.kind,
+      status: doc.status,
+      idempotencyKey: doc.idempotencyKey,
+      adeTransactionId: doc.adeTransactionId,
+      adeProgressive: doc.adeProgressive,
+      createdAt: doc.createdAt,
+      paymentMethod: pr?.paymentMethod ?? null,
+      lotteryCode: doc.lotteryCode,
+      voidedDocumentId: doc.voidedDocumentId,
+      total: total.toFixed(2),
+      lines: lines.map((l) => ({
+        description: l.description,
+        quantity: l.quantity,
+        grossUnitPrice: l.grossUnitPrice,
+        vatCode: l.vatCode,
+      })),
+    }),
+  );
 }

--- a/tests/unit/api-v1-receipt-get.test.ts
+++ b/tests/unit/api-v1-receipt-get.test.ts
@@ -8,18 +8,24 @@ const {
   mockIsApiKeyAuthError,
   mockCanUseApi,
   mockGetDb,
+  mockOrderBy,
   mockLimit,
   mockWhere,
   mockFrom,
+  mockLinesWhere,
+  mockLinesFrom,
   mockSelect,
 } = vi.hoisted(() => ({
   mockAuthenticateApiKey: vi.fn(),
   mockIsApiKeyAuthError: vi.fn(),
   mockCanUseApi: vi.fn(),
   mockGetDb: vi.fn(),
+  mockOrderBy: vi.fn(),
   mockLimit: vi.fn(),
   mockWhere: vi.fn(),
   mockFrom: vi.fn(),
+  mockLinesWhere: vi.fn(),
+  mockLinesFrom: vi.fn(),
   mockSelect: vi.fn(),
 }));
 
@@ -37,12 +43,14 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/db/schema", () => ({
-  commercialDocuments: {},
+  commercialDocuments: "commercial-documents-table",
+  commercialDocumentLines: "commercial-document-lines-table",
 }));
 
 vi.mock("drizzle-orm", () => ({
   and: vi.fn(),
   eq: vi.fn(),
+  asc: vi.fn(),
 }));
 
 // --- Helpers ---
@@ -59,7 +67,8 @@ const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
 
 describe("GET /api/v1/receipts/[id]", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks clears once-queues too, preventing accumulation across tests
+    vi.resetAllMocks();
 
     // Default: auth ok, plan ok, business key ok
     mockIsApiKeyAuthError.mockReturnValue(false);
@@ -69,11 +78,20 @@ describe("GET /api/v1/receipts/[id]", () => {
     });
     mockCanUseApi.mockReturnValue(true);
 
-    // Default DB chain
+    // Doc query chain: select().from().where().limit()
     mockLimit.mockResolvedValue([]);
     mockWhere.mockReturnValue({ limit: mockLimit });
     mockFrom.mockReturnValue({ where: mockWhere });
-    mockSelect.mockReturnValue({ from: mockFrom });
+
+    // Lines query chain: select().from().where().orderBy()
+    mockOrderBy.mockResolvedValue([]);
+    mockLinesWhere.mockReturnValue({ orderBy: mockOrderBy });
+    mockLinesFrom.mockReturnValue({ where: mockLinesWhere });
+
+    // First select() → doc chain, second select() → lines chain
+    mockSelect
+      .mockReturnValueOnce({ from: mockFrom })
+      .mockReturnValueOnce({ from: mockLinesFrom });
     mockGetDb.mockReturnValue({ select: mockSelect });
   });
 
@@ -147,14 +165,31 @@ describe("GET /api/v1/receipts/[id]", () => {
       expect(res.status).toBe(404);
     });
 
-    it("returns 200 with document when found", async () => {
-      const doc = { id: VALID_UUID, status: "SENT" };
+    it("returns 200 with document data and lines when found", async () => {
+      const doc = {
+        id: VALID_UUID,
+        status: "ACCEPTED",
+        publicRequest: { paymentMethod: "PC" },
+        lotteryCode: null,
+        voidedDocumentId: null,
+      };
+      const line = {
+        description: "Prodotto",
+        quantity: "1.000",
+        grossUnitPrice: "5.00",
+        vatCode: "22",
+      };
       mockLimit.mockResolvedValue([doc]);
+      mockOrderBy.mockResolvedValue([line]);
       const { GET } = await import("@/app/api/v1/receipts/[id]/route");
       const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toEqual(doc);
+      expect(body.id).toBe(VALID_UUID);
+      expect(body.status).toBe("ACCEPTED");
+      expect(body.paymentMethod).toBe("PC");
+      expect(body.lines).toHaveLength(1);
+      expect(body.total).toBe("5.00");
     });
   });
 });


### PR DESCRIPTION
## Summary
Enhanced the GET receipt endpoint to return complete receipt information including line items, calculated totals, payment method, and lottery code details.

## Key Changes

- **Receipt Lines**: Added support for fetching and returning `commercialDocumentLines` associated with each receipt, including description, quantity, gross unit price, and VAT code
- **Total Calculation**: Implemented server-side total calculation from line items with proper decimal precision (2 decimal places)
- **Payment Details**: Extracted and returned `paymentMethod` from the `publicRequest` field
- **Lottery Code**: Added `lotteryCode` field to response (null when not provided or payment method is cash)
- **Void Document Tracking**: Added `voidedDocumentId` field for VOID receipts to reference the original SALE document
- **Response Structure**: Restructured response to include all receipt metadata alongside line items and calculated totals

## Implementation Details

- Modified database query to select additional fields: `lotteryCode`, `voidedDocumentId`, and `publicRequest`
- Added separate database query to fetch ordered line items using `orderBy(asc(lineIndex))`
- Implemented total calculation by multiplying quantity × grossUnitPrice for each line and summing with proper rounding
- Updated test suite with comprehensive mocks for both document and lines queries
- Added 6 new test cases covering lines output, total calculation, payment method extraction, lottery code handling, void documents, and empty line scenarios
- Updated API documentation with detailed response schema and field descriptions in both marketing page and DEVELOPER.md

https://claude.ai/code/session_012kuAcC5XMoLGnyPnF4AgPA