### PR TITLE
feat(seo): Open Graph images dinamiche per route marketing

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -91,7 +91,11 @@ sonar.coverage.exclusions=\
   src/app/dashboard/storico/loading.tsx,\
   src/app/dashboard/settings/loading.tsx,\
   src/sw.ts,\
-  src/app/offline/page.tsx
+  src/app/offline/page.tsx,\
+  src/app/(marketing)/opengraph-image.tsx,\
+  src/app/(marketing)/prezzi/opengraph-image.tsx,\
+  src/app/(marketing)/funzionalita/opengraph-image.tsx,\
+  src/app/(marketing)/help/opengraph-image.tsx
 
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
 sonar.testExecutionReportPaths=test-report.xml

--- a/src/app/(marketing)/funzionalita/opengraph-image.tsx
+++ b/src/app/(marketing)/funzionalita/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { ImageResponse } from "next/og";
+import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
+
+export const alt =
+  "Funzionalità ScontrinoZero — emissione, gestione, compliance AdE";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    <OgImageTemplate
+      title="Funzionalità"
+      subtitle="Scontrini in 5 secondi, trasmissione automatica AdE, lotteria, storico, condivisione."
+    />,
+    OG_SIZE,
+  );
+}

--- a/src/app/(marketing)/funzionalita/opengraph-image.tsx
+++ b/src/app/(marketing)/funzionalita/opengraph-image.tsx
@@ -1,9 +1,10 @@
 import { ImageResponse } from "next/og";
 import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
 
+export { OG_SIZE as size } from "@/components/og-image-template";
+
 export const alt =
   "Funzionalità ScontrinoZero — emissione, gestione, compliance AdE";
-export const size = OG_SIZE;
 export const contentType = "image/png";
 
 export default async function Image() {

--- a/src/app/(marketing)/help/opengraph-image.tsx
+++ b/src/app/(marketing)/help/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { ImageResponse } from "next/og";
+import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
+
+export const alt = "Help Center ScontrinoZero — guide, tutorial, FAQ";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    <OgImageTemplate
+      title="Help Center"
+      subtitle="Guide, tutorial e risposte alle domande frequenti su ScontrinoZero."
+    />,
+    OG_SIZE,
+  );
+}

--- a/src/app/(marketing)/help/opengraph-image.tsx
+++ b/src/app/(marketing)/help/opengraph-image.tsx
@@ -1,8 +1,9 @@
 import { ImageResponse } from "next/og";
 import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
 
+export { OG_SIZE as size } from "@/components/og-image-template";
+
 export const alt = "Help Center ScontrinoZero — guide, tutorial, FAQ";
-export const size = OG_SIZE;
 export const contentType = "image/png";
 
 export default async function Image() {

--- a/src/app/(marketing)/opengraph-image.tsx
+++ b/src/app/(marketing)/opengraph-image.tsx
@@ -1,8 +1,9 @@
 import { ImageResponse } from "next/og";
 import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
 
+export { OG_SIZE as size } from "@/components/og-image-template";
+
 export const alt = "ScontrinoZero — scontrini elettronici senza registratore";
-export const size = OG_SIZE;
 export const contentType = "image/png";
 
 export default async function Image() {

--- a/src/app/(marketing)/opengraph-image.tsx
+++ b/src/app/(marketing)/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { ImageResponse } from "next/og";
+import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
+
+export const alt = "ScontrinoZero — scontrini elettronici senza registratore";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    <OgImageTemplate
+      title="ScontrinoZero"
+      subtitle="Scontrini elettronici e corrispettivi all'AdE dal cellulare, senza registratore di cassa."
+    />,
+    OG_SIZE,
+  );
+}

--- a/src/app/(marketing)/prezzi/opengraph-image.tsx
+++ b/src/app/(marketing)/prezzi/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { ImageResponse } from "next/og";
+import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
+
+export const alt =
+  "Prezzi ScontrinoZero — Starter da €4.99/mese, Pro €8.99/mese";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    <OgImageTemplate
+      title="Prezzi"
+      subtitle="Starter €4.99/mese, Pro €8.99/mese. 30 giorni di prova senza carta."
+    />,
+    OG_SIZE,
+  );
+}

--- a/src/app/(marketing)/prezzi/opengraph-image.tsx
+++ b/src/app/(marketing)/prezzi/opengraph-image.tsx
@@ -1,9 +1,10 @@
 import { ImageResponse } from "next/og";
 import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
 
+export { OG_SIZE as size } from "@/components/og-image-template";
+
 export const alt =
   "Prezzi ScontrinoZero — Starter da €4.99/mese, Pro €8.99/mese";
-export const size = OG_SIZE;
 export const contentType = "image/png";
 
 export default async function Image() {

--- a/src/components/og-image-template.test.tsx
+++ b/src/components/og-image-template.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OgImageTemplate, OG_SIZE } from "./og-image-template";
+
+describe("OG_SIZE", () => {
+  it("matches the standard 1200x630 OG image dimensions", () => {
+    expect(OG_SIZE.width).toBe(1200);
+    expect(OG_SIZE.height).toBe(630);
+  });
+});
+
+describe("OgImageTemplate", () => {
+  it("renders the title text", () => {
+    const html = renderToStaticMarkup(<OgImageTemplate title="Prezzi" />);
+    expect(html).toContain("Prezzi");
+  });
+
+  it("renders the subtitle when provided", () => {
+    const html = renderToStaticMarkup(
+      <OgImageTemplate
+        title="Funzionalità"
+        subtitle="Tutto quello che serve"
+      />,
+    );
+    expect(html).toContain("Funzionalità");
+    expect(html).toContain("Tutto quello che serve");
+  });
+
+  it("does not render any subtitle text when omitted", () => {
+    const html = renderToStaticMarkup(<OgImageTemplate title="Solo titolo" />);
+    // Heuristic: with no subtitle, the only paragraph-level text is the title itself
+    // and the brand name + domain. No leftover placeholder.
+    expect(html).toContain("Solo titolo");
+    expect(html).not.toContain("undefined");
+  });
+
+  it("includes the ScontrinoZero brand mark", () => {
+    const html = renderToStaticMarkup(<OgImageTemplate title="Home" />);
+    expect(html).toContain("ScontrinoZero");
+  });
+
+  it("includes the canonical domain footer", () => {
+    const html = renderToStaticMarkup(<OgImageTemplate title="Home" />);
+    expect(html).toContain("scontrinozero.it");
+  });
+
+  it("uses flex layout (required by next/og ImageResponse)", () => {
+    const html = renderToStaticMarkup(<OgImageTemplate title="X" />);
+    // Every <div> in the tree that has children must use display:flex
+    // (next/og constraint). We check the root container at minimum.
+    expect(html).toMatch(/display:\s*flex/);
+  });
+
+  it("escapes special characters in the title", () => {
+    const html = renderToStaticMarkup(<OgImageTemplate title="A&B <test>" />);
+    expect(html).toContain("A&amp;B &lt;test&gt;");
+  });
+});

--- a/src/components/og-image-template.tsx
+++ b/src/components/og-image-template.tsx
@@ -1,0 +1,81 @@
+import type { ReactElement } from "react";
+
+export const OG_SIZE = { width: 1200, height: 630 } as const;
+
+interface OgImageTemplateProps {
+  readonly title: string;
+  readonly subtitle?: string;
+}
+
+const BRAND_GRADIENT = "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)";
+
+export function OgImageTemplate({
+  title,
+  subtitle,
+}: OgImageTemplateProps): ReactElement {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "80px",
+        background: BRAND_GRADIENT,
+        color: "#f8fafc",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          fontSize: "36px",
+          fontWeight: 600,
+          letterSpacing: "-0.01em",
+        }}
+      >
+        ScontrinoZero
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div
+          style={{
+            fontSize: "88px",
+            fontWeight: 800,
+            lineHeight: 1.05,
+            letterSpacing: "-0.025em",
+            display: "flex",
+          }}
+        >
+          {title}
+        </div>
+        {subtitle ? (
+          <div
+            style={{
+              fontSize: "32px",
+              fontWeight: 400,
+              opacity: 0.85,
+              lineHeight: 1.3,
+              marginTop: "24px",
+              display: "flex",
+            }}
+          >
+            {subtitle}
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          fontSize: "24px",
+          opacity: 0.7,
+        }}
+      >
+        scontrinozero.it
+      </div>
+    </div>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         "src/app/**/page.tsx", // UI page shells — pure presentation, no testable logic
         "src/app/**/layout.tsx", // layout shells — pure presentation, no testable logic
         "src/app/**/loading.tsx", // loading skeletons — pure UI, no logic
+        "src/app/**/opengraph-image.tsx", // OG route files — thin next/og wrappers, render covered via og-image-template
         // UI orchestration components — pure UI shells, no testable logic
         "src/app/onboarding/onboarding-form.tsx",
         "src/components/cassa/cassa-client.tsx",


### PR DESCRIPTION
- src/components/og-image-template.tsx: template JSX puro con titolo e sottotitolo opzionale, dimensioni 1200x630, layout flex (richiesto da next/og), fallback font system-ui
- 4 opengraph-image.tsx per le route marketing top-level:
  - (marketing)/ → home
  - prezzi → "Prezzi" + payoff
  - funzionalita → "Funzionalità" + payoff
  - help → "Help Center" (ereditato dai 21 articoli)
- Test (TDD): 8 expect su titolo, sottotitolo opzionale, brand mark, dominio canonico, escape HTML, layout flex (constraint next/og)
- Coverage exclusion per i 4 route file (thin wrapper non testabili senza runtime next/og); template testato direttamente

Verifica build: tutte e 4 le OG sono prerenderizzate static.

Parte della v1.2.8 SEO Foundations (Cantiere 3).