### PR TITLE
Extract HeaderNav component with active link detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.2.2",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.2.2",
+      "version": "1.2.5",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.0",

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -7,6 +7,7 @@ import { getOnboardingStatus } from "@/server/onboarding-actions";
 import { signOut } from "@/server/auth-actions";
 import { Button } from "@/components/ui/button";
 import { BottomNav } from "@/components/dashboard/bottom-nav";
+import { HeaderNav } from "@/components/dashboard/header-nav";
 import { PwaInstallPrompt } from "@/components/pwa/install-prompt";
 
 export default async function DashboardLayout({
@@ -48,30 +49,7 @@ export default async function DashboardLayout({
           </form>
 
           <nav className="hidden items-center gap-4 md:flex">
-            <Link
-              href="/dashboard"
-              className="text-muted-foreground hover:text-foreground text-sm"
-            >
-              Dashboard
-            </Link>
-            <Link
-              href="/dashboard/cassa"
-              className="text-muted-foreground hover:text-foreground text-sm font-medium"
-            >
-              Cassa
-            </Link>
-            <Link
-              href="/dashboard/storico"
-              className="text-muted-foreground hover:text-foreground text-sm"
-            >
-              Storico
-            </Link>
-            <Link
-              href="/dashboard/settings"
-              className="text-muted-foreground hover:text-foreground text-sm"
-            >
-              Impostazioni
-            </Link>
+            <HeaderNav />
 
             <form action={signOut}>
               <Button variant="ghost" size="sm" type="submit">

--- a/src/components/dashboard/header-nav.test.tsx
+++ b/src/components/dashboard/header-nav.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { HeaderNav } from "./header-nav";
+
+// --- Mocks ---
+
+const mockUsePathname = vi.fn();
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// --- Tests ---
+
+describe("HeaderNav", () => {
+  it("renderizza i 4 link di navigazione", () => {
+    mockUsePathname.mockReturnValue("/dashboard");
+    render(<HeaderNav />);
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Cassa")).toBeInTheDocument();
+    expect(screen.getByText("Storico")).toBeInTheDocument();
+    expect(screen.getByText("Impostazioni")).toBeInTheDocument();
+  });
+
+  it("i link puntano agli href corretti", () => {
+    mockUsePathname.mockReturnValue("/dashboard");
+    render(<HeaderNav />);
+
+    expect(screen.getByText("Dashboard").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+    expect(screen.getByText("Cassa").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/cassa",
+    );
+    expect(screen.getByText("Storico").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/storico",
+    );
+    expect(screen.getByText("Impostazioni").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/settings",
+    );
+  });
+
+  it("Dashboard è attivo su /dashboard (match esatto)", () => {
+    mockUsePathname.mockReturnValue("/dashboard");
+    render(<HeaderNav />);
+
+    const dashLink = screen.getByText("Dashboard").closest("a");
+    expect(dashLink?.className).toContain("font-semibold");
+    expect(dashLink?.className).toContain("text-foreground");
+  });
+
+  it("Dashboard NON è attivo su /dashboard/cassa (match esatto, non prefix)", () => {
+    mockUsePathname.mockReturnValue("/dashboard/cassa");
+    render(<HeaderNav />);
+
+    const dashLink = screen.getByText("Dashboard").closest("a");
+    expect(dashLink?.className).not.toContain("font-semibold");
+    expect(dashLink?.className).toContain("text-muted-foreground");
+  });
+
+  it("Cassa è attivo su /dashboard/cassa", () => {
+    mockUsePathname.mockReturnValue("/dashboard/cassa");
+    render(<HeaderNav />);
+
+    const cassaLink = screen.getByText("Cassa").closest("a");
+    expect(cassaLink?.className).toContain("font-semibold");
+    expect(cassaLink?.className).toContain("text-foreground");
+  });
+
+  it("Storico è attivo su /dashboard/storico", () => {
+    mockUsePathname.mockReturnValue("/dashboard/storico");
+    render(<HeaderNav />);
+
+    const storicoLink = screen.getByText("Storico").closest("a");
+    expect(storicoLink?.className).toContain("font-semibold");
+    expect(storicoLink?.className).toContain("text-foreground");
+  });
+
+  it("Impostazioni è attivo su /dashboard/settings", () => {
+    mockUsePathname.mockReturnValue("/dashboard/settings");
+    render(<HeaderNav />);
+
+    const settingsLink = screen.getByText("Impostazioni").closest("a");
+    expect(settingsLink?.className).toContain("font-semibold");
+    expect(settingsLink?.className).toContain("text-foreground");
+  });
+
+  it("solo un link è attivo alla volta", () => {
+    mockUsePathname.mockReturnValue("/dashboard/storico");
+    render(<HeaderNav />);
+
+    const links = screen
+      .getAllByRole("link")
+      .filter((l) => l.className.includes("font-semibold"));
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent("Storico");
+  });
+
+  it("i link inattivi hanno classe text-muted-foreground", () => {
+    mockUsePathname.mockReturnValue("/dashboard/cassa");
+    render(<HeaderNav />);
+
+    const inactiveLinks = ["Dashboard", "Storico", "Impostazioni"];
+    for (const label of inactiveLinks) {
+      const link = screen.getByText(label).closest("a");
+      expect(link?.className).toContain("text-muted-foreground");
+    }
+  });
+});

--- a/src/components/dashboard/header-nav.tsx
+++ b/src/components/dashboard/header-nav.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/dashboard", label: "Dashboard", exact: true },
+  { href: "/dashboard/cassa", label: "Cassa", exact: false },
+  { href: "/dashboard/storico", label: "Storico", exact: false },
+  { href: "/dashboard/settings", label: "Impostazioni", exact: false },
+] as const;
+
+export function HeaderNav() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      {NAV_ITEMS.map(({ href, label, exact }) => {
+        const isActive = exact ? pathname === href : pathname.startsWith(href);
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`text-sm transition-colors ${
+              isActive
+                ? "text-foreground font-semibold"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Refactored the dashboard header navigation into a reusable `HeaderNav` component with proper active link detection and comprehensive test coverage.

## Key Changes
- **New Component**: Created `src/components/dashboard/header-nav.tsx` - a client component that renders navigation links with active state styling
  - Implements exact path matching for the Dashboard link (only active at `/dashboard`)
  - Uses prefix matching for other routes (Cassa, Storico, Impostazioni)
  - Applies `font-semibold` and `text-foreground` classes to active links
  - Applies `text-muted-foreground` to inactive links with hover effects

- **New Test Suite**: Added `src/components/dashboard/header-nav.test.tsx` with 9 comprehensive test cases covering:
  - Navigation link rendering
  - Correct href attributes
  - Active state styling for each route
  - Exact path matching behavior (Dashboard doesn't activate on sub-routes)
  - Single active link at a time
  - Inactive link styling

- **Refactored Layout**: Updated `src/app/dashboard/layout.tsx` to use the new `HeaderNav` component, removing 23 lines of inline navigation markup

## Implementation Details
- Uses `usePathname()` hook to determine current route
- Navigation items defined as a constant array with `href`, `label`, and `exact` flag for flexible matching logic
- Maintains existing styling and behavior while improving code organization and testability

https://claude.ai/code/session_01FMHctd3p2QyTmnkuZvbihp