### PR TITLE
Enforce strict PIN validation: exactly 10 numeric digits

### DIFF
--- a/src/app/onboarding/onboarding-form.tsx
+++ b/src/app/onboarding/onboarding-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
+import { adePinSchema } from "@/lib/validation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -52,7 +53,7 @@ const step2Schema = z.object({
     .min(16, "Codice fiscale non valido (16 caratteri).")
     .max(16, "Codice fiscale non valido (16 caratteri)."),
   password: z.string().min(1, "La password Fisconline è obbligatoria."),
-  pin: z.string().min(6, "Il PIN deve essere di almeno 6 caratteri."),
+  pin: adePinSchema,
 });
 
 type Step1Data = z.infer<typeof step1Schema>;

--- a/src/components/settings/edit-ade-credentials-section.tsx
+++ b/src/components/settings/edit-ade-credentials-section.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
+import { adePinSchema } from "@/lib/validation";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import {
@@ -25,7 +26,7 @@ const editAdeCredentialsSchema = z.object({
     .min(16, "Codice fiscale non valido (16 caratteri).")
     .max(16, "Codice fiscale non valido (16 caratteri)."),
   password: z.string().min(1, "La password Fisconline è obbligatoria."),
-  pin: z.string().min(6, "Il PIN deve essere di almeno 6 caratteri."),
+  pin: adePinSchema,
 });
 
 type EditAdeCredentialsData = z.infer<typeof editAdeCredentialsSchema>;

--- a/src/lib/ade/mock-client.test.ts
+++ b/src/lib/ade/mock-client.test.ts
@@ -11,7 +11,7 @@ import type { AdePayload, AdeCedentePrestatore } from "./types";
 const mockCredentials = {
   codiceFiscale: "RSSMRA80A01H501A",
   password: "testpassword",
-  pin: "12345678",
+  pin: "1234567890",
 };
 
 const mockCedentePrestatore: AdeCedentePrestatore = {

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -99,7 +99,7 @@ function mockReAuthSequence(fetchMock: ReturnType<typeof vi.fn>): void {
 const mockCredentials = {
   codiceFiscale: "RSSMRA80A01H501A",
   password: "testpassword",
-  pin: "12345678",
+  pin: "1234567890",
 };
 
 const mockSpidCredentials: SpidCredentials = {
@@ -391,7 +391,7 @@ describe("RealAdeClient", () => {
       >;
       expect(body.username).toBe("RSSMRA80A01H501A");
       expect(body.password).toBe("testpassword");
-      expect(body.pin).toBe("12345678");
+      expect(body.pin).toBe("1234567890");
     });
 
     it("Phase A: lancia AdeAuthError se la risposta non è 200", async () => {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,10 +1,71 @@
 import { describe, it, expect } from "vitest";
 import {
+  adePinSchema,
   isValidEmail,
   isStrongPassword,
   isValidLotteryCode,
   normalizeEmail,
 } from "./validation";
+
+describe("adePinSchema", () => {
+  const PIN_ERROR =
+    "Il PIN Fisconline è composto da 10 cifre numeriche. Se ne hai solo 4, aspetta la lettera con le ultime 6 cifre per posta.";
+
+  it("accepts exactly 10 numeric digits", () => {
+    const result = adePinSchema.safeParse("1234567890");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    const result = adePinSchema.safeParse("");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects 9 digits (too short by 1)", () => {
+    const result = adePinSchema.safeParse("123456789");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects 11 digits (too long by 1)", () => {
+    const result = adePinSchema.safeParse("12345678901");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects 10 characters containing a letter", () => {
+    const result = adePinSchema.safeParse("123456789a");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects 10 characters that are all letters", () => {
+    const result = adePinSchema.safeParse("abcdefghij");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects PIN with internal space (9 digits + 1 space)", () => {
+    const result = adePinSchema.safeParse("12345 6789");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects PIN with surrounding whitespace (schema does not trim)", () => {
+    // Trimming is the caller's responsibility before safeParse
+    const result = adePinSchema.safeParse(" 1234567890 ");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+
+  it("rejects Arabic-Indic digits (\\d without /u flag matches only [0-9])", () => {
+    // U+0660–U+0669 are Arabic-Indic numerals; \d without the u flag ignores them
+    const result = adePinSchema.safeParse("٠١٢٣٤٥٦٧٨٩");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
+  });
+});
 
 describe("isStrongPassword", () => {
   describe("valid passwords", () => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -48,6 +48,19 @@ export function normalizeEmail(raw: string): string {
 }
 
 /**
+ * Shared Zod schema for the Fisconline PIN.
+ * AdE normativa: exactly 10 numeric digits (first 4 via portal/email,
+ * last 6 by postal letter). Server must .trim() the raw input before
+ * calling safeParse — the schema itself does not trim.
+ */
+export const adePinSchema = z
+  .string()
+  .regex(
+    /^\d{10}$/,
+    "Il PIN Fisconline è composto da 10 cifre numeriche. Se ne hai solo 4, aspetta la lettera con le ultime 6 cifre per posta.",
+  );
+
+/**
  * Validates email format using linear-time string checks (no regex backtracking).
  * This is a structural check, not RFC 5322 compliance — real validation
  * happens when the confirmation email is delivered.

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -309,7 +309,7 @@ describe("onboarding-actions", () => {
           businessId: "biz-789",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "securepass",
-          pin: "123456",
+          pin: "1234567890",
         }),
       );
 
@@ -327,7 +327,7 @@ describe("onboarding-actions", () => {
           businessId: "",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
-          pin: "123456",
+          pin: "1234567890",
         }),
       );
       expect(result.error).toContain("Business ID");
@@ -340,7 +340,7 @@ describe("onboarding-actions", () => {
           businessId: "biz-789",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "",
-          pin: "123456",
+          pin: "1234567890",
         }),
       );
       expect(result.error).toContain("Password");
@@ -353,23 +353,85 @@ describe("onboarding-actions", () => {
           businessId: "biz-789",
           codiceFiscale: "SHORT",
           password: "pass",
-          pin: "123456",
+          pin: "1234567890",
         }),
       );
       expect(result.error).toContain("Codice fiscale");
     });
 
-    it("returns error for short PIN", async () => {
+    it("returns error for PIN with fewer than 10 digits", async () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
           businessId: "biz-789",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
-          pin: "12",
+          pin: "123456789",
         }),
       );
       expect(result.error).toContain("PIN");
+    });
+
+    it("returns error for PIN with more than 10 digits", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          codiceFiscale: "RSSMRA80A01H501U",
+          password: "pass",
+          pin: "12345678901",
+        }),
+      );
+      expect(result.error).toContain("PIN");
+    });
+
+    it("returns error for PIN containing non-numeric characters", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          codiceFiscale: "RSSMRA80A01H501U",
+          password: "pass",
+          pin: "abcdefghij",
+        }),
+      );
+      expect(result.error).toContain("PIN");
+    });
+
+    it("accepts PIN of exactly 10 numeric digits", async () => {
+      // Ownership check: JOIN profile+business
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      // No existing credentials
+      mockLimit.mockResolvedValueOnce([]);
+
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          codiceFiscale: "RSSMRA80A01H501U",
+          password: "pass",
+          pin: "1234567890",
+        }),
+      );
+      expect(result.error).toBeUndefined();
+    });
+
+    it("accepts PIN with surrounding whitespace (server trims before validation)", async () => {
+      // Ownership check: JOIN profile+business
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      // No existing credentials
+      mockLimit.mockResolvedValueOnce([]);
+
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          codiceFiscale: "RSSMRA80A01H501U",
+          password: "pass",
+          pin: " 1234567890 ",
+        }),
+      );
+      expect(result.error).toBeUndefined();
     });
 
     it("updates existing credentials and resets verification", async () => {
@@ -386,7 +448,7 @@ describe("onboarding-actions", () => {
           businessId: "biz-789",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "newpass",
-          pin: "654321",
+          pin: "1234567890",
         }),
       );
 
@@ -405,7 +467,7 @@ describe("onboarding-actions", () => {
           businessId: "other-user-biz",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
-          pin: "123456",
+          pin: "1234567890",
         }),
       );
 

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -19,6 +19,7 @@ import {
   getAuthenticatedUser,
   checkBusinessOwnership,
 } from "@/lib/server-auth";
+import { adePinSchema } from "@/lib/validation";
 
 function isUniqueConstraintViolation(err: unknown): boolean {
   return (
@@ -174,8 +175,11 @@ export async function saveAdeCredentials(
   if (!password) {
     return { error: "Password Fisconline obbligatoria." };
   }
-  if (!pin || pin.length < 6) {
-    return { error: "PIN Fisconline non valido (minimo 6 cifre)." };
+  const pinResult = adePinSchema.safeParse(pin ?? "");
+  if (!pinResult.success) {
+    return {
+      error: pinResult.error.issues[0]?.message ?? "PIN Fisconline non valido.",
+    };
   }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);


### PR DESCRIPTION
## Summary
This PR updates PIN validation across the application to enforce the AdE (Agenzia delle Entrate) requirement of exactly 10 numeric digits, replacing the previous minimum 6-character validation.

## Key Changes

- **New validation schema**: Created `adePinSchema` in `src/lib/validation.ts` that validates PIN format using regex `/^\d{10}$/` with a user-friendly Italian error message explaining the 10-digit requirement and postal letter process
- **Server-side validation**: Updated `saveAdeCredentials()` in `src/server/onboarding-actions.ts` to use the new schema, replacing the old `pin.length < 6` check
- **Client-side forms**: Updated both onboarding and settings forms to use `adePinSchema` instead of `.min(6)` validation
- **Comprehensive test coverage**: 
  - Added 8 new test cases in `src/lib/validation.test.ts` covering edge cases (empty, too short, too long, non-numeric, whitespace, Arabic-Indic digits)
  - Added 2 new integration tests in `src/server/onboarding-actions.test.ts` for valid PINs and whitespace handling
  - Updated all existing test fixtures to use valid 10-digit PINs
- **Test fixtures**: Updated mock credentials across all test files to use `"1234567890"` instead of shorter PINs

## Implementation Details

- The schema does **not** trim whitespace—callers are responsible for trimming before validation (documented in JSDoc)
- The regex uses standard `\d` (matches only ASCII 0-9) without the `/u` flag to prevent acceptance of non-ASCII numerals
- Error message is localized in Italian and includes helpful context about the postal letter process
- All validation is centralized in a single reusable schema to ensure consistency across client and server

https://claude.ai/code/session_01FUKAhezofDJzyJrowm1VZM