### PR TITLE
Add GET /v1/receipts endpoint for listing receipts

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -7,3 +7,4 @@ a5a40835e95ef4240016a5fc5773f017461258e6:src/app/(marketing)/help/api/page.tsx:g
 7af6a44d0cac02543ab90fd96158544d6bc6251d:src/app/(marketing)/help/api/page.tsx:curl-auth-header:299
 7af6a44d0cac02543ab90fd96158544d6bc6251d:src/app/(marketing)/help/api/page.tsx:curl-auth-header:380
 018633dd87fd76911da874961a343d618972a90a:DEVELOPER.md:curl-auth-header:169
+d5cd231267e68e5146904677937ae81df9bda5e1:src/app/(marketing)/help/api/page.tsx:curl-auth-header:405

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -406,19 +406,19 @@ export default function ApiDocsPage() {
   -H "Authorization: Bearer szk_live_XXXX"`}</code>
         </pre>
         <p className="text-muted-foreground mt-2 text-sm">
-          Se sono stati emessi più di 100 scontrini nel periodo, usa{" "}
+          {"Se sono stati emessi più di 100 scontrini nel periodo, usa "}
           <code className="bg-muted rounded px-1 font-mono text-xs">
             &page=2
           </code>
-          ,{" "}
+          {", "}
           <code className="bg-muted rounded px-1 font-mono text-xs">
             &page=3
           </code>
-          , ecc. Il campo{" "}
+          {", ecc. Il campo "}
           <code className="bg-muted rounded px-1 font-mono text-xs">
             pagination.hasNextPage
-          </code>{" "}
-          indica se esistono ulteriori pagine.
+          </code>
+          {" indica se esistono ulteriori pagine."}
         </p>
 
         <p className="mt-5 text-sm font-medium">
@@ -452,13 +452,13 @@ export default function ApiDocsPage() {
 }`}</code>
         </pre>
         <p className="text-muted-foreground mt-2 text-sm">
-          Nota: la risposta non include le righe (
+          {"Nota: la risposta non include le righe ("}
           <code className="bg-muted rounded px-1 font-mono text-xs">lines</code>
-          ). Per i dettagli di un singolo scontrino usa{" "}
+          {"). Per i dettagli di un singolo scontrino usa "}
           <code className="bg-muted rounded px-1 font-mono text-xs">
             GET /v1/receipts/{"{id}"}
           </code>
-          .
+          {"."}
         </p>
 
         {/* ─── GET /v1/receipts/{id} ─── */}

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -156,6 +156,15 @@ export default function ApiDocsPage() {
                 <td className="py-2 pr-6 font-mono text-xs font-bold text-blue-700 dark:text-blue-400">
                   GET
                 </td>
+                <td className="py-2 pr-6 font-mono text-xs">/v1/receipts</td>
+                <td className="py-2 text-xs">
+                  Lista scontrini in un intervallo di date
+                </td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-2 pr-6 font-mono text-xs font-bold text-blue-700 dark:text-blue-400">
+                  GET
+                </td>
                 <td className="py-2 pr-6 font-mono text-xs">
                   /v1/receipts/{"{id}"}
                 </td>
@@ -319,6 +328,138 @@ export default function ApiDocsPage() {
   "adeProgressive": "DCW2026/5111-2188"
 }`}</code>
         </pre>
+
+        {/* ─── GET /v1/receipts ─── */}
+        <h3 className="mt-10 text-base font-semibold">
+          <span className="mr-2 font-mono text-blue-700 dark:text-blue-400">
+            GET
+          </span>
+          {"/v1/receipts"}
+        </h3>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Restituisce la lista paginata degli scontrini emessi
+          nell&apos;intervallo di date indicato. Utile per riconciliazione
+          contabile, export periodico o sync verso sistemi gestionali.
+        </p>
+
+        <p className="mt-4 text-sm font-medium">Parametri query</p>
+        <div className="text-muted-foreground mt-2 overflow-x-auto text-sm">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b">
+                <th className="py-2 pr-4 text-left text-xs font-semibold tracking-wide uppercase">
+                  Parametro
+                </th>
+                <th className="py-2 pr-4 text-left text-xs font-semibold tracking-wide uppercase">
+                  Tipo
+                </th>
+                <th className="py-2 pr-4 text-left text-xs font-semibold tracking-wide uppercase">
+                  Req.
+                </th>
+                <th className="py-2 text-left text-xs font-semibold tracking-wide uppercase">
+                  Descrizione
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {[
+                [
+                  "from",
+                  "YYYY-MM-DD",
+                  "Sì",
+                  "Inizio intervallo (incluso, UTC)",
+                ],
+                [
+                  "to",
+                  "YYYY-MM-DD",
+                  "Sì",
+                  "Fine intervallo (incluso, UTC). Max 31 giorni da from.",
+                ],
+                ["page", "intero ≥ 1", "No", "Pagina (default: 1)"],
+                [
+                  "limit",
+                  "1–100",
+                  "No",
+                  "Risultati per pagina (default: 20, max: 100)",
+                ],
+                [
+                  "kind",
+                  "SALE | VOID",
+                  "No",
+                  "Filtra per tipo documento (default: entrambi)",
+                ],
+              ].map(([param, type, req, desc]) => (
+                <tr key={param} className="border-b last:border-0">
+                  <td className="py-2 pr-4 font-mono text-xs">{param}</td>
+                  <td className="py-2 pr-4 text-xs">{type}</td>
+                  <td className="py-2 pr-4 text-xs">{req}</td>
+                  <td className="py-2 text-xs">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="mt-5 text-sm font-medium">Esempio</p>
+        <pre className="bg-muted mt-2 overflow-x-auto rounded-md p-4 font-mono text-xs leading-relaxed">
+          <code>{String.raw`curl "https://api.scontrinozero.it/v1/receipts?from=2026-04-01&to=2026-04-30&limit=100" \
+  -H "Authorization: Bearer szk_live_XXXX"`}</code>
+        </pre>
+        <p className="text-muted-foreground mt-2 text-sm">
+          Se sono stati emessi più di 100 scontrini nel periodo, usa{" "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">
+            &page=2
+          </code>
+          ,{" "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">
+            &page=3
+          </code>
+          , ecc. Il campo{" "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">
+            pagination.hasNextPage
+          </code>{" "}
+          indica se esistono ulteriori pagine.
+        </p>
+
+        <p className="mt-5 text-sm font-medium">
+          {"Risposta — "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">
+            200 OK
+          </code>
+        </p>
+        <pre className="bg-muted mt-2 overflow-x-auto rounded-md p-4 font-mono text-xs leading-relaxed">
+          <code>{`{
+  "data": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "idempotencyKey": "550e8400-e29b-41d4-a716-446655440000",
+      "kind": "SALE",
+      "status": "ACCEPTED",
+      "adeTransactionId": "151085589",
+      "adeProgressive": "DCW2026/5111-2188",
+      "lotteryCode": null,
+      "paymentMethod": "PE",
+      "total": "18.50",
+      "createdAt": "2026-04-05T10:00:00.000Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 100,
+    "total": 1,
+    "hasNextPage": false
+  }
+}`}</code>
+        </pre>
+        <p className="text-muted-foreground mt-2 text-sm">
+          Nota: la risposta non include le righe (
+          <code className="bg-muted rounded px-1 font-mono text-xs">lines</code>
+          ). Per i dettagli di un singolo scontrino usa{" "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">
+            GET /v1/receipts/{"{id}"}
+          </code>
+          .
+        </p>
 
         {/* ─── GET /v1/receipts/{id} ─── */}
         <h3 className="mt-10 text-base font-semibold">
@@ -584,6 +725,12 @@ const idempotencyKey = crypto.randomUUID();`}</code>
                   POST /v1/receipts
                 </td>
                 <td className="py-2 text-xs">120 richieste / ora</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-2 pr-6 font-mono text-xs">
+                  GET /v1/receipts
+                </td>
+                <td className="py-2 text-xs">60 richieste / ora</td>
               </tr>
               <tr>
                 <td className="py-2 pr-6 font-mono text-xs">

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -452,13 +452,13 @@ export default function ApiDocsPage() {
 }`}</code>
         </pre>
         <p className="text-muted-foreground mt-2 text-sm">
-          {"Nota: la risposta non include le righe ("}
-          <code className="bg-muted rounded px-1 font-mono text-xs">lines</code>
-          {"). Per i dettagli di un singolo scontrino usa "}
+          {
+            "La risposta non include le righe di dettaglio. Per il contenuto completo di uno scontrino usa "
+          }
           <code className="bg-muted rounded px-1 font-mono text-xs">
-            GET /v1/receipts/{"{id}"}
+            {"GET /v1/receipts/{id}"}
           </code>
-          {"."}
+          {" (campo lines incluso)."}
         </p>
 
         {/* ─── GET /v1/receipts/{id} ─── */}

--- a/src/app/api/v1/receipts/route.ts
+++ b/src/app/api/v1/receipts/route.ts
@@ -215,16 +215,17 @@ export async function GET(request: Request): Promise<Response> {
   const limitStr = searchParams.get("limit");
   const kindStr = searchParams.get("kind");
 
-  const page = Math.max(1, parseInt(pageStr ?? "1", 10) || 1);
+  const page = Math.max(1, Number.parseInt(pageStr ?? "1", 10) || 1);
   const limit = Math.min(
     MAX_LIMIT,
     Math.max(
       1,
-      parseInt(limitStr ?? String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT,
+      Number.parseInt(limitStr ?? String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT,
     ),
   );
   const offset = (page - 1) * limit;
-  const kind = kindStr === "SALE" ? "SALE" : kindStr === "VOID" ? "VOID" : null;
+  const kind: "SALE" | "VOID" | null =
+    kindStr === "SALE" || kindStr === "VOID" ? kindStr : null;
 
   // ── DB queries ────────────────────────────────────────────────────────────
   const db = getDb();

--- a/src/app/api/v1/receipts/route.ts
+++ b/src/app/api/v1/receipts/route.ts
@@ -1,4 +1,7 @@
 import { z } from "zod/v4";
+import { and, asc, count, desc, eq, gte, inArray, lt } from "drizzle-orm";
+import { getDb } from "@/db";
+import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
 import { RateLimiter } from "@/lib/rate-limit";
 import { emitReceiptForBusiness } from "@/lib/services/receipt-service";
 import {
@@ -62,8 +65,21 @@ const receiptApiLimiter = new RateLimiter({
   windowMs: 60 * 60 * 1000,
 });
 
+// Rate limit: 60 list requests per hour per API key (read but potentially heavy)
+const listApiLimiter = new RateLimiter({
+  maxRequests: 60,
+  windowMs: 60 * 60 * 1000,
+});
+
+const MAX_RANGE_DAYS = 31;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/** Matches YYYY-MM-DD dates. Lightweight format guard — value validity checked via Date parse. */
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 export function OPTIONS(): Response {
-  return corsOptionsResponse("POST, OPTIONS");
+  return corsOptionsResponse("GET, POST, OPTIONS");
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -118,5 +134,198 @@ export async function POST(request: Request): Promise<Response> {
       },
       { status: 201 },
     ),
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  const authResult = await requireBusinessApiAuth(request);
+  if ("error" in authResult) return authResult.error;
+  const { context: auth } = authResult;
+
+  // ── Rate limit ────────────────────────────────────────────────────────────
+  const rateLimitError = checkRateLimitApi(
+    listApiLimiter,
+    `api:list:${auth.apiKey.id}`,
+    auth.apiKey.id,
+    "API receipt list rate limit exceeded",
+  );
+  if (rateLimitError) return rateLimitError;
+
+  // ── Query param validation ────────────────────────────────────────────────
+  const { searchParams } = new URL(request.url);
+  const fromStr = searchParams.get("from");
+  const toStr = searchParams.get("to");
+
+  if (!fromStr || !DATE_PATTERN.test(fromStr)) {
+    return withCors(
+      Response.json(
+        {
+          error:
+            "Il parametro 'from' è obbligatorio e deve essere nel formato YYYY-MM-DD.",
+        },
+        { status: 400 },
+      ),
+    );
+  }
+  if (!toStr || !DATE_PATTERN.test(toStr)) {
+    return withCors(
+      Response.json(
+        {
+          error:
+            "Il parametro 'to' è obbligatorio e deve essere nel formato YYYY-MM-DD.",
+        },
+        { status: 400 },
+      ),
+    );
+  }
+
+  // Append time component so Date.UTC is used unambiguously (avoids TZ-offset surprises)
+  const fromDate = new Date(fromStr + "T00:00:00.000Z");
+  const toDate = new Date(toStr + "T00:00:00.000Z");
+
+  if (toDate < fromDate) {
+    return withCors(
+      Response.json(
+        { error: "Il parametro 'to' non può essere precedente a 'from'." },
+        { status: 400 },
+      ),
+    );
+  }
+
+  const diffDays =
+    (toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24);
+  if (diffDays > MAX_RANGE_DAYS) {
+    return withCors(
+      Response.json(
+        {
+          error: `L'intervallo massimo consentito è ${MAX_RANGE_DAYS} giorni.`,
+        },
+        { status: 400 },
+      ),
+    );
+  }
+
+  // Include the entire 'to' day by advancing to the start of the next day
+  const toDateExclusive = new Date(toDate);
+  toDateExclusive.setUTCDate(toDateExclusive.getUTCDate() + 1);
+
+  // Optional params
+  const pageStr = searchParams.get("page");
+  const limitStr = searchParams.get("limit");
+  const kindStr = searchParams.get("kind");
+
+  const page = Math.max(1, parseInt(pageStr ?? "1", 10) || 1);
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(
+      1,
+      parseInt(limitStr ?? String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT,
+    ),
+  );
+  const offset = (page - 1) * limit;
+  const kind = kindStr === "SALE" ? "SALE" : kindStr === "VOID" ? "VOID" : null;
+
+  // ── DB queries ────────────────────────────────────────────────────────────
+  const db = getDb();
+
+  const conditions = [
+    eq(commercialDocuments.businessId, auth.businessId),
+    gte(commercialDocuments.createdAt, fromDate),
+    lt(commercialDocuments.createdAt, toDateExclusive),
+    inArray(commercialDocuments.status, ["ACCEPTED", "VOID_ACCEPTED"]),
+  ];
+  if (kind) {
+    conditions.push(eq(commercialDocuments.kind, kind));
+  }
+
+  // Count total matching docs (no pagination)
+  const [{ value: total }] = await db
+    .select({ value: count() })
+    .from(commercialDocuments)
+    .where(and(...conditions));
+
+  // Fetch the current page
+  const docs = await db
+    .select({
+      id: commercialDocuments.id,
+      kind: commercialDocuments.kind,
+      status: commercialDocuments.status,
+      idempotencyKey: commercialDocuments.idempotencyKey,
+      adeTransactionId: commercialDocuments.adeTransactionId,
+      adeProgressive: commercialDocuments.adeProgressive,
+      lotteryCode: commercialDocuments.lotteryCode,
+      publicRequest: commercialDocuments.publicRequest,
+      createdAt: commercialDocuments.createdAt,
+    })
+    .from(commercialDocuments)
+    .where(and(...conditions))
+    .orderBy(desc(commercialDocuments.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  if (docs.length === 0) {
+    return withCors(
+      Response.json({
+        data: [],
+        pagination: { page, limit, total, hasNextPage: page * limit < total },
+      }),
+    );
+  }
+
+  // Fetch lines for total calculation (not included in response)
+  const docIds = docs.map((d) => d.id);
+  const lines = await db
+    .select()
+    .from(commercialDocumentLines)
+    .where(inArray(commercialDocumentLines.documentId, docIds))
+    .orderBy(asc(commercialDocumentLines.lineIndex));
+
+  // Group lines by documentId for O(1) lookup
+  const linesByDocId = new Map<string, typeof lines>();
+  for (const line of lines) {
+    const existing = linesByDocId.get(line.documentId) ?? [];
+    existing.push(line);
+    linesByDocId.set(line.documentId, existing);
+  }
+
+  const data = docs.map((doc) => {
+    const docLines = linesByDocId.get(doc.id) ?? [];
+    const docTotal =
+      Math.round(
+        docLines.reduce(
+          (sum, l) =>
+            sum +
+            Number.parseFloat(l.grossUnitPrice) * Number.parseFloat(l.quantity),
+          0,
+        ) * 100,
+      ) / 100;
+
+    const pr = doc.publicRequest as { paymentMethod?: string } | null;
+
+    return {
+      id: doc.id,
+      idempotencyKey: doc.idempotencyKey,
+      kind: doc.kind,
+      status: doc.status,
+      adeTransactionId: doc.adeTransactionId,
+      adeProgressive: doc.adeProgressive,
+      lotteryCode: doc.lotteryCode,
+      paymentMethod: pr?.paymentMethod ?? null,
+      total: docTotal.toFixed(2),
+      createdAt: doc.createdAt,
+    };
+  });
+
+  return withCors(
+    Response.json({
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        hasNextPage: page * limit < total,
+      },
+    }),
   );
 }

--- a/tests/unit/api-v1-receipt-list.test.ts
+++ b/tests/unit/api-v1-receipt-list.test.ts
@@ -1,0 +1,533 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const {
+  mockAuthenticateApiKey,
+  mockIsApiKeyAuthError,
+  mockCanUseApi,
+  mockRateLimiterCheck,
+  mockGetDb,
+  mockCountWhere,
+  mockDocsOffset,
+  mockDocsLimit,
+  mockDocsOrderBy,
+  mockDocsWhere,
+  mockDocsFrom,
+  mockCountFrom,
+  mockLinesOrderBy,
+  mockLinesWhere,
+  mockLinesFrom,
+  mockSelect,
+} = vi.hoisted(() => ({
+  mockAuthenticateApiKey: vi.fn(),
+  mockIsApiKeyAuthError: vi.fn(),
+  mockCanUseApi: vi.fn(),
+  mockRateLimiterCheck: vi.fn(),
+  mockGetDb: vi.fn(),
+  mockCountWhere: vi.fn(),
+  mockDocsOffset: vi.fn(),
+  mockDocsLimit: vi.fn(),
+  mockDocsOrderBy: vi.fn(),
+  mockDocsWhere: vi.fn(),
+  mockDocsFrom: vi.fn(),
+  mockCountFrom: vi.fn(),
+  mockLinesOrderBy: vi.fn(),
+  mockLinesWhere: vi.fn(),
+  mockLinesFrom: vi.fn(),
+  mockSelect: vi.fn(),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  authenticateApiKey: mockAuthenticateApiKey,
+  isApiKeyAuthError: mockIsApiKeyAuthError,
+}));
+
+vi.mock("@/lib/plans", () => ({
+  canUseApi: mockCanUseApi,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockRateLimiterCheck };
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+// Needed because route.ts imports emitReceiptForBusiness at module level
+vi.mock("@/lib/services/receipt-service", () => ({
+  emitReceiptForBusiness: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  getDb: mockGetDb,
+}));
+
+vi.mock("@/db/schema", () => ({
+  commercialDocuments: "commercial-documents-table",
+  commercialDocumentLines: "commercial-document-lines-table",
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  gte: vi.fn(),
+  lt: vi.fn(),
+  desc: vi.fn(),
+  count: vi.fn(),
+  inArray: vi.fn(),
+  asc: vi.fn(),
+}));
+
+// --- Helpers ---
+
+const BIZ_ID = "biz-123";
+const API_KEY_ID = "key-456";
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(params: Record<string, string> = {}): Request {
+  const url = new URL("https://example.com/api/v1/receipts");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new Request(url.toString());
+}
+
+/** Sets up DB mocks for count + docs + lines (full happy-path chain). */
+function setupDbMocks(
+  total: number,
+  docs: unknown[],
+  lines: unknown[] = [],
+): void {
+  // 1. Count query: select({value}).from().where() → [{value: total}]
+  mockCountWhere.mockResolvedValue([{ value: total }]);
+  mockCountFrom.mockReturnValue({ where: mockCountWhere });
+
+  // 2. Docs query: select({...}).from().where().orderBy().limit().offset() → docs
+  mockDocsOffset.mockResolvedValue(docs);
+  mockDocsLimit.mockReturnValue({ offset: mockDocsOffset });
+  mockDocsOrderBy.mockReturnValue({ limit: mockDocsLimit });
+  mockDocsWhere.mockReturnValue({ orderBy: mockDocsOrderBy });
+  mockDocsFrom.mockReturnValue({ where: mockDocsWhere });
+
+  // 3. Lines query (only reached when docs.length > 0):
+  //    select().from().where().orderBy() → lines
+  mockLinesOrderBy.mockResolvedValue(lines);
+  mockLinesWhere.mockReturnValue({ orderBy: mockLinesOrderBy });
+  mockLinesFrom.mockReturnValue({ where: mockLinesWhere });
+
+  mockSelect
+    .mockReturnValueOnce({ from: mockCountFrom }) // 1st call → count
+    .mockReturnValueOnce({ from: mockDocsFrom }) // 2nd call → docs
+    .mockReturnValueOnce({ from: mockLinesFrom }); // 3rd call → lines
+
+  mockGetDb.mockReturnValue({ select: mockSelect });
+}
+
+/** Sets up DB mocks for empty result (count + docs only, no lines query). */
+function setupDbMocksEmpty(total = 0): void {
+  mockCountWhere.mockResolvedValue([{ value: total }]);
+  mockCountFrom.mockReturnValue({ where: mockCountWhere });
+
+  mockDocsOffset.mockResolvedValue([]);
+  mockDocsLimit.mockReturnValue({ offset: mockDocsOffset });
+  mockDocsOrderBy.mockReturnValue({ limit: mockDocsLimit });
+  mockDocsWhere.mockReturnValue({ orderBy: mockDocsOrderBy });
+  mockDocsFrom.mockReturnValue({ where: mockDocsWhere });
+
+  mockSelect
+    .mockReturnValueOnce({ from: mockCountFrom })
+    .mockReturnValueOnce({ from: mockDocsFrom });
+
+  mockGetDb.mockReturnValue({ select: mockSelect });
+}
+
+const VALID_FROM = "2026-04-01";
+const VALID_TO = "2026-04-10";
+
+describe("GET /api/v1/receipts (list)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Default: auth ok, plan ok, business key
+    mockIsApiKeyAuthError.mockReturnValue(false);
+    mockAuthenticateApiKey.mockResolvedValue({
+      plan: "pro",
+      businessId: BIZ_ID,
+      apiKey: { id: API_KEY_ID },
+    });
+    mockCanUseApi.mockReturnValue(true);
+    mockRateLimiterCheck.mockReturnValue({ success: true });
+  });
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  describe("auth", () => {
+    it("returns 401 when API key is missing or invalid", async () => {
+      mockIsApiKeyAuthError.mockReturnValue(true);
+      mockAuthenticateApiKey.mockResolvedValue({
+        error: "Unauthorized",
+        status: 401,
+      });
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 402 when plan does not include API access", async () => {
+      mockCanUseApi.mockReturnValue(false);
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(402);
+    });
+
+    it("returns 403 when no businessId (management key)", async () => {
+      mockAuthenticateApiKey.mockResolvedValue({
+        plan: "pro",
+        businessId: null,
+        apiKey: { id: API_KEY_ID },
+      });
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── Rate limit ─────────────────────────────────────────────────────────────
+
+  describe("rate limit", () => {
+    it("returns 429 when rate limit exceeded", async () => {
+      mockRateLimiterCheck.mockReturnValue({
+        success: false,
+        resetAt: Date.now() + 60_000,
+      });
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(429);
+      expect(res.headers.get("Retry-After")).toBeDefined();
+    });
+  });
+
+  // ── Query param validation ────────────────────────────────────────────────
+
+  describe("query param validation", () => {
+    it("returns 400 when 'from' is missing", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ to: VALID_TO }));
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/from/i);
+    });
+
+    it("returns 400 when 'to' is missing", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM }));
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/to/i);
+    });
+
+    it("returns 400 when 'from' has invalid format", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: "01/04/2026", to: VALID_TO }));
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when 'to' has invalid format", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: VALID_FROM, to: "not-a-date" }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when 'to' is before 'from'", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: "2026-04-10", to: "2026-04-01" }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/to/i);
+    });
+
+    it("returns 400 when range exceeds 31 days", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: "2026-01-01", to: "2026-02-10" }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/31/);
+    });
+
+    it("accepts range of exactly 31 days", async () => {
+      setupDbMocksEmpty();
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: "2026-04-01", to: "2026-05-02" }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts same-day range (from == to)", async () => {
+      setupDbMocksEmpty();
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: "2026-04-10", to: "2026-04-10" }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("does not query DB when params are invalid", async () => {
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      await GET(makeRequest({ to: VALID_TO }));
+
+      expect(mockGetDb).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+
+  describe("pagination", () => {
+    it("caps limit to 100 when limit > 100 is requested", async () => {
+      setupDbMocksEmpty(0);
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: VALID_FROM, to: VALID_TO, limit: "500" }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pagination.limit).toBe(100);
+    });
+
+    it("uses default limit of 20 when not specified", async () => {
+      setupDbMocksEmpty(0);
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pagination.limit).toBe(20);
+    });
+
+    it("sets hasNextPage true when total > page * limit", async () => {
+      setupDbMocksEmpty(150);
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({
+          from: VALID_FROM,
+          to: VALID_TO,
+          page: "1",
+          limit: "100",
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pagination.hasNextPage).toBe(true);
+      expect(body.pagination.total).toBe(150);
+    });
+
+    it("sets hasNextPage false on last page", async () => {
+      setupDbMocksEmpty(5);
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: VALID_FROM, to: VALID_TO, page: "1", limit: "20" }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pagination.hasNextPage).toBe(false);
+    });
+
+    it("returns correct page number in pagination", async () => {
+      setupDbMocksEmpty(0);
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: VALID_FROM, to: VALID_TO, page: "3", limit: "20" }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.pagination.page).toBe(3);
+    });
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  describe("happy path", () => {
+    it("returns 200 with data array and pagination envelope", async () => {
+      const doc = {
+        id: VALID_UUID,
+        kind: "SALE",
+        status: "ACCEPTED",
+        idempotencyKey: "ik-1",
+        adeTransactionId: "tx-1",
+        adeProgressive: "001",
+        lotteryCode: null,
+        publicRequest: { paymentMethod: "PC" },
+        createdAt: new Date("2026-04-05T10:00:00.000Z"),
+      };
+      const line = {
+        documentId: VALID_UUID,
+        description: "Caffè",
+        quantity: "1.000",
+        grossUnitPrice: "1.50",
+        vatCode: "22",
+        lineIndex: 0,
+      };
+      setupDbMocks(1, [doc], [line]);
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].id).toBe(VALID_UUID);
+      expect(body.data[0].kind).toBe("SALE");
+      expect(body.data[0].status).toBe("ACCEPTED");
+      expect(body.data[0].paymentMethod).toBe("PC");
+      expect(body.data[0].total).toBe("1.50");
+      expect(body.data[0].lotteryCode).toBeNull();
+      expect(body.data[0].lines).toBeUndefined();
+      expect(body.pagination.total).toBe(1);
+      expect(body.pagination.page).toBe(1);
+    });
+
+    it("includes CORS header in response", async () => {
+      setupDbMocksEmpty();
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    });
+
+    it("returns empty data array when no receipts in range", async () => {
+      setupDbMocksEmpty(0);
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([]);
+      expect(body.pagination.total).toBe(0);
+      expect(body.pagination.hasNextPage).toBe(false);
+    });
+
+    it("calculates total correctly from line quantity and price", async () => {
+      const doc = {
+        id: VALID_UUID,
+        kind: "SALE",
+        status: "ACCEPTED",
+        idempotencyKey: "ik-2",
+        adeTransactionId: null,
+        adeProgressive: null,
+        lotteryCode: null,
+        publicRequest: { paymentMethod: "PE" },
+        createdAt: new Date("2026-04-05T10:00:00.000Z"),
+      };
+      const lines = [
+        {
+          documentId: VALID_UUID,
+          description: "A",
+          quantity: "2.000",
+          grossUnitPrice: "3.50",
+          vatCode: "22",
+          lineIndex: 0,
+        },
+        {
+          documentId: VALID_UUID,
+          description: "B",
+          quantity: "1.000",
+          grossUnitPrice: "1.00",
+          vatCode: "10",
+          lineIndex: 1,
+        },
+      ];
+      setupDbMocks(1, [doc], lines);
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      const body = await res.json();
+      // (2 * 3.50) + (1 * 1.00) = 8.00
+      expect(body.data[0].total).toBe("8.00");
+    });
+
+    it("does not include lines[] in response items", async () => {
+      const doc = {
+        id: VALID_UUID,
+        kind: "SALE",
+        status: "ACCEPTED",
+        idempotencyKey: "ik-3",
+        adeTransactionId: null,
+        adeProgressive: null,
+        lotteryCode: null,
+        publicRequest: { paymentMethod: "PC" },
+        createdAt: new Date("2026-04-05T10:00:00.000Z"),
+      };
+      setupDbMocks(1, [doc], []);
+
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      const body = await res.json();
+      expect(body.data[0].lines).toBeUndefined();
+    });
+  });
+
+  // ── kind filter ───────────────────────────────────────────────────────────
+
+  describe("kind filter", () => {
+    it("accepts kind=SALE without error", async () => {
+      setupDbMocksEmpty();
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: VALID_FROM, to: VALID_TO, kind: "SALE" }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts kind=VOID without error", async () => {
+      setupDbMocksEmpty();
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(
+        makeRequest({ from: VALID_FROM, to: VALID_TO, kind: "VOID" }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns all kinds when kind param is omitted", async () => {
+      setupDbMocksEmpty();
+      const { GET } = await import("@/app/api/v1/receipts/route");
+      const res = await GET(makeRequest({ from: VALID_FROM, to: VALID_TO }));
+
+      expect(res.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements a new `GET /v1/receipts` API endpoint that allows authenticated users to retrieve a paginated list of receipts within a specified date range. This complements the existing POST endpoint and enables use cases like accounting reconciliation, periodic exports, and system synchronization.

## Key Changes

- **New GET endpoint** (`src/app/api/v1/receipts/route.ts`):
  - Accepts required query parameters `from` and `to` (YYYY-MM-DD format)
  - Validates date range (max 31 days, `to` ≥ `from`)
  - Supports optional pagination (`page`, `limit`) with sensible defaults (page 1, limit 20, max 100)
  - Supports optional `kind` filter (SALE or VOID)
  - Implements separate rate limiter (60 requests/hour per API key)
  - Queries documents with status ACCEPTED or VOID_ACCEPTED
  - Calculates receipt totals from line items (quantity × price)
  - Returns paginated response with `hasNextPage` indicator
  - Excludes line details from response (available via GET /v1/receipts/{id})

- **Authentication & Authorization**:
  - Requires valid business API key (rejects management keys with 403)
  - Enforces plan-based API access (402 if not available)
  - Rate limiting with Retry-After header on 429

- **Database queries**:
  - Count query for total matching documents
  - Paginated document fetch with descending creation date ordering
  - Batch line fetch for total calculation (grouped by document ID for O(1) lookup)

- **Documentation** (`src/app/(marketing)/help/api/page.tsx`):
  - Added GET /v1/receipts to API endpoint table
  - Documented query parameters with types and requirements
  - Included curl example and response schema
  - Added rate limit information (60 req/hour)

- **OPTIONS method**: Updated to include GET in allowed methods

- **Comprehensive test suite** (`tests/unit/api-v1-receipt-list.test.ts`):
  - 533 lines covering auth, rate limiting, validation, pagination, and happy path scenarios
  - Tests for edge cases (31-day limit, same-day ranges, empty results)
  - Validates response structure and total calculation logic
  - Mocks all dependencies (auth, DB, rate limiter)

https://claude.ai/code/session_01VSsXUXD3PwCaLY4mzccUCY