### PR TITLE
Refactor loading skeletons to match updated UI layouts

### DIFF
--- a/src/app/dashboard/cassa/loading.tsx
+++ b/src/app/dashboard/cassa/loading.tsx
@@ -1,63 +1,50 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 const ITEM_KEYS = ["a", "b", "c"] as const;
-const KEYPAD_KEYS = [
-  "k1",
-  "k2",
-  "k3",
-  "k4",
-  "k5",
-  "k6",
-  "k7",
-  "k8",
-  "k9",
-  "k10",
-  "k11",
-  "k12",
-] as const;
 
 export default function CassaLoading() {
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <Skeleton className="h-8 w-24" />
+    <div className="mx-auto max-w-sm space-y-4">
+      {/* Header: titolo + bottone Svuota (assume carrello con items) */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
 
-      {/* Item list */}
-      <div className="space-y-3">
+      {/* Lista articoli (CartLineItem shape) */}
+      <div className="flex flex-col gap-2">
         {ITEM_KEYS.map((key) => (
           <div
             key={key}
-            className="flex items-center gap-3 rounded-lg border p-3"
+            className="bg-card flex items-start gap-3 rounded-lg border p-3"
           >
-            <Skeleton className="h-5 flex-1" />
-            <Skeleton className="h-5 w-16" />
-            <Skeleton className="h-5 w-20" />
-            <Skeleton className="h-8 w-8 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-2/3" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-4 w-12 rounded-full" />
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <Skeleton className="mr-1 h-5 w-16" />
+              <Skeleton className="h-7 w-7 rounded-lg" />
+              <Skeleton className="h-7 w-7 rounded-lg" />
+            </div>
           </div>
         ))}
       </div>
 
-      {/* Totale */}
-      <div className="space-y-2 rounded-lg border p-4">
-        <div className="flex justify-between">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-5 w-20" />
-        </div>
-        <div className="flex justify-between">
-          <Skeleton className="h-6 w-16" />
-          <Skeleton className="h-6 w-24" />
-        </div>
+      {/* Barra totale */}
+      <div className="bg-muted flex items-center justify-between rounded-xl px-4 py-3">
+        <Skeleton className="h-5 w-16" />
+        <Skeleton className="h-6 w-24" />
       </div>
 
-      {/* Keypad placeholder */}
-      <div className="grid grid-cols-3 gap-2">
-        {KEYPAD_KEYS.map((key) => (
-          <Skeleton key={key} className="h-14 rounded-xl" />
-        ))}
+      {/* Azioni: Aggiungi + Continua, affiancati */}
+      <div className="flex gap-3">
+        <Skeleton className="h-11 flex-1 rounded-md" />
+        <Skeleton className="h-11 flex-1 rounded-md" />
       </div>
-
-      {/* Emetti button */}
-      <Skeleton className="h-12 w-full rounded-xl" />
     </div>
   );
 }

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,28 +1,29 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-const CARD_KEYS = ["a", "b", "c", "d", "e", "f"] as const;
+const ROW_KEYS = ["a", "b", "c", "d", "e"] as const;
 
 export default function CatalogoLoading() {
   return (
-    <div className="space-y-6">
-      {/* Header */}
+    <div className="mx-auto max-w-sm space-y-4">
+      {/* Header: titolo + bottoni Modifica/Aggiungi */}
       <div className="flex items-center justify-between">
-        <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-9 w-36" />
+        <Skeleton className="h-7 w-28" />
+        <div className="flex gap-2">
+          <Skeleton className="h-8 w-20" />
+          <Skeleton className="h-8 w-24" />
+        </div>
       </div>
 
-      {/* Product grid */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {CARD_KEYS.map((key) => (
-          <div key={key} className="space-y-3 rounded-xl border p-4">
-            <div className="flex items-start justify-between">
-              <Skeleton className="h-5 w-32" />
-              <Skeleton className="h-5 w-16" />
-            </div>
-            <Skeleton className="h-4 w-20" />
-            <div className="flex gap-2 pt-1">
-              <Skeleton className="h-8 flex-1" />
-              <Skeleton className="h-8 w-8" />
+      {/* Lista prodotti: righe single-line */}
+      <div className="flex flex-col gap-2">
+        {ROW_KEYS.map((key) => (
+          <div
+            key={key}
+            className="flex items-center rounded-xl border px-4 py-3"
+          >
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-3 w-1/2" />
             </div>
           </div>
         ))}

--- a/src/app/dashboard/settings/loading.tsx
+++ b/src/app/dashboard/settings/loading.tsx
@@ -2,14 +2,20 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 const ALL_ROW_KEYS = ["a", "b", "c", "d"] as const;
 
-function SkeletonCard({ rows = 2 }: Readonly<{ rows?: number }>) {
+interface SkeletonCardProps {
+  readonly rows?: number;
+  readonly withEditButton?: boolean;
+}
+
+function SkeletonCard({ rows = 2, withEditButton = false }: SkeletonCardProps) {
   const rowKeys = ALL_ROW_KEYS.slice(0, rows);
   return (
-    <div className="rounded-xl border">
-      <div className="px-4 pt-4 pb-2">
+    <div className="ring-foreground/10 bg-card flex flex-col gap-4 rounded-xl py-4 ring-1">
+      <div className="flex items-center justify-between px-4">
         <Skeleton className="h-5 w-28" />
+        {withEditButton && <Skeleton className="h-8 w-20" />}
       </div>
-      <div className="space-y-2 px-4 pb-4">
+      <div className="space-y-2 px-4">
         {rowKeys.map((key) => (
           <Skeleton key={key} className="h-4 w-full max-w-xs" />
         ))}
@@ -18,24 +24,47 @@ function SkeletonCard({ rows = 2 }: Readonly<{ rows?: number }>) {
   );
 }
 
+function SkeletonFlatSection({
+  destructive = false,
+}: Readonly<{ destructive?: boolean }>) {
+  return (
+    <div
+      className={
+        destructive
+          ? "border-destructive/30 bg-destructive/5 rounded-lg border p-4"
+          : "rounded-lg border p-4"
+      }
+    >
+      <Skeleton className="mb-2 h-5 w-44" />
+      <Skeleton className="mb-4 h-3 w-full max-w-md" />
+      <Skeleton className="h-9 w-32" />
+    </div>
+  );
+}
+
 export default function SettingsLoading() {
   return (
     <div className="space-y-6">
-      {/* Titolo */}
-      <Skeleton className="h-8 w-36" />
+      {/* Titolo pagina */}
+      <Skeleton className="h-8 w-44" />
 
-      {/* Profilo */}
-      <SkeletonCard rows={2} />
+      {/* Profilo (Card shadcn, con edit button nell'header) */}
+      <SkeletonCard rows={2} withEditButton />
 
-      {/* Attività */}
-      <SkeletonCard rows={4} />
-
-      {/* Credenziali AdE */}
-      <SkeletonCard rows={2} />
-
-      {/* Export + Elimina account */}
+      {/* Sicurezza (Card shadcn, contiene il bottone Cambia password) */}
       <SkeletonCard rows={1} />
+
+      {/* Credenziali AdE (Card shadcn, con edit button) */}
+      <SkeletonCard rows={2} withEditButton />
+
+      {/* Sessione (Card shadcn, contiene il bottone Esci) */}
       <SkeletonCard rows={1} />
+
+      {/* Export dati (sezione flat, rounded-lg border) */}
+      <SkeletonFlatSection />
+
+      {/* Elimina account (sezione flat con bordo destructive) */}
+      <SkeletonFlatSection destructive />
     </div>
   );
 }

--- a/src/app/dashboard/storico/loading.tsx
+++ b/src/app/dashboard/storico/loading.tsx
@@ -1,43 +1,51 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-const ROW_KEYS = ["a", "b", "c", "d", "e", "f"] as const;
+const ROW_KEYS = ["a", "b", "c", "d", "e"] as const;
 
 export default function StoricoLoading() {
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <Skeleton className="h-8 w-28" />
-
-      {/* Filtri */}
-      <div className="flex flex-wrap gap-3">
-        <Skeleton className="h-9 w-36" />
-        <Skeleton className="h-9 w-36" />
-        <Skeleton className="h-9 w-28" />
-        <Skeleton className="h-9 w-24" />
+      {/* Header: titolo + summary line */}
+      <div>
+        <Skeleton className="h-8 w-44" />
+        <Skeleton className="mt-2 h-4 w-40" />
       </div>
 
-      {/* Tabella */}
-      <div className="overflow-hidden rounded-xl border">
+      {/* Form filtri (dentro container bordato, con label sopra ogni control) */}
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border px-3 py-2">
+        <div className="min-w-[200px] space-y-1">
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+        <div className="min-w-[140px] space-y-1">
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+        <Skeleton className="h-9 w-20" />
+      </div>
+
+      {/* Tabella scontrini */}
+      <div className="overflow-hidden rounded-lg border">
         {/* Header tabella */}
-        <div className="bg-muted/40 flex gap-4 border-b px-4 py-3">
+        <div className="bg-muted/50 flex items-center gap-3 border-b px-3 py-2">
           <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-4 flex-1" />
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="ml-auto h-4 w-16" />
+          <Skeleton className="h-4 w-12" />
+          <Skeleton className="h-4 w-4" />
         </div>
 
         {/* Righe */}
         {ROW_KEYS.map((key) => (
           <div
             key={key}
-            className="flex items-center gap-4 border-b px-4 py-3 last:border-0"
+            className="flex items-center gap-3 border-b px-3 py-2 last:border-0"
           >
             <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-4 w-14" />
-            <Skeleton className="h-4 flex-1" />
-            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="ml-auto h-4 w-16" />
             <Skeleton className="h-6 w-20 rounded-full" />
+            <Skeleton className="h-4 w-3" />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
Updated loading skeleton components across the dashboard to align with refined UI layouts and component structures. These changes ensure loading states accurately reflect the final rendered UI.

## Key Changes

### Cassa (Cart) Loading
- Simplified layout from 6 sections to 4 core sections
- Removed keypad placeholder (12-item grid) - no longer part of the UI
- Restructured cart items to show product details with quantity controls side-by-side
- Updated total bar styling with muted background
- Replaced "Emetti" button with dual action buttons ("Aggiungi" + "Continua")
- Constrained max-width to `sm` for mobile-first design

### Settings Loading
- Enhanced `SkeletonCard` component with optional edit button support
- Reorganized sections: Profile, Security, AdE Credentials, Session
- Added new `SkeletonFlatSection` component for non-card sections (Export, Delete Account)
- Implemented destructive styling variant for dangerous actions
- Improved card styling with ring borders and better spacing

### Storico (History) Loading
- Reduced row count from 6 to 5 items
- Added header summary line below title
- Restructured filter form with labeled inputs in bordered container
- Updated table layout with improved column alignment and spacing
- Adjusted padding and gap values for consistency

### Dashboard (Catalog) Loading
- Changed from grid layout (3 columns) to single-column list
- Converted product cards to single-line rows with minimal information
- Constrained max-width to `sm` for mobile-first design
- Simplified header with dual action buttons (Modifica/Aggiungi)
- Reduced spacing from `space-y-6` to `space-y-4`

## Implementation Details
- All changes maintain semantic HTML structure and accessibility
- Skeleton dimensions adjusted to match actual component heights
- Consistent use of Tailwind classes for spacing, borders, and backgrounds
- Mobile-first approach with constrained max-widths where appropriate

https://claude.ai/code/session_012JsxDyEUbedgyfG6tnUoZ8