### PR TITLE
Update help docs: credential security and cassetto fiscale

### DIFF
--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -66,10 +66,11 @@ export default function CassettoFiscalePage() {
             CIE — le stesse usate per collegare ScontrinoZero all&apos;AdE.
           </li>
           <li>
-            Dal menu principale seleziona <strong>Corrispettivi</strong>.
+            Dal menu principale seleziona <strong>Corrispettivi</strong>, poi{" "}
+            <strong>Documento commerciale on line</strong>.
           </li>
           <li>
-            Clicca su <strong>Consultazione documenti commerciali</strong>.
+            Clicca su <strong>Ricerca documento commerciale</strong>.
           </li>
         </ol>
 
@@ -94,8 +95,8 @@ export default function CassettoFiscalePage() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Ogni documento mostra: data, numero, importo, aliquote IVA e stato
-          (Trasmesso, Annullato).
+          Ogni documento mostra: data, numero progressivo, importo totale e
+          aliquote IVA applicate.
         </p>
 
         {/* ─── Tempistiche ─── */}
@@ -107,7 +108,7 @@ export default function CassettoFiscalePage() {
           in genere entro <strong>pochi minuti</strong>. In alcuni casi,
           soprattutto nelle ore di punta del portale AdE, possono volerci fino a{" "}
           <strong>24 ore</strong>. Se uno scontrino risulta{" "}
-          <strong>Trasmesso</strong> in ScontrinoZero ma non compare ancora nel
+          <strong>Emesso</strong> in ScontrinoZero ma non compare ancora nel
           cassetto, attendi qualche ora prima di preoccuparti.
         </p>
 
@@ -122,10 +123,17 @@ export default function CassettoFiscalePage() {
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Vai in <strong>Storico</strong> e controlla lo stato dello
-              scontrino. Se è <strong>Trasmesso</strong>, il documento è
-              arrivato all&apos;AdE — attendi la visibilità nel cassetto. Se è{" "}
-              <strong>In elaborazione</strong>, la trasmissione è ancora in
-              corso: riprova dopo qualche minuto.
+              scontrino. Se è <strong>Emesso</strong>, il documento è stato
+              accettato dall&apos;AdE — attendi la visibilità nel cassetto. Se
+              uno scontrino atteso non compare in Storico, la trasmissione
+              potrebbe essere fallita: vedi{" "}
+              <Link
+                href="/help/errori-ade"
+                className="text-primary hover:underline"
+              >
+                {"Errori comuni AdE"}
+              </Link>
+              {"."}
             </p>
           </div>
           <div>
@@ -152,7 +160,7 @@ export default function CassettoFiscalePage() {
           <div>
             <p className="text-sm font-medium">4. Contatta l&apos;assistenza</p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Se lo scontrino è Trasmesso da più di 24 ore ma non compare nel
+              Se lo scontrino è Emesso da più di 24 ore ma non compare nel
               cassetto, scrivici a{" "}
               <a
                 href="mailto:info@scontrinozero.it"
@@ -170,16 +178,17 @@ export default function CassettoFiscalePage() {
           Riepilogo corrispettivi per periodo
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Il portale AdE permette di esportare un prospetto riepilogativo dei
+          Il portale AdE permette di consultare un prospetto riepilogativo dei
           corrispettivi per periodo (mensile, trimestrale, annuale) — utile per
           la liquidazione IVA e per i controlli del commercialista. Puoi
-          accedervi dalla sezione{" "}
-          <strong>Corrispettivi &gt; Riepilogo corrispettivi</strong>.
+          accedervi dalla sezione <strong>Corrispettivi</strong> del portale
+          Fatture e Corrispettivi.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          In alternativa, da ScontrinoZero puoi esportare direttamente un CSV
-          dello Storico con tutti i dati degli scontrini (funzione disponibile
-          nel piano Pro).
+          In alternativa, l&apos;esportazione dello Storico in CSV è una
+          funzione <strong>in arrivo sul piano Pro</strong>: appena disponibile
+          potrai scaricare tutti i dati degli scontrini direttamente
+          dall&apos;app.
         </p>
 
         {/* ─── Articoli correlati ─── */}

--- a/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
+++ b/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title:
     "Sicurezza e privacy: come proteggiamo le tue credenziali | ScontrinoZero Help",
   description:
-    "Come ScontrinoZero protegge le credenziali Fisconline: cifratura AES-256-GCM, architettura zero-knowledge, chi può accedere ai tuoi dati e come revocare l'accesso.",
+    "Come ScontrinoZero protegge le credenziali Fisconline: cifratura AES-256-GCM at-rest, chiave fuori dal database, chi può accedere ai tuoi dati e come revocare l'accesso.",
 };
 
 export default function SicurezzaCredenzialiPage() {
@@ -66,10 +66,10 @@ export default function SicurezzaCredenzialiPage() {
           Cifratura AES-256-GCM: cosa significa in pratica
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Le tue credenziali (codice fiscale Fisconline e PIN) vengono cifrate
-          con <strong>AES-256-GCM</strong> prima di essere salvate nel database.
-          Questo è lo stesso standard usato dalle banche e dai servizi di
-          pagamento più sicuri al mondo.
+          Le tue credenziali Fisconline (codice fiscale, password e PIN) vengono
+          cifrate con <strong>AES-256-GCM</strong> prima di essere salvate nel
+          database. Questo è lo stesso standard usato dalle banche e dai servizi
+          di pagamento più sicuri al mondo.
         </p>
         <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
           <li>
@@ -91,14 +91,13 @@ export default function SicurezzaCredenzialiPage() {
           </li>
         </ul>
 
-        {/* ─── Zero-knowledge ─── */}
+        {/* ─── Cifratura at-rest ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Architettura zero-knowledge: il team non può leggere le tue
-          credenziali
+          Cifratura at-rest: il team non può leggere le tue credenziali
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Le credenziali non sono mai visibili in chiaro, nemmeno agli
-          amministratori di ScontrinoZero. Ecco perché:
+          Le credenziali non sono mai visibili in chiaro nel database, nemmeno
+          agli amministratori di ScontrinoZero. Ecco perché:
         </p>
         <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
           <li>
@@ -144,8 +143,8 @@ export default function SicurezzaCredenzialiPage() {
         </h2>
         <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
           <li>
-            <strong>Tu</strong> — puoi aggiornare o eliminare le credenziali in
-            qualsiasi momento da <strong>Impostazioni → Attività</strong>.
+            <strong>Tu</strong> — puoi aggiornare le credenziali in qualsiasi
+            momento da <strong>Impostazioni → Credenziali AdE</strong>.
           </li>
           <li>
             <strong>Il server applicativo</strong> — usa le credenziali
@@ -174,7 +173,7 @@ export default function SicurezzaCredenzialiPage() {
         </p>
         <ol className="text-muted-foreground mt-2 list-decimal space-y-1 pl-5 text-sm leading-relaxed">
           <li>
-            Vai su <strong>Impostazioni → Attività → Credenziali AdE</strong>.
+            Vai su <strong>Impostazioni → Credenziali AdE</strong>.
           </li>
           <li>
             Clicca su <strong>Modifica credenziali</strong>.
@@ -182,8 +181,10 @@ export default function SicurezzaCredenzialiPage() {
           <li>Inserisci il nuovo PIN e salva.</li>
         </ol>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Gli scontrini rimasti in coda vengono trasmessi automaticamente appena
-          le nuove credenziali sono valide.
+          Gli scontrini emessi prima dell&apos;aggiornamento e rifiutati
+          dall&apos;AdE per credenziali scadute vanno{" "}
+          <strong>riemessi manualmente</strong> dopo aver salvato le nuove
+          credenziali: al momento non è prevista una ritrasmissione automatica.
         </p>
 
         {/* ─── Come revocare ─── */}
@@ -191,25 +192,23 @@ export default function SicurezzaCredenzialiPage() {
           Come revocare l&apos;accesso e cancellare le credenziali
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Puoi eliminare le credenziali AdE salvate in qualsiasi momento:
-        </p>
-        <ol className="text-muted-foreground mt-2 list-decimal space-y-1 pl-5 text-sm leading-relaxed">
-          <li>
-            Vai su <strong>Impostazioni → Attività → Credenziali AdE</strong>.
-          </li>
-          <li>
-            Clicca su <strong>Rimuovi credenziali</strong> e conferma.
-          </li>
-        </ol>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Dopo la rimozione, ScontrinoZero non potrà trasmettere nuovi scontrini
-          all&apos;AdE fino a quando non inserirai nuovamente le credenziali. I
-          dati cifrati vengono eliminati definitivamente dal database.
+          Per modificare le credenziali AdE salvate vai su{" "}
+          <strong>Impostazioni → Credenziali AdE</strong> e clicca{" "}
+          <strong>Modifica credenziali</strong>: i nuovi valori sostituiscono
+          quelli precedenti, che vengono cifrati di nuovo e sovrascritti nel
+          database.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Se elimini l&apos;account ScontrinoZero, tutte le credenziali e i dati
-          personali vengono eliminati entro 24 ore, come previsto dal diritto
-          alla cancellazione (GDPR art. 17).
+          Per <strong>revocare completamente</strong> l&apos;accesso e
+          cancellare i dati cifrati, puoi eliminare l&apos;account ScontrinoZero
+          da <strong>Impostazioni → Zona pericolosa → Elimina account</strong>:
+          la cancellazione è <strong>immediata</strong> e include credenziali
+          AdE, anagrafica, scontrini e catalogo (cascade delete sul profilo). Il
+          diritto alla cancellazione è garantito dal GDPR art. 17.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Un pulsante dedicato per rimuovere solo le credenziali AdE senza
+          eliminare l&apos;account è in roadmap.
         </p>
 
         {/* ─── FAQ ─── */}


### PR DESCRIPTION
## Summary
Updated help documentation pages to clarify credential security architecture and improve cassetto fiscale (tax filing) instructions with more accurate terminology and UI navigation paths.

## Key Changes

### Sicurezza Credenziali Page
- **Metadata**: Updated description to emphasize "at-rest" encryption and key separation from database instead of "zero-knowledge architecture"
- **Section title**: Changed "Architettura zero-knowledge" to "Cifratura at-rest" for clearer terminology
- **Credential details**: Expanded to explicitly mention password alongside codice fiscale and PIN
- **Navigation paths**: Updated from "Impostazioni → Attività → Credenziali AdE" to "Impostazioni → Credenziali AdE"
- **Credential update flow**: Clarified that scontrini rejected by AdE for expired credentials require manual re-submission (removed mention of automatic retransmission)
- **Revocation/deletion**: Restructured section to explain:
  - Modifying credentials via "Impostazioni → Credenziali AdE"
  - Complete account deletion via "Impostazioni → Zona pericolosa → Elimina account" with GDPR art. 17 reference
  - Noted that dedicated credential-only removal button is in roadmap

### Cassetto Fiscale Page
- **Navigation**: Updated AdE portal steps from "Consultazione documenti commerciali" to "Documento commerciale on line" → "Ricerca documento commerciale"
- **Document display**: Changed description from showing "stato (Trasmesso, Annullato)" to "numero progressivo" and "aliquote IVA applicate"
- **Status terminology**: Replaced "Trasmesso" with "Emesso" throughout to match current app terminology
- **Troubleshooting**: Enhanced with link to "Errori comuni AdE" help page for failed transmissions
- **CSV export**: Updated from "available in Pro plan" to "coming soon to Pro plan" with clarified timeline

## Implementation Details
- All changes are documentation-only (no code logic changes)
- Terminology updates align with current app UI and actual feature capabilities
- Navigation paths corrected to match current app structure
- More accurate descriptions of encryption implementation (at-rest vs zero-knowledge distinction)

https://claude.ai/code/session_01VW3dotiQJPKMSgTsH6LBhE