### PR TITLE
Add password change, profile name, and business data editing to setti…

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -64,6 +64,9 @@ sonar.coverage.exclusions=\
   src/components/settings/account-delete-section.tsx,\
   src/components/settings/api-key-section.tsx,\
   src/components/settings/ade-credentials-section.tsx,\
+  src/components/settings/change-password-section.tsx,\
+  src/components/settings/edit-profile-section.tsx,\
+  src/components/settings/edit-business-section.tsx,\
   src/app/dashboard/loading.tsx,\
   src/app/dashboard/cassa/loading.tsx,\
   src/app/dashboard/storico/loading.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -67,6 +67,7 @@ sonar.coverage.exclusions=\
   src/components/settings/change-password-section.tsx,\
   src/components/settings/edit-profile-section.tsx,\
   src/components/settings/edit-business-section.tsx,\
+  src/components/settings/edit-settings-dialog.tsx,\
   src/app/dashboard/loading.tsx,\
   src/app/dashboard/cassa/loading.tsx,\
   src/app/dashboard/storico/loading.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -68,6 +68,7 @@ sonar.coverage.exclusions=\
   src/components/settings/edit-profile-section.tsx,\
   src/components/settings/edit-business-section.tsx,\
   src/components/settings/edit-settings-dialog.tsx,\
+  src/components/settings/edit-ade-credentials-section.tsx,\
   src/app/dashboard/loading.tsx,\
   src/app/dashboard/cassa/loading.tsx,\
   src/app/dashboard/storico/loading.tsx,\

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { signUp } from "@/server/auth-actions";
+import { passwordFieldSchema } from "@/lib/validation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PasswordInput } from "@/components/ui/password-input";
@@ -26,13 +27,7 @@ import {
 const registerSchema = z
   .object({
     email: z.string().email("Inserisci un'email valida."),
-    password: z
-      .string()
-      .min(8, "Almeno 8 caratteri.")
-      .regex(/[A-Z]/, "Serve almeno una maiuscola.")
-      .regex(/[a-z]/, "Serve almeno una minuscola.")
-      .regex(/\d/, "Serve almeno un numero.")
-      .regex(/[^A-Za-z0-9]/, "Serve almeno un carattere speciale (es. !)."),
+    password: passwordFieldSchema,
     confirmPassword: z.string().min(1, "Conferma la password."),
     termsAccepted: z
       .boolean()

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@ import { signOut } from "@/server/auth-actions";
 import { AccountDeleteSection } from "@/components/settings/account-delete-section";
 import { ExportDataSection } from "@/components/settings/export-data-section";
 import { AdeCredentialsSection } from "@/components/settings/ade-credentials-section";
+import { EditAdeCredentialsSection } from "@/components/settings/edit-ade-credentials-section";
 import { EditProfileSection } from "@/components/settings/edit-profile-section";
 import { EditBusinessSection } from "@/components/settings/edit-business-section";
 import { ChangePasswordSection } from "@/components/settings/change-password-section";
@@ -200,8 +201,9 @@ export default async function SettingsPage() {
       )}
 
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Credenziali AdE</CardTitle>
+          {business && <EditAdeCredentialsSection businessId={business.id} />}
         </CardHeader>
         <CardContent>
           <AdeCredentialsSection

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -10,6 +10,9 @@ import { signOut } from "@/server/auth-actions";
 import { AccountDeleteSection } from "@/components/settings/account-delete-section";
 import { ExportDataSection } from "@/components/settings/export-data-section";
 import { AdeCredentialsSection } from "@/components/settings/ade-credentials-section";
+import { EditProfileSection } from "@/components/settings/edit-profile-section";
+import { EditBusinessSection } from "@/components/settings/edit-business-section";
+import { ChangePasswordSection } from "@/components/settings/change-password-section";
 import { getProfilePlan } from "@/server/billing-actions";
 import { canUseApi, isTrialExpired, TRIAL_DAYS } from "@/lib/plans";
 import { PRICE_IDS } from "@/lib/stripe";
@@ -111,8 +114,12 @@ export default async function SettingsPage() {
       <h1 className="text-2xl font-bold">Impostazioni</h1>
 
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Profilo</CardTitle>
+          <EditProfileSection
+            firstName={profile?.firstName ?? null}
+            lastName={profile?.lastName ?? null}
+          />
         </CardHeader>
         <CardContent className="space-y-2">
           <p>
@@ -125,10 +132,28 @@ export default async function SettingsPage() {
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader>
+          <CardTitle>Sicurezza</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChangePasswordSection />
+        </CardContent>
+      </Card>
+
       {business && (
         <Card>
-          <CardHeader>
-            <CardTitle>Attivita</CardTitle>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Attività</CardTitle>
+            <EditBusinessSection
+              businessId={business.id}
+              businessName={business.businessName ?? null}
+              address={business.address ?? null}
+              streetNumber={business.streetNumber ?? null}
+              city={business.city ?? null}
+              province={business.province ?? null}
+              zipCode={business.zipCode ?? null}
+            />
           </CardHeader>
           <CardContent className="space-y-2">
             {business.businessName && (

--- a/src/components/settings/change-password-section.tsx
+++ b/src/components/settings/change-password-section.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod/v4";
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormPasswordField,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { PasswordInput } from "@/components/ui/password-input";
+import { changePassword } from "@/server/profile-actions";
+import { passwordFieldSchema } from "@/lib/validation";
+
+const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Inserisci la password attuale."),
+    newPassword: passwordFieldSchema,
+    confirmPassword: z.string().min(1, "Conferma la nuova password."),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Le password non coincidono.",
+    path: ["confirmPassword"],
+  });
+
+type ChangePasswordData = z.infer<typeof changePasswordSchema>;
+
+export function ChangePasswordSection() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState(false);
+
+  const form = useForm<ChangePasswordData>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      currentPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: ChangePasswordData) => {
+      const fd = new FormData();
+      fd.set("currentPassword", data.currentPassword);
+      fd.set("newPassword", data.newPassword);
+      fd.set("confirmPassword", data.confirmPassword);
+      return changePassword(fd);
+    },
+    onSuccess: (result) => {
+      if (result.error) {
+        form.setError("root", { message: result.error });
+      } else {
+        setSuccessMessage(true);
+        form.reset();
+        setTimeout(() => {
+          setIsOpen(false);
+          setSuccessMessage(false);
+        }, 1500);
+      }
+    },
+    onError: () => {
+      form.setError("root", {
+        message: "Si è verificato un errore. Riprova più tardi.",
+      });
+    },
+  });
+
+  function handleOpen() {
+    form.reset();
+    setSuccessMessage(false);
+    setIsOpen(true);
+  }
+
+  function handleSubmit(data: ChangePasswordData) {
+    mutation.mutate(data);
+  }
+
+  return (
+    <>
+      <p className="text-muted-foreground mb-4 text-sm">
+        Cambia la password di accesso al tuo account.
+      </p>
+      <Button variant="outline" onClick={handleOpen}>
+        Cambia password
+      </Button>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="overscroll-contain">
+          <DialogHeader>
+            <DialogTitle>Cambia password</DialogTitle>
+            <DialogDescription>
+              Inserisci la password attuale e scegline una nuova.
+            </DialogDescription>
+          </DialogHeader>
+
+          {successMessage ? (
+            <p className="py-4 text-center text-sm text-green-600">
+              Password aggiornata con successo.
+            </p>
+          ) : (
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(handleSubmit)}
+                noValidate
+                className="space-y-4"
+              >
+                <FormPasswordField
+                  control={form.control}
+                  name="currentPassword"
+                  label="Password attuale"
+                  autoComplete="current-password"
+                  disabled={mutation.isPending}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="newPassword"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel>Nuova password</FormLabel>
+                      <FormControl>
+                        <PasswordInput
+                          autoComplete="new-password"
+                          disabled={mutation.isPending}
+                          {...field}
+                        />
+                      </FormControl>
+                      {!fieldState.error && (
+                        <FormDescription>
+                          Almeno 8 caratteri con maiuscola, minuscola, numero e
+                          carattere speciale (es.&nbsp;!)
+                        </FormDescription>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormPasswordField
+                  control={form.control}
+                  name="confirmPassword"
+                  label="Conferma nuova password"
+                  autoComplete="new-password"
+                  disabled={mutation.isPending}
+                />
+
+                {form.formState.errors.root && (
+                  <p className="text-destructive text-sm" role="alert">
+                    {form.formState.errors.root.message}
+                  </p>
+                )}
+
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setIsOpen(false)}
+                    disabled={mutation.isPending}
+                  >
+                    Annulla
+                  </Button>
+                  <Button type="submit" disabled={mutation.isPending}>
+                    {mutation.isPending ? "Salvataggio…" : "Salva password"}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/settings/edit-ade-credentials-section.tsx
+++ b/src/components/settings/edit-ade-credentials-section.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod/v4";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+  FormPasswordField,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { saveAdeCredentials } from "@/server/onboarding-actions";
+import { EditSettingsDialog } from "./edit-settings-dialog";
+
+const editAdeCredentialsSchema = z.object({
+  codiceFiscale: z
+    .string()
+    .min(16, "Codice fiscale non valido (16 caratteri).")
+    .max(16, "Codice fiscale non valido (16 caratteri)."),
+  password: z.string().min(1, "La password Fisconline è obbligatoria."),
+  pin: z.string().min(6, "Il PIN deve essere di almeno 6 caratteri."),
+});
+
+type EditAdeCredentialsData = z.infer<typeof editAdeCredentialsSchema>;
+
+interface EditAdeCredentialsSectionProps {
+  readonly businessId: string;
+}
+
+export function EditAdeCredentialsSection({
+  businessId,
+}: EditAdeCredentialsSectionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  const form = useForm<EditAdeCredentialsData>({
+    resolver: zodResolver(editAdeCredentialsSchema),
+    defaultValues: { codiceFiscale: "", password: "", pin: "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: EditAdeCredentialsData) => {
+      const fd = new FormData();
+      fd.set("businessId", businessId);
+      fd.set("codiceFiscale", data.codiceFiscale);
+      fd.set("password", data.password);
+      fd.set("pin", data.pin);
+      return saveAdeCredentials(fd);
+    },
+    onSuccess: (result) => {
+      if (result.error) {
+        form.setError("root", { message: result.error });
+      } else {
+        setIsOpen(false);
+        router.refresh();
+      }
+    },
+    onError: () => {
+      form.setError("root", {
+        message: "Si è verificato un errore. Riprova più tardi.",
+      });
+    },
+  });
+
+  function handleOpen() {
+    form.reset();
+    setIsOpen(true);
+  }
+
+  return (
+    <Form {...form}>
+      <EditSettingsDialog
+        ariaLabel="Modifica credenziali AdE"
+        title="Modifica credenziali Fisconline"
+        description="Inserisci le nuove credenziali. Dopo il salvataggio dovrai riverificare la connessione con l'AdE."
+        isOpen={isOpen}
+        isPending={mutation.isPending}
+        rootError={form.formState.errors.root?.message}
+        onOpen={handleOpen}
+        onClose={() => setIsOpen(false)}
+        onSubmit={form.handleSubmit((data) => mutation.mutate(data))}
+      >
+        {/* codiceFiscale: auto-uppercase transform */}
+        <FormField
+          control={form.control}
+          name="codiceFiscale"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Codice fiscale</FormLabel>
+              <FormControl>
+                <Input
+                  maxLength={16}
+                  spellCheck={false}
+                  autoComplete="off"
+                  disabled={mutation.isPending}
+                  {...field}
+                  onChange={(e) => field.onChange(e.target.value.toUpperCase())}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormPasswordField
+          control={form.control}
+          name="password"
+          label="Password Fisconline"
+          autoComplete="off"
+          disabled={mutation.isPending}
+        />
+
+        <FormPasswordField
+          control={form.control}
+          name="pin"
+          label="PIN Fisconline"
+          autoComplete="off"
+          disabled={mutation.isPending}
+        />
+      </EditSettingsDialog>
+    </Form>
+  );
+}

--- a/src/components/settings/edit-business-section.tsx
+++ b/src/components/settings/edit-business-section.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod/v4";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormInputField } from "@/components/ui/form";
+import { updateBusiness } from "@/server/profile-actions";
+
+const editBusinessSchema = z.object({
+  businessName: z
+    .string()
+    .max(120, "La ragione sociale non può superare 120 caratteri.")
+    .optional()
+    .or(z.literal("")),
+  address: z
+    .string()
+    .min(1, "L'indirizzo è obbligatorio.")
+    .max(150, "L'indirizzo non può superare 150 caratteri."),
+  streetNumber: z.string().optional().or(z.literal("")),
+  city: z
+    .string()
+    .max(80, "Il comune non può superare 80 caratteri.")
+    .optional()
+    .or(z.literal("")),
+  province: z
+    .string()
+    .max(3, "La provincia non può superare 3 caratteri.")
+    .optional()
+    .or(z.literal("")),
+  zipCode: z.string().regex(/^\d{5}$/, "CAP non valido (5 cifre numeriche)."),
+});
+
+type EditBusinessData = z.infer<typeof editBusinessSchema>;
+
+interface EditBusinessSectionProps {
+  businessId: string;
+  businessName: string | null;
+  address: string | null;
+  streetNumber: string | null;
+  city: string | null;
+  province: string | null;
+  zipCode: string | null;
+}
+
+export function EditBusinessSection({
+  businessId,
+  businessName,
+  address,
+  streetNumber,
+  city,
+  province,
+  zipCode,
+}: EditBusinessSectionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  const defaultValues = {
+    businessName: businessName ?? "",
+    address: address ?? "",
+    streetNumber: streetNumber ?? "",
+    city: city ?? "",
+    province: province ?? "",
+    zipCode: zipCode ?? "",
+  };
+
+  const form = useForm<EditBusinessData>({
+    resolver: zodResolver(editBusinessSchema),
+    defaultValues,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: EditBusinessData) => {
+      const fd = new FormData();
+      fd.set("businessId", businessId);
+      fd.set("businessName", data.businessName ?? "");
+      fd.set("address", data.address);
+      fd.set("streetNumber", data.streetNumber ?? "");
+      fd.set("city", data.city ?? "");
+      fd.set("province", data.province ?? "");
+      fd.set("zipCode", data.zipCode);
+      return updateBusiness(fd);
+    },
+    onSuccess: (result) => {
+      if (result.error) {
+        form.setError("root", { message: result.error });
+      } else {
+        setIsOpen(false);
+        router.refresh();
+      }
+    },
+    onError: () => {
+      form.setError("root", {
+        message: "Si è verificato un errore. Riprova più tardi.",
+      });
+    },
+  });
+
+  function handleOpen() {
+    form.reset({
+      businessName: businessName ?? "",
+      address: address ?? "",
+      streetNumber: streetNumber ?? "",
+      city: city ?? "",
+      province: province ?? "",
+      zipCode: zipCode ?? "",
+    });
+    setIsOpen(true);
+  }
+
+  function handleSubmit(data: EditBusinessData) {
+    mutation.mutate(data);
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleOpen}
+        aria-label="Modifica attività"
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="overscroll-contain">
+          <DialogHeader>
+            <DialogTitle>Modifica attività</DialogTitle>
+            <DialogDescription>
+              Aggiorna i dati della tua attività. P.IVA e Codice Fiscale sono
+              gestiti dall&apos;Agenzia delle Entrate e non modificabili qui.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              noValidate
+              className="space-y-4"
+            >
+              <FormInputField
+                control={form.control}
+                name="businessName"
+                label="Ragione sociale"
+                autoComplete="organization"
+                disabled={mutation.isPending}
+              />
+
+              <div className="grid grid-cols-3 gap-3">
+                <div className="col-span-2">
+                  <FormInputField
+                    control={form.control}
+                    name="address"
+                    label="Indirizzo"
+                    autoComplete="street-address"
+                    disabled={mutation.isPending}
+                  />
+                </div>
+                <FormInputField
+                  control={form.control}
+                  name="streetNumber"
+                  label="Civico"
+                  autoComplete="off"
+                  disabled={mutation.isPending}
+                />
+              </div>
+
+              <div className="grid grid-cols-3 gap-3">
+                <div className="col-span-2">
+                  <FormInputField
+                    control={form.control}
+                    name="city"
+                    label="Comune"
+                    autoComplete="address-level2"
+                    disabled={mutation.isPending}
+                  />
+                </div>
+                <FormInputField
+                  control={form.control}
+                  name="province"
+                  label="Prov."
+                  autoComplete="address-level1"
+                  disabled={mutation.isPending}
+                />
+              </div>
+
+              <FormInputField
+                control={form.control}
+                name="zipCode"
+                label="CAP"
+                autoComplete="postal-code"
+                inputMode="numeric"
+                maxLength={5}
+                disabled={mutation.isPending}
+              />
+
+              {form.formState.errors.root && (
+                <p className="text-destructive text-sm" role="alert">
+                  {form.formState.errors.root.message}
+                </p>
+              )}
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setIsOpen(false)}
+                  disabled={mutation.isPending}
+                >
+                  Annulla
+                </Button>
+                <Button type="submit" disabled={mutation.isPending}>
+                  {mutation.isPending ? "Salvataggio…" : "Salva"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/settings/edit-business-section.tsx
+++ b/src/components/settings/edit-business-section.tsx
@@ -6,18 +6,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { Pencil } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Form, FormInputField } from "@/components/ui/form";
 import { updateBusiness } from "@/server/profile-actions";
+import { EditSettingsDialog } from "./edit-settings-dialog";
 
 const editBusinessSchema = z.object({
   businessName: z
@@ -120,116 +111,80 @@ export function EditBusinessSection({
     setIsOpen(true);
   }
 
-  function handleSubmit(data: EditBusinessData) {
-    mutation.mutate(data);
-  }
-
   return (
-    <>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handleOpen}
-        aria-label="Modifica attività"
+    <Form {...form}>
+      <EditSettingsDialog
+        ariaLabel="Modifica attività"
+        title="Modifica attività"
+        description={
+          <>
+            Aggiorna i dati della tua attività. P.IVA e Codice Fiscale sono
+            gestiti dall&apos;Agenzia delle Entrate e non modificabili qui.
+          </>
+        }
+        isOpen={isOpen}
+        isPending={mutation.isPending}
+        rootError={form.formState.errors.root?.message}
+        onOpen={handleOpen}
+        onClose={() => setIsOpen(false)}
+        onSubmit={form.handleSubmit((data) => mutation.mutate(data))}
       >
-        <Pencil className="h-4 w-4" />
-      </Button>
+        <FormInputField
+          control={form.control}
+          name="businessName"
+          label="Ragione sociale"
+          autoComplete="organization"
+          disabled={mutation.isPending}
+        />
 
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent className="overscroll-contain">
-          <DialogHeader>
-            <DialogTitle>Modifica attività</DialogTitle>
-            <DialogDescription>
-              Aggiorna i dati della tua attività. P.IVA e Codice Fiscale sono
-              gestiti dall&apos;Agenzia delle Entrate e non modificabili qui.
-            </DialogDescription>
-          </DialogHeader>
+        <div className="grid grid-cols-3 gap-3">
+          <div className="col-span-2">
+            <FormInputField
+              control={form.control}
+              name="address"
+              label="Indirizzo"
+              autoComplete="street-address"
+              disabled={mutation.isPending}
+            />
+          </div>
+          <FormInputField
+            control={form.control}
+            name="streetNumber"
+            label="Civico"
+            autoComplete="off"
+            disabled={mutation.isPending}
+          />
+        </div>
 
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(handleSubmit)}
-              noValidate
-              className="space-y-4"
-            >
-              <FormInputField
-                control={form.control}
-                name="businessName"
-                label="Ragione sociale"
-                autoComplete="organization"
-                disabled={mutation.isPending}
-              />
+        <div className="grid grid-cols-3 gap-3">
+          <div className="col-span-2">
+            <FormInputField
+              control={form.control}
+              name="city"
+              label="Comune"
+              autoComplete="address-level2"
+              disabled={mutation.isPending}
+            />
+          </div>
+          <FormInputField
+            control={form.control}
+            name="province"
+            label="Prov."
+            autoComplete="address-level1"
+            disabled={mutation.isPending}
+          />
+        </div>
 
-              <div className="grid grid-cols-3 gap-3">
-                <div className="col-span-2">
-                  <FormInputField
-                    control={form.control}
-                    name="address"
-                    label="Indirizzo"
-                    autoComplete="street-address"
-                    disabled={mutation.isPending}
-                  />
-                </div>
-                <FormInputField
-                  control={form.control}
-                  name="streetNumber"
-                  label="Civico"
-                  autoComplete="off"
-                  disabled={mutation.isPending}
-                />
-              </div>
-
-              <div className="grid grid-cols-3 gap-3">
-                <div className="col-span-2">
-                  <FormInputField
-                    control={form.control}
-                    name="city"
-                    label="Comune"
-                    autoComplete="address-level2"
-                    disabled={mutation.isPending}
-                  />
-                </div>
-                <FormInputField
-                  control={form.control}
-                  name="province"
-                  label="Prov."
-                  autoComplete="address-level1"
-                  disabled={mutation.isPending}
-                />
-              </div>
-
-              <FormInputField
-                control={form.control}
-                name="zipCode"
-                label="CAP"
-                autoComplete="postal-code"
-                inputMode="numeric"
-                maxLength={5}
-                disabled={mutation.isPending}
-              />
-
-              {form.formState.errors.root && (
-                <p className="text-destructive text-sm" role="alert">
-                  {form.formState.errors.root.message}
-                </p>
-              )}
-
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setIsOpen(false)}
-                  disabled={mutation.isPending}
-                >
-                  Annulla
-                </Button>
-                <Button type="submit" disabled={mutation.isPending}>
-                  {mutation.isPending ? "Salvataggio…" : "Salva"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-    </>
+        <FormInputField
+          control={form.control}
+          name="zipCode"
+          label="CAP"
+          autoComplete="postal-code"
+          inputMode="numeric"
+          maxLength={5}
+          disabled={mutation.isPending}
+        />
+      </EditSettingsDialog>
+    </Form>
   );
 }

--- a/src/components/settings/edit-business-section.tsx
+++ b/src/components/settings/edit-business-section.tsx
@@ -37,13 +37,13 @@ const editBusinessSchema = z.object({
 type EditBusinessData = z.infer<typeof editBusinessSchema>;
 
 interface EditBusinessSectionProps {
-  businessId: string;
-  businessName: string | null;
-  address: string | null;
-  streetNumber: string | null;
-  city: string | null;
-  province: string | null;
-  zipCode: string | null;
+  readonly businessId: string;
+  readonly businessName: string | null;
+  readonly address: string | null;
+  readonly streetNumber: string | null;
+  readonly city: string | null;
+  readonly province: string | null;
+  readonly zipCode: string | null;
 }
 
 export function EditBusinessSection({

--- a/src/components/settings/edit-profile-section.tsx
+++ b/src/components/settings/edit-profile-section.tsx
@@ -24,8 +24,8 @@ const editProfileSchema = z.object({
 type EditProfileData = z.infer<typeof editProfileSchema>;
 
 interface EditProfileSectionProps {
-  firstName: string | null;
-  lastName: string | null;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
 }
 
 export function EditProfileSection({

--- a/src/components/settings/edit-profile-section.tsx
+++ b/src/components/settings/edit-profile-section.tsx
@@ -6,18 +6,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { Pencil } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Form, FormInputField } from "@/components/ui/form";
 import { updateProfile } from "@/server/profile-actions";
+import { EditSettingsDialog } from "./edit-settings-dialog";
 
 const editProfileSchema = z.object({
   firstName: z
@@ -79,75 +70,35 @@ export function EditProfileSection({
     setIsOpen(true);
   }
 
-  function handleSubmit(data: EditProfileData) {
-    mutation.mutate(data);
-  }
-
   return (
-    <>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handleOpen}
-        aria-label="Modifica profilo"
+    <Form {...form}>
+      <EditSettingsDialog
+        ariaLabel="Modifica profilo"
+        title="Modifica profilo"
+        description="Aggiorna il tuo nome e cognome."
+        isOpen={isOpen}
+        isPending={mutation.isPending}
+        rootError={form.formState.errors.root?.message}
+        onOpen={handleOpen}
+        onClose={() => setIsOpen(false)}
+        onSubmit={form.handleSubmit((data) => mutation.mutate(data))}
       >
-        <Pencil className="h-4 w-4" />
-      </Button>
+        <FormInputField
+          control={form.control}
+          name="firstName"
+          label="Nome"
+          autoComplete="given-name"
+          disabled={mutation.isPending}
+        />
 
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent className="overscroll-contain">
-          <DialogHeader>
-            <DialogTitle>Modifica profilo</DialogTitle>
-            <DialogDescription>
-              Aggiorna il tuo nome e cognome.
-            </DialogDescription>
-          </DialogHeader>
-
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(handleSubmit)}
-              noValidate
-              className="space-y-4"
-            >
-              <FormInputField
-                control={form.control}
-                name="firstName"
-                label="Nome"
-                autoComplete="given-name"
-                disabled={mutation.isPending}
-              />
-
-              <FormInputField
-                control={form.control}
-                name="lastName"
-                label="Cognome"
-                autoComplete="family-name"
-                disabled={mutation.isPending}
-              />
-
-              {form.formState.errors.root && (
-                <p className="text-destructive text-sm" role="alert">
-                  {form.formState.errors.root.message}
-                </p>
-              )}
-
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setIsOpen(false)}
-                  disabled={mutation.isPending}
-                >
-                  Annulla
-                </Button>
-                <Button type="submit" disabled={mutation.isPending}>
-                  {mutation.isPending ? "Salvataggio…" : "Salva"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-    </>
+        <FormInputField
+          control={form.control}
+          name="lastName"
+          label="Cognome"
+          autoComplete="family-name"
+          disabled={mutation.isPending}
+        />
+      </EditSettingsDialog>
+    </Form>
   );
 }

--- a/src/components/settings/edit-profile-section.tsx
+++ b/src/components/settings/edit-profile-section.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod/v4";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormInputField } from "@/components/ui/form";
+import { updateProfile } from "@/server/profile-actions";
+
+const editProfileSchema = z.object({
+  firstName: z
+    .string()
+    .min(1, "Il nome è obbligatorio.")
+    .max(80, "Il nome non può superare 80 caratteri."),
+  lastName: z
+    .string()
+    .min(1, "Il cognome è obbligatorio.")
+    .max(80, "Il cognome non può superare 80 caratteri."),
+});
+
+type EditProfileData = z.infer<typeof editProfileSchema>;
+
+interface EditProfileSectionProps {
+  firstName: string | null;
+  lastName: string | null;
+}
+
+export function EditProfileSection({
+  firstName,
+  lastName,
+}: EditProfileSectionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  const form = useForm<EditProfileData>({
+    resolver: zodResolver(editProfileSchema),
+    defaultValues: {
+      firstName: firstName ?? "",
+      lastName: lastName ?? "",
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: EditProfileData) => {
+      const fd = new FormData();
+      fd.set("firstName", data.firstName);
+      fd.set("lastName", data.lastName);
+      return updateProfile(fd);
+    },
+    onSuccess: (result) => {
+      if (result.error) {
+        form.setError("root", { message: result.error });
+      } else {
+        setIsOpen(false);
+        router.refresh();
+      }
+    },
+    onError: () => {
+      form.setError("root", {
+        message: "Si è verificato un errore. Riprova più tardi.",
+      });
+    },
+  });
+
+  function handleOpen() {
+    form.reset({ firstName: firstName ?? "", lastName: lastName ?? "" });
+    setIsOpen(true);
+  }
+
+  function handleSubmit(data: EditProfileData) {
+    mutation.mutate(data);
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleOpen}
+        aria-label="Modifica profilo"
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="overscroll-contain">
+          <DialogHeader>
+            <DialogTitle>Modifica profilo</DialogTitle>
+            <DialogDescription>
+              Aggiorna il tuo nome e cognome.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              noValidate
+              className="space-y-4"
+            >
+              <FormInputField
+                control={form.control}
+                name="firstName"
+                label="Nome"
+                autoComplete="given-name"
+                disabled={mutation.isPending}
+              />
+
+              <FormInputField
+                control={form.control}
+                name="lastName"
+                label="Cognome"
+                autoComplete="family-name"
+                disabled={mutation.isPending}
+              />
+
+              {form.formState.errors.root && (
+                <p className="text-destructive text-sm" role="alert">
+                  {form.formState.errors.root.message}
+                </p>
+              )}
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setIsOpen(false)}
+                  disabled={mutation.isPending}
+                >
+                  Annulla
+                </Button>
+                <Button type="submit" disabled={mutation.isPending}>
+                  {mutation.isPending ? "Salvataggio…" : "Salva"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/settings/edit-settings-dialog.tsx
+++ b/src/components/settings/edit-settings-dialog.tsx
@@ -12,16 +12,16 @@ import {
 } from "@/components/ui/dialog";
 
 interface EditSettingsDialogProps {
-  ariaLabel: string;
-  title: string;
-  description: React.ReactNode;
-  isOpen: boolean;
-  isPending: boolean;
-  rootError?: string;
-  onOpen: () => void;
-  onClose: () => void;
-  onSubmit: React.FormEventHandler<HTMLFormElement>;
-  children: React.ReactNode;
+  readonly ariaLabel: string;
+  readonly title: string;
+  readonly description: React.ReactNode;
+  readonly isOpen: boolean;
+  readonly isPending: boolean;
+  readonly rootError?: string;
+  readonly onOpen: () => void;
+  readonly onClose: () => void;
+  readonly onSubmit: React.FormEventHandler<HTMLFormElement>;
+  readonly children: React.ReactNode;
 }
 
 /**

--- a/src/components/settings/edit-settings-dialog.tsx
+++ b/src/components/settings/edit-settings-dialog.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface EditSettingsDialogProps {
+  ariaLabel: string;
+  title: string;
+  description: React.ReactNode;
+  isOpen: boolean;
+  isPending: boolean;
+  rootError?: string;
+  onOpen: () => void;
+  onClose: () => void;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared shell for settings edit dialogs: renders the pencil trigger button,
+ * the Dialog with header, a <form> wrapper with error display and footer buttons.
+ * The parent is responsible for wrapping this with <Form {...form}> (RHF context).
+ */
+export function EditSettingsDialog({
+  ariaLabel,
+  title,
+  description,
+  isOpen,
+  isPending,
+  rootError,
+  onOpen,
+  onClose,
+  onSubmit,
+  children,
+}: EditSettingsDialogProps) {
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onOpen}
+        aria-label={ariaLabel}
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="overscroll-contain">
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={onSubmit} noValidate className="space-y-4">
+            {children}
+
+            {rootError && (
+              <p className="text-destructive text-sm" role="alert">
+                {rootError}
+              </p>
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isPending}
+              >
+                Annulla
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Salvataggio…" : "Salva"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,3 +1,18 @@
+import { z } from "zod/v4";
+
+/**
+ * Shared Zod schema for password fields.
+ * Used by the registration form and the change-password form to ensure
+ * identical validation rules without duplication.
+ */
+export const passwordFieldSchema = z
+  .string()
+  .min(8, "Almeno 8 caratteri.")
+  .regex(/[A-Z]/, "Serve almeno una maiuscola.")
+  .regex(/[a-z]/, "Serve almeno una minuscola.")
+  .regex(/\d/, "Serve almeno un numero.")
+  .regex(/[^A-Za-z0-9]/, "Serve almeno un carattere speciale (es. !).");
+
 /**
  * Validates password strength:
  * - At least 8 characters

--- a/src/server/profile-actions.test.ts
+++ b/src/server/profile-actions.test.ts
@@ -1,0 +1,327 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Hoisted mocks ---
+
+const {
+  mockGetUser,
+  mockSignInWithPassword,
+  mockUpdateUser,
+  mockCheck,
+  mockRevalidatePath,
+  mockGetClientIp,
+  mockHeaders,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockSignInWithPassword: vi.fn(),
+  mockUpdateUser: vi.fn(),
+  mockCheck: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+  mockGetClientIp: vi.fn().mockReturnValue("1.2.3.4"),
+  mockHeaders: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+vi.mock("next/headers", () => ({ headers: mockHeaders }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: mockGetUser,
+      signInWithPassword: mockSignInWithPassword,
+      updateUser: mockUpdateUser,
+    },
+  }),
+}));
+
+vi.mock("@/lib/get-client-ip", () => ({ getClientIp: mockGetClientIp }));
+
+const mockDbUpdate = vi.fn();
+const mockDbUpdateSet = vi.fn().mockReturnValue({ where: vi.fn() });
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({
+    update: mockDbUpdate,
+  }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  profiles: "profiles-table",
+  businesses: "businesses-table",
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: vi.fn(), and: vi.fn() }));
+
+// checkBusinessOwnership mock: null = ownership confirmed
+const mockCheckBusinessOwnership = vi.fn().mockResolvedValue(null);
+vi.mock("@/lib/server-auth", () => ({
+  getAuthenticatedUser: vi.fn().mockImplementation(async () => {
+    const result = await mockGetUser();
+    if (!result?.data?.user) throw new Error("Not authenticated");
+    return result.data.user;
+  }),
+  checkBusinessOwnership: mockCheckBusinessOwnership,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockCheck };
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// --- Helpers ---
+
+function formData(entries: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+const FAKE_USER = { id: "user-123", email: "test@example.com" };
+const FAKE_HEADERS = {} as Parameters<typeof mockHeaders>[0];
+
+// --- Tests ---
+
+describe("profile-actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: FAKE_USER } });
+    mockCheck.mockReturnValue({ success: true });
+    mockHeaders.mockResolvedValue(FAKE_HEADERS);
+    mockDbUpdate.mockReturnValue({ set: mockDbUpdateSet });
+    mockCheckBusinessOwnership.mockResolvedValue(null);
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateProfile
+  // ---------------------------------------------------------------------------
+
+  describe("updateProfile", () => {
+    const VALID = { firstName: "Mario", lastName: "Rossi" };
+
+    it("returns empty object on success", async () => {
+      const { updateProfile } = await import("./profile-actions");
+      const result = await updateProfile(formData(VALID));
+      expect(result).toEqual({});
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dashboard/settings");
+    });
+
+    it("returns error for missing firstName", async () => {
+      const { updateProfile } = await import("./profile-actions");
+      const result = await updateProfile(formData({ ...VALID, firstName: "" }));
+      expect(result.error).toMatch(/nome/i);
+    });
+
+    it("returns error for missing lastName", async () => {
+      const { updateProfile } = await import("./profile-actions");
+      const result = await updateProfile(formData({ ...VALID, lastName: "" }));
+      expect(result.error).toMatch(/cognome/i);
+    });
+
+    it("returns error when firstName exceeds 80 chars", async () => {
+      const { updateProfile } = await import("./profile-actions");
+      const result = await updateProfile(
+        formData({ ...VALID, firstName: "A".repeat(81) }),
+      );
+      expect(result.error).toMatch(/80/);
+    });
+
+    it("returns error when lastName exceeds 80 chars", async () => {
+      const { updateProfile } = await import("./profile-actions");
+      const result = await updateProfile(
+        formData({ ...VALID, lastName: "A".repeat(81) }),
+      );
+      expect(result.error).toMatch(/80/);
+    });
+
+    it("returns rate limit error when limiter rejects", async () => {
+      mockCheck.mockReturnValue({ success: false });
+      const { updateProfile } = await import("./profile-actions");
+      const result = await updateProfile(formData(VALID));
+      expect(result.error).toMatch(/troppi/i);
+    });
+
+    it("throws when user is unauthenticated", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { updateProfile } = await import("./profile-actions");
+      await expect(updateProfile(formData(VALID))).rejects.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateBusiness
+  // ---------------------------------------------------------------------------
+
+  describe("updateBusiness", () => {
+    const VALID = {
+      businessId: "biz-uuid",
+      address: "Via Roma 1",
+      zipCode: "00100",
+    };
+
+    it("returns empty object on success", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(formData(VALID));
+      expect(result).toEqual({});
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dashboard/settings");
+    });
+
+    it("returns error for missing businessId", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, businessId: "" }),
+      );
+      expect(result.error).toMatch(/business id/i);
+    });
+
+    it("returns error for missing address", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(formData({ ...VALID, address: "" }));
+      expect(result.error).toMatch(/indirizzo/i);
+    });
+
+    it("returns error for invalid zipCode (non-5-digit)", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, zipCode: "123" }),
+      );
+      expect(result.error).toMatch(/CAP/i);
+    });
+
+    it("returns error for non-numeric zipCode", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, zipCode: "AB123" }),
+      );
+      expect(result.error).toMatch(/CAP/i);
+    });
+
+    it("returns error when businessName exceeds 120 chars", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, businessName: "A".repeat(121) }),
+      );
+      expect(result.error).toMatch(/120/);
+    });
+
+    it("returns error when province exceeds 3 chars", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, province: "XXXX" }),
+      );
+      expect(result.error).toMatch(/provincia/i);
+    });
+
+    it("returns ownership error when checkBusinessOwnership fails", async () => {
+      mockCheckBusinessOwnership.mockResolvedValue({
+        error: "Business non trovato o non autorizzato.",
+      });
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(formData(VALID));
+      expect(result.error).toMatch(/non autorizzato/i);
+    });
+
+    it("returns rate limit error when limiter rejects", async () => {
+      mockCheck.mockReturnValue({ success: false });
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(formData(VALID));
+      expect(result.error).toMatch(/troppi/i);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // changePassword
+  // ---------------------------------------------------------------------------
+
+  describe("changePassword", () => {
+    const VALID = {
+      currentPassword: "OldPass1!",
+      newPassword: "NewPass1!",
+      confirmPassword: "NewPass1!",
+    };
+
+    beforeEach(() => {
+      mockSignInWithPassword.mockResolvedValue({ error: null });
+      mockUpdateUser.mockResolvedValue({ error: null });
+    });
+
+    it("returns empty object on success", async () => {
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(formData(VALID));
+      expect(result).toEqual({});
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: FAKE_USER.email,
+        password: VALID.currentPassword,
+      });
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        password: VALID.newPassword,
+      });
+    });
+
+    it("returns error for missing currentPassword", async () => {
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(
+        formData({ ...VALID, currentPassword: "" }),
+      );
+      expect(result.error).toMatch(/password attuale/i);
+    });
+
+    it("returns error for weak new password (no uppercase)", async () => {
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(
+        formData({
+          ...VALID,
+          newPassword: "weakpass1!",
+          confirmPassword: "weakpass1!",
+        }),
+      );
+      expect(result.error).toMatch(/sicura/i);
+    });
+
+    it("returns error when confirmPassword does not match", async () => {
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(
+        formData({ ...VALID, confirmPassword: "Different1!" }),
+      );
+      expect(result.error).toMatch(/coincidono/i);
+    });
+
+    it("returns error when current password is wrong", async () => {
+      mockSignInWithPassword.mockResolvedValue({
+        error: { message: "Invalid login credentials" },
+      });
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(formData(VALID));
+      expect(result.error).toMatch(/password attuale non corretta/i);
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("returns error when updateUser fails", async () => {
+      mockUpdateUser.mockResolvedValue({
+        error: { message: "update failed" },
+      });
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(formData(VALID));
+      expect(result.error).toMatch(/aggiornamento/i);
+    });
+
+    it("returns rate limit error when limiter rejects", async () => {
+      mockCheck.mockReturnValue({ success: false });
+      const { changePassword } = await import("./profile-actions");
+      const result = await changePassword(formData(VALID));
+      expect(result.error).toMatch(/troppi/i);
+    });
+
+    it("throws when user is unauthenticated", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { changePassword } = await import("./profile-actions");
+      await expect(changePassword(formData(VALID))).rejects.toThrow();
+    });
+  });
+});

--- a/src/server/profile-actions.ts
+++ b/src/server/profile-actions.ts
@@ -1,0 +1,168 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { getDb } from "@/db";
+import { profiles, businesses } from "@/db/schema";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import {
+  getAuthenticatedUser,
+  checkBusinessOwnership,
+} from "@/lib/server-auth";
+import { isStrongPassword } from "@/lib/validation";
+import { getClientIp } from "@/lib/get-client-ip";
+import { RateLimiter } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+export type ProfileActionResult = { error?: string };
+
+const updateProfileLimiter = new RateLimiter({
+  maxRequests: 10,
+  windowMs: 60 * 60 * 1000, // 1 hour
+});
+
+const updateBusinessLimiter = new RateLimiter({
+  maxRequests: 10,
+  windowMs: 60 * 60 * 1000, // 1 hour
+});
+
+const changePasswordLimiter = new RateLimiter({
+  maxRequests: 5,
+  windowMs: 15 * 60 * 1000, // 15 minutes — same threshold as other auth actions
+});
+
+export async function updateProfile(
+  formData: FormData,
+): Promise<ProfileActionResult> {
+  const user = await getAuthenticatedUser();
+
+  const firstName = (formData.get("firstName") as string)?.trim();
+  const lastName = (formData.get("lastName") as string)?.trim();
+
+  if (!firstName) return { error: "Il nome è obbligatorio." };
+  if (firstName.length > 80)
+    return { error: "Il nome non può superare 80 caratteri." };
+  if (!lastName) return { error: "Il cognome è obbligatorio." };
+  if (lastName.length > 80)
+    return { error: "Il cognome non può superare 80 caratteri." };
+
+  const rateLimitResult = updateProfileLimiter.check(
+    `updateProfile:${user.id}`,
+  );
+  if (!rateLimitResult.success) {
+    logger.warn({ userId: user.id }, "updateProfile rate limit exceeded");
+    return { error: "Troppi tentativi. Riprova tra qualche minuto." };
+  }
+
+  const db = getDb();
+  await db
+    .update(profiles)
+    .set({ firstName, lastName })
+    .where(eq(profiles.authUserId, user.id));
+
+  revalidatePath("/dashboard/settings");
+  return {};
+}
+
+export async function updateBusiness(
+  formData: FormData,
+): Promise<ProfileActionResult> {
+  const user = await getAuthenticatedUser();
+
+  const businessId = (formData.get("businessId") as string)?.trim();
+  const businessName = (formData.get("businessName") as string)?.trim() || null;
+  const address = (formData.get("address") as string)?.trim();
+  const streetNumber = (formData.get("streetNumber") as string)?.trim() || null;
+  const city = (formData.get("city") as string)?.trim() || null;
+  const province = (formData.get("province") as string)?.trim() || null;
+  const zipCode = (formData.get("zipCode") as string)?.trim();
+
+  if (!businessId) return { error: "Business ID mancante." };
+  if (businessName && businessName.length > 120)
+    return { error: "La ragione sociale non può superare 120 caratteri." };
+  if (!address) return { error: "L'indirizzo è obbligatorio." };
+  if (address.length > 150)
+    return { error: "L'indirizzo non può superare 150 caratteri." };
+  if (city && city.length > 80)
+    return { error: "Il comune non può superare 80 caratteri." };
+  if (province && province.length > 3)
+    return { error: "La provincia non può superare 3 caratteri." };
+  if (!zipCode || !/^\d{5}$/.test(zipCode))
+    return { error: "CAP non valido (5 cifre numeriche)." };
+
+  const ownershipError = await checkBusinessOwnership(user.id, businessId);
+  if (ownershipError) return ownershipError;
+
+  const rateLimitResult = updateBusinessLimiter.check(
+    `updateBusiness:${user.id}`,
+  );
+  if (!rateLimitResult.success) {
+    logger.warn({ userId: user.id }, "updateBusiness rate limit exceeded");
+    return { error: "Troppi tentativi. Riprova tra qualche minuto." };
+  }
+
+  const db = getDb();
+  await db
+    .update(businesses)
+    .set({ businessName, address, streetNumber, city, province, zipCode })
+    .where(eq(businesses.id, businessId));
+
+  revalidatePath("/dashboard/settings");
+  return {};
+}
+
+export async function changePassword(
+  formData: FormData,
+): Promise<ProfileActionResult> {
+  const user = await getAuthenticatedUser();
+
+  const currentPassword = formData.get("currentPassword") as string;
+  const newPassword = formData.get("newPassword") as string;
+  const confirmPassword = formData.get("confirmPassword") as string;
+
+  if (!currentPassword) return { error: "Inserisci la password attuale." };
+  if (!newPassword || !isStrongPassword(newPassword)) {
+    return {
+      error:
+        "La nuova password non è sicura. Usa almeno 8 caratteri con maiuscola, minuscola, numero e carattere speciale.",
+    };
+  }
+  if (newPassword !== confirmPassword) {
+    return { error: "Le password non coincidono." };
+  }
+
+  const hdrs = await headers();
+  const ip = getClientIp(hdrs);
+  const rateLimitResult = changePasswordLimiter.check(`changePassword:${ip}`);
+  if (!rateLimitResult.success) {
+    logger.warn({ ip }, "changePassword rate limit exceeded");
+    return { error: "Troppi tentativi. Riprova tra qualche minuto." };
+  }
+
+  const email = user.email;
+  if (!email) return { error: "Email utente non disponibile." };
+
+  // Re-authenticate to verify the current password before allowing a change.
+  const supabase = await createServerSupabaseClient();
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email,
+    password: currentPassword,
+  });
+  if (signInError) {
+    return { error: "Password attuale non corretta." };
+  }
+
+  const { error: updateError } = await supabase.auth.updateUser({
+    password: newPassword,
+  });
+  if (updateError) {
+    logger.error(
+      { err: updateError, userId: user.id },
+      "changePassword: updateUser failed",
+    );
+    return { error: "Aggiornamento password fallito. Riprova." };
+  }
+
+  return {};
+}

--- a/tests/unit/settings-page-card-state.test.ts
+++ b/tests/unit/settings-page-card-state.test.ts
@@ -96,6 +96,9 @@ vi.mock("@/components/settings/edit-business-section", () => ({
 vi.mock("@/components/settings/change-password-section", () => ({
   ChangePasswordSection: () => null,
 }));
+vi.mock("@/components/settings/edit-ade-credentials-section", () => ({
+  EditAdeCredentialsSection: () => null,
+}));
 vi.mock("@/types/cassa", () => ({
   VAT_DESCRIPTIONS: {},
   VAT_CODES: [],

--- a/tests/unit/settings-page-card-state.test.ts
+++ b/tests/unit/settings-page-card-state.test.ts
@@ -87,6 +87,15 @@ vi.mock("@/components/settings/export-data-section", () => ({
 vi.mock("@/components/settings/account-delete-section", () => ({
   AccountDeleteSection: () => null,
 }));
+vi.mock("@/components/settings/edit-profile-section", () => ({
+  EditProfileSection: () => null,
+}));
+vi.mock("@/components/settings/edit-business-section", () => ({
+  EditBusinessSection: () => null,
+}));
+vi.mock("@/components/settings/change-password-section", () => ({
+  ChangePasswordSection: () => null,
+}));
 vi.mock("@/types/cassa", () => ({
   VAT_DESCRIPTIONS: {},
   VAT_CODES: [],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
         "src/components/settings/edit-profile-section.tsx", // UI client component — form + dialog, pure UI
         "src/components/settings/edit-business-section.tsx", // UI client component — form + dialog, pure UI
         "src/components/settings/edit-settings-dialog.tsx", // UI client component — shared dialog shell, pure UI
+        "src/components/settings/edit-ade-credentials-section.tsx", // UI client component — form + dialog, pure UI
         "src/sw.ts", // service worker entry point — pure infrastructure, no testable logic
         "src/app/offline/page.tsx", // static offline shell — pure UI, no logic
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
         "src/components/settings/account-delete-section.tsx", // UI client component — mutation + dialog, pure UI
         "src/components/settings/api-key-section.tsx", // UI client component — mutation + dialog, pure UI
         "src/components/settings/ade-credentials-section.tsx", // UI client component — verify action + timer, pure UI
+        "src/components/settings/change-password-section.tsx", // UI client component — form + dialog, pure UI
+        "src/components/settings/edit-profile-section.tsx", // UI client component — form + dialog, pure UI
+        "src/components/settings/edit-business-section.tsx", // UI client component — form + dialog, pure UI
         "src/sw.ts", // service worker entry point — pure infrastructure, no testable logic
         "src/app/offline/page.tsx", // static offline shell — pure UI, no logic
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         "src/components/settings/change-password-section.tsx", // UI client component — form + dialog, pure UI
         "src/components/settings/edit-profile-section.tsx", // UI client component — form + dialog, pure UI
         "src/components/settings/edit-business-section.tsx", // UI client component — form + dialog, pure UI
+        "src/components/settings/edit-settings-dialog.tsx", // UI client component — shared dialog shell, pure UI
         "src/sw.ts", // service worker entry point — pure infrastructure, no testable logic
         "src/app/offline/page.tsx", // static offline shell — pure UI, no logic
       ],


### PR DESCRIPTION
…ngs page

- Extract `passwordFieldSchema` (Zod) from register page to `src/lib/validation.ts` so the same validation rules are shared with the new change-password form
- Add three server actions in `src/server/profile-actions.ts`: `updateProfile` (name), `updateBusiness` (address fields), `changePassword` (re-authenticates with current password before updating)
- Add three client components: `EditProfileSection`, `EditBusinessSection`, `ChangePasswordSection` — each renders a pencil/button affordance that opens a Dialog (per-card edit pattern, following GitHub/Stripe convention)
- Wire components into settings page: pencil in Profilo and Attività card headers; new Sicurezza card for password change
- 24 new unit tests for the server actions; settings-page test updated with mocks
- Rate limiting: profile/business 10/h per-user; password 5/15min per-IP

https://claude.ai/code/session_01643TKwyVJuPiZT6fS5Bivy