### PR TITLE
feat: rileva password Fisconline scaduta e gestisce cambio in-app

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -8,3 +8,5 @@ a5a40835e95ef4240016a5fc5773f017461258e6:src/app/(marketing)/help/api/page.tsx:g
 7af6a44d0cac02543ab90fd96158544d6bc6251d:src/app/(marketing)/help/api/page.tsx:curl-auth-header:380
 018633dd87fd76911da874961a343d618972a90a:DEVELOPER.md:curl-auth-header:169
 d5cd231267e68e5146904677937ae81df9bda5e1:src/app/(marketing)/help/api/page.tsx:curl-auth-header:405
+61c69a3323cda09ee38fa0e6a6e431a611589692:tests/unit/change-ade-password-dialog.test.ts:generic-api-key:50
+61c69a3323cda09ee38fa0e6a6e431a611589692:tests/unit/change-ade-password-dialog.test.ts:generic-api-key:51

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -84,6 +84,7 @@ sonar.coverage.exclusions=\
   src/components/settings/edit-business-section.tsx,\
   src/components/settings/edit-settings-dialog.tsx,\
   src/components/settings/edit-ade-credentials-section.tsx,\
+  src/components/ade/change-ade-password-dialog.tsx,\
   src/app/dashboard/loading.tsx,\
   src/app/dashboard/cassa/loading.tsx,\
   src/app/dashboard/storico/loading.tsx,\

--- a/src/components/ade/change-ade-password-dialog.tsx
+++ b/src/components/ade/change-ade-password-dialog.tsx
@@ -25,7 +25,7 @@ import { PasswordInput } from "@/components/ui/password-input";
 import { changeAdePassword } from "@/server/onboarding-actions";
 
 // Lettere non accentate, numeri, caratteri speciali ammessi da Fisconline
-const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(\/&%$£!|\\<>]{8,15}$/;
+const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(/&%$£!|\\<>]{8,15}$/;
 
 const schema = z
   .object({
@@ -34,7 +34,7 @@ const schema = z
       .string()
       .regex(
         ADE_PASSWORD_REGEX,
-        "8–15 caratteri: lettere (non accentate), numeri o * + § ° ç @ ^ ? = ) ( / & % $ £ ! | \\ < >",
+        String.raw`8–15 caratteri: lettere (non accentate), numeri o * + § ° ç @ ^ ? = ) ( / & % $ £ ! | \ < >`,
       ),
     confirmNewPassword: z.string().min(1, "Conferma la nuova password."),
   })

--- a/src/components/ade/change-ade-password-dialog.tsx
+++ b/src/components/ade/change-ade-password-dialog.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod/v4";
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { PasswordInput } from "@/components/ui/password-input";
+import { changeAdePassword } from "@/server/onboarding-actions";
+
+// Lettere non accentate, numeri, caratteri speciali ammessi da Fisconline
+const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(\/&%$£!|\\<>]{8,15}$/;
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(1, "Inserisci la password attuale."),
+    newPassword: z
+      .string()
+      .regex(
+        ADE_PASSWORD_REGEX,
+        "8–15 caratteri: lettere (non accentate), numeri o * + § ° ç @ ^ ? = ) ( / & % $ £ ! | \\ < >",
+      ),
+    confirmNewPassword: z.string().min(1, "Conferma la nuova password."),
+  })
+  .refine((d) => d.newPassword === d.confirmNewPassword, {
+    message: "Le password non coincidono.",
+    path: ["confirmNewPassword"],
+  })
+  .refine((d) => d.newPassword !== d.currentPassword, {
+    message: "La nuova password deve essere diversa da quella attuale.",
+    path: ["newPassword"],
+  });
+
+type FormData = z.infer<typeof schema>;
+
+interface ChangeAdePasswordDialogProps {
+  readonly businessId: string;
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onSuccess?: () => void;
+}
+
+export function ChangeAdePasswordDialog({
+  businessId,
+  open,
+  onClose,
+  onSuccess,
+}: ChangeAdePasswordDialogProps) {
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      currentPassword: "",
+      newPassword: "",
+      confirmNewPassword: "",
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: FormData) =>
+      changeAdePassword(
+        businessId,
+        data.currentPassword,
+        data.newPassword,
+        data.confirmNewPassword,
+      ),
+    onSuccess: (result) => {
+      if (result.error) {
+        form.setError("root", { message: result.error });
+      } else {
+        form.reset();
+        onSuccess?.();
+      }
+    },
+    onError: () => {
+      form.setError("root", {
+        message: "Si è verificato un errore. Riprova più tardi.",
+      });
+    },
+  });
+
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) {
+      form.reset();
+      mutation.reset();
+      onClose();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="overscroll-contain">
+        <DialogHeader>
+          <DialogTitle>Aggiorna password Fisconline</DialogTitle>
+          <DialogDescription>
+            {"Inserisci la password Fisconline attuale e scegline una nuova."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((data) => mutation.mutate(data))}
+            noValidate
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="currentPassword"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>{"Password attuale"}</FormLabel>
+                  <FormControl>
+                    <PasswordInput
+                      autoComplete="current-password"
+                      disabled={mutation.isPending}
+                      aria-invalid={!!fieldState.error}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="newPassword"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>{"Nuova password"}</FormLabel>
+                  <FormControl>
+                    <PasswordInput
+                      autoComplete="new-password"
+                      disabled={mutation.isPending}
+                      aria-invalid={!!fieldState.error}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmNewPassword"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>{"Conferma nuova password"}</FormLabel>
+                  <FormControl>
+                    <PasswordInput
+                      autoComplete="new-password"
+                      disabled={mutation.isPending}
+                      aria-invalid={!!fieldState.error}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {form.formState.errors.root && (
+              <p role="alert" className="text-destructive text-sm">
+                {form.formState.errors.root.message}
+              </p>
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={mutation.isPending}
+              >
+                {"Annulla"}
+              </Button>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending
+                  ? "Aggiornamento in corso…"
+                  : "Aggiorna password"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/cassa/cassa-client.tsx
+++ b/src/components/cassa/cassa-client.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { formatCurrency } from "@/lib/utils";
 import { emitReceipt } from "@/server/receipt-actions";
+import { ChangeAdePasswordDialog } from "@/components/ade/change-ade-password-dialog";
 
 type Step = "cart" | "add-item" | "summary" | "success";
 
@@ -49,6 +50,7 @@ export function CassaClient({
   // id dell'articolo in modifica (null = nuova aggiunta)
   const [editingLineId, setEditingLineId] = useState<string | null>(null);
   const [lotteryCode, setLotteryCode] = useState("");
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
 
   // Ref guard: evita doppia esecuzione in React Strict Mode
   const catalogParamConsumed = useRef(false);
@@ -296,24 +298,42 @@ export function CassaClient({
     return (
       <div className="mx-auto max-w-sm space-y-2">
         {mutationError && (
-          <p
+          <div
             role="alert"
-            className="text-destructive rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm"
+            className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm"
           >
-            {mutationError}
-            {mutationError.includes("Credenziali AdE non verificate") && (
-              <>
-                {" "}
-                <Link
-                  href="/dashboard/settings"
-                  className="font-medium underline"
-                >
-                  Verificale ora
-                </Link>
-              </>
+            <p className="text-destructive">
+              {mutationError}
+              {mutationError.includes("Credenziali AdE non verificate") && (
+                <>
+                  {" "}
+                  <Link
+                    href="/dashboard/settings"
+                    className="font-medium underline"
+                  >
+                    {"Verificale ora"}
+                  </Link>
+                </>
+              )}
+            </p>
+            {mutation.data?.passwordExpired && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => setChangePasswordOpen(true)}
+              >
+                {"Cambia password Fisconline"}
+              </Button>
             )}
-          </p>
+          </div>
         )}
+        <ChangeAdePasswordDialog
+          businessId={businessId}
+          open={changePasswordOpen}
+          onClose={() => setChangePasswordOpen(false)}
+          onSuccess={() => setChangePasswordOpen(false)}
+        />
         <ReceiptSummary
           lines={lines}
           total={total}

--- a/src/components/settings/ade-credentials-section.test.tsx
+++ b/src/components/settings/ade-credentials-section.test.tsx
@@ -10,6 +10,10 @@ import { AdeCredentialsSection } from "./ade-credentials-section";
 
 // --- Mocks ---
 
+vi.mock("@/components/ade/change-ade-password-dialog", () => ({
+  ChangeAdePasswordDialog: () => null,
+}));
+
 const mockVerifyAdeCredentials = vi.fn();
 vi.mock("@/server/onboarding-actions", () => ({
   verifyAdeCredentials: (id: string) => mockVerifyAdeCredentials(id),

--- a/src/components/settings/ade-credentials-section.tsx
+++ b/src/components/settings/ade-credentials-section.tsx
@@ -6,6 +6,7 @@ import { RefreshCw, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { verifyAdeCredentials } from "@/server/onboarding-actions";
+import { ChangeAdePasswordDialog } from "@/components/ade/change-ade-password-dialog";
 
 type VerifyState =
   | { status: "idle" }
@@ -32,6 +33,7 @@ export function AdeCredentialsSection({
     status: "idle",
   });
   const [hasEverVerified, setHasEverVerified] = useState(!!verifiedAt);
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -63,6 +65,11 @@ export function AdeCredentialsSection({
       const result = await verifyAdeCredentials(id);
 
       if (result.error) {
+        if (result.passwordExpired) {
+          setVerifyState({ status: "idle" });
+          setChangePasswordOpen(true);
+          return;
+        }
         setVerifyState({ status: "error", message: result.error });
         return;
       }
@@ -86,55 +93,69 @@ export function AdeCredentialsSection({
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-sm">Stato:</span>
-          {hasEverVerified ? (
-            <Badge variant="default">Verificate</Badge>
-          ) : (
-            <Badge variant="secondary">Non verificate</Badge>
-          )}
+    <>
+      {businessId && (
+        <ChangeAdePasswordDialog
+          businessId={businessId}
+          open={changePasswordOpen}
+          onClose={() => setChangePasswordOpen(false)}
+          onSuccess={() => {
+            setChangePasswordOpen(false);
+            setHasEverVerified(true);
+            router.refresh();
+          }}
+        />
+      )}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-sm">Stato:</span>
+            {hasEverVerified ? (
+              <Badge variant="default">Verificate</Badge>
+            ) : (
+              <Badge variant="secondary">Non verificate</Badge>
+            )}
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleVerify}
+            disabled={verifyState.status === "pending"}
+          >
+            {verifyState.status === "pending" ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            {buttonLabel}
+          </Button>
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={handleVerify}
-          disabled={verifyState.status === "pending"}
-        >
-          {verifyState.status === "pending" ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <RefreshCw className="mr-2 h-4 w-4" />
-          )}
-          {buttonLabel}
-        </Button>
+
+        {verifiedAt && verifyState.status !== "success" && (
+          <p className="text-muted-foreground text-xs">
+            Ultima verifica:{" "}
+            {verifiedAt.toLocaleDateString("it-IT", {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            })}
+          </p>
+        )}
+
+        {verifyState.status === "success" && (
+          <p className="flex items-center gap-1.5 text-sm text-green-600">
+            <CheckCircle2 className="h-4 w-4" />
+            Connessione verificata.
+          </p>
+        )}
+
+        {verifyState.status === "error" && (
+          <p className="text-destructive flex items-center gap-1.5 text-sm">
+            <AlertCircle className="h-4 w-4" />
+            {verifyState.message}
+          </p>
+        )}
       </div>
-
-      {verifiedAt && verifyState.status !== "success" && (
-        <p className="text-muted-foreground text-xs">
-          Ultima verifica:{" "}
-          {verifiedAt.toLocaleDateString("it-IT", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-          })}
-        </p>
-      )}
-
-      {verifyState.status === "success" && (
-        <p className="flex items-center gap-1.5 text-sm text-green-600">
-          <CheckCircle2 className="h-4 w-4" />
-          Connessione verificata.
-        </p>
-      )}
-
-      {verifyState.status === "error" && (
-        <p className="text-destructive flex items-center gap-1.5 text-sm">
-          <AlertCircle className="h-4 w-4" />
-          {verifyState.message}
-        </p>
-      )}
-    </div>
+    </>
   );
 }

--- a/src/lib/ade/client.ts
+++ b/src/lib/ade/client.ts
@@ -86,6 +86,20 @@ export interface AdeClient {
    */
   searchDocuments(params: AdeSearchParams): Promise<AdeDocumentList>;
 
+  /**
+   * Cambia la password Fisconline tramite il portale telematici AdE.
+   * Non richiede login previo — funziona anche con password scaduta.
+   *
+   * HAR: cambio_password_*.har
+   * Endpoint: POST telematici.agenziaentrate.gov.it/Abilitazione/CambioPassword/CambioPassword.do
+   */
+  changePasswordFisconline(params: {
+    codiceFiscale: string;
+    oldPassword: string;
+    newPassword: string;
+    confirmNewPassword: string;
+  }): Promise<void>;
+
   /** Logout dalla sessione AdE */
   logout(): Promise<void>;
 }

--- a/src/lib/ade/errors.ts
+++ b/src/lib/ade/errors.ts
@@ -24,6 +24,20 @@ export class AdeAuthError extends AdeError {
   }
 }
 
+/**
+ * Fisconline password expired — user must change it via the AdE portal.
+ *
+ * HAR finding (login_password_scaduta.har): POST /api/login/telematico
+ * returns 401 with {"details":"PASSWORD_EXPIRED"} when the password has expired.
+ * This is distinct from wrong credentials ({"details":"INVALID_CREDENTIALS"}).
+ */
+export class AdePasswordExpiredError extends AdeError {
+  constructor() {
+    super("ADE_PASSWORD_EXPIRED", "Password Fisconline scaduta");
+    this.name = "AdePasswordExpiredError";
+  }
+}
+
 /** Session expired, re-auth was attempted and also failed. */
 export class AdeSessionExpiredError extends AdeError {
   constructor() {

--- a/src/lib/ade/mock-client.ts
+++ b/src/lib/ade/mock-client.ts
@@ -126,6 +126,15 @@ export class MockAdeClient implements AdeClient {
     return { totalCount: 0, elencoRisultati: [] };
   }
 
+  async changePasswordFisconline(_params: {
+    codiceFiscale: string;
+    oldPassword: string;
+    newPassword: string;
+    confirmNewPassword: string;
+  }): Promise<void> {
+    // Mock: always succeeds (no HTTP call)
+  }
+
   async logout(): Promise<void> {
     this.session = null;
   }

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -6,7 +6,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RealAdeClient } from "./real-client";
 import {
   AdeAuthError,
+  AdeError,
   AdeNetworkError,
+  AdePasswordExpiredError,
   AdePortalError,
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
@@ -398,6 +400,46 @@ describe("RealAdeClient", () => {
       fetchMock.mockResolvedValueOnce(mockResponse({ status: 401 }));
 
       await expect(client.login(mockCredentials)).rejects.toThrow(AdeAuthError);
+    });
+
+    it("Phase A: lancia AdePasswordExpiredError se details è PASSWORD_EXPIRED", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 401,
+          body: {
+            error: "Autenticazione fallita",
+            errorCode: "AUTH_ERROR",
+            details: "PASSWORD_EXPIRED",
+          },
+        }),
+      );
+
+      await expect(client.login(mockCredentials)).rejects.toThrow(
+        AdePasswordExpiredError,
+      );
+    });
+
+    it("Phase A: lancia AdeAuthError (non AdePasswordExpiredError) se details è INVALID_CREDENTIALS", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 401,
+          body: { details: "INVALID_CREDENTIALS" },
+        }),
+      );
+
+      const err = await client.login(mockCredentials).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(AdeAuthError);
+      expect(err).not.toBeInstanceOf(AdePasswordExpiredError);
+    });
+
+    it("Phase A: lancia AdeAuthError anche se il body non è JSON parseable", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ status: 401, body: "not json {{{{" }),
+      );
+
+      const err = await client.login(mockCredentials).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(AdeAuthError);
+      expect(err).not.toBeInstanceOf(AdePasswordExpiredError);
     });
 
     it("Phase B: GET portale.agenziaentrate.gov.it/PortaleWeb/home?to=FATBTB", async () => {
@@ -1231,6 +1273,103 @@ describe("RealAdeClient", () => {
   // -----------------------------------------------------------------------
   // logout
   // -----------------------------------------------------------------------
+
+  describe("changePasswordFisconline", () => {
+    const mockParams = {
+      codiceFiscale: "RSSMRA80A01H501A",
+      oldPassword: "OldPass123",
+      newPassword: "NewPass456",
+      confirmNewPassword: "NewPass456",
+    };
+
+    it("POST al corretto URL con form fields (user/oldpw/newpw/newpwf)", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ body: "Cambio password effettuato con successo." }),
+      );
+
+      await client.changePasswordFisconline(mockParams);
+
+      const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain(
+        "telematici.agenziaentrate.gov.it/Abilitazione/CambioPassword/CambioPassword.do",
+      );
+      expect(url).toContain(`userCP=${mockParams.codiceFiscale}`);
+      expect(opts.method).toBe("POST");
+      const body = opts.body as string;
+      expect(body).toContain(`user=${mockParams.codiceFiscale}`);
+      expect(body).toContain(`oldpw=${mockParams.oldPassword}`);
+      expect(body).toContain(`newpw=${mockParams.newPassword}`);
+      expect(body).toContain(`newpwf=${mockParams.confirmNewPassword}`);
+    });
+
+    it("risolve void quando la risposta HTML contiene la stringa di successo", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ body: "Cambio password effettuato con successo." }),
+      );
+
+      await expect(
+        client.changePasswordFisconline(mockParams),
+      ).resolves.toBeUndefined();
+    });
+
+    it("lancia AdeAuthError quando la password attuale è errata", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          body: "L'utente non risulta associato alla password indicata oppure la password non è scaduta.",
+        }),
+      );
+
+      await expect(client.changePasswordFisconline(mockParams)).rejects.toThrow(
+        AdeAuthError,
+      );
+    });
+
+    it("lancia AdeError ADE_CHANGE_PW_MISMATCH quando nuova != conferma", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          body: "Inserire la stessa password nel campo di conferma.",
+        }),
+      );
+
+      const err = await client
+        .changePasswordFisconline(mockParams)
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(AdeError);
+      expect((err as AdeError).code).toBe("ADE_CHANGE_PW_MISMATCH");
+    });
+
+    it("lancia AdeError ADE_CHANGE_PW_SAME quando nuova == attuale", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          body: "La nuova password non puo' essere uguale a quella attuale.",
+        }),
+      );
+
+      const err = await client
+        .changePasswordFisconline(mockParams)
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(AdeError);
+      expect((err as AdeError).code).toBe("ADE_CHANGE_PW_SAME");
+    });
+
+    it("lancia AdePortalError se la risposta HTTP non è 200", async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse({ status: 500, body: "" }));
+
+      await expect(client.changePasswordFisconline(mockParams)).rejects.toThrow(
+        AdePortalError,
+      );
+    });
+
+    it("lancia AdePortalError se la risposta HTML è inattesa", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ body: "Risposta completamente inattesa dal portale." }),
+      );
+
+      await expect(client.changePasswordFisconline(mockParams)).rejects.toThrow(
+        AdePortalError,
+      );
+    });
+  });
 
   describe("logout", () => {
     it("chiama i due endpoint iampe (best-effort)", async () => {

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -23,7 +23,9 @@ import type {
 import { CookieJar } from "./cookie-jar";
 import {
   AdeAuthError,
+  AdeError,
   AdeNetworkError,
+  AdePasswordExpiredError,
   AdePortalError,
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
@@ -43,6 +45,7 @@ export interface RealAdeClientOptions {
 const ADE_BASE_URL = "https://ivaservizi.agenziaentrate.gov.it";
 const ADE_IAM_BASE_URL = "https://iampe.agenziaentrate.gov.it";
 const ADE_PORTALE_BASE_URL = "https://portale.agenziaentrate.gov.it";
+const ADE_TELEMATICI_BASE_URL = "https://telematici.agenziaentrate.gov.it";
 const ADE_INSTR_PATH = "/instr/instradamento-fatture-rest/rs";
 
 /**
@@ -183,6 +186,23 @@ export class RealAdeClient implements AdeClient {
     });
 
     if (!response.ok) {
+      let details: string | undefined;
+      try {
+        const body = (await response.json()) as { details?: string };
+        details = body.details;
+      } catch {
+        // ignore JSON parse error — fall through to generic auth error
+      }
+
+      if (details === "PASSWORD_EXPIRED") {
+        logger.warn(
+          { phase: "A", codiceFiscale: credentials.codiceFiscale },
+          "ade:password_expired",
+        );
+        throw new AdePasswordExpiredError();
+      }
+
+      logger.warn({ phase: "A", details }, "ade:auth_failed");
       throw new AdeAuthError(
         "Login failed: invalid credentials or account locked",
       );
@@ -1146,6 +1166,73 @@ export class RealAdeClient implements AdeClient {
     }
 
     return response.json() as Promise<AdeDocumentList>;
+  }
+
+  /**
+   * Cambia la password Fisconline tramite il portale telematici AdE.
+   * Non richiede login previo — funziona anche con password scaduta.
+   *
+   * HAR: cambio_password_*.har — form POST con campi user/oldpw/newpw/newpwf.
+   * Risposta sempre HTTP 200; esito rilevato via testo nel body HTML.
+   */
+  async changePasswordFisconline(params: {
+    codiceFiscale: string;
+    oldPassword: string;
+    newPassword: string;
+    confirmNewPassword: string;
+  }): Promise<void> {
+    const url =
+      `${ADE_TELEMATICI_BASE_URL}/Abilitazione/CambioPassword/CambioPassword.do` +
+      `?userCP=${encodeURIComponent(params.codiceFiscale)}`;
+
+    const body = new URLSearchParams({
+      user: params.codiceFiscale,
+      oldpw: params.oldPassword,
+      newpw: params.newPassword,
+      newpwf: params.confirmNewPassword,
+    });
+
+    const response = await this.request(url, {
+      method: "POST",
+      body: body.toString(),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    if (!response.ok) {
+      throw new AdePortalError(
+        response.status,
+        `changePasswordFisconline request failed with status ${response.status}`,
+      );
+    }
+
+    const html = await response.text();
+
+    if (html.includes("Cambio password effettuato con successo")) {
+      return;
+    }
+    if (
+      html.includes("L'utente non risulta associato alla password indicata")
+    ) {
+      throw new AdeAuthError("Wrong current Fisconline password");
+    }
+    if (html.includes("Inserire la stessa password nel campo di conferma")) {
+      throw new AdeError(
+        "ADE_CHANGE_PW_MISMATCH",
+        "New password confirmation does not match",
+      );
+    }
+    if (
+      html.includes("La nuova password non puo' essere uguale a quella attuale")
+    ) {
+      throw new AdeError(
+        "ADE_CHANGE_PW_SAME",
+        "New password must differ from current password",
+      );
+    }
+    throw new AdePortalError(
+      200,
+      "Unexpected changePasswordFisconline response",
+    );
   }
 
   async logout(): Promise<void> {

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -12,6 +12,7 @@ import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
 import { createAdeClient } from "@/lib/ade";
+import { AdePasswordExpiredError } from "@/lib/ade/errors";
 import { mapSaleToAdePayload } from "@/lib/ade/mapper";
 import { logger } from "@/lib/logger";
 import { fetchAdePrerequisites } from "@/lib/server-auth";
@@ -268,6 +269,14 @@ export async function emitReceiptForBusiness(
       .update(commercialDocuments)
       .set({ status: "ERROR" })
       .where(eq(commercialDocuments.id, documentId));
+
+    if (err instanceof AdePasswordExpiredError) {
+      return {
+        error:
+          "La password Fisconline è scaduta. Aggiornala per continuare a emettere scontrini.",
+        passwordExpired: true,
+      };
+    }
 
     return {
       error: "Errore durante l'emissione dello scontrino. Riprova più tardi.",

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -467,7 +467,7 @@ export async function changeAdePassword(
     return { error: "Errore durante il cambio password. Riprova più tardi." };
   }
 
-  const newEncryptedPassword = encrypt(newPassword, key);
+  const newEncryptedPassword = encrypt(newPassword, key, cred.keyVersion);
   await db
     .update(adeCredentials)
     .set({ encryptedPassword: newEncryptedPassword, verifiedAt: new Date() })

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -12,6 +12,12 @@ import {
   getKeyVersion,
 } from "@/lib/crypto";
 import { createAdeClient } from "@/lib/ade";
+import {
+  AdeAuthError,
+  AdeError,
+  AdePasswordExpiredError,
+} from "@/lib/ade/errors";
+import { RateLimiter } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { sendEmail } from "@/lib/email";
 import { WelcomeEmail } from "@/emails/welcome";
@@ -33,7 +39,13 @@ function isUniqueConstraintViolation(err: unknown): boolean {
 export type OnboardingActionResult = {
   error?: string;
   businessId?: string;
+  passwordExpired?: boolean;
 };
+
+const changePasswordLimiter = new RateLimiter({
+  maxRequests: 5,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+});
 
 export type OnboardingStatus = {
   hasProfile: boolean;
@@ -265,6 +277,13 @@ export async function verifyAdeCredentials(
   try {
     await adeClient.login({ codiceFiscale, password, pin });
   } catch (err) {
+    if (err instanceof AdePasswordExpiredError) {
+      logger.warn({ businessId }, "AdE password scaduta durante verifica");
+      return {
+        error: "La password Fisconline è scaduta.",
+        passwordExpired: true,
+      };
+    }
     logger.error({ err, businessId }, "AdE credential verification failed");
     return { error: "Verifica fallita. Controlla le credenziali Fisconline." };
   }
@@ -373,4 +392,88 @@ export async function getOnboardingStatus(): Promise<OnboardingStatus> {
     hasCredentials: !!cred,
     credentialsVerified: !!cred?.verifiedAt,
   };
+}
+
+const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(\/&%$£!|\\<>]{8,15}$/;
+
+export async function changeAdePassword(
+  businessId: string,
+  currentPassword: string,
+  newPassword: string,
+  confirmNewPassword: string,
+): Promise<OnboardingActionResult> {
+  const user = await getAuthenticatedUser();
+
+  const ownershipError = await checkBusinessOwnership(user.id, businessId);
+  if (ownershipError) return ownershipError;
+
+  const rateLimitResult = changePasswordLimiter.check(
+    `change-ade-pw:${user.id}`,
+  );
+  if (!rateLimitResult.success) {
+    logger.warn({ userId: user.id }, "changeAdePassword rate limit exceeded");
+    return { error: "Troppi tentativi. Riprova tra qualche minuto." };
+  }
+
+  if (!ADE_PASSWORD_REGEX.test(newPassword)) {
+    return {
+      error:
+        "Password non valida. Usa 8–15 caratteri: lettere (non accentate), numeri o caratteri speciali.",
+    };
+  }
+  if (newPassword !== confirmNewPassword) {
+    return { error: "Le password non coincidono." };
+  }
+  if (newPassword === currentPassword) {
+    return {
+      error: "La nuova password deve essere diversa da quella attuale.",
+    };
+  }
+
+  const db = getDb();
+  const [cred] = await db
+    .select()
+    .from(adeCredentials)
+    .where(eq(adeCredentials.businessId, businessId))
+    .limit(1);
+
+  if (!cred) return { error: "Credenziali non trovate." };
+
+  const key = getEncryptionKey();
+  const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);
+  const codiceFiscale = decrypt(cred.encryptedCodiceFiscale, keys);
+
+  const adeMode = (process.env.ADE_MODE as "mock" | "real") || "mock";
+  const adeClient = createAdeClient(adeMode);
+
+  try {
+    await adeClient.changePasswordFisconline({
+      codiceFiscale,
+      oldPassword: currentPassword,
+      newPassword,
+      confirmNewPassword,
+    });
+  } catch (err) {
+    if (err instanceof AdeAuthError) {
+      logger.warn({ businessId }, "changeAdePassword: password attuale errata");
+      return { error: "Password attuale non corretta." };
+    }
+    if (err instanceof AdeError && err.code === "ADE_CHANGE_PW_SAME") {
+      return {
+        error: "La nuova password deve essere diversa da quella attuale.",
+      };
+    }
+    logger.error({ err, businessId }, "Cambio password AdE fallito");
+    return { error: "Errore durante il cambio password. Riprova più tardi." };
+  }
+
+  const newEncryptedPassword = encrypt(newPassword, key);
+  await db
+    .update(adeCredentials)
+    .set({ encryptedPassword: newEncryptedPassword, verifiedAt: new Date() })
+    .where(eq(adeCredentials.businessId, businessId));
+
+  revalidatePath("/dashboard", "layout");
+  logger.info({ businessId }, "Password Fisconline aggiornata con successo");
+  return { businessId };
 }

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -394,7 +394,7 @@ export async function getOnboardingStatus(): Promise<OnboardingStatus> {
   };
 }
 
-const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(\/&%$£!|\\<>]{8,15}$/;
+const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(/&%$£!|\\<>]{8,15}$/;
 
 export async function changeAdePassword(
   businessId: string,

--- a/src/types/cassa.ts
+++ b/src/types/cassa.ts
@@ -94,4 +94,5 @@ export type SubmitReceiptResult = {
   documentId?: string;
   adeTransactionId?: string;
   adeProgressive?: string;
+  passwordExpired?: boolean;
 };

--- a/tests/unit/change-ade-password-dialog.test.ts
+++ b/tests/unit/change-ade-password-dialog.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+// Replica della schema di validazione del dialog (logica client-side)
+const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(\/&%$£!|\\<>]{8,15}$/;
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(1, "Inserisci la password attuale."),
+    newPassword: z
+      .string()
+      .regex(
+        ADE_PASSWORD_REGEX,
+        "8–15 caratteri: lettere (non accentate), numeri o caratteri speciali",
+      ),
+    confirmNewPassword: z.string().min(1, "Conferma la nuova password."),
+  })
+  .refine((d) => d.newPassword === d.confirmNewPassword, {
+    message: "Le password non coincidono.",
+    path: ["confirmNewPassword"],
+  })
+  .refine((d) => d.newPassword !== d.currentPassword, {
+    message: "La nuova password deve essere diversa da quella attuale.",
+    path: ["newPassword"],
+  });
+
+describe("ChangeAdePasswordDialog — validazione client-side", () => {
+  it("accetta password valida con lettere e numeri (8 char)", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "NewPass2",
+      confirmNewPassword: "NewPass2",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accetta password valida con caratteri speciali", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "Pass@12*",
+      confirmNewPassword: "Pass@12*",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accetta password di esattamente 15 caratteri", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "ValidPass123456",
+      confirmNewPassword: "ValidPass123456",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rifiuta password troppo corta (< 8 char)", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "Short1",
+      confirmNewPassword: "Short1",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("newPassword");
+    }
+  });
+
+  it("rifiuta password troppo lunga (> 15 char)", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "ThisIsWayTooLong1",
+      confirmNewPassword: "ThisIsWayTooLong1",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rifiuta password con lettere accentate", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "Pàssword1",
+      confirmNewPassword: "Pàssword1",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rifiuta quando nuova password != conferma", () => {
+    const result = schema.safeParse({
+      currentPassword: "OldPass1",
+      newPassword: "NewPass2",
+      confirmNewPassword: "NewPass9",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const confirmError = result.error.issues.find(
+        (i) => i.path[0] === "confirmNewPassword",
+      );
+      expect(confirmError?.message).toMatch(/non coincidono/i);
+    }
+  });
+
+  it("rifiuta quando nuova password == password attuale", () => {
+    const result = schema.safeParse({
+      currentPassword: "SamePass1",
+      newPassword: "SamePass1",
+      confirmNewPassword: "SamePass1",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const newPwError = result.error.issues.find(
+        (i) => i.path[0] === "newPassword",
+      );
+      expect(newPwError?.message).toMatch(/diversa da quella attuale/i);
+    }
+  });
+
+  it("rifiuta password vuota attuale", () => {
+    const result = schema.safeParse({
+      currentPassword: "",
+      newPassword: "NewPass2",
+      confirmNewPassword: "NewPass2",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/receipt-service-password-expired.test.ts
+++ b/tests/unit/receipt-service-password-expired.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Hoisted mocks ---
+
+const {
+  mockGetDb,
+  mockSelect,
+  mockFrom,
+  mockWhere,
+  mockLimit,
+  mockInsert,
+  mockInsertValues,
+  mockInsertReturning,
+  mockUpdate,
+  mockSet,
+  mockUpdateWhere,
+  mockTransaction,
+  mockFetchAdePrerequisites,
+  mockCreateAdeClient,
+  mockAdeLogin,
+  mockAdeSubmitSale,
+  mockAdeLogout,
+  mockMapSaleToAdePayload,
+} = vi.hoisted(() => ({
+  mockGetDb: vi.fn(),
+  mockSelect: vi.fn(),
+  mockFrom: vi.fn(),
+  mockWhere: vi.fn(),
+  mockLimit: vi.fn(),
+  mockInsert: vi.fn(),
+  mockInsertValues: vi.fn(),
+  mockInsertReturning: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockFetchAdePrerequisites: vi.fn(),
+  mockCreateAdeClient: vi.fn(),
+  mockAdeLogin: vi.fn(),
+  mockAdeSubmitSale: vi.fn(),
+  mockAdeLogout: vi.fn(),
+  mockMapSaleToAdePayload: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({ getDb: mockGetDb }));
+vi.mock("@/db/schema", () => ({
+  commercialDocuments: "commercial_documents",
+  commercialDocumentLines: "commercial_document_lines",
+}));
+vi.mock("@/lib/server-auth", () => ({
+  fetchAdePrerequisites: mockFetchAdePrerequisites,
+}));
+vi.mock("@/lib/ade", () => ({
+  createAdeClient: mockCreateAdeClient,
+}));
+vi.mock("@/lib/ade/mapper", () => ({
+  mapSaleToAdePayload: mockMapSaleToAdePayload,
+}));
+vi.mock("@/lib/ade/errors", () => {
+  class AdeError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  }
+  class AdeAuthError extends AdeError {
+    constructor(msg = "Auth failed") {
+      super("ADE_AUTH_FAILED", msg);
+    }
+  }
+  class AdePasswordExpiredError extends AdeError {
+    constructor() {
+      super("ADE_PASSWORD_EXPIRED", "Password scaduta");
+    }
+  }
+  return { AdeError, AdeAuthError, AdePasswordExpiredError };
+});
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@/lib/date-utils", () => ({
+  getFiscalDate: vi.fn().mockReturnValue("2024-01-01"),
+}));
+vi.mock("@/lib/validation", () => ({
+  isValidLotteryCode: vi.fn().mockReturnValue(false),
+}));
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return { ...actual, eq: vi.fn((a, b) => ({ eq: { a, b } })) };
+});
+
+// --- Helpers ---
+
+const BIZ_ID = "biz-test";
+const DOC_ID = "doc-abc-123";
+
+function makeValidInput() {
+  return {
+    businessId: BIZ_ID,
+    lines: [
+      {
+        id: "l1",
+        description: "Test",
+        quantity: 1,
+        grossUnitPrice: 10.0,
+        vatCode: "22" as const,
+      },
+    ],
+    paymentMethod: "PC" as const,
+    idempotencyKey: "550e8400-e29b-41d4-a716-446655440000",
+    lotteryCode: null,
+  };
+}
+
+function setupDb() {
+  // outer db (for idempotency re-select and status updates)
+  mockUpdateWhere.mockResolvedValue([]);
+  mockSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdate.mockReturnValue({ set: mockSet });
+
+  mockLimit.mockResolvedValue([]);
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+
+  // transaction: tx.insert().values().onConflictDoNothing().returning()
+  mockInsertReturning.mockResolvedValue([{ id: DOC_ID }]);
+  const mockOnConflict = vi.fn().mockReturnValue({
+    returning: mockInsertReturning,
+  });
+  mockInsertValues.mockReturnValue({ onConflictDoNothing: mockOnConflict });
+  // second insert (lines) doesn't need returning
+  mockInsert.mockReturnValue({ values: mockInsertValues });
+
+  mockTransaction.mockImplementation(
+    async (fn: (tx: object) => Promise<unknown>) =>
+      fn({
+        insert: mockInsert,
+        select: mockSelect,
+        update: mockUpdate,
+      }),
+  );
+
+  mockGetDb.mockReturnValue({
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+    transaction: mockTransaction,
+  });
+}
+
+// --- Tests ---
+
+describe("emitReceiptForBusiness — AdePasswordExpiredError", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setupDb();
+    mockFetchAdePrerequisites.mockResolvedValue({
+      codiceFiscale: "CF123",
+      password: "pw",
+      pin: "1234567890",
+      cedentePrestatore: {},
+    });
+    mockMapSaleToAdePayload.mockReturnValue({});
+    mockAdeLogout.mockResolvedValue(undefined);
+    mockCreateAdeClient.mockReturnValue({
+      login: mockAdeLogin,
+      submitSale: mockAdeSubmitSale,
+      logout: mockAdeLogout,
+    });
+  });
+
+  it("restituisce passwordExpired: true quando il login AdE fallisce con password scaduta", async () => {
+    const { AdePasswordExpiredError } = await import("@/lib/ade/errors");
+    mockAdeLogin.mockRejectedValue(new AdePasswordExpiredError());
+
+    const { emitReceiptForBusiness } =
+      await import("@/lib/services/receipt-service");
+    const result = await emitReceiptForBusiness(makeValidInput());
+
+    expect(result.passwordExpired).toBe(true);
+    expect(result.error).toMatch(/scaduta/i);
+    expect(result.documentId).toBeUndefined();
+  });
+
+  it("NON restituisce passwordExpired per un errore generico", async () => {
+    mockAdeLogin.mockRejectedValue(new Error("Network failure"));
+
+    const { emitReceiptForBusiness } =
+      await import("@/lib/services/receipt-service");
+    const result = await emitReceiptForBusiness(makeValidInput());
+
+    expect(result.passwordExpired).toBeUndefined();
+    expect(result.error).toMatch(/Riprova più tardi/);
+  });
+});

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -1,0 +1,306 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Hoisted mocks ---
+
+const {
+  mockGetAuthenticatedUser,
+  mockCheckBusinessOwnership,
+  mockRateLimiterCheck,
+  mockGetDb,
+  mockSelect,
+  mockFrom,
+  mockWhere,
+  mockLimit,
+  mockUpdate,
+  mockSet,
+  mockUpdateWhere,
+  mockGetEncryptionKey,
+  mockDecrypt,
+  mockEncrypt,
+  mockCreateAdeClient,
+  mockAdeLogin,
+  mockAdeChangePassword,
+  mockRevalidatePath,
+} = vi.hoisted(() => ({
+  mockGetAuthenticatedUser: vi.fn(),
+  mockCheckBusinessOwnership: vi.fn(),
+  mockRateLimiterCheck: vi.fn(),
+  mockGetDb: vi.fn(),
+  mockSelect: vi.fn(),
+  mockFrom: vi.fn(),
+  mockWhere: vi.fn(),
+  mockLimit: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockGetEncryptionKey: vi.fn(),
+  mockDecrypt: vi.fn(),
+  mockEncrypt: vi.fn(),
+  mockCreateAdeClient: vi.fn(),
+  mockAdeLogin: vi.fn(),
+  mockAdeChangePassword: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/server-auth", () => ({
+  getAuthenticatedUser: mockGetAuthenticatedUser,
+  checkBusinessOwnership: mockCheckBusinessOwnership,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockRateLimiterCheck };
+  }),
+}));
+
+vi.mock("@/db", () => ({ getDb: mockGetDb }));
+vi.mock("@/db/schema", () => ({
+  adeCredentials: "ade_credentials",
+  businesses: "businesses",
+  profiles: "profiles",
+}));
+
+vi.mock("@/lib/crypto", () => ({
+  encrypt: mockEncrypt,
+  decrypt: mockDecrypt,
+  getEncryptionKey: mockGetEncryptionKey,
+  getKeyVersion: vi.fn().mockReturnValue(1),
+}));
+
+vi.mock("@/lib/ade", () => ({
+  createAdeClient: mockCreateAdeClient,
+}));
+
+vi.mock("@/lib/ade/errors", () => {
+  class AdeError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  }
+  class AdeAuthError extends AdeError {
+    constructor(msg = "Auth failed") {
+      super("ADE_AUTH_FAILED", msg);
+    }
+  }
+  class AdePasswordExpiredError extends AdeError {
+    constructor() {
+      super("ADE_PASSWORD_EXPIRED", "Password scaduta");
+    }
+  }
+  return { AdeError, AdeAuthError, AdePasswordExpiredError };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@/lib/email", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/emails/welcome", () => ({ WelcomeEmail: vi.fn() }));
+vi.mock("react", () => ({ createElement: vi.fn() }));
+vi.mock("@/lib/validation", () => ({ adePinSchema: { parse: vi.fn() } }));
+
+// --- Helpers ---
+
+const USER_ID = "user-test";
+const BIZ_ID = "biz-test";
+
+const FAKE_CRED = {
+  businessId: BIZ_ID,
+  encryptedCodiceFiscale: "enc-cf",
+  encryptedPassword: "enc-pw",
+  encryptedPin: "enc-pin",
+  keyVersion: 1,
+  verifiedAt: null,
+};
+
+const FAKE_KEY = Buffer.from("a".repeat(64), "hex");
+
+function setupDb(credRow: object | null = FAKE_CRED) {
+  mockLimit.mockResolvedValue(credRow ? [credRow] : []);
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+
+  mockUpdateWhere.mockResolvedValue([]);
+  mockSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdate.mockReturnValue({ set: mockSet });
+
+  mockGetDb.mockReturnValue({
+    select: mockSelect,
+    update: mockUpdate,
+  });
+}
+
+// --- Tests: changeAdePassword ---
+
+describe("changeAdePassword", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetAuthenticatedUser.mockResolvedValue({ id: USER_ID });
+    mockCheckBusinessOwnership.mockResolvedValue(null);
+    mockRateLimiterCheck.mockReturnValue({ success: true });
+    mockGetEncryptionKey.mockReturnValue(FAKE_KEY);
+    mockDecrypt.mockReturnValue("CODICEFISCALE12");
+    mockEncrypt.mockReturnValue("new-enc-pw");
+    mockAdeChangePassword.mockResolvedValue(undefined);
+    mockCreateAdeClient.mockReturnValue({
+      changePasswordFisconline: mockAdeChangePassword,
+    });
+    setupDb();
+  });
+
+  it("rifiuta quando la nuova password non rispetta il charset/lunghezza", async () => {
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "àccented",
+      "àccented",
+    );
+    expect(result.error).toMatch(/Password non valida/);
+  });
+
+  it("rifiuta quando la nuova password è troppo corta (< 8 caratteri)", async () => {
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "Short1",
+      "Short1",
+    );
+    expect(result.error).toMatch(/Password non valida/);
+  });
+
+  it("rifiuta quando la nuova password è troppo lunga (> 15 caratteri)", async () => {
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "ThisIsWayTooLong1",
+      "ThisIsWayTooLong1",
+    );
+    expect(result.error).toMatch(/Password non valida/);
+  });
+
+  it("rifiuta quando nuova != conferma", async () => {
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass99",
+    );
+    expect(result.error).toMatch(/non coincidono/);
+  });
+
+  it("rifiuta quando nuova == attuale", async () => {
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "SamePass1",
+      "SamePass1",
+      "SamePass1",
+    );
+    expect(result.error).toMatch(/diversa da quella attuale/);
+  });
+
+  it("rifiuta se il rate limit è superato", async () => {
+    mockRateLimiterCheck.mockReturnValue({ success: false, remaining: 0 });
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass12",
+    );
+    expect(result.error).toMatch(/Troppi tentativi/);
+  });
+
+  it("restituisce errore se le credenziali non sono trovate nel DB", async () => {
+    setupDb(null);
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass12",
+    );
+    expect(result.error).toMatch(/Credenziali non trovate/);
+  });
+
+  it("restituisce errore 'Password attuale non corretta' quando AdE lancia AdeAuthError", async () => {
+    const { AdeAuthError } = await import("@/lib/ade/errors");
+    mockAdeChangePassword.mockRejectedValue(new AdeAuthError());
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass12",
+    );
+    expect(result.error).toMatch(/Password attuale non corretta/);
+  });
+
+  it("aggiorna la password cifrata e verifiedAt in caso di successo", async () => {
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass12",
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.businessId).toBe(BIZ_ID);
+    expect(mockEncrypt).toHaveBeenCalledWith("NewPass12", FAKE_KEY);
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ encryptedPassword: "new-enc-pw" }),
+    );
+  });
+});
+
+// --- Tests: verifyAdeCredentials — password scaduta ---
+
+describe("verifyAdeCredentials — AdePasswordExpiredError", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetAuthenticatedUser.mockResolvedValue({ id: USER_ID });
+    mockCheckBusinessOwnership.mockResolvedValue(null);
+    mockGetEncryptionKey.mockReturnValue(FAKE_KEY);
+    mockDecrypt.mockReturnValue("decoded");
+    mockAdeLogin.mockResolvedValue({});
+    mockCreateAdeClient.mockReturnValue({
+      login: mockAdeLogin,
+      getFiscalData: vi.fn().mockResolvedValue({
+        identificativiFiscali: {
+          partitaIva: "12345678901",
+          codiceFiscale: "CF",
+        },
+      }),
+      logout: vi.fn().mockResolvedValue(undefined),
+    });
+    setupDb();
+  });
+
+  it("restituisce passwordExpired: true quando AdE lancia AdePasswordExpiredError", async () => {
+    const { AdePasswordExpiredError } = await import("@/lib/ade/errors");
+    mockAdeLogin.mockRejectedValue(new AdePasswordExpiredError());
+    const { verifyAdeCredentials } =
+      await import("@/server/onboarding-actions");
+    const result = await verifyAdeCredentials(BIZ_ID);
+    expect(result.passwordExpired).toBe(true);
+    expect(result.error).toMatch(/scaduta/i);
+  });
+
+  it("NON restituisce passwordExpired per un errore generico di credenziali", async () => {
+    const { AdeAuthError } = await import("@/lib/ade/errors");
+    mockAdeLogin.mockRejectedValue(new AdeAuthError());
+    const { verifyAdeCredentials } =
+      await import("@/server/onboarding-actions");
+    const result = await verifyAdeCredentials(BIZ_ID);
+    expect(result.passwordExpired).toBeUndefined();
+    expect(result.error).toMatch(/Verifica fallita/);
+  });
+});

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -244,6 +244,33 @@ describe("changeAdePassword", () => {
     expect(result.error).toMatch(/Password attuale non corretta/);
   });
 
+  it("restituisce errore 'diversa da quella attuale' quando AdE lancia ADE_CHANGE_PW_SAME", async () => {
+    const { AdeError } = await import("@/lib/ade/errors");
+    mockAdeChangePassword.mockRejectedValue(
+      new AdeError("ADE_CHANGE_PW_SAME", "Same password"),
+    );
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass12",
+    );
+    expect(result.error).toMatch(/diversa da quella attuale/);
+  });
+
+  it("restituisce errore generico quando AdE lancia un errore non classificato", async () => {
+    mockAdeChangePassword.mockRejectedValue(new Error("Network error"));
+    const { changeAdePassword } = await import("@/server/onboarding-actions");
+    const result = await changeAdePassword(
+      BIZ_ID,
+      "OldPass1",
+      "NewPass12",
+      "NewPass12",
+    );
+    expect(result.error).toMatch(/Riprova più tardi/);
+  });
+
   it("aggiorna la password cifrata e verifiedAt in caso di successo", async () => {
     const { changeAdePassword } = await import("@/server/onboarding-actions");
     const result = await changeAdePassword(

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -254,7 +254,11 @@ describe("changeAdePassword", () => {
     );
     expect(result.error).toBeUndefined();
     expect(result.businessId).toBe(BIZ_ID);
-    expect(mockEncrypt).toHaveBeenCalledWith("NewPass12", FAKE_KEY);
+    expect(mockEncrypt).toHaveBeenCalledWith(
+      "NewPass12",
+      FAKE_KEY,
+      FAKE_CRED.keyVersion,
+    );
     expect(mockSet).toHaveBeenCalledWith(
       expect.objectContaining({ encryptedPassword: "new-enc-pw" }),
     );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         "src/components/settings/edit-business-section.tsx", // UI client component — form + dialog, pure UI
         "src/components/settings/edit-settings-dialog.tsx", // UI client component — shared dialog shell, pure UI
         "src/components/settings/edit-ade-credentials-section.tsx", // UI client component — form + dialog, pure UI
+        "src/components/ade/change-ade-password-dialog.tsx", // UI client component — form + dialog, pure UI
         "src/sw.ts", // service worker entry point — pure infrastructure, no testable logic
         "src/app/offline/page.tsx", // static offline shell — pure UI, no logic
       ],


### PR DESCRIPTION
## Summary

- **Nuovo `AdePasswordExpiredError`**: distingue il caso password scaduta (AdE risponde `details: "PASSWORD_EXPIRED"`) da credenziali errate — con log `warn` dedicato
- **`changePasswordFisconline()`** sull'AdeClient: POST a `telematici.agenziaentrate.gov.it/CambioPassword.do` (non richiede login previo, funziona con password scaduta), risposta HTML parsata per distinguere successo/errori
- **`changeAdePassword` server action**: validazione server-side del charset/lunghezza Fisconline, rate limit 5/15min, dopo successo aggiorna la password cifrata e `verifiedAt` automaticamente
- **Propagazione `passwordExpired: true`** da `emitReceiptForBusiness` e `verifyAdeCredentials` ai caller
- **`ChangeAdePasswordDialog`**: dialog riusabile con validazione client-side Zod (8–15 char, charset Fisconline, nuova ≠ attuale, nuova == conferma), integrato in cassa e impostazioni

## Test plan

- [ ] CI verde (lint + type-check + test)
- [ ] `tests/unit/change-ade-password-dialog.test.ts` — validazione schema Zod
- [ ] `tests/unit/server-onboarding-change-password.test.ts` — `changeAdePassword` + `verifyAdeCredentials` password scaduta
- [ ] `tests/unit/receipt-service-password-expired.test.ts` — `emitReceiptForBusiness` con `AdePasswordExpiredError`
- [ ] `src/lib/ade/real-client.test.ts` — detection `PASSWORD_EXPIRED` + metodo `changePasswordFisconline`
- [ ] Verifica in sandbox con password realmente scaduta (ADE_MODE=real)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)