### PR TITLE
Add Analytics page and update navigation structure

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -64,6 +64,7 @@ sonar.coverage.exclusions=\
   src/app/onboarding/onboarding-form.tsx,\
   src/app/dashboard/layout.tsx,\
   src/app/dashboard/page.tsx,\
+  src/app/dashboard/analytics/page.tsx,\
   src/app/dashboard/settings/page.tsx,\
   src/app/dashboard/cassa/page.tsx,\
   src/app/dashboard/storico/page.tsx,\

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -1,0 +1,15 @@
+import { BarChart2 } from "lucide-react";
+
+export default function AnalyticsPage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <BarChart2 className="text-muted-foreground mb-4 h-12 w-12" />
+      <h1 className="text-2xl font-bold">Analytics</h1>
+      <p className="text-muted-foreground mt-2 max-w-sm text-sm">
+        {
+          "La dashboard analytics è in arrivo. Potrai visualizzare l'andamento delle vendite, i totali giornalieri e molto altro."
+        }
+      </p>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { redirect } from "next/navigation";
-import { LogOut } from "lucide-react";
+import { LogOut, Settings } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getOnboardingStatus } from "@/server/onboarding-actions";
 import { signOut } from "@/server/auth-actions";
@@ -42,11 +42,28 @@ export default async function DashboardLayout({
             ScontrinoZero
           </Link>
 
-          <form action={signOut} className="md:hidden">
-            <Button variant="ghost" size="icon" type="submit" aria-label="Esci">
-              <LogOut className="h-5 w-5" />
+          <div className="flex items-center md:hidden">
+            <Button
+              variant="ghost"
+              size="icon"
+              asChild
+              aria-label="Impostazioni"
+            >
+              <Link href="/dashboard/settings">
+                <Settings className="h-5 w-5" />
+              </Link>
             </Button>
-          </form>
+            <form action={signOut}>
+              <Button
+                variant="ghost"
+                size="icon"
+                type="submit"
+                aria-label="Esci"
+              >
+                <LogOut className="h-5 w-5" />
+              </Button>
+            </form>
+          </div>
 
           <nav className="hidden items-center gap-4 md:flex">
             <HeaderNav />

--- a/src/components/dashboard/bottom-nav.test.tsx
+++ b/src/components/dashboard/bottom-nav.test.tsx
@@ -35,7 +35,7 @@ describe("BottomNav", () => {
     expect(screen.getByText("Catalogo")).toBeInTheDocument();
     expect(screen.getByText("Cassa")).toBeInTheDocument();
     expect(screen.getByText("Storico")).toBeInTheDocument();
-    expect(screen.getByText("Impostazioni")).toBeInTheDocument();
+    expect(screen.getByText("Analytics")).toBeInTheDocument();
   });
 
   it("i link puntano agli href corretti", () => {
@@ -54,9 +54,9 @@ describe("BottomNav", () => {
       "href",
       "/dashboard/storico",
     );
-    expect(screen.getByText("Impostazioni").closest("a")).toHaveAttribute(
+    expect(screen.getByText("Analytics").closest("a")).toHaveAttribute(
       "href",
-      "/dashboard/settings",
+      "/dashboard/analytics",
     );
   });
 
@@ -92,11 +92,11 @@ describe("BottomNav", () => {
     expect(storicoLink?.className).toContain("text-primary");
   });
 
-  it("Impostazioni è attivo su /dashboard/settings", () => {
-    mockUsePathname.mockReturnValue("/dashboard/settings");
+  it("Analytics è attivo su /dashboard/analytics", () => {
+    mockUsePathname.mockReturnValue("/dashboard/analytics");
     render(<BottomNav />);
 
-    const settingsLink = screen.getByText("Impostazioni").closest("a");
-    expect(settingsLink?.className).toContain("text-primary");
+    const analyticsLink = screen.getByText("Analytics").closest("a");
+    expect(analyticsLink?.className).toContain("text-primary");
   });
 });

--- a/src/components/dashboard/bottom-nav.tsx
+++ b/src/components/dashboard/bottom-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Package, ShoppingCart, History, Settings } from "lucide-react";
+import { Package, ShoppingCart, History, BarChart2 } from "lucide-react";
 
 const NAV_ITEMS = [
   {
@@ -25,9 +25,9 @@ const NAV_ITEMS = [
     exact: false,
   },
   {
-    href: "/dashboard/settings",
-    label: "Impostazioni",
-    icon: Settings,
+    href: "/dashboard/analytics",
+    label: "Analytics",
+    icon: BarChart2,
     exact: false,
   },
 ] as const;

--- a/src/components/dashboard/header-nav.test.tsx
+++ b/src/components/dashboard/header-nav.test.tsx
@@ -28,13 +28,14 @@ vi.mock("next/link", () => ({
 // --- Tests ---
 
 describe("HeaderNav", () => {
-  it("renderizza i 4 link di navigazione", () => {
+  it("renderizza i 5 link di navigazione", () => {
     mockUsePathname.mockReturnValue("/dashboard");
     render(<HeaderNav />);
 
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Cassa")).toBeInTheDocument();
     expect(screen.getByText("Storico")).toBeInTheDocument();
+    expect(screen.getByText("Analytics")).toBeInTheDocument();
     expect(screen.getByText("Impostazioni")).toBeInTheDocument();
   });
 
@@ -53,6 +54,10 @@ describe("HeaderNav", () => {
     expect(screen.getByText("Storico").closest("a")).toHaveAttribute(
       "href",
       "/dashboard/storico",
+    );
+    expect(screen.getByText("Analytics").closest("a")).toHaveAttribute(
+      "href",
+      "/dashboard/analytics",
     );
     expect(screen.getByText("Impostazioni").closest("a")).toHaveAttribute(
       "href",
@@ -96,6 +101,15 @@ describe("HeaderNav", () => {
     expect(storicoLink?.className).toContain("text-foreground");
   });
 
+  it("Analytics è attivo su /dashboard/analytics", () => {
+    mockUsePathname.mockReturnValue("/dashboard/analytics");
+    render(<HeaderNav />);
+
+    const analyticsLink = screen.getByText("Analytics").closest("a");
+    expect(analyticsLink?.className).toContain("font-semibold");
+    expect(analyticsLink?.className).toContain("text-foreground");
+  });
+
   it("Impostazioni è attivo su /dashboard/settings", () => {
     mockUsePathname.mockReturnValue("/dashboard/settings");
     render(<HeaderNav />);
@@ -120,7 +134,7 @@ describe("HeaderNav", () => {
     mockUsePathname.mockReturnValue("/dashboard/cassa");
     render(<HeaderNav />);
 
-    const inactiveLinks = ["Dashboard", "Storico", "Impostazioni"];
+    const inactiveLinks = ["Dashboard", "Storico", "Analytics", "Impostazioni"];
     for (const label of inactiveLinks) {
       const link = screen.getByText(label).closest("a");
       expect(link?.className).toContain("text-muted-foreground");

--- a/src/components/dashboard/header-nav.tsx
+++ b/src/components/dashboard/header-nav.tsx
@@ -7,6 +7,7 @@ const NAV_ITEMS = [
   { href: "/dashboard", label: "Dashboard", exact: true },
   { href: "/dashboard/cassa", label: "Cassa", exact: false },
   { href: "/dashboard/storico", label: "Storico", exact: false },
+  { href: "/dashboard/analytics", label: "Analytics", exact: false },
   { href: "/dashboard/settings", label: "Impostazioni", exact: false },
 ] as const;
 


### PR DESCRIPTION
## Summary
This PR introduces a new Analytics page to the dashboard and reorganizes the mobile navigation layout. The Analytics section is added to both header and bottom navigation components, replacing Settings in the bottom navigation while keeping it in the header navigation.

## Key Changes
- **New Analytics Page**: Created `/dashboard/analytics/page.tsx` with a placeholder UI indicating the feature is coming soon
- **Navigation Updates**:
  - Added Analytics link to `HeaderNav` component (desktop navigation)
  - Replaced Settings with Analytics in `BottomNav` component (mobile navigation)
  - Settings remains accessible in the header navigation
- **Mobile Layout Improvement**: Reorganized dashboard layout mobile controls to display both Settings and LogOut buttons in a flex container
- **Test Updates**: Updated all navigation component tests to reflect the new Analytics link and verify correct routing and active states
- **SonarQube Configuration**: Added the new analytics page to coverage exclusions

## Implementation Details
- Analytics uses the `BarChart2` icon from lucide-react for visual consistency
- The Analytics page includes a descriptive message about upcoming sales analytics features
- Mobile navigation now shows Settings icon alongside the LogOut button in a dedicated flex container
- All navigation tests verify the Analytics link appears in the correct position and responds to route changes appropriately

https://claude.ai/code/session_0173Xw7jFGr3fA8Q2fQtzsfU