### PR TITLE
fix(sonar): risolvi S6772 in storico-ed-esportazione

### DIFF
--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -112,9 +112,9 @@ export default function StoricoEdEsportazionePage() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Dal dettaglio puoi anche avviare l&apos;
-          <strong>annullamento</strong> dello scontrino, se è in stato
-          Trasmesso.
+          {"Dal dettaglio puoi anche avviare l'"}
+          <strong>annullamento</strong>
+          {" dello scontrino, se è in stato Trasmesso."}
         </p>
 
         {/* ─── Export CSV ─── */}


### PR DESCRIPTION
Testo 'l&apos;' su riga separata prima di <strong> triggera S6772 (Ambiguous spacing). Fix: usa espressioni JSX {"..."} per i segmenti di testo adiacenti all'elemento inline.

https://claude.ai/code/session_01WGpfUGEPM3No7FuPEjoytx