### PR TITLE
Enable promotion codes in Stripe checkout sessions

### DIFF
--- a/src/app/api/stripe/checkout/route.test.ts
+++ b/src/app/api/stripe/checkout/route.test.ts
@@ -236,6 +236,21 @@ describe("POST /api/stripe/checkout", () => {
     expect(body.url).toBe("https://checkout.stripe.com/session");
   });
 
+  it("passa allow_promotion_codes: true alla checkout session", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([{ stripeCustomerId: "cus_existing" }]),
+    );
+
+    await POST(makeRequest({ priceId: "price_pro" }));
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ allow_promotion_codes: true }),
+    );
+  });
+
   it("passa subscription_data.metadata con userId alla checkout session", async () => {
     mockGetAuthenticatedUser.mockResolvedValue({
       id: "user-42",

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -117,6 +117,7 @@ export async function POST(req: Request): Promise<Response> {
       customer: stripeCustomerId ?? undefined,
       line_items: [{ price: priceId, quantity: 1 }],
       mode: "subscription",
+      allow_promotion_codes: true,
       subscription_data: {
         metadata: { userId: user.id },
       },


### PR DESCRIPTION
## Summary
Enable customers to apply promotion codes during the Stripe checkout process by setting `allow_promotion_codes: true` in the checkout session configuration.

## Changes
- Added `allow_promotion_codes: true` parameter to the Stripe checkout session creation in the POST handler
- Added corresponding test case to verify the parameter is passed correctly to the Stripe API

## Implementation Details
The `allow_promotion_codes` flag is now included in all checkout sessions, allowing customers to enter and apply discount codes at checkout time. This is a straightforward configuration change to the Stripe session parameters with no breaking changes to existing functionality.

https://claude.ai/code/session_01MGujn4S4Kyq3c7qESyAGSX