### PR TITLE
Refactor forfettario and annullo documentation for clarity

### DIFF
--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -30,10 +30,10 @@ export default function AnnullareScontrinoPage() {
           <Badge variant="secondary">Gestione scontrini</Badge>
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Un scontrino fiscale non si &quot;cancella&quot; — si emette un{" "}
-          <strong>documento di annullamento</strong> che rettifica il documento
+          Uno scontrino elettronico non si &quot;cancella&quot;: si emette un{" "}
+          <strong>documento di annullo</strong> che rettifica il documento
           originale nel cassetto fiscale dell&apos;Agenzia delle Entrate. Questa
-          guida spiega come fare e in quali casi è possibile.
+          guida spiega come farlo da ScontrinoZero e in quali casi è possibile.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -44,36 +44,67 @@ export default function AnnullareScontrinoPage() {
           Quando è possibile annullare
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          L&apos;annullamento è consentito per:
+          In ScontrinoZero puoi annullare uno scontrino che è stato{" "}
+          <strong>accettato dall&apos;AdE</strong> (nello Storico vedrai il
+          badge verde <strong>&quot;Emesso&quot;</strong>). Il caso d&apos;uso
+          tipico è:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
-            Scontrini emessi per errore (importo sbagliato, prodotto errato).
+            Scontrino emesso per errore (importo sbagliato, prodotto errato,
+            duplicato).
           </li>
-          <li>Vendite stornate dal cliente (reso merce, recesso).</li>
           <li>
-            Scontrini trasmessi all&apos;AdE con stato{" "}
-            <strong>Trasmesso</strong>.
+            Storno concordato con il cliente prima che la vendita si consolidi
+            (p.es. il cliente cambia idea subito dopo l&apos;emissione).
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Non è possibile annullare</strong> scontrini già annullati o
-          scontrini in stato <em>In elaborazione</em> (attendi che la
-          trasmissione si completi prima di procedere).
+          <strong>Non è possibile annullare:</strong>
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Scontrini già annullati (badge{" "}
+            <strong>&quot;Annullato&quot;</strong>
+            ).
+          </li>
+          <li>
+            Scontrini ancora in attesa di conferma AdE (badge giallo{" "}
+            <strong>&quot;PENDING&quot;</strong>): aspetta che diventino
+            <em> Emesso</em> prima di annullare.
+          </li>
+          <li>
+            Scontrini con stato <strong>&quot;Errore&quot;</strong>: non sono
+            mai stati registrati dall&apos;AdE, quindi non c&apos;è nulla da
+            annullare. Riemetti la vendita dalla Cassa.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Reso merce post-vendita:</strong> il Provvedimento AdE sui
+          corrispettivi telematici prevede, per il reso di prodotti già
+          consegnati, un <em>documento commerciale per reso merce</em> distinto
+          dall&apos;annullo. In questa versione ScontrinoZero non espone quel
+          tipo di documento: in pratica il reso si gestisce annullando lo
+          scontrino originale e, se il reso è parziale, ri-emettendo dalla Cassa
+          uno scontrino con il solo importo effettivamente venduto. Per casi
+          complessi (reso dopo mesi, parziale con più prodotti) consulta il tuo
+          commercialista.
         </p>
 
         {/* ─── Limiti temporali ─── */}
         <h2 className="mt-10 text-xl font-semibold">Limiti temporali</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          La normativa AdE non fissa una scadenza precisa per
-          l&apos;annullamento, ma vale la regola generale:{" "}
+          Per il Documento Commerciale Online non esiste una finestra rigida di
+          annullo: puoi procedere anche diversi giorni dopo l&apos;emissione
+          (diversamente dai registratori telematici fisici, dove spesso la
+          finestra coincide con la chiusura giornaliera). La best practice
+          fiscale resta però di{" "}
           <strong>
-            il documento di annullamento deve essere emesso nel periodo
-            d&apos;imposta in cui è stato emesso il documento originale
+            annullare il prima possibile e comunque entro il periodo
+            d&apos;imposta
           </strong>
-          {
-            ", salvo casi eccezionali. In pratica: prima annulli, meglio è. Evita di lasciare annullamenti aperti per settimane o mesi."
-          }
+          : ogni ritardo rende più complicata la riconciliazione dei
+          corrispettivi giornalieri nel cassetto fiscale.
         </p>
 
         {/* ─── Come fare ─── */}
@@ -85,40 +116,49 @@ export default function AnnullareScontrinoPage() {
             Vai nella sezione <strong>Storico</strong> dalla barra laterale.
           </li>
           <li>
-            Trova lo scontrino da annullare usando i filtri per data o importo.
+            Trova lo scontrino usando i filtri per intervallo di date o
+            paginando la lista.
           </li>
           <li>
-            Clicca sullo scontrino per aprire il dettaglio, poi tocca{" "}
-            <strong>Annulla scontrino</strong>.
+            Clicca sullo scontrino per aprire il dettaglio, quindi tocca{" "}
+            <strong>Annulla scontrino</strong> (il pulsante compare solo se lo
+            stato è <em>Emesso</em>).
           </li>
           <li>
-            Conferma l&apos;operazione nella finestra di dialogo. È
-            irreversibile.
+            Leggi il riepilogo, poi conferma cliccando di nuovo{" "}
+            <strong>Annulla scontrino</strong> nel dialog rosso. Un avviso ti
+            ricorda che l&apos;operazione è irreversibile.
           </li>
           <li>
-            ScontrinoZero invia il documento di annullamento all&apos;AdE. Lo
-            stato dello scontrino originale diventa <strong>Annullato</strong>.
+            ScontrinoZero invia il documento di annullo all&apos;AdE. A conferma
+            vedrai il <strong>progressivo dell&apos;annullo</strong>; lo
+            scontrino originale passa a stato <strong>Annullato</strong>.
           </li>
         </ol>
 
         {/* ─── Cosa succede dopo ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Cosa succede dopo l&apos;annullamento
+          Cosa succede dopo l&apos;annullo
         </h2>
         <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            L&apos;AdE registra il documento di annullamento nel cassetto
-            fiscale e rettifica i corrispettivi di quel giorno.
+            L&apos;AdE registra il documento di annullo nel cassetto fiscale e
+            rettifica i corrispettivi del giorno.
           </li>
           <li>
-            Lo scontrino originale non viene eliminato — rimane nello Storico
-            con stato <strong>Annullato</strong>, insieme al riferimento al
-            documento di annullamento.
+            Lo scontrino originale <strong>non viene eliminato</strong>: rimane
+            nello Storico con badge <em>Annullato</em> e un riferimento al
+            documento di annullo.
+          </li>
+          <li>
+            Un secondo tentativo di annullo sullo stesso scontrino viene
+            bloccato automaticamente da un vincolo del database: è garantito che
+            non puoi creare due annulli per lo stesso documento.
           </li>
           <li>
             Se vuoi emettere uno scontrino corretto al posto di quello
-            annullato, devi farlo separatamente dalla <strong>Cassa</strong>{" "}
-            come una nuova vendita.
+            annullato, fallo separatamente dalla <strong>Cassa</strong> come
+            nuova vendita.
           </li>
         </ul>
 
@@ -127,7 +167,7 @@ export default function AnnullareScontrinoPage() {
           Reso merce: devo fare altro?
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          L&apos;annullamento dello scontrino è sufficiente ai fini fiscali. Il
+          L&apos;annullo dello scontrino è sufficiente ai fini fiscali. Il
           rimborso al cliente (contante, bonifico, voucher) è una questione
           commerciale separata che gestisci tu direttamente — non passa
           attraverso ScontrinoZero.
@@ -141,19 +181,32 @@ export default function AnnullareScontrinoPage() {
               Il pulsante &quot;Annulla scontrino&quot; non compare
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Verifica che lo scontrino sia in stato <strong>Trasmesso</strong>.
-              Se è ancora <em>In elaborazione</em>, attendi la conferma AdE
-              prima di procedere.
+              Succede quando lo scontrino non è in stato <em>Emesso</em>: se è
+              ancora <strong>PENDING</strong> aspetta la conferma AdE, se è{" "}
+              <strong>Errore</strong> non è stato registrato all&apos;origine
+              quindi non c&apos;è nulla da annullare, se è già{" "}
+              <strong>Annullato</strong> l&apos;operazione è stata fatta.
             </p>
           </div>
           <div>
             <p className="text-sm font-medium">
-              L&apos;annullamento è rimasto in stato &quot;In elaborazione&quot;
+              Ricevo un errore durante l&apos;annullo — cosa faccio?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Come per l&apos;emissione normale, il portale AdE può essere
-              temporaneamente lento. ScontrinoZero riprova automaticamente.
-              Controlla lo stato dopo qualche minuto.
+              L&apos;errore viene mostrato in rosso nel dialog e lo scontrino
+              resta in stato <em>Emesso</em> (l&apos;annullo non è andato a buon
+              fine). Puoi <strong>riprovare manualmente</strong> chiudendo e
+              riaprendo il dialog: ScontrinoZero usa una chiave di idempotenza
+              per garantire che eventuali retry non creino annulli duplicati. Se
+              l&apos;errore persiste, controlla lo stato del portale AdE e
+              contatta il supporto a{" "}
+              <a
+                href="mailto:info@scontrinozero.it"
+                className="text-primary hover:underline"
+              >
+                info@scontrinozero.it
+              </a>
+              {"."}
             </p>
           </div>
           <div>
@@ -161,8 +214,8 @@ export default function AnnullareScontrinoPage() {
               Ho annullato per errore — posso tornare indietro?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              No: il documento di annullamento trasmesso all&apos;AdE non può
-              essere ritirato. Devi emettere un nuovo scontrino dalla Cassa con
+              No: il documento di annullo trasmesso all&apos;AdE non può essere
+              ritirato. Devi emettere un nuovo scontrino dalla Cassa con
               l&apos;importo corretto.
             </p>
           </div>
@@ -177,6 +230,14 @@ export default function AnnullareScontrinoPage() {
               className="text-primary hover:underline"
             >
               Come emettere il primo scontrino elettronico
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/storico-ed-esportazione"
+              className="text-primary hover:underline"
+            >
+              Storico scontrini: filtri, ricerca ed esportazione
             </Link>
           </li>
           <li>

--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -64,14 +64,16 @@ export default function AnnullareScontrinoPage() {
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
-            Scontrini già annullati (badge{" "}
+            {"Scontrini già annullati (badge "}
             <strong>&quot;Annullato&quot;</strong>
-            ).
+            {")."}
           </li>
           <li>
-            Scontrini ancora in attesa di conferma AdE (badge giallo{" "}
-            <strong>&quot;PENDING&quot;</strong>): aspetta che diventino
-            <em> Emesso</em> prima di annullare.
+            {"Scontrini ancora in attesa di conferma AdE (badge giallo "}
+            <strong>&quot;PENDING&quot;</strong>
+            {": aspetta che diventino "}
+            <em>Emesso</em>
+            {" prima di annullare."}
           </li>
           <li>
             Scontrini con stato <strong>&quot;Errore&quot;</strong>: non sono
@@ -94,17 +96,16 @@ export default function AnnullareScontrinoPage() {
         {/* ─── Limiti temporali ─── */}
         <h2 className="mt-10 text-xl font-semibold">Limiti temporali</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Per il Documento Commerciale Online non esiste una finestra rigida di
-          annullo: puoi procedere anche diversi giorni dopo l&apos;emissione
-          (diversamente dai registratori telematici fisici, dove spesso la
-          finestra coincide con la chiusura giornaliera). La best practice
-          fiscale resta però di{" "}
+          {
+            "Per il Documento Commerciale Online non esiste una finestra rigida di annullo: puoi procedere anche diversi giorni dopo l\u2019emissione (diversamente dai registratori telematici fisici, dove spesso la finestra coincide con la chiusura giornaliera). La best practice fiscale resta però di "
+          }
           <strong>
             annullare il prima possibile e comunque entro il periodo
             d&apos;imposta
           </strong>
-          : ogni ritardo rende più complicata la riconciliazione dei
-          corrispettivi giornalieri nel cassetto fiscale.
+          {
+            ": ogni ritardo rende più complicata la riconciliazione dei corrispettivi giornalieri nel cassetto fiscale."
+          }
         </p>
 
         {/* ─── Come fare ─── */}

--- a/src/app/(marketing)/help/regime-forfettario/page.tsx
+++ b/src/app/(marketing)/help/regime-forfettario/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 export const metadata: Metadata = {
   title: "Regime forfettario: configurazione IVA corretta | ScontrinoZero Help",
   description:
-    "Come configurare ScontrinoZero per il regime forfettario: aliquota IVA corretta, dicitura sullo scontrino e impostazioni fiscali per chi non applica IVA.",
+    "Come configurare ScontrinoZero per il regime forfettario: natura IVA N2 per operazioni non soggette, impostazioni in onboarding e nel catalogo prodotti.",
 };
 
 export default function RegimeForfettarioPage() {
@@ -31,7 +31,7 @@ export default function RegimeForfettarioPage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           I contribuenti in regime forfettario non applicano l&apos;IVA sulle
           vendite. Questa guida spiega come configurare ScontrinoZero
-          correttamente per evitare errori nei documenti trasmessi
+          correttamente per evitare errori nei documenti commerciali trasmessi
           all&apos;Agenzia delle Entrate.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
@@ -50,55 +50,77 @@ export default function RegimeForfettarioPage() {
             non addebita IVA al cliente e non la detrae sugli acquisti
           </strong>
           {
-            ". Sullo scontrino o documento commerciale deve invece comparire la dicitura di esonero."
+            ". Sul documento commerciale trasmesso all\u2019AdE le righe di vendita vanno quindi certificate con una "
           }
+          <strong>natura IVA</strong>
+          {
+            ", non con un\u2019aliquota percentuale. In ScontrinoZero il codice da usare \u00e8 "
+          }
+          <strong>N2 (operazioni non soggette)</strong>
+          {"."}
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           L&apos;errore più comune è impostare l&apos;aliquota IVA al 22% (o
-          altra aliquota ordinaria) anziché usare il codice di esonero — lo
-          scontrino risulterebbe fiscalmente scorretto.
+          altra aliquota ordinaria) anziché usare una natura N2: lo scontrino
+          risulterebbe fiscalmente scorretto e l&apos;esoneratore si troverebbe
+          ad aver certificato operazioni come imponibili.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Nota per la fatturazione elettronica B2B:</strong> nel
+          tracciato della fattura elettronica il codice granulare richiesto per
+          i forfettari è <strong>N2.2</strong> (in vigore dal 1° luglio 2022);
+          separatamente, il blocco RegimeFiscale del cedente si valorizza con{" "}
+          <strong>RF19</strong>. Questi due codici riguardano però la fattura
+          elettronica, non il documento commerciale gestito da ScontrinoZero.
         </p>
 
         {/* ─── Configurazione in ScontrinoZero ─── */}
         <h2 className="mt-10 text-xl font-semibold">
           Come configurare il regime forfettario in ScontrinoZero
         </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero non ha un selettore &quot;Regime forfettario&quot;
+          dedicato: la configurazione avviene impostando l&apos;aliquota IVA
+          predefinita della tua attività e, se usi il catalogo rapido, quella
+          dei singoli prodotti.
+        </p>
+        <h3 className="mt-6 text-base font-semibold">
+          1. Durante l&apos;onboarding (prima configurazione)
+        </h3>
         <ol className="text-muted-foreground mt-3 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            Vai su{" "}
-            <strong>
-              Impostazioni → Configurazione attività → Regime fiscale
-            </strong>
-            {"."}
+            Nello <strong>Step 1 — Attività</strong> del wizard, alla voce{" "}
+            <strong>Aliquota IVA prevalente</strong> seleziona{" "}
+            <strong>&quot;0% – Non soggette&quot; (codice N2)</strong>.
           </li>
           <li>
-            Seleziona <strong>Regime forfettario</strong> dall&apos;elenco a
-            tendina. ScontrinoZero imposta automaticamente:
-            <ul className="mt-1 list-disc space-y-1 pl-5">
-              <li>
-                Aliquota IVA predefinita:{" "}
-                <strong>RF19 — Regime forfettario (non soggetto IVA)</strong>
-              </li>
-              <li>
-                Dicitura aggiuntiva sullo scontrino:{" "}
-                <em>
-                  &quot;Operazione effettuata da contribuente in regime
-                  forfettario ai sensi dell&apos;art. 1 cc. 54-89 L. 190/2014 —
-                  non soggetta a IVA&quot;
-                </em>
-              </li>
-            </ul>
-          </li>
-          <li>
-            Salva le impostazioni. Da questo momento tutti gli scontrini emessi
-            useranno la natura IVA RF19.
+            Completa gli altri step (credenziali AdE, riepilogo) e termina
+            l&apos;onboarding.
           </li>
         </ol>
+        <h3 className="mt-6 text-base font-semibold">
+          2. Prodotti del catalogo rapido
+        </h3>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Se hai già aggiunto prodotti al catalogo rapido prima di configurare
-          il regime, controlla che le aliquote IVA dei singoli prodotti siano
-          anch&apos;esse impostate su <strong>RF19</strong> (puoi farlo in{" "}
-          <strong>Catalogo → modifica prodotto</strong>).
+          Per ogni prodotto che aggiungi da <strong>Catalogo → Nuovo</strong>{" "}
+          (oppure modificando un prodotto esistente), nel campo{" "}
+          <strong>Aliquota IVA</strong> seleziona anche qui{" "}
+          <strong>&quot;0% – Non soggette&quot; (N2)</strong>. Le righe manuali
+          (importo libero) usano automaticamente l&apos;aliquota predefinita
+          impostata in onboarding.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Attenzione:</strong> al momento l&apos;aliquota IVA prevalente
+          non è modificabile dalla pagina <em>Impostazioni</em> dopo
+          l&apos;onboarding. Se hai sbagliato la selezione iniziale contatta il
+          supporto scrivendo a{" "}
+          <a
+            href="mailto:info@scontrinozero.it"
+            className="text-primary hover:underline"
+          >
+            info@scontrinozero.it
+          </a>
+          {"."}
         </p>
 
         {/* ─── Come appare lo scontrino ─── */}
@@ -107,38 +129,65 @@ export default function RegimeForfettarioPage() {
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Il documento commerciale trasmesso all&apos;AdE per un forfettario
-          mostra:
+          configurato con N2 mostra:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
-            <strong>Importo totale</strong> senza IVA separata — il prezzo è
-            &quot;tutto incluso&quot; senza scorporo.
+            <strong>Importo totale</strong> senza IVA separata: il prezzo è
+            &quot;tutto incluso&quot; e non c&apos;è scorporo.
           </li>
           <li>
-            <strong>Natura RF19</strong> nel campo aliquota/natura IVA.
+            <strong>Natura N2</strong> nel campo aliquota/natura IVA delle
+            righe.
           </li>
           <li>
-            <strong>Dicitura legale</strong> di esonero (aggiunta
-            automaticamente da ScontrinoZero).
+            <strong>Nessuna voce &quot;IVA: € 0,00&quot;</strong>: semplicemente
+            l&apos;IVA non è esposta.
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Il cliente vede un documento corretto e conforme. Non deve comparire
-          nessuna cifra come &quot;IVA: €0,00&quot; — semplicemente non c&apos;è
-          la voce IVA.
+          ScontrinoZero <strong>non inserisce automaticamente</strong> una
+          dicitura di esonero (&quot;Operazione effettuata da contribuente in
+          regime forfettario…&quot;) sul documento commerciale: la normativa sul
+          DCO non la richiede, ma se ti è utile per la tua comunicazione al
+          cliente puoi stamparla/scriverla a parte. La dicitura{" "}
+          <em>
+            &quot;Operazione in franchigia da IVA ai sensi dell&apos;art. 1 co.
+            54-89 L. 190/2014&quot;
+          </em>{" "}
+          resta invece obbligatoria sulle fatture emesse (non sugli scontrini).
         </p>
 
-        {/* ─── Cosa cambia dal 2024 ─── */}
+        {/* ─── Soglie di ricavo ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Soglia ricavi 2024–2025: chi rientra ancora nel forfettario?
+          Soglie di ricavo: 85.000 € e 100.000 €
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Dal 2024 la soglia di ricavi per accedere al regime forfettario è{" "}
-          <strong>€ 85.000 annui</strong> (modificata dalla Legge di Bilancio
-          2023). Superata questa soglia nel corso dell&apos;anno, esci dal
-          regime dall&apos;anno successivo. ScontrinoZero non verifica
-          automaticamente il superamento della soglia — consulta il tuo
-          commercialista se sei vicino al limite.
+          La soglia base per accedere e rimanere nel regime forfettario è{" "}
+          <strong>€ 85.000 annui</strong> di incassi (principio di cassa),
+          innalzata dai precedenti € 65.000 dalla{" "}
+          <strong>Legge di Bilancio 2023</strong> (L. 197/2022), con decorrenza{" "}
+          <strong>dal 2023</strong>. Due scenari possibili in caso di
+          superamento nel corso dell&apos;anno:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Tra 85.000 e 100.000 €:</strong> mantieni il regime
+            forfettario per l&apos;anno in corso ed esci dal{" "}
+            <strong>1° gennaio dell&apos;anno successivo</strong>.
+          </li>
+          <li>
+            <strong>Oltre 100.000 €:</strong> uscita <strong>immediata</strong>{" "}
+            dal regime, con applicazione dell&apos;IVA{" "}
+            <strong>retroattiva</strong> a partire dall&apos;operazione che ha
+            determinato il superamento (art. 1 comma 71, L. 190/2014, come
+            novellato dalla L. 197/2022).
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero non verifica automaticamente il superamento delle
+          soglie. Se sei vicino al limite consulta il tuo commercialista per
+          valutare tempestivamente il passaggio al regime ordinario.
         </p>
 
         {/* ─── Domande frequenti ─── */}
@@ -146,15 +195,15 @@ export default function RegimeForfettarioPage() {
         <div className="mt-3 space-y-4">
           <div>
             <p className="text-sm font-medium">
-              Ho selezionato &quot;Regime forfettario&quot; ma lo scontrino
+              Ho selezionato &quot;0% – Non soggette&quot; ma uno scontrino
               mostra ancora IVA al 22% — perché?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Probabilmente hai aggiunto prodotti al catalogo prima di
-              configurare il regime, e quei prodotti hanno ancora
-              l&apos;aliquota ordinaria. Vai in <strong>Catalogo</strong> e
-              aggiorna l&apos;aliquota di ciascun prodotto su{" "}
-              <strong>RF19</strong>. Le righe manuali (importo libero) usano
+              configurare l&apos;aliquota prevalente, e quei prodotti hanno
+              ancora l&apos;aliquota ordinaria. Vai in <strong>Catalogo</strong>{" "}
+              e aggiorna l&apos;aliquota di ciascun prodotto su{" "}
+              <strong>N2</strong>. Le righe manuali (importo libero) usano
               sempre l&apos;aliquota predefinita dell&apos;attività.
             </p>
           </div>
@@ -163,24 +212,30 @@ export default function RegimeForfettarioPage() {
               Posso vendere ad aliquote diverse (es. alcune voci a IVA 10%)?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              In regime forfettario no — sei completamente esonerato
-              dall&apos;IVA su tutte le operazioni. Non è possibile applicare
-              aliquote diverse su singole vendite rimanendo nel forfettario. Se
-              devi applicare IVA, devi prima uscire dal regime forfettario
-              (contatta il tuo commercialista).
+              In regime forfettario no: sei completamente esonerato
+              dall&apos;IVA su tutte le operazioni e devi certificarle come non
+              soggette. Se devi applicare IVA su una vendita, devi prima uscire
+              dal regime forfettario (contatta il tuo commercialista).
             </p>
           </div>
           <div>
             <p className="text-sm font-medium">
-              Ho sbagliato regime — ho emesso scontrini con IVA quando ero
+              Ho emesso per errore uno scontrino con IVA al 22% quando ero
               forfettario. Cosa faccio?
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Questo è un errore fiscale che richiede la consulenza di un
-              commercialista. ScontrinoZero non può correggere retroattivamente
-              i documenti già trasmessi all&apos;AdE. Puoi contattare il
-              supporto per ricevere un elenco degli scontrini emessi nel
-              periodo.
+              Il documento commerciale emesso va{" "}
+              <Link
+                href="/help/annullare-scontrino"
+                className="text-primary hover:underline"
+              >
+                annullato
+              </Link>{" "}
+              e ri-emesso con la natura IVA corretta. ScontrinoZero non può
+              modificare retroattivamente i documenti già trasmessi
+              all&apos;AdE: l&apos;unica strada è il void seguito da una nuova
+              emissione. Per errori estesi nel tempo, rivolgiti al tuo
+              commercialista.
             </p>
           </div>
           <div>
@@ -206,6 +261,14 @@ export default function RegimeForfettarioPage() {
               className="text-primary hover:underline"
             >
               Come emettere il primo scontrino elettronico
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/help/annullare-scontrino"
+              className="text-primary hover:underline"
+            >
+              Annullare uno scontrino: quando si può e come fare
             </Link>
           </li>
           <li>


### PR DESCRIPTION
## Summary
Updated help documentation for the "Regime forfettario" and "Annullare scontrino" pages to reflect accurate IVA coding practices and improve user guidance. The changes clarify that forfettario businesses must use IVA nature code **N2 (non-soggette)** rather than RF19, and provide more detailed instructions on configuration and document cancellation procedures.

## Key Changes

### Regime Forfettario Page (`regime-forfettario/page.tsx`)
- **IVA Nature Correction**: Changed from RF19 (regime code) to N2 (non-soggette nature code) as the correct classification for forfettario operations
- **Configuration Flow**: Restructured setup instructions to emphasize onboarding step (Step 1 — Attività) where users select "0% – Non soggette (N2)" as the default IVA rate
- **Product Catalog**: Added explicit guidance that individual catalog products must also use N2 classification
- **E-invoice Clarification**: Added new section explaining that N2.2 and RF19 codes apply to electronic invoicing (B2B), not to the commercial documents managed by ScontrinoZero
- **Revenue Thresholds**: Expanded section on €85,000 and €100,000 thresholds with clearer scenarios for when businesses must exit the regime
- **Error Handling**: Updated FAQ to explain that incorrectly issued receipts with IVA must be annulled and re-issued with correct N2 nature
- **Removed Automatic Disclaimer**: Clarified that ScontrinoZero no longer automatically inserts the exemption disclaimer on receipts (not required by DCO regulations)

### Annullo Scontrino Page (`annullare-scontrino/page.tsx`)
- **Terminology**: Changed "documento di annullamento" to "documento di annullo" for consistency
- **Status Clarity**: Refined explanation of when annullment is possible—only for receipts with "Emesso" status (green badge), not PENDING or Errore states
- **Temporal Limits**: Clarified that while no strict deadline exists for DCO, best practice is to annul within the same tax period
- **Reso Merce Guidance**: Added detailed explanation that product returns use annullo + re-issuance workflow (not a separate reso document in current version)
- **Step-by-Step Process**: Enhanced instructions with clearer status indicators and confirmation dialog details
- **Error Recovery**: Improved FAQ with idempotency explanation and support contact for persistent errors
- **Cross-linking**: Added link to "Storico ed esportazione" help page for better navigation

## Notable Implementation Details
- Both pages now consistently use N2 as the correct IVA nature code for forfettario operations
- Configuration is now clearly tied to the onboarding wizard rather than post-setup settings
- Added explicit warnings about the non-modifiability of default IVA rate after onboarding
- Improved error scenarios and recovery paths in FAQ sections
- Enhanced cross-references between related help articles

https://claude.ai/code/session_01GyzobKcmyUmaYpFMdXML9n