### PR TITLE
Add comprehensive help center articles for ScontrinoZero

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,6 +30,12 @@ sonar.coverage.exclusions=\
   src/app/(marketing)/help/errori-ade/page.tsx,\
   src/app/(marketing)/help/sicurezza-credenziali/page.tsx,\
   src/app/(marketing)/help/installare-app/page.tsx,\
+  src/app/(marketing)/help/chiusura-giornaliera/page.tsx,\
+  src/app/(marketing)/help/cassetto-fiscale/page.tsx,\
+  src/app/(marketing)/help/normativa-pos-2026/page.tsx,\
+  src/app/(marketing)/help/piani-e-prezzi/page.tsx,\
+  src/app/(marketing)/help/storico-ed-esportazione/page.tsx,\
+  src/app/(marketing)/help/aliquote-iva/page.tsx,\
   src/app/(marketing)/termini/page.tsx,\
   src/app/(marketing)/cookie-policy/page.tsx,\
   src/app/(marketing)/cookie-policy/v01/page.tsx,\

--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -1,0 +1,294 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const metadata: Metadata = {
+  title:
+    "Come gestire aliquote IVA, reparti e metodi di pagamento | ScontrinoZero Help",
+  description:
+    "Guida alla configurazione delle aliquote IVA (4%, 10%, 22%, esente), dei reparti e dei metodi di pagamento in ScontrinoZero.",
+};
+
+export default function AliquoteIvaPage() {
+  return (
+    <section className="px-4 py-16">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Help Center
+        </Link>
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Come gestire aliquote IVA, reparti e metodi di pagamento
+          </h1>
+          <Badge variant="secondary">Configurazione attività</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero supporta tutte le aliquote IVA italiane e permette di
+          configurare reparti merceologici e metodi di pagamento. Questa guida
+          spiega come impostarli correttamente in base alla tua attività.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> aprile 2026
+        </p>
+
+        {/* ─── Aliquote IVA in Italia ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Le aliquote IVA in Italia
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il sistema IVA italiano prevede quattro aliquote principali:
+        </p>
+        <div className="mt-3 overflow-x-auto">
+          <table className="text-muted-foreground w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left">
+                <th className="pb-2 font-semibold text-foreground">
+                  Aliquota
+                </th>
+                <th className="pb-2 font-semibold text-foreground">
+                  Esempi di applicazione
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              <tr>
+                <td className="py-2 font-medium text-foreground">4%</td>
+                <td className="py-2">
+                  Alimenti di prima necessità, libri, giornali, farmaci
+                </td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">10%</td>
+                <td className="py-2">
+                  Alimenti, bevande, somministrazione al tavolo, spettacoli
+                </td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">22%</td>
+                <td className="py-2">
+                  Prodotti generici, abbigliamento, elettronica, servizi
+                </td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">Esente</td>
+                <td className="py-2">
+                  Operazioni esenti ex art. 10 DPR 633/72 (servizi finanziari,
+                  sanitari, formativi, ecc.)
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Se sei in <strong>regime forfettario</strong>, tutte le vendite sono
+          fuori campo IVA. Consulta la guida dedicata per la configurazione
+          corretta.
+        </p>
+
+        {/* ─── Configurare le aliquote ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Come configurare le aliquote in ScontrinoZero
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Le aliquote IVA sono pre-caricate nel sistema. Non devi attivarle
+          separatamente: compaiono come opzione ogni volta che aggiungi una
+          riga allo scontrino o crei un prodotto nel catalogo.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Al momento dell&apos;emissione, per ogni riga dello scontrino
+          seleziona l&apos;aliquota corretta dal menu a tendina. ScontrinoZero
+          calcola automaticamente:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            L&apos;importo IVA per ciascuna aliquota (prezzi IVA inclusa).
+          </li>
+          <li>Il totale del documento con riepilogo per aliquota.</li>
+          <li>
+            La struttura corretta per la trasmissione al portale AdE (codici
+            natura IVA conformi al tracciato DCO).
+          </li>
+        </ul>
+
+        {/* ─── Reparti merceologici ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Reparti merceologici</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Puoi organizzare i prodotti in <strong>reparti</strong> (es.
+          &quot;Alimentari&quot;, &quot;Bevande&quot;, &quot;Abbigliamento&quot;)
+          ai quali associare un&apos;aliquota IVA predefinita. In questo modo,
+          quando aggiungi una riga allo scontrino e selezioni il reparto,
+          l&apos;aliquota viene impostata automaticamente.
+        </p>
+        <h3 className="mt-5 text-base font-semibold">
+          Come creare un reparto
+        </h3>
+        <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Vai in{" "}
+            <strong>Dashboard &gt; Impostazioni &gt; Reparti</strong>.
+          </li>
+          <li>
+            Clicca su <strong>Aggiungi reparto</strong>.
+          </li>
+          <li>Inserisci nome e aliquota IVA predefinita.</li>
+          <li>
+            Salva. Il reparto sarà disponibile durante l&apos;emissione e
+            nella creazione di prodotti nel catalogo.
+          </li>
+        </ol>
+
+        {/* ─── Metodi di pagamento ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Metodi di pagamento</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero supporta tutti i metodi di pagamento previsti dal
+          tracciato DCO dell&apos;AdE:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Contante</strong>
+          </li>
+          <li>
+            <strong>Carta</strong> (credito, debito, prepagata)
+          </li>
+          <li>
+            <strong>Assegno</strong>
+          </li>
+          <li>
+            <strong>Ticket / Buono pasto</strong>
+          </li>
+          <li>
+            <strong>Altro</strong> (per metodi non standard: valore, omaggio,
+            ecc.)
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Al momento dell&apos;emissione, seleziona il metodo usato dal
+          cliente. I dati vengono trasmessi all&apos;AdE come parte del
+          documento commerciale.
+        </p>
+
+        {/* ─── Pagamento misto ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Pagamento misto (contante + carta)
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Se il cliente paga una parte in contante e una parte con carta, puoi
+          registrare entrambi i metodi sullo stesso scontrino:
+        </p>
+        <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Aggiungi le righe dello scontrino normalmente.
+          </li>
+          <li>
+            Nella schermata di pagamento, seleziona{" "}
+            <strong>Pagamento misto</strong>.
+          </li>
+          <li>
+            Inserisci l&apos;importo pagato in contante: ScontrinoZero
+            calcola automaticamente la quota residua da addebitare su carta.
+          </li>
+          <li>
+            Conferma ed emetti. Il documento trasmesso all&apos;AdE riporta
+            la ripartizione corretta tra i due metodi.
+          </li>
+        </ol>
+
+        {/* ─── Errori frequenti ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Errori frequenti</h2>
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-sm font-medium">
+              Ho selezionato l&apos;aliquota sbagliata su uno scontrino già
+              emesso
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Non è possibile modificare uno scontrino già trasmesso. Devi
+              annullarlo ed emettere un nuovo scontrino con l&apos;aliquota
+              corretta. Consulta la guida{" "}
+              <Link
+                href="/help/annullare-scontrino"
+                className="text-primary hover:underline"
+              >
+                Annullare uno scontrino
+              </Link>{" "}
+              per i dettagli.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Sono in regime forfettario ma vedo le opzioni IVA
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Verifica la configurazione del regime fiscale in{" "}
+              <strong>Impostazioni &gt; Attività</strong>. Se hai selezionato
+              &quot;Regime forfettario&quot;, le righe dello scontrino vengono
+              automaticamente impostate come fuori campo IVA (codice natura
+              N2.2) e le opzioni IVA vengono nascoste.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Non trovo l&apos;aliquota del 5% o altre aliquote ridotte
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Le aliquote del 5% e altre aliquote temporanee o speciali sono
+              gestite tramite il campo <strong>Altro</strong> con indicazione
+              manuale. Contattaci se hai necessità specifiche non coperte dalle
+              aliquote standard.
+            </p>
+          </div>
+        </div>
+
+        {/* ─── Articoli correlati ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+        <ul className="mt-3 space-y-1 text-sm">
+          <li>
+            <Link
+              href="/help/regime-forfettario"
+              className="text-primary hover:underline"
+            >
+              Regime forfettario: configurazione IVA corretta
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/primo-scontrino"
+              className="text-primary hover:underline"
+            >
+              Come emettere il primo scontrino elettronico
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/annullare-scontrino"
+              className="text-primary hover:underline"
+            >
+              Annullare uno scontrino: quando si può e come fare
+            </Link>
+          </li>
+        </ul>
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -49,35 +49,33 @@ export default function AliquoteIvaPage() {
           <table className="text-muted-foreground w-full text-sm">
             <thead>
               <tr className="border-border border-b text-left">
-                <th className="pb-2 font-semibold text-foreground">
-                  Aliquota
-                </th>
-                <th className="pb-2 font-semibold text-foreground">
+                <th className="text-foreground pb-2 font-semibold">Aliquota</th>
+                <th className="text-foreground pb-2 font-semibold">
                   Esempi di applicazione
                 </th>
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
               <tr>
-                <td className="py-2 font-medium text-foreground">4%</td>
+                <td className="text-foreground py-2 font-medium">4%</td>
                 <td className="py-2">
                   Alimenti di prima necessità, libri, giornali, farmaci
                 </td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">10%</td>
+                <td className="text-foreground py-2 font-medium">10%</td>
                 <td className="py-2">
                   Alimenti, bevande, somministrazione al tavolo, spettacoli
                 </td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">22%</td>
+                <td className="text-foreground py-2 font-medium">22%</td>
                 <td className="py-2">
                   Prodotti generici, abbigliamento, elettronica, servizi
                 </td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">Esente</td>
+                <td className="text-foreground py-2 font-medium">Esente</td>
                 <td className="py-2">
                   Operazioni esenti ex art. 10 DPR 633/72 (servizi finanziari,
                   sanitari, formativi, ecc.)
@@ -98,8 +96,8 @@ export default function AliquoteIvaPage() {
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Le aliquote IVA sono pre-caricate nel sistema. Non devi attivarle
-          separatamente: compaiono come opzione ogni volta che aggiungi una
-          riga allo scontrino o crei un prodotto nel catalogo.
+          separatamente: compaiono come opzione ogni volta che aggiungi una riga
+          allo scontrino o crei un prodotto nel catalogo.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Al momento dell&apos;emissione, per ogni riga dello scontrino
@@ -121,26 +119,23 @@ export default function AliquoteIvaPage() {
         <h2 className="mt-10 text-xl font-semibold">Reparti merceologici</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Puoi organizzare i prodotti in <strong>reparti</strong> (es.
-          &quot;Alimentari&quot;, &quot;Bevande&quot;, &quot;Abbigliamento&quot;)
-          ai quali associare un&apos;aliquota IVA predefinita. In questo modo,
-          quando aggiungi una riga allo scontrino e selezioni il reparto,
-          l&apos;aliquota viene impostata automaticamente.
+          &quot;Alimentari&quot;, &quot;Bevande&quot;,
+          &quot;Abbigliamento&quot;) ai quali associare un&apos;aliquota IVA
+          predefinita. In questo modo, quando aggiungi una riga allo scontrino e
+          selezioni il reparto, l&apos;aliquota viene impostata automaticamente.
         </p>
-        <h3 className="mt-5 text-base font-semibold">
-          Come creare un reparto
-        </h3>
+        <h3 className="mt-5 text-base font-semibold">Come creare un reparto</h3>
         <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            Vai in{" "}
-            <strong>Dashboard &gt; Impostazioni &gt; Reparti</strong>.
+            Vai in <strong>Dashboard &gt; Impostazioni &gt; Reparti</strong>.
           </li>
           <li>
             Clicca su <strong>Aggiungi reparto</strong>.
           </li>
           <li>Inserisci nome e aliquota IVA predefinita.</li>
           <li>
-            Salva. Il reparto sarà disponibile durante l&apos;emissione e
-            nella creazione di prodotti nel catalogo.
+            Salva. Il reparto sarà disponibile durante l&apos;emissione e nella
+            creazione di prodotti nel catalogo.
           </li>
         </ol>
 
@@ -169,9 +164,9 @@ export default function AliquoteIvaPage() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Al momento dell&apos;emissione, seleziona il metodo usato dal
-          cliente. I dati vengono trasmessi all&apos;AdE come parte del
-          documento commerciale.
+          Al momento dell&apos;emissione, seleziona il metodo usato dal cliente.
+          I dati vengono trasmessi all&apos;AdE come parte del documento
+          commerciale.
         </p>
 
         {/* ─── Pagamento misto ─── */}
@@ -183,20 +178,18 @@ export default function AliquoteIvaPage() {
           registrare entrambi i metodi sullo stesso scontrino:
         </p>
         <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
-          <li>
-            Aggiungi le righe dello scontrino normalmente.
-          </li>
+          <li>Aggiungi le righe dello scontrino normalmente.</li>
           <li>
             Nella schermata di pagamento, seleziona{" "}
             <strong>Pagamento misto</strong>.
           </li>
           <li>
-            Inserisci l&apos;importo pagato in contante: ScontrinoZero
-            calcola automaticamente la quota residua da addebitare su carta.
+            Inserisci l&apos;importo pagato in contante: ScontrinoZero calcola
+            automaticamente la quota residua da addebitare su carta.
           </li>
           <li>
-            Conferma ed emetti. Il documento trasmesso all&apos;AdE riporta
-            la ripartizione corretta tra i due metodi.
+            Conferma ed emetti. Il documento trasmesso all&apos;AdE riporta la
+            ripartizione corretta tra i due metodi.
           </li>
         </ol>
 

--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -32,9 +32,8 @@ export default function CassettoFiscalePage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Dopo aver emesso uno scontrino con ScontrinoZero, i dati arrivano
           all&apos;Agenzia delle Entrate e sono consultabili nel{" "}
-          <strong>cassetto fiscale</strong> del portale Fatture e
-          Corrispettivi. Questa guida spiega dove cercarli e cosa fare se
-          qualcosa non torna.
+          <strong>cassetto fiscale</strong> del portale Fatture e Corrispettivi.
+          Questa guida spiega dove cercarli e cosa fare se qualcosa non torna.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -47,10 +46,10 @@ export default function CassettoFiscalePage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Il cassetto fiscale è l&apos;area riservata del portale dell&apos;AdE
           dove confluiscono tutte le informazioni tributarie a te intestate:
-          dichiarazioni, fatture, corrispettivi, rimborsi e molto altro.
-          Nella sezione <strong>Corrispettivi</strong> trovi i documenti
-          commerciali emessi tramite la procedura online — inclusi quelli
-          inviati da ScontrinoZero.
+          dichiarazioni, fatture, corrispettivi, rimborsi e molto altro. Nella
+          sezione <strong>Corrispettivi</strong> trovi i documenti commerciali
+          emessi tramite la procedura online — inclusi quelli inviati da
+          ScontrinoZero.
         </p>
 
         {/* ─── Come accedere ─── */}
@@ -59,18 +58,15 @@ export default function CassettoFiscalePage() {
         </h2>
         <ol className="text-muted-foreground mt-3 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            Vai su{" "}
-            <strong>ivaservizi.agenziaentrate.gov.it</strong> (portale Fatture
-            e Corrispettivi).
+            Vai su <strong>ivaservizi.agenziaentrate.gov.it</strong> (portale
+            Fatture e Corrispettivi).
           </li>
           <li>
-            Accedi con le tue credenziali{" "}
-            <strong>Fisconline</strong>, SPID o CIE — le stesse usate per
-            collegare ScontrinoZero all&apos;AdE.
+            Accedi con le tue credenziali <strong>Fisconline</strong>, SPID o
+            CIE — le stesse usate per collegare ScontrinoZero all&apos;AdE.
           </li>
           <li>
-            Dal menu principale seleziona{" "}
-            <strong>Corrispettivi</strong>.
+            Dal menu principale seleziona <strong>Corrispettivi</strong>.
           </li>
           <li>
             Clicca su <strong>Consultazione documenti commerciali</strong>.
@@ -90,8 +86,8 @@ export default function CassettoFiscalePage() {
             trovare i documenti di un giorno o periodo specifico.
           </li>
           <li>
-            <strong>Numero documento</strong> — ogni scontrino ScontrinoZero
-            ha un numero progressivo visibile nel dettaglio dello scontrino.
+            <strong>Numero documento</strong> — ogni scontrino ScontrinoZero ha
+            un numero progressivo visibile nel dettaglio dello scontrino.
           </li>
           <li>
             <strong>Tipo documento</strong> — Vendita o Annullamento.
@@ -109,8 +105,8 @@ export default function CassettoFiscalePage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           I documenti trasmessi da ScontrinoZero compaiono nel cassetto fiscale
           in genere entro <strong>pochi minuti</strong>. In alcuni casi,
-          soprattutto nelle ore di punta del portale AdE, possono volerci fino
-          a <strong>24 ore</strong>. Se uno scontrino risulta{" "}
+          soprattutto nelle ore di punta del portale AdE, possono volerci fino a{" "}
+          <strong>24 ore</strong>. Se uno scontrino risulta{" "}
           <strong>Trasmesso</strong> in ScontrinoZero ma non compare ancora nel
           cassetto, attendi qualche ora prima di preoccuparti.
         </p>
@@ -127,9 +123,9 @@ export default function CassettoFiscalePage() {
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Vai in <strong>Storico</strong> e controlla lo stato dello
               scontrino. Se è <strong>Trasmesso</strong>, il documento è
-              arrivato all&apos;AdE — attendi la visibilità nel cassetto.
-              Se è <strong>In elaborazione</strong>, la trasmissione è ancora
-              in corso: riprova dopo qualche minuto.
+              arrivato all&apos;AdE — attendi la visibilità nel cassetto. Se è{" "}
+              <strong>In elaborazione</strong>, la trasmissione è ancora in
+              corso: riprova dopo qualche minuto.
             </p>
           </div>
           <div>
@@ -138,8 +134,8 @@ export default function CassettoFiscalePage() {
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Assicurati che l&apos;intervallo di date nel portale AdE includa
-              il giorno di emissione. Un filtro troppo stretto può escludere
-              il documento che cerchi.
+              il giorno di emissione. Un filtro troppo stretto può escludere il
+              documento che cerchi.
             </p>
           </div>
           <div>
@@ -147,16 +143,14 @@ export default function CassettoFiscalePage() {
               3. Verifica la P.IVA collegata
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Accertati di aver effettuato l&apos;accesso al portale AdE con
-              le credenziali della P.IVA configurata in ScontrinoZero. Se hai
-              più codici fiscali/P.IVA, i documenti potrebbero trovarsi sotto
+              Accertati di aver effettuato l&apos;accesso al portale AdE con le
+              credenziali della P.IVA configurata in ScontrinoZero. Se hai più
+              codici fiscali/P.IVA, i documenti potrebbero trovarsi sotto
               un&apos;altra posizione.
             </p>
           </div>
           <div>
-            <p className="text-sm font-medium">
-              4. Contatta l&apos;assistenza
-            </p>
+            <p className="text-sm font-medium">4. Contatta l&apos;assistenza</p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Se lo scontrino è Trasmesso da più di 24 ore ma non compare nel
               cassetto, scrivici a{" "}
@@ -177,8 +171,8 @@ export default function CassettoFiscalePage() {
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Il portale AdE permette di esportare un prospetto riepilogativo dei
-          corrispettivi per periodo (mensile, trimestrale, annuale) — utile
-          per la liquidazione IVA e per i controlli del commercialista. Puoi
+          corrispettivi per periodo (mensile, trimestrale, annuale) — utile per
+          la liquidazione IVA e per i controlli del commercialista. Puoi
           accedervi dalla sezione{" "}
           <strong>Corrispettivi &gt; Riepilogo corrispettivi</strong>.
         </p>

--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -1,0 +1,236 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const metadata: Metadata = {
+  title:
+    "Dove verificare i corrispettivi nel cassetto fiscale | ScontrinoZero Help",
+  description:
+    "Scopri come accedere al cassetto fiscale dell'Agenzia delle Entrate per verificare che i tuoi scontrini siano stati trasmessi correttamente.",
+};
+
+export default function CassettoFiscalePage() {
+  return (
+    <section className="px-4 py-16">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Help Center
+        </Link>
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Dove verificare i corrispettivi nel cassetto fiscale
+          </h1>
+          <Badge variant="secondary">Fiscalizzazione</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Dopo aver emesso uno scontrino con ScontrinoZero, i dati arrivano
+          all&apos;Agenzia delle Entrate e sono consultabili nel{" "}
+          <strong>cassetto fiscale</strong> del portale Fatture e
+          Corrispettivi. Questa guida spiega dove cercarli e cosa fare se
+          qualcosa non torna.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> aprile 2026
+        </p>
+
+        {/* ─── Cos'è il cassetto fiscale ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Cos&apos;è il cassetto fiscale
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il cassetto fiscale è l&apos;area riservata del portale dell&apos;AdE
+          dove confluiscono tutte le informazioni tributarie a te intestate:
+          dichiarazioni, fatture, corrispettivi, rimborsi e molto altro.
+          Nella sezione <strong>Corrispettivi</strong> trovi i documenti
+          commerciali emessi tramite la procedura online — inclusi quelli
+          inviati da ScontrinoZero.
+        </p>
+
+        {/* ─── Come accedere ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Come accedere al portale Fatture e Corrispettivi
+        </h2>
+        <ol className="text-muted-foreground mt-3 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Vai su{" "}
+            <strong>ivaservizi.agenziaentrate.gov.it</strong> (portale Fatture
+            e Corrispettivi).
+          </li>
+          <li>
+            Accedi con le tue credenziali{" "}
+            <strong>Fisconline</strong>, SPID o CIE — le stesse usate per
+            collegare ScontrinoZero all&apos;AdE.
+          </li>
+          <li>
+            Dal menu principale seleziona{" "}
+            <strong>Corrispettivi</strong>.
+          </li>
+          <li>
+            Clicca su <strong>Consultazione documenti commerciali</strong>.
+          </li>
+        </ol>
+
+        {/* ─── Trovare i corrispettivi ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Come trovare i tuoi scontrini
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Nella schermata di consultazione puoi filtrare per:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Data di emissione</strong> — seleziona un intervallo per
+            trovare i documenti di un giorno o periodo specifico.
+          </li>
+          <li>
+            <strong>Numero documento</strong> — ogni scontrino ScontrinoZero
+            ha un numero progressivo visibile nel dettaglio dello scontrino.
+          </li>
+          <li>
+            <strong>Tipo documento</strong> — Vendita o Annullamento.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Ogni documento mostra: data, numero, importo, aliquote IVA e stato
+          (Trasmesso, Annullato).
+        </p>
+
+        {/* ─── Tempistiche ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Tempistiche di visibilità
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          I documenti trasmessi da ScontrinoZero compaiono nel cassetto fiscale
+          in genere entro <strong>pochi minuti</strong>. In alcuni casi,
+          soprattutto nelle ore di punta del portale AdE, possono volerci fino
+          a <strong>24 ore</strong>. Se uno scontrino risulta{" "}
+          <strong>Trasmesso</strong> in ScontrinoZero ma non compare ancora nel
+          cassetto, attendi qualche ora prima di preoccuparti.
+        </p>
+
+        {/* ─── Cosa fare se non compare ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Cosa fare se uno scontrino non compare
+        </h2>
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-sm font-medium">
+              1. Verifica lo stato in ScontrinoZero
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Vai in <strong>Storico</strong> e controlla lo stato dello
+              scontrino. Se è <strong>Trasmesso</strong>, il documento è
+              arrivato all&apos;AdE — attendi la visibilità nel cassetto.
+              Se è <strong>In elaborazione</strong>, la trasmissione è ancora
+              in corso: riprova dopo qualche minuto.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              2. Controlla il periodo di ricerca
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Assicurati che l&apos;intervallo di date nel portale AdE includa
+              il giorno di emissione. Un filtro troppo stretto può escludere
+              il documento che cerchi.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              3. Verifica la P.IVA collegata
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Accertati di aver effettuato l&apos;accesso al portale AdE con
+              le credenziali della P.IVA configurata in ScontrinoZero. Se hai
+              più codici fiscali/P.IVA, i documenti potrebbero trovarsi sotto
+              un&apos;altra posizione.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              4. Contatta l&apos;assistenza
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Se lo scontrino è Trasmesso da più di 24 ore ma non compare nel
+              cassetto, scrivici a{" "}
+              <a
+                href="mailto:info@scontrinozero.it"
+                className="text-primary hover:underline"
+              >
+                info@scontrinozero.it
+              </a>{" "}
+              indicando il numero e la data del documento.
+            </p>
+          </div>
+        </div>
+
+        {/* ─── Corrispettivi periodici ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Riepilogo corrispettivi per periodo
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il portale AdE permette di esportare un prospetto riepilogativo dei
+          corrispettivi per periodo (mensile, trimestrale, annuale) — utile
+          per la liquidazione IVA e per i controlli del commercialista. Puoi
+          accedervi dalla sezione{" "}
+          <strong>Corrispettivi &gt; Riepilogo corrispettivi</strong>.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          In alternativa, da ScontrinoZero puoi esportare direttamente un CSV
+          dello Storico con tutti i dati degli scontrini (funzione disponibile
+          nel piano Pro).
+        </p>
+
+        {/* ─── Articoli correlati ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+        <ul className="mt-3 space-y-1 text-sm">
+          <li>
+            <Link
+              href="/help/primo-scontrino"
+              className="text-primary hover:underline"
+            >
+              Come emettere il primo scontrino elettronico
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/errori-ade"
+              className="text-primary hover:underline"
+            >
+              Errori comuni di accesso AdE e come risolverli
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/storico-ed-esportazione"
+              className="text-primary hover:underline"
+            >
+              Storico scontrini: filtri, ricerca ed esportazione
+            </Link>
+          </li>
+        </ul>
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
+++ b/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
@@ -1,0 +1,232 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const metadata: Metadata = {
+  title:
+    "Chiusura giornaliera: è obbligatoria? | ScontrinoZero Help",
+  description:
+    "Con ScontrinoZero non devi fare nessuna chiusura giornaliera. Scopri perché il Documento Commerciale Online funziona diversamente dal registratore telematico fisico.",
+};
+
+export default function ChiusuraGiornalieraPage() {
+  return (
+    <section className="px-4 py-16">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Help Center
+        </Link>
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Chiusura giornaliera: è obbligatoria?
+          </h1>
+          <Badge variant="secondary">Gestione scontrini</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          No. Con ScontrinoZero{" "}
+          <strong>non devi fare nessuna chiusura giornaliera</strong>. I
+          corrispettivi vengono trasmessi all&apos;Agenzia delle Entrate in
+          tempo reale, scontrino per scontrino. Nessun gesto manuale a fine
+          giornata, nessun rischio di dimenticarsi.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> aprile 2026
+        </p>
+
+        {/* ─── Cos'è la chiusura giornaliera ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Cos&apos;è la chiusura giornaliera (e perché non ti riguarda)
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          I registratori telematici fisici (RT) archiviano gli scontrini in
+          memoria locale durante la giornata. A fine servizio l&apos;esercente
+          deve eseguire una{" "}
+          <strong>chiusura di cassa</strong> — un comando che stampa il
+          totale del giorno e invia i dati all&apos;AdE in un unico blocco
+          (il cosiddetto &quot;corrispettivo giornaliero&quot;).
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero usa la procedura{" "}
+          <strong>Documento Commerciale Online</strong>, che funziona in modo
+          completamente diverso: ogni scontrino viene trasmesso{" "}
+          <strong>individualmente e in tempo reale</strong> al portale Fatture
+          e Corrispettivi. Non c&apos;è nulla da raggruppare a fine giornata
+          perché i dati sono già arrivati all&apos;AdE nel momento in cui hai
+          premuto &quot;Emetti&quot;.
+        </p>
+
+        {/* ─── Cosa fare a fine giornata ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Cosa devo fare a fine giornata?
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Niente di speciale.</strong> Non esiste un pulsante di
+          chiusura né una procedura obbligatoria. Puoi semplicemente chiudere
+          l&apos;app.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Se vuoi un riepilogo dei corrispettivi del giorno, puoi consultare
+          lo <strong>Storico</strong> e filtrare per data odierna: vedrai
+          l&apos;elenco di tutti gli scontrini emessi con importi e metodi di
+          pagamento.
+        </p>
+
+        {/* ─── Confronto RT fisico ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Riepilogo: RT fisico vs. Documento Commerciale Online
+        </h2>
+        <div className="mt-3 overflow-x-auto">
+          <table className="text-muted-foreground w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left">
+                <th className="pb-2 font-semibold text-foreground">
+                  Aspetto
+                </th>
+                <th className="pb-2 font-semibold text-foreground">
+                  RT fisico
+                </th>
+                <th className="pb-2 font-semibold text-foreground">
+                  ScontrinoZero (DCO)
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Trasmissione
+                </td>
+                <td className="py-2">Batch a fine giornata</td>
+                <td className="py-2">In tempo reale per ogni scontrino</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Chiusura giornaliera
+                </td>
+                <td className="py-2">Obbligatoria</td>
+                <td className="py-2 font-semibold text-green-600">
+                  Non necessaria
+                </td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Rischio di dimenticarsi
+                </td>
+                <td className="py-2">Sì (sanzione)</td>
+                <td className="py-2">No</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Hardware richiesto
+                </td>
+                <td className="py-2">RT certificato (€200-800)</td>
+                <td className="py-2">Smartphone o PC</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* ─── Sanzioni ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Rischio sanzioni per mancata chiusura
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Con gli RT fisici, dimenticare la chiusura giornaliera può
+          comportare sanzioni amministrative (omessa trasmissione dei
+          corrispettivi). Con ScontrinoZero questo rischio{" "}
+          <strong>non esiste</strong>: ogni scontrino emesso è già stato
+          trasmesso, indipendentemente da qualsiasi azione manuale.
+        </p>
+
+        {/* ─── FAQ ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Domande frequenti</h2>
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-sm font-medium">
+              Se perdo la connessione durante la giornata, i dati vengono
+              persi?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              No. ScontrinoZero non permette di emettere uno scontrino senza
+              connessione internet (la trasmissione all&apos;AdE avviene in
+              tempo reale). Se la connessione cade, l&apos;app ti avvisa e
+              attendi il ripristino prima di procedere.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Ho un POS fisico collegato a un RT: devo comunque fare la
+              chiusura sull&apos;RT?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Sì, se usi un RT fisico <em>in parallelo</em> a ScontrinoZero,
+              le obbligazioni dell&apos;RT rimangono invariate. ScontrinoZero
+              non sostituisce un RT già in uso: lo affianca o lo sostituisce
+              completamente a seconda del tuo setup.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Devo tenere un registro cartaceo dei corrispettivi?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              No. I corrispettivi sono già registrati nel cassetto fiscale
+              dell&apos;AdE e nello Storico di ScontrinoZero. Puoi esportare
+              un CSV in qualsiasi momento per i tuoi archivi o per il
+              commercialista.
+            </p>
+          </div>
+        </div>
+
+        {/* ─── Articoli correlati ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+        <ul className="mt-3 space-y-1 text-sm">
+          <li>
+            <Link
+              href="/help/primo-scontrino"
+              className="text-primary hover:underline"
+            >
+              Come emettere il primo scontrino elettronico
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/cassetto-fiscale"
+              className="text-primary hover:underline"
+            >
+              Dove verificare i corrispettivi nel cassetto fiscale
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/storico-ed-esportazione"
+              className="text-primary hover:underline"
+            >
+              Storico scontrini: filtri, ricerca ed esportazione
+            </Link>
+          </li>
+        </ul>
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
+++ b/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
@@ -4,8 +4,7 @@ import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 
 export const metadata: Metadata = {
-  title:
-    "Chiusura giornaliera: è obbligatoria? | ScontrinoZero Help",
+  title: "Chiusura giornaliera: è obbligatoria? | ScontrinoZero Help",
   description:
     "Con ScontrinoZero non devi fare nessuna chiusura giornaliera. Scopri perché il Documento Commerciale Online funziona diversamente dal registratore telematico fisico.",
 };
@@ -47,17 +46,16 @@ export default function ChiusuraGiornalieraPage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           I registratori telematici fisici (RT) archiviano gli scontrini in
           memoria locale durante la giornata. A fine servizio l&apos;esercente
-          deve eseguire una{" "}
-          <strong>chiusura di cassa</strong> — un comando che stampa il
-          totale del giorno e invia i dati all&apos;AdE in un unico blocco
-          (il cosiddetto &quot;corrispettivo giornaliero&quot;).
+          deve eseguire una <strong>chiusura di cassa</strong> — un comando che
+          stampa il totale del giorno e invia i dati all&apos;AdE in un unico
+          blocco (il cosiddetto &quot;corrispettivo giornaliero&quot;).
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           ScontrinoZero usa la procedura{" "}
           <strong>Documento Commerciale Online</strong>, che funziona in modo
           completamente diverso: ogni scontrino viene trasmesso{" "}
-          <strong>individualmente e in tempo reale</strong> al portale Fatture
-          e Corrispettivi. Non c&apos;è nulla da raggruppare a fine giornata
+          <strong>individualmente e in tempo reale</strong> al portale Fatture e
+          Corrispettivi. Non c&apos;è nulla da raggruppare a fine giornata
           perché i dati sono già arrivati all&apos;AdE nel momento in cui hai
           premuto &quot;Emetti&quot;.
         </p>
@@ -72,8 +70,8 @@ export default function ChiusuraGiornalieraPage() {
           l&apos;app.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Se vuoi un riepilogo dei corrispettivi del giorno, puoi consultare
-          lo <strong>Storico</strong> e filtrare per data odierna: vedrai
+          Se vuoi un riepilogo dei corrispettivi del giorno, puoi consultare lo{" "}
+          <strong>Storico</strong> e filtrare per data odierna: vedrai
           l&apos;elenco di tutti gli scontrini emessi con importi e metodi di
           pagamento.
         </p>
@@ -86,27 +84,25 @@ export default function ChiusuraGiornalieraPage() {
           <table className="text-muted-foreground w-full text-sm">
             <thead>
               <tr className="border-border border-b text-left">
-                <th className="pb-2 font-semibold text-foreground">
-                  Aspetto
-                </th>
-                <th className="pb-2 font-semibold text-foreground">
+                <th className="text-foreground pb-2 font-semibold">Aspetto</th>
+                <th className="text-foreground pb-2 font-semibold">
                   RT fisico
                 </th>
-                <th className="pb-2 font-semibold text-foreground">
+                <th className="text-foreground pb-2 font-semibold">
                   ScontrinoZero (DCO)
                 </th>
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Trasmissione
                 </td>
                 <td className="py-2">Batch a fine giornata</td>
                 <td className="py-2">In tempo reale per ogni scontrino</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Chiusura giornaliera
                 </td>
                 <td className="py-2">Obbligatoria</td>
@@ -115,14 +111,14 @@ export default function ChiusuraGiornalieraPage() {
                 </td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Rischio di dimenticarsi
                 </td>
                 <td className="py-2">Sì (sanzione)</td>
                 <td className="py-2">No</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Hardware richiesto
                 </td>
                 <td className="py-2">RT certificato (€200-800)</td>
@@ -137,11 +133,11 @@ export default function ChiusuraGiornalieraPage() {
           Rischio sanzioni per mancata chiusura
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Con gli RT fisici, dimenticare la chiusura giornaliera può
-          comportare sanzioni amministrative (omessa trasmissione dei
-          corrispettivi). Con ScontrinoZero questo rischio{" "}
-          <strong>non esiste</strong>: ogni scontrino emesso è già stato
-          trasmesso, indipendentemente da qualsiasi azione manuale.
+          Con gli RT fisici, dimenticare la chiusura giornaliera può comportare
+          sanzioni amministrative (omessa trasmissione dei corrispettivi). Con
+          ScontrinoZero questo rischio <strong>non esiste</strong>: ogni
+          scontrino emesso è già stato trasmesso, indipendentemente da qualsiasi
+          azione manuale.
         </p>
 
         {/* ─── FAQ ─── */}
@@ -149,8 +145,7 @@ export default function ChiusuraGiornalieraPage() {
         <div className="mt-3 space-y-4">
           <div>
             <p className="text-sm font-medium">
-              Se perdo la connessione durante la giornata, i dati vengono
-              persi?
+              Se perdo la connessione durante la giornata, i dati vengono persi?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               No. ScontrinoZero non permette di emettere uno scontrino senza
@@ -161,13 +156,13 @@ export default function ChiusuraGiornalieraPage() {
           </div>
           <div>
             <p className="text-sm font-medium">
-              Ho un POS fisico collegato a un RT: devo comunque fare la
-              chiusura sull&apos;RT?
+              Ho un POS fisico collegato a un RT: devo comunque fare la chiusura
+              sull&apos;RT?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Sì, se usi un RT fisico <em>in parallelo</em> a ScontrinoZero,
-              le obbligazioni dell&apos;RT rimangono invariate. ScontrinoZero
-              non sostituisce un RT già in uso: lo affianca o lo sostituisce
+              Sì, se usi un RT fisico <em>in parallelo</em> a ScontrinoZero, le
+              obbligazioni dell&apos;RT rimangono invariate. ScontrinoZero non
+              sostituisce un RT già in uso: lo affianca o lo sostituisce
               completamente a seconda del tuo setup.
             </p>
           </div>
@@ -177,8 +172,8 @@ export default function ChiusuraGiornalieraPage() {
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               No. I corrispettivi sono già registrati nel cassetto fiscale
-              dell&apos;AdE e nello Storico di ScontrinoZero. Puoi esportare
-              un CSV in qualsiasi momento per i tuoi archivi o per il
+              dell&apos;AdE e nello Storico di ScontrinoZero. Puoi esportare un
+              CSV in qualsiasi momento per i tuoi archivi o per il
               commercialista.
             </p>
           </div>

--- a/src/app/(marketing)/help/normativa-pos-2026/page.tsx
+++ b/src/app/(marketing)/help/normativa-pos-2026/page.tsx
@@ -30,10 +30,10 @@ export default function NormativaPos2026Page() {
           <Badge variant="secondary">POS e normativa</Badge>
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Dal 2026 gli esercenti con registratore telematico devono integrare
-          il POS con il sistema di cassa. Questa guida spiega in modo chiaro
-          chi è obbligato, cosa cambia concretamente e perché chi usa
-          ScontrinoZero è già in una posizione vantaggiosa.
+          Dal 2026 gli esercenti con registratore telematico devono integrare il
+          POS con il sistema di cassa. Questa guida spiega in modo chiaro chi è
+          obbligato, cosa cambia concretamente e perché chi usa ScontrinoZero è
+          già in una posizione vantaggiosa.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -42,8 +42,8 @@ export default function NormativaPos2026Page() {
         {/* ─── La normativa in sintesi ─── */}
         <h2 className="mt-10 text-xl font-semibold">La normativa in sintesi</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Il collegamento obbligatorio tra POS e registratore telematico (RT)
-          è previsto dalla{" "}
+          Il collegamento obbligatorio tra POS e registratore telematico (RT) è
+          previsto dalla{" "}
           <strong>Legge di Bilancio 2023 (art. 1, co. 385)</strong>, con
           attuazione progressiva. L&apos;obiettivo è che i pagamenti elettronici
           siano automaticamente abbinati agli scontrini fiscali, riducendo
@@ -86,16 +86,14 @@ export default function NormativaPos2026Page() {
             Soggetti in regime di esonero dall&apos;obbligo di scontrino (es.
             alcune categorie di venditori ambulanti).
           </li>
-          <li>
-            Professionisti che emettono esclusivamente fattura.
-          </li>
+          <li>Professionisti che emettono esclusivamente fattura.</li>
         </ul>
 
         {/* ─── Scadenze ─── */}
         <h2 className="mt-10 text-xl font-semibold">Scadenze operative</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Le scadenze per il collegamento tecnico POS-RT sono state
-          oggetto di proroghe successive. Al momento:
+          Le scadenze per il collegamento tecnico POS-RT sono state oggetto di
+          proroghe successive. Al momento:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-2 pl-5 text-sm leading-relaxed">
           <li>
@@ -103,8 +101,8 @@ export default function NormativaPos2026Page() {
             produttori di RT e POS.
           </li>
           <li>
-            <strong>2026:</strong> obbligo operativo per i soggetti con RT.
-            I fornitori di POS (Nexi, SumUp, Stripe Terminal, ecc.) stanno
+            <strong>2026:</strong> obbligo operativo per i soggetti con RT. I
+            fornitori di POS (Nexi, SumUp, Stripe Terminal, ecc.) stanno
             rilasciando aggiornamenti firmware per la compatibilità.
           </li>
         </ul>
@@ -122,11 +120,9 @@ export default function NormativaPos2026Page() {
           <strong>Sì, e la situazione è ancora più semplice.</strong>{" "}
           ScontrinoZero usa la procedura{" "}
           <strong>Documento Commerciale Online</strong>, che trasmette ogni
-          scontrino all&apos;AdE in tempo reale, scontrino per scontrino.
-          Questa procedura{" "}
-          <strong>
-            non rientra nell&apos;obbligo di collegamento POS-RT
-          </strong>{" "}
+          scontrino all&apos;AdE in tempo reale, scontrino per scontrino. Questa
+          procedura{" "}
+          <strong>non rientra nell&apos;obbligo di collegamento POS-RT</strong>{" "}
           previsto dalla Legge di Bilancio 2023, che si applica solo ai
           registratori telematici fisici.
         </p>
@@ -147,23 +143,22 @@ export default function NormativaPos2026Page() {
           <li>
             <strong>Aggiornare l&apos;RT esistente</strong> con il firmware
             compatibile POS-RT fornito dal produttore (Epson, Custom, Ditron,
-            ecc.) e collegarlo al POS certificato. Costo: dipende dal
-            contratto con il fornitore.
+            ecc.) e collegarlo al POS certificato. Costo: dipende dal contratto
+            con il fornitore.
           </li>
           <li>
             <strong>Passare a ScontrinoZero</strong> come alternativa
             completamente software. Nessun hardware da aggiornare, nessun
-            collegamento POS-RT richiesto, costi fissi molto inferiori.
-            Il POS rimane indipendente e tu registri comunque ogni incasso
-            in ScontrinoZero.
+            collegamento POS-RT richiesto, costi fissi molto inferiori. Il POS
+            rimane indipendente e tu registri comunque ogni incasso in
+            ScontrinoZero.
           </li>
         </ol>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           La scelta dipende dalla tua attività, dal volume di transazioni e
           dalla necessità di funzionamento offline. Se vuoi valutare la
-          transizione, il{" "}
-          <strong>trial gratuito di 30 giorni</strong> di ScontrinoZero ti
-          permette di testare senza impegno.
+          transizione, il <strong>trial gratuito di 30 giorni</strong> di
+          ScontrinoZero ti permette di testare senza impegno.
         </p>
 
         {/* ─── Differenza RT vs DCO ─── */}
@@ -174,28 +169,30 @@ export default function NormativaPos2026Page() {
           <table className="text-muted-foreground w-full text-sm">
             <thead>
               <tr className="border-border border-b text-left">
-                <th className="pb-2 font-semibold text-foreground">Aspetto</th>
-                <th className="pb-2 font-semibold text-foreground">RT fisico</th>
-                <th className="pb-2 font-semibold text-foreground">
+                <th className="text-foreground pb-2 font-semibold">Aspetto</th>
+                <th className="text-foreground pb-2 font-semibold">
+                  RT fisico
+                </th>
+                <th className="text-foreground pb-2 font-semibold">
                   ScontrinoZero (DCO)
                 </th>
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
               <tr>
-                <td className="py-2 font-medium text-foreground">Hardware</td>
+                <td className="text-foreground py-2 font-medium">Hardware</td>
                 <td className="py-2">RT certificato (€200-800+)</td>
                 <td className="py-2">Smartphone o PC</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Obbligo POS-RT 2026
                 </td>
                 <td className="py-2">Sì</td>
                 <td className="py-2 font-semibold text-green-600">No</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Chiusura giornaliera
                 </td>
                 <td className="py-2">Obbligatoria</td>
@@ -204,14 +201,14 @@ export default function NormativaPos2026Page() {
                 </td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Manutenzione
                 </td>
                 <td className="py-2">Tecnico specializzato</td>
                 <td className="py-2">Aggiornamenti automatici</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Costo annuo
                 </td>
                 <td className="py-2">€150-400+ (canone + manutenzione)</td>
@@ -250,8 +247,8 @@ export default function NormativaPos2026Page() {
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Le sanzioni per omessa o tardiva trasmissione dei corrispettivi
-              sono previste dall&apos;art. 2 comma 6 del D.Lgs. 127/2015.
-              I dettagli applicativi al collegamento POS-RT saranno chiariti
+              sono previste dall&apos;art. 2 comma 6 del D.Lgs. 127/2015. I
+              dettagli applicativi al collegamento POS-RT saranno chiariti
               dall&apos;AdE con appositi provvedimenti. Mantieniti aggiornato
               tramite il sito dell&apos;Agenzia delle Entrate o il tuo
               consulente fiscale.

--- a/src/app/(marketing)/help/normativa-pos-2026/page.tsx
+++ b/src/app/(marketing)/help/normativa-pos-2026/page.tsx
@@ -1,0 +1,307 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const metadata: Metadata = {
+  title:
+    "Nuova normativa POS 2026: cosa cambia per gli esercenti | ScontrinoZero Help",
+  description:
+    "Tutto quello che devi sapere sugli obblighi di collegamento POS-RT del 2026: chi è coinvolto, le scadenze e come ScontrinoZero ti aiuta a essere in regola.",
+};
+
+export default function NormativaPos2026Page() {
+  return (
+    <section className="px-4 py-16">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Help Center
+        </Link>
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Nuova normativa POS 2026: cosa cambia per gli esercenti
+          </h1>
+          <Badge variant="secondary">POS e normativa</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Dal 2026 gli esercenti con registratore telematico devono integrare
+          il POS con il sistema di cassa. Questa guida spiega in modo chiaro
+          chi è obbligato, cosa cambia concretamente e perché chi usa
+          ScontrinoZero è già in una posizione vantaggiosa.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> aprile 2026
+        </p>
+
+        {/* ─── La normativa in sintesi ─── */}
+        <h2 className="mt-10 text-xl font-semibold">La normativa in sintesi</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il collegamento obbligatorio tra POS e registratore telematico (RT)
+          è previsto dalla{" "}
+          <strong>Legge di Bilancio 2023 (art. 1, co. 385)</strong>, con
+          attuazione progressiva. L&apos;obiettivo è che i pagamenti elettronici
+          siano automaticamente abbinati agli scontrini fiscali, riducendo
+          l&apos;evasione sul fronte degli incassi.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          In pratica: quando un cliente paga con carta, il POS deve
+          &quot;parlare&quot; con il registratore telematico e i dati devono
+          confluire in un&apos;unica trasmissione all&apos;AdE.
+        </p>
+
+        {/* ─── Chi è obbligato ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Chi è obbligato al collegamento POS-RT
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          L&apos;obbligo riguarda gli esercenti che usano un{" "}
+          <strong>registratore telematico fisico</strong> (RT) e accettano
+          pagamenti con POS. In particolare:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Commercianti al dettaglio, ristoratori, artigiani con RT già
+            installato.
+          </li>
+          <li>
+            Esercenti che hanno accettato almeno un pagamento elettronico
+            nell&apos;anno precedente.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Non sono obbligati</strong> (o hanno regole diverse):
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Chi usa la procedura <strong>Documento Commerciale Online</strong>{" "}
+            (come ScontrinoZero) — vedi sotto.
+          </li>
+          <li>
+            Soggetti in regime di esonero dall&apos;obbligo di scontrino (es.
+            alcune categorie di venditori ambulanti).
+          </li>
+          <li>
+            Professionisti che emettono esclusivamente fattura.
+          </li>
+        </ul>
+
+        {/* ─── Scadenze ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Scadenze operative</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Le scadenze per il collegamento tecnico POS-RT sono state
+          oggetto di proroghe successive. Al momento:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>2024–2025:</strong> fase sperimentale e adeguamento dei
+            produttori di RT e POS.
+          </li>
+          <li>
+            <strong>2026:</strong> obbligo operativo per i soggetti con RT.
+            I fornitori di POS (Nexi, SumUp, Stripe Terminal, ecc.) stanno
+            rilasciando aggiornamenti firmware per la compatibilità.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Ti consigliamo di verificare con il tuo fornitore RT e POS lo stato
+          dell&apos;adeguamento, poiché le scadenze esatte possono variare in
+          base all&apos;hardware in uso.
+        </p>
+
+        {/* ─── ScontrinoZero e la normativa ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          ScontrinoZero è già conforme?
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Sì, e la situazione è ancora più semplice.</strong>{" "}
+          ScontrinoZero usa la procedura{" "}
+          <strong>Documento Commerciale Online</strong>, che trasmette ogni
+          scontrino all&apos;AdE in tempo reale, scontrino per scontrino.
+          Questa procedura{" "}
+          <strong>
+            non rientra nell&apos;obbligo di collegamento POS-RT
+          </strong>{" "}
+          previsto dalla Legge di Bilancio 2023, che si applica solo ai
+          registratori telematici fisici.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          In altre parole: se usi ScontrinoZero come unico sistema di cassa,{" "}
+          <strong>non devi fare nulla</strong> per essere conforme alla nuova
+          normativa POS-RT.
+        </p>
+
+        {/* ─── Cosa fare se hai un RT ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Ho già un RT fisico: devo passare a ScontrinoZero?
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Non necessariamente. Hai due opzioni:
+        </p>
+        <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Aggiornare l&apos;RT esistente</strong> con il firmware
+            compatibile POS-RT fornito dal produttore (Epson, Custom, Ditron,
+            ecc.) e collegarlo al POS certificato. Costo: dipende dal
+            contratto con il fornitore.
+          </li>
+          <li>
+            <strong>Passare a ScontrinoZero</strong> come alternativa
+            completamente software. Nessun hardware da aggiornare, nessun
+            collegamento POS-RT richiesto, costi fissi molto inferiori.
+            Il POS rimane indipendente e tu registri comunque ogni incasso
+            in ScontrinoZero.
+          </li>
+        </ol>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          La scelta dipende dalla tua attività, dal volume di transazioni e
+          dalla necessità di funzionamento offline. Se vuoi valutare la
+          transizione, il{" "}
+          <strong>trial gratuito di 30 giorni</strong> di ScontrinoZero ti
+          permette di testare senza impegno.
+        </p>
+
+        {/* ─── Differenza RT vs DCO ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          RT fisico vs. Documento Commerciale Online: differenze chiave
+        </h2>
+        <div className="mt-3 overflow-x-auto">
+          <table className="text-muted-foreground w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left">
+                <th className="pb-2 font-semibold text-foreground">Aspetto</th>
+                <th className="pb-2 font-semibold text-foreground">RT fisico</th>
+                <th className="pb-2 font-semibold text-foreground">
+                  ScontrinoZero (DCO)
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              <tr>
+                <td className="py-2 font-medium text-foreground">Hardware</td>
+                <td className="py-2">RT certificato (€200-800+)</td>
+                <td className="py-2">Smartphone o PC</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Obbligo POS-RT 2026
+                </td>
+                <td className="py-2">Sì</td>
+                <td className="py-2 font-semibold text-green-600">No</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Chiusura giornaliera
+                </td>
+                <td className="py-2">Obbligatoria</td>
+                <td className="py-2 font-semibold text-green-600">
+                  Non necessaria
+                </td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Manutenzione
+                </td>
+                <td className="py-2">Tecnico specializzato</td>
+                <td className="py-2">Aggiornamenti automatici</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Costo annuo
+                </td>
+                <td className="py-2">€150-400+ (canone + manutenzione)</td>
+                <td className="py-2">Da €29,99/anno</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* ─── FAQ ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Domande frequenti</h2>
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-sm font-medium">
+              Uso SumUp o Square come POS: sono obbligato al collegamento?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Solo se hai anche un RT fisico. Se usi ScontrinoZero al posto
+              dell&apos;RT, non c&apos;è nessun obbligo di collegamento POS-RT.
+              Il POS rimane indipendente.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Sono un ambulante: mi riguarda questa normativa?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Dipende dal tuo regime. Molti ambulanti rientrano in esoneri
+              specifici. Ti consigliamo di verificare con il tuo commercialista
+              quale obbligo si applica alla tua attività specifica.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Esiste una sanzione per chi non adegua l&apos;RT entro il 2026?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Le sanzioni per omessa o tardiva trasmissione dei corrispettivi
+              sono previste dall&apos;art. 2 comma 6 del D.Lgs. 127/2015.
+              I dettagli applicativi al collegamento POS-RT saranno chiariti
+              dall&apos;AdE con appositi provvedimenti. Mantieniti aggiornato
+              tramite il sito dell&apos;Agenzia delle Entrate o il tuo
+              consulente fiscale.
+            </p>
+          </div>
+        </div>
+
+        {/* ─── Articoli correlati ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+        <ul className="mt-3 space-y-1 text-sm">
+          <li>
+            <Link
+              href="/help/prima-configurazione"
+              className="text-primary hover:underline"
+            >
+              Prima configurazione passo-passo (onboarding completo)
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/chiusura-giornaliera"
+              className="text-primary hover:underline"
+            >
+              Chiusura giornaliera: è obbligatoria?
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/regime-forfettario"
+              className="text-primary hover:underline"
+            >
+              Regime forfettario: configurazione IVA corretta
+            </Link>
+          </li>
+        </ul>
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -75,7 +75,10 @@ const helpCategories: HelpCategory[] = [
         title: "Credenziali Fisconline: dove trovarle e come verificarle",
         href: "/help/credenziali-fisconline",
       },
-      { title: "Dove verificare i corrispettivi nel cassetto fiscale" },
+      {
+        title: "Dove verificare i corrispettivi nel cassetto fiscale",
+        href: "/help/cassetto-fiscale",
+      },
       {
         title: "Errori comuni di accesso AdE e come risolverli",
         href: "/help/errori-ade",
@@ -98,8 +101,14 @@ const helpCategories: HelpCategory[] = [
         title: "Annullare uno scontrino: quando si può e come fare",
         href: "/help/annullare-scontrino",
       },
-      { title: "Chiusura giornaliera: è obbligatoria?" },
-      { title: "Storico scontrini: filtri, ricerca ed esportazione" },
+      {
+        title: "Chiusura giornaliera: è obbligatoria?",
+        href: "/help/chiusura-giornaliera",
+      },
+      {
+        title: "Storico scontrini: filtri, ricerca ed esportazione",
+        href: "/help/storico-ed-esportazione",
+      },
     ],
   },
   {
@@ -110,7 +119,10 @@ const helpCategories: HelpCategory[] = [
         title: "Regime forfettario: configurazione IVA corretta",
         href: "/help/regime-forfettario",
       },
-      { title: "Come gestire aliquote IVA, reparti e metodi di pagamento" },
+      {
+        title: "Come gestire aliquote IVA, reparti e metodi di pagamento",
+        href: "/help/aliquote-iva",
+      },
       { title: "Personalizzare intestazione e dati dello scontrino" },
       { title: "Gestione operatori e permessi" },
     ],
@@ -123,7 +135,10 @@ const helpCategories: HelpCategory[] = [
       {
         title: "Come registrare un POS nel portale Fatture e Corrispettivi",
       },
-      { title: "Nuova normativa POS 2026: cosa cambia per gli esercenti" },
+      {
+        title: "Nuova normativa POS 2026: cosa cambia per gli esercenti",
+        href: "/help/normativa-pos-2026",
+      },
     ],
   },
   {
@@ -160,7 +175,10 @@ const helpCategories: HelpCategory[] = [
     name: "Abbonamento, fatture e supporto",
     description: "Piano, pagamenti e assistenza.",
     articles: [
-      { title: "Piani disponibili: Starter, Pro e versione gratuita" },
+      {
+        title: "Piani disponibili: Starter, Pro e versione gratuita",
+        href: "/help/piani-e-prezzi",
+      },
       { title: "Come passare da mensile ad annuale" },
       { title: "Dove trovare fatture e ricevute di pagamento" },
       { title: "Come contattare l'assistenza" },

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -1,0 +1,342 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const metadata: Metadata = {
+  title:
+    "Piani disponibili: Starter, Pro e self-hosted gratuito | ScontrinoZero Help",
+  description:
+    "Scopri le differenze tra i piani Starter, Pro e la versione self-hosted gratuita di ScontrinoZero. Prezzi, feature e come scegliere il piano giusto.",
+};
+
+export default function PianiEPrezziPage() {
+  return (
+    <section className="px-4 py-16">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Help Center
+        </Link>
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Piani disponibili: Starter, Pro e self-hosted gratuito
+          </h1>
+          <Badge variant="secondary">Abbonamento</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero è disponibile in tre versioni: due piani hosted a
+          pagamento (Starter e Pro) con un trial gratuito di 30 giorni, e una
+          versione self-hosted completamente gratuita per chi preferisce
+          gestire il proprio server.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> aprile 2026
+        </p>
+
+        {/* ─── Panoramica piani ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Panoramica dei piani</h2>
+        <div className="mt-3 overflow-x-auto">
+          <table className="text-muted-foreground w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left">
+                <th className="pb-2 font-semibold text-foreground">Piano</th>
+                <th className="pb-2 font-semibold text-foreground">Mensile</th>
+                <th className="pb-2 font-semibold text-foreground">Annuale</th>
+                <th className="pb-2 font-semibold text-foreground">Target</th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              <tr>
+                <td className="py-2 font-medium text-foreground">Starter</td>
+                <td className="py-2">€4,99/mese</td>
+                <td className="py-2">€29,99/anno</td>
+                <td className="py-2">Micro-attività, ambulanti</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">Pro</td>
+                <td className="py-2">€8,99/mese</td>
+                <td className="py-2">€49,99/anno</td>
+                <td className="py-2">Negozi, attività regolari</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Self-hosted
+                </td>
+                <td className="py-2 font-semibold text-green-600">Gratuito</td>
+                <td className="py-2 font-semibold text-green-600">Gratuito</td>
+                <td className="py-2">Tecnici, smanettoni</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          L&apos;abbonamento annuale fa risparmiare il <strong>50%</strong>{" "}
+          rispetto al mensile per Starter e il <strong>54%</strong> per Pro.
+          Non è richiesta nessuna carta di credito per iniziare il trial.
+        </p>
+
+        {/* ─── Piano Starter ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Piano Starter</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Pensato per chi emette pochi scontrini al giorno e non ha bisogno di
+          funzioni avanzate. Include tutto il necessario per operare in modo
+          conforme:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>Scontrini elettronici illimitati</li>
+          <li>Annullamento scontrini</li>
+          <li>Metodi di pagamento misti (contante + carta + altro)</li>
+          <li>Catalogo rapido fino a <strong>5 prodotti</strong></li>
+          <li>Analytics base (totale giornaliero, metodi di pagamento)</li>
+          <li>Lotteria degli Scontrini</li>
+          <li>PWA installabile su smartphone</li>
+          <li>Supporto via email entro 48 ore</li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          A <strong>€29,99/anno</strong> è il prezzo più basso del mercato
+          per un registratore di cassa virtuale conforme all&apos;AdE.
+        </p>
+
+        {/* ─── Piano Pro ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Piano Pro</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Per esercenti con un volume di vendite regolare che hanno bisogno di
+          strumenti avanzati per la gestione e la contabilità. Tutto quello
+          che include Starter, più:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Catalogo rapido <strong>illimitato</strong>
+          </li>
+          <li>Analytics avanzata con dashboard storica</li>
+          <li>
+            <strong>Export CSV</strong> dello storico scontrini (per
+            commercialista o contabilità)
+          </li>
+          <li>
+            Recupero corrispettivi da AdE (sincronizzazione dati storici)
+          </li>
+          <li>Sync catalogo prodotti da rubrica AdE</li>
+          <li>Supporto prioritario via email entro 24 ore</li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          A <strong>€49,99/anno</strong> Pro è più conveniente di Starter su
+          base percentuale (54% di risparmio sul mensile vs. 50% di Starter),
+          pensato per chi usa ScontrinoZero tutti i giorni.
+        </p>
+
+        {/* ─── Self-hosted ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Versione self-hosted (gratuita)
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero è open source con licenza O&apos;Saasy. Puoi
+          scaricare il codice sorgente, installarlo sul tuo server e usarlo
+          gratuitamente con tutte le funzioni del piano Pro. È la scelta
+          giusta se:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Hai competenze tecniche (Linux, Docker, Node.js) o un team IT.
+          </li>
+          <li>
+            Vuoi che le tue credenziali Fisconline non transitino da server di
+            terzi.
+          </li>
+          <li>
+            Preferisci un controllo totale sull&apos;infrastruttura.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Con la versione self-hosted sei responsabile di hosting, backup e
+          aggiornamenti. Non è incluso supporto tecnico.
+        </p>
+
+        {/* ─── Trial gratuito ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Trial gratuito di 30 giorni
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Tutti i nuovi account hanno <strong>30 giorni di prova</strong>{" "}
+          gratuita con accesso completo alle funzioni Pro. Nessuna carta di
+          credito richiesta per iniziare.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Cosa succede alla scadenza del trial:</strong>
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Se aggiungi una carta di credito e scegli un piano, l&apos;account
+            resta attivo senza interruzioni.
+          </li>
+          <li>
+            Se non aggiungi una carta, l&apos;account passa in{" "}
+            <strong>sola lettura</strong>: puoi consultare lo storico degli
+            scontrini ma non emetterne di nuovi.
+          </li>
+          <li>I tuoi dati vengono conservati e rimangono accessibili.</li>
+        </ul>
+
+        {/* ─── Confronto feature ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Confronto feature per piano
+        </h2>
+        <div className="mt-3 overflow-x-auto">
+          <table className="text-muted-foreground w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left">
+                <th className="pb-2 font-semibold text-foreground">Feature</th>
+                <th className="pb-2 font-semibold text-foreground">Starter</th>
+                <th className="pb-2 font-semibold text-foreground">Pro</th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Scontrini illimitati
+                </td>
+                <td className="py-2">✓</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Pagamenti misti
+                </td>
+                <td className="py-2">✓</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Lotteria Scontrini
+                </td>
+                <td className="py-2">✓</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Catalogo prodotti
+                </td>
+                <td className="py-2">Max 5</td>
+                <td className="py-2">Illimitato</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Analytics avanzata
+                </td>
+                <td className="py-2">—</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Export CSV
+                </td>
+                <td className="py-2">—</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Recupero corrispettivi AdE
+                </td>
+                <td className="py-2">—</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="py-2 font-medium text-foreground">
+                  Supporto prioritario
+                </td>
+                <td className="py-2">—</td>
+                <td className="py-2">✓</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* ─── Come scegliere ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Come scegliere il piano giusto
+        </h2>
+        <div className="mt-3 space-y-3">
+          <div>
+            <p className="text-sm font-medium">Scegli Starter se:</p>
+            <ul className="text-muted-foreground mt-1 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+              <li>Emetti meno di 20-30 scontrini al giorno.</li>
+              <li>Non hai bisogno di export CSV o analytics storica.</li>
+              <li>
+                Hai un catalogo piccolo (ambulante, mercatino, servizio
+                occasionale).
+              </li>
+            </ul>
+          </div>
+          <div>
+            <p className="text-sm font-medium">Scegli Pro se:</p>
+            <ul className="text-muted-foreground mt-1 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+              <li>Hai un negozio aperto tutti i giorni.</li>
+              <li>
+                Il tuo commercialista ti chiede un export mensile degli
+                scontrini.
+              </li>
+              <li>Hai più di 5 prodotti nel catalogo rapido.</li>
+              <li>
+                Vuoi sincronizzare il catalogo con il portale AdE (rubrica
+                prodotti).
+              </li>
+            </ul>
+          </div>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Ricorda: puoi provare tutto con il{" "}
+          <strong>trial di 30 giorni</strong> e decidere alla scadenza.
+        </p>
+
+        {/* ─── Articoli correlati ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+        <ul className="mt-3 space-y-1 text-sm">
+          <li>
+            <Link
+              href="/help/prima-configurazione"
+              className="text-primary hover:underline"
+            >
+              Prima configurazione passo-passo (onboarding completo)
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/storico-ed-esportazione"
+              className="text-primary hover:underline"
+            >
+              Storico scontrini: filtri, ricerca ed esportazione
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/sicurezza-credenziali"
+              className="text-primary hover:underline"
+            >
+              Sicurezza e privacy: come proteggiamo le tue credenziali
+            </Link>
+          </li>
+        </ul>
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -32,8 +32,8 @@ export default function PianiEPrezziPage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           ScontrinoZero è disponibile in tre versioni: due piani hosted a
           pagamento (Starter e Pro) con un trial gratuito di 30 giorni, e una
-          versione self-hosted completamente gratuita per chi preferisce
-          gestire il proprio server.
+          versione self-hosted completamente gratuita per chi preferisce gestire
+          il proprio server.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -45,27 +45,27 @@ export default function PianiEPrezziPage() {
           <table className="text-muted-foreground w-full text-sm">
             <thead>
               <tr className="border-border border-b text-left">
-                <th className="pb-2 font-semibold text-foreground">Piano</th>
-                <th className="pb-2 font-semibold text-foreground">Mensile</th>
-                <th className="pb-2 font-semibold text-foreground">Annuale</th>
-                <th className="pb-2 font-semibold text-foreground">Target</th>
+                <th className="text-foreground pb-2 font-semibold">Piano</th>
+                <th className="text-foreground pb-2 font-semibold">Mensile</th>
+                <th className="text-foreground pb-2 font-semibold">Annuale</th>
+                <th className="text-foreground pb-2 font-semibold">Target</th>
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
               <tr>
-                <td className="py-2 font-medium text-foreground">Starter</td>
+                <td className="text-foreground py-2 font-medium">Starter</td>
                 <td className="py-2">€4,99/mese</td>
                 <td className="py-2">€29,99/anno</td>
                 <td className="py-2">Micro-attività, ambulanti</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">Pro</td>
+                <td className="text-foreground py-2 font-medium">Pro</td>
                 <td className="py-2">€8,99/mese</td>
                 <td className="py-2">€49,99/anno</td>
                 <td className="py-2">Negozi, attività regolari</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Self-hosted
                 </td>
                 <td className="py-2 font-semibold text-green-600">Gratuito</td>
@@ -77,8 +77,8 @@ export default function PianiEPrezziPage() {
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           L&apos;abbonamento annuale fa risparmiare il <strong>50%</strong>{" "}
-          rispetto al mensile per Starter e il <strong>54%</strong> per Pro.
-          Non è richiesta nessuna carta di credito per iniziare il trial.
+          rispetto al mensile per Starter e il <strong>54%</strong> per Pro. Non
+          è richiesta nessuna carta di credito per iniziare il trial.
         </p>
 
         {/* ─── Piano Starter ─── */}
@@ -92,23 +92,25 @@ export default function PianiEPrezziPage() {
           <li>Scontrini elettronici illimitati</li>
           <li>Annullamento scontrini</li>
           <li>Metodi di pagamento misti (contante + carta + altro)</li>
-          <li>Catalogo rapido fino a <strong>5 prodotti</strong></li>
+          <li>
+            Catalogo rapido fino a <strong>5 prodotti</strong>
+          </li>
           <li>Analytics base (totale giornaliero, metodi di pagamento)</li>
           <li>Lotteria degli Scontrini</li>
           <li>PWA installabile su smartphone</li>
           <li>Supporto via email entro 48 ore</li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          A <strong>€29,99/anno</strong> è il prezzo più basso del mercato
-          per un registratore di cassa virtuale conforme all&apos;AdE.
+          A <strong>€29,99/anno</strong> è il prezzo più basso del mercato per
+          un registratore di cassa virtuale conforme all&apos;AdE.
         </p>
 
         {/* ─── Piano Pro ─── */}
         <h2 className="mt-10 text-xl font-semibold">Piano Pro</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Per esercenti con un volume di vendite regolare che hanno bisogno di
-          strumenti avanzati per la gestione e la contabilità. Tutto quello
-          che include Starter, più:
+          strumenti avanzati per la gestione e la contabilità. Tutto quello che
+          include Starter, più:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
@@ -119,9 +121,7 @@ export default function PianiEPrezziPage() {
             <strong>Export CSV</strong> dello storico scontrini (per
             commercialista o contabilità)
           </li>
-          <li>
-            Recupero corrispettivi da AdE (sincronizzazione dati storici)
-          </li>
+          <li>Recupero corrispettivi da AdE (sincronizzazione dati storici)</li>
           <li>Sync catalogo prodotti da rubrica AdE</li>
           <li>Supporto prioritario via email entro 24 ore</li>
         </ul>
@@ -136,10 +136,9 @@ export default function PianiEPrezziPage() {
           Versione self-hosted (gratuita)
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          ScontrinoZero è open source con licenza O&apos;Saasy. Puoi
-          scaricare il codice sorgente, installarlo sul tuo server e usarlo
-          gratuitamente con tutte le funzioni del piano Pro. È la scelta
-          giusta se:
+          ScontrinoZero è open source con licenza O&apos;Saasy. Puoi scaricare
+          il codice sorgente, installarlo sul tuo server e usarlo gratuitamente
+          con tutte le funzioni del piano Pro. È la scelta giusta se:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
@@ -149,9 +148,7 @@ export default function PianiEPrezziPage() {
             Vuoi che le tue credenziali Fisconline non transitino da server di
             terzi.
           </li>
-          <li>
-            Preferisci un controllo totale sull&apos;infrastruttura.
-          </li>
+          <li>Preferisci un controllo totale sull&apos;infrastruttura.</li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Con la versione self-hosted sei responsabile di hosting, backup e
@@ -191,63 +188,61 @@ export default function PianiEPrezziPage() {
           <table className="text-muted-foreground w-full text-sm">
             <thead>
               <tr className="border-border border-b text-left">
-                <th className="pb-2 font-semibold text-foreground">Feature</th>
-                <th className="pb-2 font-semibold text-foreground">Starter</th>
-                <th className="pb-2 font-semibold text-foreground">Pro</th>
+                <th className="text-foreground pb-2 font-semibold">Feature</th>
+                <th className="text-foreground pb-2 font-semibold">Starter</th>
+                <th className="text-foreground pb-2 font-semibold">Pro</th>
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Scontrini illimitati
                 </td>
                 <td className="py-2">✓</td>
                 <td className="py-2">✓</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Pagamenti misti
                 </td>
                 <td className="py-2">✓</td>
                 <td className="py-2">✓</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Lotteria Scontrini
                 </td>
                 <td className="py-2">✓</td>
                 <td className="py-2">✓</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Catalogo prodotti
                 </td>
                 <td className="py-2">Max 5</td>
                 <td className="py-2">Illimitato</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Analytics avanzata
                 </td>
                 <td className="py-2">—</td>
                 <td className="py-2">✓</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
-                  Export CSV
-                </td>
+                <td className="text-foreground py-2 font-medium">Export CSV</td>
                 <td className="py-2">—</td>
                 <td className="py-2">✓</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Recupero corrispettivi AdE
                 </td>
                 <td className="py-2">—</td>
                 <td className="py-2">✓</td>
               </tr>
               <tr>
-                <td className="py-2 font-medium text-foreground">
+                <td className="text-foreground py-2 font-medium">
                   Supporto prioritario
                 </td>
                 <td className="py-2">—</td>
@@ -290,8 +285,8 @@ export default function PianiEPrezziPage() {
           </div>
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Ricorda: puoi provare tutto con il{" "}
-          <strong>trial di 30 giorni</strong> e decidere alla scadenza.
+          Ricorda: puoi provare tutto con il <strong>trial di 30 giorni</strong>{" "}
+          e decidere alla scadenza.
         </p>
 
         {/* ─── Articoli correlati ─── */}

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -32,27 +32,29 @@ export default function StoricoEdEsportazionePage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           La sezione <strong>Storico</strong> raccoglie tutti gli scontrini
           emessi e annullati. Puoi filtrare per data e importo, aprire il
-          dettaglio di ogni documento e — con il piano Pro — esportare tutto
-          in CSV per il commercialista.
+          dettaglio di ogni documento e — con il piano Pro — esportare tutto in
+          CSV per il commercialista.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
 
         {/* ─── Come accedere ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Come accedere allo Storico</h2>
+        <h2 className="mt-10 text-xl font-semibold">
+          Come accedere allo Storico
+        </h2>
         <ol className="text-muted-foreground mt-3 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            Dalla dashboard, tocca <strong>Storico</strong> nella barra
-            laterale (o nel menu in basso su mobile).
+            Dalla dashboard, tocca <strong>Storico</strong> nella barra laterale
+            (o nel menu in basso su mobile).
           </li>
           <li>
-            Vedrai l&apos;elenco degli scontrini in ordine cronologico
-            inverso, dal più recente al più vecchio.
+            Vedrai l&apos;elenco degli scontrini in ordine cronologico inverso,
+            dal più recente al più vecchio.
           </li>
           <li>
-            Ogni riga mostra: data, ora, importo totale, metodo di pagamento
-            e stato (Trasmesso, In elaborazione, Annullato).
+            Ogni riga mostra: data, ora, importo totale, metodo di pagamento e
+            stato (Trasmesso, In elaborazione, Annullato).
           </li>
         </ol>
 
@@ -74,10 +76,10 @@ export default function StoricoEdEsportazionePage() {
             <p className="text-sm font-medium">Stato</p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Filtra per <strong>Trasmesso</strong>,{" "}
-              <strong>In elaborazione</strong> o <strong>Annullato</strong>.
-              Il filtro &quot;In elaborazione&quot; è utile per individuare
-              rapidamente documenti la cui trasmissione all&apos;AdE è ancora
-              in corso.
+              <strong>In elaborazione</strong> o <strong>Annullato</strong>. Il
+              filtro &quot;In elaborazione&quot; è utile per individuare
+              rapidamente documenti la cui trasmissione all&apos;AdE è ancora in
+              corso.
             </p>
           </div>
           <div>
@@ -103,9 +105,7 @@ export default function StoricoEdEsportazionePage() {
           <li>Elenco delle righe con descrizione, aliquota IVA e importo.</li>
           <li>Totale e ripartizione per metodo di pagamento.</li>
           <li>Codice lotteria (se applicabile).</li>
-          <li>
-            Stato trasmissione AdE con timestamp di conferma.
-          </li>
+          <li>Stato trasmissione AdE con timestamp di conferma.</li>
           <li>
             Link al PDF dello scontrino (condivisibile via WhatsApp, email,
             ecc.).
@@ -125,9 +125,9 @@ export default function StoricoEdEsportazionePage() {
           </Badge>
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Gli utenti con piano <strong>Pro</strong> possono esportare lo
-          storico scontrini in formato CSV. Il file è compatibile con Excel,
-          Google Sheets e qualsiasi software di contabilità.
+          Gli utenti con piano <strong>Pro</strong> possono esportare lo storico
+          scontrini in formato CSV. Il file è compatibile con Excel, Google
+          Sheets e qualsiasi software di contabilità.
         </p>
         <h3 className="mt-5 text-base font-semibold">Come esportare</h3>
         <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
@@ -142,9 +142,7 @@ export default function StoricoEdEsportazionePage() {
             Il file viene generato e scaricato automaticamente nel browser.
           </li>
         </ol>
-        <h3 className="mt-5 text-base font-semibold">
-          Cosa contiene il CSV
-        </h3>
+        <h3 className="mt-5 text-base font-semibold">Cosa contiene il CSV</h3>
         <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
           Il file include una riga per ogni scontrino con le colonne:
         </p>
@@ -158,8 +156,8 @@ export default function StoricoEdEsportazionePage() {
           <li>Codice lotteria (se presente)</li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Se sei nel piano Starter e vuoi accedere all&apos;export CSV,
-          puoi passare a Pro dalla sezione{" "}
+          Se sei nel piano Starter e vuoi accedere all&apos;export CSV, puoi
+          passare a Pro dalla sezione{" "}
           <strong>Dashboard &gt; Impostazioni &gt; Abbonamento</strong>.
         </p>
 
@@ -182,8 +180,8 @@ export default function StoricoEdEsportazionePage() {
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Usa il filtro per data e importo per identificare rapidamente lo
-              scontrino. Dal dettaglio puoi riaprire il PDF e ricondividerlo
-              via WhatsApp o email.
+              scontrino. Dal dettaglio puoi riaprire il PDF e ricondividerlo via
+              WhatsApp o email.
             </p>
           </div>
           <div>
@@ -192,8 +190,8 @@ export default function StoricoEdEsportazionePage() {
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Filtra per stato <strong>In elaborazione</strong>: se vedi
-              documenti fermi da più di 15 minuti, potrebbe esserci un
-              problema di connessione o un errore AdE. Consulta la guida{" "}
+              documenti fermi da più di 15 minuti, potrebbe esserci un problema
+              di connessione o un errore AdE. Consulta la guida{" "}
               <Link
                 href="/help/errori-ade"
                 className="text-primary hover:underline"

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -1,0 +1,253 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const metadata: Metadata = {
+  title:
+    "Storico scontrini: filtri, ricerca ed esportazione | ScontrinoZero Help",
+  description:
+    "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e esportare i dati in CSV per la contabilità.",
+};
+
+export default function StoricoEdEsportazionePage() {
+  return (
+    <section className="px-4 py-16">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href="/help"
+          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Help Center
+        </Link>
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Storico scontrini: filtri, ricerca ed esportazione
+          </h1>
+          <Badge variant="secondary">Gestione scontrini</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          La sezione <strong>Storico</strong> raccoglie tutti gli scontrini
+          emessi e annullati. Puoi filtrare per data e importo, aprire il
+          dettaglio di ogni documento e — con il piano Pro — esportare tutto
+          in CSV per il commercialista.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> aprile 2026
+        </p>
+
+        {/* ─── Come accedere ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Come accedere allo Storico</h2>
+        <ol className="text-muted-foreground mt-3 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Dalla dashboard, tocca <strong>Storico</strong> nella barra
+            laterale (o nel menu in basso su mobile).
+          </li>
+          <li>
+            Vedrai l&apos;elenco degli scontrini in ordine cronologico
+            inverso, dal più recente al più vecchio.
+          </li>
+          <li>
+            Ogni riga mostra: data, ora, importo totale, metodo di pagamento
+            e stato (Trasmesso, In elaborazione, Annullato).
+          </li>
+        </ol>
+
+        {/* ─── Filtri disponibili ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Filtri disponibili</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Usa i filtri in cima alla lista per restringere i risultati:
+        </p>
+        <div className="mt-3 space-y-3">
+          <div>
+            <p className="text-sm font-medium">Intervallo di date</p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Seleziona una data di inizio e una di fine per vedere solo gli
+              scontrini di quel periodo. Utile per riepilogo mensile o
+              trimestrale.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">Stato</p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Filtra per <strong>Trasmesso</strong>,{" "}
+              <strong>In elaborazione</strong> o <strong>Annullato</strong>.
+              Il filtro &quot;In elaborazione&quot; è utile per individuare
+              rapidamente documenti la cui trasmissione all&apos;AdE è ancora
+              in corso.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">Importo</p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Inserisci un importo minimo e/o massimo per trovare scontrini di
+              un certo valore — comodo per identificare una transazione
+              specifica.
+            </p>
+          </div>
+        </div>
+
+        {/* ─── Dettaglio scontrino ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Aprire il dettaglio di uno scontrino
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Tocca una riga per aprire il dettaglio completo del documento. Qui
+          trovi:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>Numero documento e data/ora di emissione.</li>
+          <li>Elenco delle righe con descrizione, aliquota IVA e importo.</li>
+          <li>Totale e ripartizione per metodo di pagamento.</li>
+          <li>Codice lotteria (se applicabile).</li>
+          <li>
+            Stato trasmissione AdE con timestamp di conferma.
+          </li>
+          <li>
+            Link al PDF dello scontrino (condivisibile via WhatsApp, email,
+            ecc.).
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Dal dettaglio puoi anche avviare l&apos;
+          <strong>annullamento</strong> dello scontrino, se è in stato
+          Trasmesso.
+        </p>
+
+        {/* ─── Export CSV ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Esportazione CSV{" "}
+          <Badge className="ml-1" variant="secondary">
+            Piano Pro
+          </Badge>
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Gli utenti con piano <strong>Pro</strong> possono esportare lo
+          storico scontrini in formato CSV. Il file è compatibile con Excel,
+          Google Sheets e qualsiasi software di contabilità.
+        </p>
+        <h3 className="mt-5 text-base font-semibold">Come esportare</h3>
+        <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Vai in <strong>Storico</strong> e imposta i filtri desiderati
+            (periodo, stato).
+          </li>
+          <li>
+            Clicca su <strong>Esporta CSV</strong> in alto a destra.
+          </li>
+          <li>
+            Il file viene generato e scaricato automaticamente nel browser.
+          </li>
+        </ol>
+        <h3 className="mt-5 text-base font-semibold">
+          Cosa contiene il CSV
+        </h3>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Il file include una riga per ogni scontrino con le colonne:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>Numero documento</li>
+          <li>Data e ora di emissione</li>
+          <li>Stato (Trasmesso / Annullato)</li>
+          <li>Importo lordo totale</li>
+          <li>IVA per aliquota (4%, 10%, 22%, Esente)</li>
+          <li>Metodo di pagamento (Contante, Carta, Altro)</li>
+          <li>Codice lotteria (se presente)</li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Se sei nel piano Starter e vuoi accedere all&apos;export CSV,
+          puoi passare a Pro dalla sezione{" "}
+          <strong>Dashboard &gt; Impostazioni &gt; Abbonamento</strong>.
+        </p>
+
+        {/* ─── Casi d'uso comuni ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Casi d&apos;uso comuni</h2>
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-sm font-medium">
+              Riepilogo mensile per il commercialista
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Filtra per il mese di riferimento, esporta il CSV e invialo al
+              commercialista. Il file contiene già la ripartizione IVA per
+              aliquota, pronta per la liquidazione.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Trovare uno scontrino specifico per un cliente
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Usa il filtro per data e importo per identificare rapidamente lo
+              scontrino. Dal dettaglio puoi riaprire il PDF e ricondividerlo
+              via WhatsApp o email.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Verificare scontrini in attesa di conferma AdE
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Filtra per stato <strong>In elaborazione</strong>: se vedi
+              documenti fermi da più di 15 minuti, potrebbe esserci un
+              problema di connessione o un errore AdE. Consulta la guida{" "}
+              <Link
+                href="/help/errori-ade"
+                className="text-primary hover:underline"
+              >
+                Errori comuni di accesso AdE
+              </Link>{" "}
+              per diagnosticare.
+            </p>
+          </div>
+        </div>
+
+        {/* ─── Articoli correlati ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+        <ul className="mt-3 space-y-1 text-sm">
+          <li>
+            <Link
+              href="/help/annullare-scontrino"
+              className="text-primary hover:underline"
+            >
+              Annullare uno scontrino: quando si può e come fare
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/cassetto-fiscale"
+              className="text-primary hover:underline"
+            >
+              Dove verificare i corrispettivi nel cassetto fiscale
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/piani-e-prezzi"
+              className="text-primary hover:underline"
+            >
+              Piani disponibili: Starter, Pro e self-hosted gratuito
+            </Link>
+          </li>
+        </ul>
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds six new comprehensive help center articles to the ScontrinoZero marketing site, covering pricing plans, regulatory compliance, configuration, and operational procedures. These articles expand the help center with detailed guides for users and potential customers.

## Key Changes

- **Piani e Prezzi** (`piani-e-prezzi/page.tsx`): Complete pricing guide covering Starter and Pro plans, self-hosted option, 30-day free trial, and detailed feature comparison tables
- **Normativa POS 2026** (`normativa-pos-2026/page.tsx`): Regulatory guide explaining new POS-RT integration requirements, who is affected, implementation timelines, and how ScontrinoZero's DCO approach provides compliance advantages
- **Aliquote IVA** (`aliquote-iva/page.tsx`): Configuration guide for VAT rates (4%, 10%, 22%, exempt), merchandise departments, and payment methods with practical setup instructions
- **Storico ed Esportazione** (`storico-ed-esportazione/page.tsx`): User guide for receipt history navigation, filtering, search functionality, and CSV export feature (Pro plan only)
- **Cassetto Fiscale** (`cassetto-fiscale/page.tsx`): Guide to accessing and verifying receipts in the Italian tax authority's (AdE) portal, troubleshooting missing documents
- **Chiusura Giornaliera** (`chiusura-giornaliera/page.tsx`): Explanation of why daily closing is not required with ScontrinoZero's DCO approach, contrasting with traditional POS systems

## Implementation Details

- All articles follow consistent structure with metadata, navigation breadcrumbs, and semantic HTML
- Each article includes appropriate badges for categorization (Abbonamento, POS e normativa, Configurazione attività, Gestione scontrini, Fiscalizzazione)
- Articles contain comparison tables, feature lists, and step-by-step instructions where applicable
- Updated help center index (`help/page.tsx`) to link new articles and remove placeholder entries
- All content is in Italian, matching the application's target market
- Articles include "Last updated" timestamps (April 2026) for transparency

https://claude.ai/code/session_01WGpfUGEPM3No7FuPEjoytx