### PR TITLE
Update Help Center docs to reflect current UI and error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,18 @@
     node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
     ```
 
+25. **Quando si modifica una funzionalità, verificare se le pagine Help associate vanno aggiornate.**
+    Ogni modifica a UI label, percorsi di menu, stati visualizzati, opzioni di filtro,
+    flussi di errore, gating dei piani o nomi di bottoni può rendere obsoleta la documentazione
+    in `src/app/(marketing)/help/**/page.tsx`. Prima di chiudere un task che cambia uno di
+    questi aspetti, fare un grep mirato del termine modificato (es. `grep -rn "Verifica connessione" src/app/\(marketing\)/help`)
+    e aggiornare gli articoli che lo citano. Le revisioni periodiche del Help Center hanno già
+    rivelato discrepanze evidenti (es. label "Trasmesso" vs UI reale "Emesso", filtro "importo"
+    inesistente, sezioni che descrivevano feature ancora `comingSoon`): tenere allineata la
+    documentazione contestualmente al codice evita che si accumulino. Per le feature ancora
+    non implementate, riformulare al condizionale come roadmap (es. "In arrivo · Piano Pro")
+    anziché descriverle come attive.
+
 ## Progetto
 
 ScontrinoZero è un registratore di cassa virtuale (SaaS) mobile-first che consente a

--- a/src/app/(marketing)/help/errori-ade/page.tsx
+++ b/src/app/(marketing)/help/errori-ade/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 export const metadata: Metadata = {
   title: "Errori comuni di accesso AdE e come risolverli | ScontrinoZero Help",
   description:
-    "Guida alla risoluzione degli errori più frequenti nel collegamento con l'Agenzia delle Entrate: PIN scaduto, credenziali errate, attività non autorizzata e servizio non disponibile.",
+    "Guida alla risoluzione degli errori più frequenti nel collegamento con l'Agenzia delle Entrate: password scaduta, credenziali errate, password bloccata e portale non disponibile.",
 };
 
 export default function ErroriAdePage() {
@@ -30,8 +30,11 @@ export default function ErroriAdePage() {
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Quando ScontrinoZero non riesce a comunicare con il portale Fatture e
-          Corrispettivi dell&apos;Agenzia delle Entrate, lo scontrino rimane in
-          stato <strong>In elaborazione</strong> o mostra un errore esplicito.
+          Corrispettivi dell&apos;Agenzia delle Entrate, l&apos;emissione dello
+          scontrino fallisce subito e il documento viene marcato come{" "}
+          <strong>Errore</strong>, oppure il pulsante{" "}
+          <strong>Verifica connessione</strong> in{" "}
+          <strong>Impostazioni → Credenziali AdE</strong> mostra un messaggio.
           Questa guida copre i casi più frequenti con la soluzione per ciascuno.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
@@ -40,51 +43,49 @@ export default function ErroriAdePage() {
 
         {/* ─── Errore 1 ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          PIN scaduto o non ancora personalizzato
+          Password Fisconline scaduta
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Sintomo:</strong> il test di connessione AdE fallisce con un
-          messaggio del tipo &quot;credenziali non valide&quot; o &quot;accesso
-          negato&quot;.
+          <strong>Sintomo:</strong> il pulsante{" "}
+          <strong>Verifica connessione</strong> apre automaticamente una
+          finestra di dialogo che ti chiede di impostare una nuova password
+          Fisconline.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Causa:</strong> il PIN Fisconline ha una validità di 3 anni.
-          Alla prima registrazione viene rilasciato un PIN temporaneo di 6 cifre
-          che deve essere personalizzato in un PIN di 8 cifre entro 30 giorni.
+          <strong>Causa:</strong> la password Fisconline scade ogni 90 giorni
+          per motivi di sicurezza. È il caso più frequente di blocco delle
+          credenziali e ScontrinoZero lo rileva automaticamente.
         </p>
         <p className="text-muted-foreground mt-3 text-sm font-medium">
           Soluzione:
         </p>
         <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            {"Vai su "}
-            <strong>
-              ivaservizi.agenziaentrate.gov.it → Fisconline → Accedi
-            </strong>
-            {"."}
+            Nella finestra di dialogo inserisci la vecchia password e scegline
+            una nuova (8-15 caratteri tra lettere non accentate, numeri e
+            caratteri speciali).
           </li>
           <li>
-            Prova ad accedere: se il PIN è scaduto, il portale AdE ti chiede
-            direttamente di cambiarlo.
+            ScontrinoZero comunica direttamente con il portale AdE per
+            aggiornare la password e salva la nuova nelle credenziali del tuo
+            account.
           </li>
           <li>
-            Scegli un nuovo PIN di 8 cifre e confermalo. Il nuovo PIN è
-            immediatamente attivo.
-          </li>
-          <li>
-            {"Torna su ScontrinoZero, vai in "}
-            <strong>Impostazioni → Attività → Credenziali AdE</strong> e
-            aggiorna il PIN con il nuovo valore.
+            Al termine il badge dello stato torna su <strong>Verificate</strong>
+            {" e puoi emettere scontrini normalmente."}
           </li>
         </ol>
 
         {/* ─── Errore 2 ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Credenziali errate (codice fiscale o PIN sbagliato)
+          Credenziali errate (codice fiscale, PIN o password)
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Sintomo:</strong> il test fallisce con &quot;credenziali non
-          valide&quot; anche con un PIN che ritieni corretto.
+          <strong>Sintomo:</strong> il pulsante{" "}
+          <strong>Verifica connessione</strong> mostra il messaggio{" "}
+          <em>
+            &quot;Verifica fallita. Controlla le credenziali Fisconline.&quot;
+          </em>
         </p>
         <p className="text-muted-foreground mt-3 text-sm font-medium">
           Cosa verificare:
@@ -97,39 +98,88 @@ export default function ErroriAdePage() {
             gestisce l&apos;account Fisconline (non il CF della società).
           </li>
           <li>
-            Il <strong>PIN</strong> deve essere quello di 8 cifre
-            personalizzato, non il PIN temporaneo di 6 cifre ricevuto
-            inizialmente.
+            Il <strong>PIN</strong> Fisconline è composto da{" "}
+            <strong>10 caratteri totali</strong>: i primi 4 vengono forniti
+            online al momento della richiesta, gli ultimi 6 arrivano per posta
+            entro 15 giorni insieme alla password di primo accesso. Devi
+            inserire il PIN completo di 10 caratteri.
           </li>
           <li>
-            {
-              "Verifica le credenziali accedendo direttamente al portale AdE. Se funzionano lì ma non su ScontrinoZero, aggiornale in "
-            }
-            <strong>Impostazioni → Attività → Credenziali AdE</strong>.
+            La <strong>password</strong> ha lunghezza tra 8 e 15 caratteri ed è
+            case-sensitive. Se l&apos;hai appena cambiata, ricordati di
+            aggiornarla anche su ScontrinoZero.
+          </li>
+          <li>
+            {"Per aggiornare le credenziali vai in "}
+            <strong>Impostazioni → Credenziali AdE</strong> e usa il pulsante{" "}
+            <strong>Modifica</strong>.
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Attenzione: 5 tentativi falliti consecutivi sul portale AdE bloccano
-          l&apos;account per 24 ore. Se sei bloccato, attendi il giorno
-          successivo prima di ritentare.
+          Attenzione: dopo 8 tentativi consecutivi con password errata, la
+          password viene bloccata sul portale AdE. Vedi la sezione successiva.
         </p>
 
         {/* ─── Errore 3 ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Attività non registrata o non autorizzata sul portale AdE
+          Password Fisconline bloccata per troppi tentativi
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Sintomo:</strong> il portale AdE mostra un messaggio del tipo
+          &quot;la password è stata bloccata poiché è stato superato il numero
+          di tentativi di accesso&quot;.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Causa:</strong> 8 tentativi consecutivi con password errata
+          attivano il blocco automatico della password sui Servizi Telematici
+          dell&apos;AdE.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm font-medium">
+          Soluzione:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            {"Esegui il "}
+            <strong>ripristino password</strong>
+            {" sul portale AdE: "}
+            <a
+              href="https://telematici.agenziaentrate.gov.it/Abilitazione/RipristinaPassword/IRipristinaPassword.jsp"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              telematici.agenziaentrate.gov.it → Ripristina Password
+            </a>
+            {"."}
+          </li>
+          <li>
+            In alternativa, accedi all&apos;area riservata AdE con SPID, CIE o
+            CNS e usa la funzione &quot;Prelievo credenziali&quot; in Profilo
+            utente per recuperare o reimpostare le credenziali Fisconline.
+          </li>
+          <li>
+            {"Una volta impostata la nuova password, aggiornala in "}
+            <strong>Impostazioni → Credenziali AdE → Modifica</strong>
+            {" su ScontrinoZero."}
+          </li>
+        </ul>
+
+        {/* ─── Errore 4 ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Attività non abilitata sul portale Fatture e Corrispettivi
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           <strong>Sintomo:</strong> le credenziali Fisconline funzionano sul
-          portale AdE, ma ScontrinoZero riceve un errore di tipo &quot;soggetto
-          non abilitato&quot; o &quot;partita IVA non trovata&quot; al momento
-          di emettere uno scontrino.
+          portale AdE, ma ScontrinoZero non riesce ad emettere scontrini con un
+          errore di tipo &quot;soggetto non abilitato&quot; o &quot;servizio non
+          disponibile per questo soggetto&quot;.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           <strong>Causa:</strong> per emettere documenti commerciali elettronici
           sul portale Fatture e Corrispettivi, l&apos;attività deve essere
           abilitata. L&apos;abilitazione avviene automaticamente per la maggior
-          parte delle attività, ma potrebbe non essere ancora attiva per le
-          P.IVA aperte di recente.
+          parte delle attività, ma può non essere ancora attiva per le P.IVA
+          aperte di recente.
         </p>
         <p className="text-muted-foreground mt-3 text-sm font-medium">
           Soluzione:
@@ -146,51 +196,58 @@ export default function ErroriAdePage() {
           <li>
             Se riesci ad accedere alla sezione e vedi il modulo di emissione, la
             tua attività è abilitata: il problema è probabilmente nelle
-            credenziali inserite su ScontrinoZero (vedi errore precedente).
+            credenziali (vedi le sezioni precedenti).
           </li>
           <li>
             Se il portale mostra &quot;servizio non disponibile per questo
-            soggetto&quot;, contatta il supporto AdE (800.90.96.96) o uno
-            sportello dell&apos;Agenzia delle Entrate per richiedere
-            l&apos;abilitazione.
+            soggetto&quot;, contatta l&apos;assistenza AdE da rete fissa al
+            numero <strong>800.90.96.96</strong> (lun-ven 9-17) oppure da mobile
+            al <strong>06.96668907</strong>, o rivolgiti a uno sportello
+            territoriale per richiedere l&apos;abilitazione.
           </li>
         </ol>
 
-        {/* ─── Errore 4 ─── */}
+        {/* ─── Errore 5 ─── */}
         <h2 className="mt-10 text-xl font-semibold">
           Portale AdE temporaneamente non disponibile o lento
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Sintomo:</strong>
-          {" gli scontrini restano in stato "}
-          <strong>In elaborazione</strong> più a lungo del solito (oltre 5
-          minuti), oppure il test di connessione fallisce con errori di timeout.
+          <strong>Sintomo:</strong> l&apos;emissione di uno scontrino fallisce
+          con un errore di rete o timeout, oppure il pulsante{" "}
+          <strong>Verifica connessione</strong> impiega molto tempo e poi
+          fallisce.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           <strong>Causa:</strong> il portale dell&apos;Agenzia delle Entrate ha
-          picchi di carico (in particolare a fine mese) o periodi di
-          manutenzione programmata (solitamente la notte o il fine settimana).
+          picchi di carico o periodi di manutenzione programmata (di solito di
+          notte o nel fine settimana).
         </p>
         <p className="text-muted-foreground mt-3 text-sm font-medium">
           Come comportarsi:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            ScontrinoZero riprova automaticamente la trasmissione a intervalli
-            crescenti per diverse ore. Non è necessario fare nulla.
+            <strong>Importante:</strong> ScontrinoZero non accoda né ritrasmette
+            automaticamente gli scontrini. Quando il portale AdE non risponde,
+            l&apos;emissione fallisce subito e lo scontrino non viene generato.
+            Devi ritentare manualmente l&apos;emissione una volta che il portale
+            torna disponibile.
           </li>
           <li>
-            Puoi continuare ad emettere scontrini normalmente: si accodano e
-            vengono trasmessi appena il portale torna disponibile.
-          </li>
-          <li>
-            {"Verifica lo stato del portale AdE su "}
-            <strong>stato.agenziaentrate.gov.it</strong> o cercando
-            &quot;Fatture e Corrispettivi manutenzione&quot; sul sito AdE.
+            {"Verifica gli avvisi di manutenzione su "}
+            <a
+              href="https://telematici.agenziaentrate.gov.it/Main/ArchivioNotizie.do?ambiente=ALL"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              telematici.agenziaentrate.gov.it → Avvisi
+            </a>
+            {"."}
           </li>
           <li>
             {
-              "Se il problema persiste per oltre 24 ore, contatta il supporto ScontrinoZero a "
+              "Se il problema persiste e nessun avviso di manutenzione è attivo, contatta il supporto ScontrinoZero a "
             }
             <a
               href="mailto:info@scontrinozero.it"
@@ -202,59 +259,26 @@ export default function ErroriAdePage() {
           </li>
         </ul>
 
-        {/* ─── Errore 5 ─── */}
-        <h2 className="mt-10 text-xl font-semibold">
-          Troppi tentativi — account Fisconline bloccato
-        </h2>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Sintomo:</strong> il portale AdE mostra &quot;utente
-          bloccato&quot; o &quot;accesso sospeso per sicurezza&quot;.
-        </p>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Causa:</strong> 5 tentativi di accesso falliti consecutivi
-          attivano un blocco automatico di sicurezza di 24 ore.
-        </p>
-        <p className="text-muted-foreground mt-3 text-sm font-medium">
-          Soluzione:
-        </p>
-        <ul className="text-muted-foreground mt-2 list-disc space-y-2 pl-5 text-sm leading-relaxed">
-          <li>Attendi 24 ore, poi accedi con le credenziali corrette.</li>
-          <li>
-            Se non ricordi il PIN, puoi reimpostarlo tramite la funzione di
-            recupero sul portale Fisconline o rivolgendoti a un CAF o a uno
-            sportello AdE.
-          </li>
-          <li>
-            Nel frattempo puoi continuare ad emettere scontrini su
-            ScontrinoZero: verranno trasmessi all&apos;AdE non appena le
-            credenziali saranno di nuovo valide.
-          </li>
-        </ul>
-
         {/* ─── Errore 6 ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Credenziali delegate (professionista o intermediario)
+          Credenziali del commercialista o intermediario fiscale
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           <strong>Sintomo:</strong> stai usando le credenziali del tuo
-          commercialista o intermediario fiscale e ricevi un errore di accesso
-          negato.
+          commercialista o intermediario e ricevi un errore di accesso negato.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          <strong>Causa:</strong>
-          {
-            " le credenziali delegate funzionano per alcune sezioni del portale AdE, ma "
-          }
+          <strong>Causa:</strong> ScontrinoZero accede al portale Fatture e
+          Corrispettivi tramite il flusso Fisconline diretto. Servono quindi le{" "}
           <strong>
-            il Documento Commerciale Online richiede le credenziali del titolare
-            dell&apos;attività
+            credenziali Fisconline associate al codice fiscale del titolare o
+            legale rappresentante dell&apos;attività
           </strong>
-          {", non quelle di un intermediario."}
+          {", non quelle di un intermediario delegato. "}
+          Se hai sempre operato sul portale AdE tramite SPID, CIE o CNS, non hai
+          ancora un PIN Fisconline e devi richiederlo.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          {
-            "Devi usare le tue credenziali Fisconline personali, associate al codice fiscale del titolare/legale rappresentante dell'attività. "
-          }
           <Link
             href="/help/credenziali-fisconline"
             className="text-primary hover:underline"
@@ -279,18 +303,21 @@ export default function ErroriAdePage() {
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
-            Le credenziali funzionano sul portale AdE ma non su ScontrinoZero.
+            Le credenziali funzionano sul portale AdE ma il pulsante{" "}
+            <strong>Verifica connessione</strong> di ScontrinoZero continua a
+            fallire.
           </li>
           <li>
-            Uno scontrino è rimasto in stato &quot;In elaborazione&quot; per più
-            di 24 ore.
+            Uno scontrino è andato in stato <strong>Errore</strong> dopo
+            l&apos;emissione e non capisci perché.
           </li>
           <li>Ricevi messaggi di errore diversi da quelli descritti sopra.</li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Includi nella mail l&apos;ID dello scontrino problematico (visibile
-          nello Storico) e uno screenshot del messaggio di errore, se
-          disponibile.
+          Includi nella mail uno screenshot del messaggio di errore e, se
+          disponibile, l&apos;identificativo dello scontrino problematico: puoi
+          copiarlo dall&apos;URL della pagina di dettaglio dello scontrino (la
+          parte dopo <code>/r/</code>).
         </p>
 
         {/* ─── Articoli correlati ─── */}

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title:
     "Storico scontrini: filtri, ricerca ed esportazione | ScontrinoZero Help",
   description:
-    "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e esportare i dati in CSV per la contabilità.",
+    "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e ricondividere il PDF dei singoli scontrini. L'export CSV è una funzione in arrivo sul piano Pro.",
 };
 
 export default function StoricoEdEsportazionePage() {
@@ -30,10 +30,11 @@ export default function StoricoEdEsportazionePage() {
           <Badge variant="secondary">Gestione scontrini</Badge>
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          La sezione <strong>Storico</strong> raccoglie tutti gli scontrini
-          emessi e annullati. Puoi filtrare per data e importo, aprire il
-          dettaglio di ogni documento e — con il piano Pro — esportare tutto in
-          CSV per il commercialista.
+          La sezione <strong>Storico</strong> raccoglie gli scontrini emessi e
+          annullati con successo. Puoi filtrare per periodo e per stato, aprire
+          il dettaglio di ogni documento e ricondividerlo come PDF al cliente.
+          L&apos;esportazione CSV per il commercialista è una funzione in arrivo
+          sul piano Pro.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -45,18 +46,34 @@ export default function StoricoEdEsportazionePage() {
         </h2>
         <ol className="text-muted-foreground mt-3 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            Dalla dashboard, tocca <strong>Storico</strong> nella barra laterale
-            (o nel menu in basso su mobile).
+            Dalla dashboard, tocca <strong>Storico</strong> nella barra di
+            navigazione (in alto su desktop, in basso su mobile).
           </li>
           <li>
             Vedrai l&apos;elenco degli scontrini in ordine cronologico inverso,
-            dal più recente al più vecchio.
+            dal più recente al più vecchio, con paginazione.
           </li>
           <li>
-            Ogni riga mostra: data, ora, importo totale, metodo di pagamento e
-            stato (Trasmesso, In elaborazione, Annullato).
+            Ogni riga mostra: <strong>data</strong>,{" "}
+            <strong>progressivo</strong> (numero scontrino assegnato
+            dall&apos;AdE), <strong>totale</strong> e <strong>stato</strong>{" "}
+            (Emesso o Annullato).
           </li>
         </ol>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Lo Storico mostra solo gli scontrini che hanno completato la
+          trasmissione all&apos;AdE: emessi correttamente o annullati. Se
+          un&apos;emissione fallisce, l&apos;errore viene mostrato subito nella
+          schermata di emissione e lo scontrino non viene aggiunto allo Storico.
+          Per i casi di errore vedi{" "}
+          <Link
+            href="/help/errori-ade"
+            className="text-primary hover:underline"
+          >
+            Errori comuni di accesso AdE
+          </Link>
+          {"."}
+        </p>
 
         {/* ─── Filtri disponibili ─── */}
         <h2 className="mt-10 text-xl font-semibold">Filtri disponibili</h2>
@@ -65,100 +82,86 @@ export default function StoricoEdEsportazionePage() {
         </p>
         <div className="mt-3 space-y-3">
           <div>
-            <p className="text-sm font-medium">Intervallo di date</p>
+            <p className="text-sm font-medium">Periodo</p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Seleziona una data di inizio e una di fine per vedere solo gli
-              scontrini di quel periodo. Utile per riepilogo mensile o
-              trimestrale.
+              scontrini di quel periodo. Utile per il riepilogo mensile o
+              trimestrale da inviare al commercialista.
             </p>
           </div>
           <div>
             <p className="text-sm font-medium">Stato</p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Filtra per <strong>Trasmesso</strong>,{" "}
-              <strong>In elaborazione</strong> o <strong>Annullato</strong>. Il
-              filtro &quot;In elaborazione&quot; è utile per individuare
-              rapidamente documenti la cui trasmissione all&apos;AdE è ancora in
-              corso.
-            </p>
-          </div>
-          <div>
-            <p className="text-sm font-medium">Importo</p>
-            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Inserisci un importo minimo e/o massimo per trovare scontrini di
-              un certo valore — comodo per identificare una transazione
-              specifica.
+              Le opzioni sono <strong>Emesso</strong>,{" "}
+              <strong>Annullato</strong> e <strong>Tutti</strong>. La voce
+              &quot;Tutti&quot; mostra comunque solo gli scontrini emessi e
+              annullati con successo: gli scontrini la cui emissione è fallita
+              non compaiono mai nello Storico.
             </p>
           </div>
         </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Premi <strong>Cerca</strong> per applicare i filtri. Il numero totale
+          di scontrini trovati viene mostrato in alto.
+        </p>
 
         {/* ─── Dettaglio scontrino ─── */}
         <h2 className="mt-10 text-xl font-semibold">
           Aprire il dettaglio di uno scontrino
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Tocca una riga per aprire il dettaglio completo del documento. Qui
-          trovi:
+          Tocca una riga per aprire la finestra di dettaglio. Mostra:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
-          <li>Numero documento e data/ora di emissione.</li>
-          <li>Elenco delle righe con descrizione, aliquota IVA e importo.</li>
-          <li>Totale e ripartizione per metodo di pagamento.</li>
-          <li>Codice lotteria (se applicabile).</li>
-          <li>Stato trasmissione AdE con timestamp di conferma.</li>
+          <li>Numero scontrino (progressivo AdE) e data di emissione.</li>
           <li>
-            Link al PDF dello scontrino (condivisibile via WhatsApp, email,
-            ecc.).
+            Elenco delle righe con descrizione, quantità, prezzo unitario,
+            aliquota IVA e importo riga.
           </li>
+          <li>Totale dello scontrino.</li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          {"Dal dettaglio puoi anche avviare l'"}
-          <strong>annullamento</strong>
-          {" dello scontrino, se è in stato Trasmesso."}
+          {"Dalla finestra di dettaglio puoi inoltre:"}
         </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
+          <li>
+            Premere <strong>Invia ricevuta</strong> per aprire la pagina
+            pubblica dello scontrino: il link è condivisibile via WhatsApp,
+            email o messaggio, e dalla pagina il cliente può salvare il PDF.
+          </li>
+          <li>
+            Premere <strong>Annulla scontrino</strong> per avviare la procedura
+            di annullo, disponibile solo se lo scontrino è in stato{" "}
+            <strong>Emesso</strong>. Verrà chiesta una conferma esplicita perché
+            l&apos;annullo è irreversibile e viene trasmesso all&apos;AdE come
+            documento di annullo.
+          </li>
+        </ul>
 
-        {/* ─── Export CSV ─── */}
+        {/* ─── Export CSV (in arrivo) ─── */}
         <h2 className="mt-10 text-xl font-semibold">
           Esportazione CSV{" "}
           <Badge className="ml-1" variant="secondary">
-            Piano Pro
+            In arrivo · Piano Pro
           </Badge>
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Gli utenti con piano <strong>Pro</strong> possono esportare lo storico
-          scontrini in formato CSV. Il file è compatibile con Excel, Google
-          Sheets e qualsiasi software di contabilità.
+          L&apos;esportazione dello storico scontrini in formato CSV è una
+          funzione prevista per il piano <strong>Pro</strong> e non è ancora
+          disponibile nell&apos;app. Quando sarà rilasciata troverai un pulsante
+          dedicato nella pagina Storico e questo articolo verrà aggiornato con i
+          dettagli sulle colonne incluse.
         </p>
-        <h3 className="mt-5 text-base font-semibold">Come esportare</h3>
-        <ol className="text-muted-foreground mt-2 list-decimal space-y-2 pl-5 text-sm leading-relaxed">
-          <li>
-            Vai in <strong>Storico</strong> e imposta i filtri desiderati
-            (periodo, stato).
-          </li>
-          <li>
-            Clicca su <strong>Esporta CSV</strong> in alto a destra.
-          </li>
-          <li>
-            Il file viene generato e scaricato automaticamente nel browser.
-          </li>
-        </ol>
-        <h3 className="mt-5 text-base font-semibold">Cosa contiene il CSV</h3>
-        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-          Il file include una riga per ogni scontrino con le colonne:
-        </p>
-        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
-          <li>Numero documento</li>
-          <li>Data e ora di emissione</li>
-          <li>Stato (Trasmesso / Annullato)</li>
-          <li>Importo lordo totale</li>
-          <li>IVA per aliquota (4%, 10%, 22%, Esente)</li>
-          <li>Metodo di pagamento (Contante, Carta, Altro)</li>
-          <li>Codice lotteria (se presente)</li>
-        </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Se sei nel piano Starter e vuoi accedere all&apos;export CSV, puoi
-          passare a Pro dalla sezione{" "}
-          <strong>Dashboard &gt; Impostazioni &gt; Abbonamento</strong>.
+          Nel frattempo, per il riepilogo periodico al commercialista puoi
+          filtrare lo Storico per periodo, prendere nota dei totali e dei
+          progressivi, e condividere all&apos;occorrenza i singoli scontrini
+          tramite il bottone <strong>Invia ricevuta</strong>.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Quando la funzione sarà attiva, gli utenti del piano Starter potranno
+          passare al Pro dalla sezione{" "}
+          <strong>Impostazioni → Piano e Abbonamento</strong> nella dashboard.
         </p>
 
         {/* ─── Casi d'uso comuni ─── */}
@@ -169,9 +172,10 @@ export default function StoricoEdEsportazionePage() {
               Riepilogo mensile per il commercialista
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Filtra per il mese di riferimento, esporta il CSV e invialo al
-              commercialista. Il file contiene già la ripartizione IVA per
-              aliquota, pronta per la liquidazione.
+              Filtra lo Storico per il mese di riferimento, comunica al
+              commercialista il totale degli scontrini emessi e
+              l&apos;intervallo di progressivi. L&apos;export CSV strutturato
+              arriverà sul piano Pro.
             </p>
           </div>
           <div>
@@ -179,26 +183,21 @@ export default function StoricoEdEsportazionePage() {
               Trovare uno scontrino specifico per un cliente
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Usa il filtro per data e importo per identificare rapidamente lo
-              scontrino. Dal dettaglio puoi riaprire il PDF e ricondividerlo via
-              WhatsApp o email.
+              Filtra per periodo per restringere la lista, individua lo
+              scontrino dal totale o dal progressivo, aprilo e premi{" "}
+              <strong>Invia ricevuta</strong> per ottenere il link pubblico da
+              condividere via WhatsApp o email.
             </p>
           </div>
           <div>
             <p className="text-sm font-medium">
-              Verificare scontrini in attesa di conferma AdE
+              Ricondividere il PDF a un cliente che lo ha perso
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Filtra per stato <strong>In elaborazione</strong>: se vedi
-              documenti fermi da più di 15 minuti, potrebbe esserci un problema
-              di connessione o un errore AdE. Consulta la guida{" "}
-              <Link
-                href="/help/errori-ade"
-                className="text-primary hover:underline"
-              >
-                Errori comuni di accesso AdE
-              </Link>{" "}
-              per diagnosticare.
+              Apri il dettaglio dello scontrino dallo Storico, premi{" "}
+              <strong>Invia ricevuta</strong>: si apre una pagina pubblica
+              dedicata, dalla quale il cliente può salvare o stampare il PDF. Il
+              link non scade.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Comprehensive update to Help Center articles to align with current application behavior, UI labels, and error handling flows. This includes corrections to outdated terminology, clarification of actual user workflows, and documentation of features that are still in development.

## Key Changes

### Errori ADE page (`errori-ade/page.tsx`)
- **Updated error categories and descriptions** to match current error handling:
  - Renamed "PIN scaduto" → "Password Fisconline scaduta" (reflects actual 90-day expiry)
  - Renamed "Attività non registrata" → "Attività non abilitata sul portale Fatture e Corrispettivi"
  - Added new section "Password Fisconline bloccata per troppi tentativi" (8 failed attempts)
  - Removed outdated "Troppi tentativi — account Fisconline bloccato" (24-hour lockout no longer applies)

- **Corrected UI terminology**:
  - Changed "In elaborazione" → "Errore" (reflects actual receipt status)
  - Updated button label references to "Verifica connessione" (actual UI button)
  - Updated navigation path to "Impostazioni → Credenziali AdE" (removed "Attività")

- **Clarified actual behavior**:
  - Scontrini fail immediately on AdE unavailability (not queued/retried automatically)
  - Password reset flow now handled directly in app dialog
  - PIN structure corrected: 10 characters total (4 online + 6 by mail)
  - Password requirements: 8-15 characters, case-sensitive

- **Updated support information**:
  - Added direct phone numbers for AdE assistance (800.90.96.96, 06.96668907)
  - Added link to password recovery page on AdE portal
  - Added link to maintenance notices on telematici.agenziaentrate.gov.it

### Storico page (`storico-ed-esportazione/page.tsx`)
- **Clarified what appears in history**:
  - Only successfully emitted/cancelled receipts shown (failed emissions don't appear)
  - Added explanation that errors are shown immediately in emission screen

- **Updated filter descriptions**:
  - Removed non-existent "Importo" (amount) filter
  - Clarified "Stato" filter options: "Emesso", "Annullato", "Tutti"
  - Renamed "Intervallo di date" → "Periodo"

- **Corrected feature status**:
  - CSV export marked as "In arrivo · Piano Pro" (not yet available)
  - Updated instructions to reflect current workflow: filter → note totals → share individual receipts

- **Updated UI references**:
  - Changed "Invia ricevuta" button description (public shareable link, not email)
  - Clarified "Annulla scontrino" button behavior and irreversibility
  - Updated navigation references to match current sidebar/menu structure

- **Removed outdated content**:
  - Removed CSV export instructions (feature not yet live)
  - Removed "In elaborazione" status references
  - Removed payment method and lottery code fields (not in current UI)

### CLAUDE.md
- Added guideline #25 documenting the process for keeping Help Center in sync with code changes, including grep-based verification and handling of in-development features with conditional language.

## Implementation Notes
- All changes are documentation-only; no application logic modified
- Terminology updates reflect actual current UI labels and behavior
- Feature status clearly marked with badges ("In arrivo · Piano Pro") where applicable
- Links updated to point to correct AdE portal pages
- Navigation paths corrected to match current app structure

https://claude.ai/code/session_014UquAB7geDEFkHDDrFz2Wa