### PR TITLE
Update POS-RT compliance documentation with 2025 law changes

### DIFF
--- a/src/app/(marketing)/help/contatto-assistenza/page.tsx
+++ b/src/app/(marketing)/help/contatto-assistenza/page.tsx
@@ -117,8 +117,9 @@ export default function ContattoAssistenzaPage() {
           >
             Errori comuni di accesso AdE e come risolverli
           </Link>
-          . La maggior parte dei problemi si risolve rinnovando la sessione AdE
-          senza dover contattare il supporto.
+          . La maggior parte dei problemi si risolve cliccando{" "}
+          <strong>Verifica connessione</strong> in Impostazioni → Credenziali
+          AdE, senza dover contattare il supporto.
         </p>
 
         {/* ─── Articoli correlati ─── */}

--- a/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
+++ b/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title:
     "Collegamento POS-RT: chi è obbligato e scadenze 2026 | ScontrinoZero Help",
   description:
-    "Tutto sull'obbligo di collegare il POS al registratore telematico dal 2026: chi è obbligato, scadenze, sanzioni e come ScontrinoZero ti mette in regola.",
+    "Tutto sull'obbligo di collegare il POS al registratore telematico dal 2026: fonte normativa, scadenze, sanzioni e come si effettua l'associazione POS-DCO sul portale Fatture e Corrispettivi dell'Agenzia delle Entrate.",
 };
 
 export default function PosRtObbligoPage() {
@@ -30,10 +30,14 @@ export default function PosRtObbligoPage() {
           <Badge variant="secondary">POS / Normativa</Badge>
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Dal 1° gennaio 2026 scatta l&apos;obbligo di collegare il POS al
-          registratore telematico (o a un equivalente sistema di trasmissione
-          dei corrispettivi). Chi usa ScontrinoZero è già in regola: il
-          collegamento avviene via software, senza hardware aggiuntivo.
+          Dal 1° gennaio 2026 è in vigore l&apos;obbligo di collegare il POS al
+          registratore telematico (o, come nel caso di ScontrinoZero, alla
+          procedura web Documento Commerciale Online che fa le sue veci).
+          ScontrinoZero invia in automatico i corrispettivi all&apos;Agenzia
+          delle Entrate, ma l&apos;associazione tra il tuo POS e il DCO va
+          comunicata <strong>una volta</strong> sul portale{" "}
+          <em>Fatture e Corrispettivi</em>: è una procedura a carico
+          dell&apos;esercente.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -44,18 +48,22 @@ export default function PosRtObbligoPage() {
           Cosa prevede la normativa
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Il D.Lgs. n. 153/2024 (attuativo della Legge Delega fiscale 2023)
-          introduce l&apos;obbligo di collegamento tra POS e strumento di
-          certificazione dei corrispettivi. L&apos;obiettivo è garantire che
-          ogni pagamento elettronico risulti automaticamente certificato
-          all&apos;Agenzia delle Entrate.
+          La <strong>Legge di Bilancio 2025</strong> (L. 30 dicembre 2024 n.
+          207, commi 74-76) ha sostituito il comma 3 dell&apos;art. 2 del D.Lgs.
+          127/2015. La nuova formulazione richiede la{" "}
+          <strong>piena integrazione</strong> tra il processo di registrazione
+          dei corrispettivi e quello di pagamento elettronico: lo strumento con
+          cui si accettano pagamenti elettronici deve essere <em>sempre</em>{" "}
+          collegato a quello con cui si memorizzano e trasmettono i
+          corrispettivi.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          In pratica, ogni pagamento con carta o bancomat deve essere
-          tracciabile e abbinabile allo scontrino elettronico emesso per quella
-          transazione. Le modalità tecniche specifiche (es. integrazione
-          automatica POS-RT) sono in attesa di circolare attuativa
-          dell&apos;Agenzia delle Entrate.
+          Il collegamento è <strong>logico</strong>, non fisico: non servono
+          cavi né aggiornamenti hardware. Si effettua online, associando la
+          matricola del POS al registratore telematico (o al DCO) tramite la
+          funzione <em>Gestione collegamenti</em> del portale{" "}
+          <em>Fatture e Corrispettivi</em> dell&apos;Agenzia delle Entrate. Il
+          servizio è attivo dal <strong>5 marzo 2026</strong>.
         </p>
 
         {/* ─── Chi è obbligato ─── */}
@@ -66,7 +74,8 @@ export default function PosRtObbligoPage() {
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
             Sono tenuti alla memorizzazione e trasmissione telematica dei
-            corrispettivi (art. 2 D.Lgs. 127/2015).
+            corrispettivi (art. 2 D.Lgs. 127/2015), <strong>incluso</strong> chi
+            usa la procedura web Documento Commerciale Online.
           </li>
           <li>
             Accettano pagamenti con carte di debito, credito o tramite
@@ -77,6 +86,15 @@ export default function PosRtObbligoPage() {
           Sono inclusi negozi al dettaglio, ristoranti, bar, ambulanti con POS,
           professionisti e in generale chiunque emetta scontrini elettronici.
         </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Eccezione:</strong> chi usa il POS{" "}
+          <strong>esclusivamente</strong> per operazioni esenti
+          dall&apos;obbligo di certificazione (es. tabacchi e generi di
+          monopolio, vendite a distanza) può dichiararlo come{" "}
+          <em>POS non collegato</em> nel portale AdE, senza associarlo. Se però
+          lo stesso POS viene usato anche occasionalmente per operazioni
+          soggette a certificazione, il collegamento torna obbligatorio.
+        </p>
 
         {/* ─── ScontrinoZero e la conformità ─── */}
         <h2 className="mt-10 text-xl font-semibold">
@@ -86,28 +104,29 @@ export default function PosRtObbligoPage() {
           ScontrinoZero usa la procedura{" "}
           <strong>Documento Commerciale Online</strong> dell&apos;Agenzia delle
           Entrate, che equivale a un registratore telematico virtuale. Non è
-          richiesto nessun hardware aggiuntivo.
+          richiesto nessun hardware aggiuntivo per la trasmissione dei
+          corrispettivi.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Quando selezioni <strong>Carta/Elettronico</strong> come metodo di
-          pagamento al momento dell&apos;emissione, ScontrinoZero trasmette
-          all&apos;AdE il tipo di pagamento corretto (codice{" "}
-          <code className="bg-muted rounded px-1 font-mono text-xs">PE</code>).
-          Il collegamento con il tuo POS fisico non è richiesto né necessario:
-          l&apos;esercente seleziona manualmente il metodo di pagamento
-          nell&apos;app.
+          Quando emetti uno scontrino e selezioni <strong>Carta</strong> come
+          metodo di pagamento, ScontrinoZero trasmette all&apos;AdE il codice
+          pagamento elettronico{" "}
+          <code className="bg-muted rounded px-1 font-mono text-xs">PE</code>{" "}
+          insieme al documento. La selezione del metodo di pagamento è{" "}
+          <strong>manuale</strong>: ScontrinoZero non si interfaccia con il POS
+          fisico, è l&apos;esercente a scegliere nell&apos;app come è stato
+          incassato lo scontrino.
         </p>
-        <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm dark:border-blue-800 dark:bg-blue-950">
-          <strong>Nota:</strong> l&apos;integrazione automatica tra POS fisico e
-          ScontrinoZero (senza intervento manuale) è una funzione pianificata
-          per una release futura. Verifica la{" "}
-          <Link
-            href="/help/normativa-pos-2026"
-            className="text-primary hover:underline"
-          >
-            guida normativa POS 2026
-          </Link>{" "}
-          per aggiornamenti.
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm dark:border-amber-800 dark:bg-amber-950">
+          <strong>Procedura obbligatoria a carico dell&apos;esercente:</strong>{" "}
+          accedi al portale Fatture e Corrispettivi, apri la funzione{" "}
+          <em>Gestione collegamenti</em> e associa la matricola del tuo POS al
+          DCO. Per chi usa la procedura DCO l&apos;associazione{" "}
+          <strong>non è delegabile</strong> a intermediari (commercialista,
+          CAF): la deve fare direttamente l&apos;operatore titolare delle
+          credenziali Fisconline. Servono il numero di matricola del POS, i dati
+          identificativi dello strumento di pagamento e l&apos;indirizzo
+          dell&apos;esercizio.
         </div>
 
         {/* ─── Scadenze ─── */}
@@ -128,34 +147,54 @@ export default function PosRtObbligoPage() {
               <tr className="border-b">
                 <td className="py-2 pr-6 font-medium">1° gen. 2026</td>
                 <td className="py-2">
-                  Obbligo di collegamento POS-RT in vigore (D.Lgs. 153/2024).
+                  Entrata in vigore dell&apos;obbligo di collegamento POS-RT (L.
+                  207/2024, commi 74-76).
                 </td>
               </tr>
               <tr className="border-b">
-                <td className="py-2 pr-6 font-medium">2026 (da definire)</td>
+                <td className="py-2 pr-6 font-medium">5 mar. 2026</td>
                 <td className="py-2">
-                  Avvio accertamenti e regime sanzionatorio (in attesa di
-                  circolare attuativa AdE).
+                  Attivazione del servizio <em>Gestione collegamenti</em> sul
+                  portale Fatture e Corrispettivi dell&apos;AdE.
+                </td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-2 pr-6 font-medium">20 apr. 2026</td>
+                <td className="py-2">
+                  Scadenza prima comunicazione per i POS già attivi al 1°
+                  gennaio 2026 o utilizzati entro il 31 gennaio 2026.
+                </td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-2 pr-6 font-medium">POS nuovi</td>
+                <td className="py-2">
+                  Comunicazione tra il 6° giorno e l&apos;ultimo giorno
+                  lavorativo del 2° mese successivo all&apos;attivazione del
+                  POS.
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Le modalità operative e le specifiche tecniche per il collegamento
-          fisico POS-RT sono in attesa di circolare attuativa dell&apos;Agenzia
-          delle Entrate. Chi usa ScontrinoZero non deve attendere istruzioni
-          aggiuntive: la trasmissione telematica è già attiva.
-        </p>
 
         {/* ─── Sanzioni ─── */}
         <h2 className="mt-10 text-xl font-semibold">Sanzioni</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Le sanzioni per mancata certificazione dei corrispettivi rimangono
-          quelle già previste dal D.Lgs. 127/2015: da{" "}
-          <strong>€500 a €2.000 per ogni violazione</strong>, con possibile
-          sospensione della licenza in caso di recidiva. Emettendo scontrini
-          elettronici con ScontrinoZero sei già coperto.
+          Per il <strong>mancato collegamento</strong> tra POS e strumento di
+          memorizzazione dei corrispettivi si applica la sanzione amministrativa
+          da <strong>€1.000 a €4.000</strong> (art. 11 comma 5 D.Lgs. 471/97,
+          richiamato dall&apos;art. 2 comma 6 D.Lgs. 127/2015 nella versione
+          modificata dalla L. 207/2024). È inoltre prevista la sospensione della
+          licenza o dell&apos;autorizzazione all&apos;esercizio
+          dell&apos;attività da <strong>3 giorni a 1 mese</strong> (art. 12
+          comma 3 D.Lgs. 471/97).
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          ScontrinoZero copre la <em>trasmissione</em> dei corrispettivi
+          all&apos;AdE, ma l&apos;<em>associazione POS-DCO</em> sul portale
+          Fatture e Corrispettivi è una procedura separata che spetta
+          all&apos;esercente: assicurati di completarla entro le scadenze sopra
+          indicate per evitare sanzioni.
         </p>
 
         {/* ─── Articoli correlati ─── */}


### PR DESCRIPTION
## Summary
Updated help documentation to reflect the new POS-RT (Registratore Telematico) compliance requirements introduced by the 2025 Budget Law, with clarifications on the DCO (Documento Commerciale Online) procedure and mandatory user actions.

## Key Changes

- **Normative source update**: Replaced references to D.Lgs. 153/2024 with the actual source law (L. 207/2024, commi 74-76 from the 2025 Budget Law) that modified art. 2 of D.Lgs. 127/2015
- **DCO procedure clarification**: Emphasized that ScontrinoZero uses DCO (virtual telematic register) and that users must manually associate their POS with the DCO on the Agenzia delle Entrate portal
- **User responsibility**: Added prominent warning that POS-DCO association is a mandatory user action (not delegable to intermediaries) that must be completed by the account holder with Fisconline credentials
- **Timeline updates**: Added specific dates including March 5, 2026 (service activation) and April 20, 2026 (first communication deadline) for POS already active
- **Sanctions clarification**: Updated penalty amounts to €1,000-€4,000 for non-compliance and added license suspension details (3 days to 1 month)
- **Technical details**: Clarified that the connection is logical (not physical), requires no hardware updates, and is managed through the "Gestione collegamenti" (Link Management) function
- **Exception documentation**: Added information about POS used exclusively for exempt operations (tobacco, monopoly goods, distance sales)
- **Support documentation**: Minor update to contact/support page clarifying the "Verifica connessione" (Verify Connection) button location in Settings

## Notable Implementation Details

- Removed outdated note about future automatic POS-ScontrinoZero integration
- Changed warning box color from blue to amber to emphasize mandatory user action
- Clarified that manual payment method selection in ScontrinoZero is by design (not a limitation)
- Emphasized that ScontrinoZero handles transmission to AdE, but POS-DCO association is separate and user-initiated

https://claude.ai/code/session_01KATBVNtY7rGwBtaE19CTsp