### PR TITLE
feat(seo): related articles centralizzati + CTA /register su /help/*

### DIFF
--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -298,34 +299,7 @@ export default function AliquoteIvaPage() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/regime-forfettario"
-              className="text-primary hover:underline"
-            >
-              Regime forfettario: configurazione IVA corretta
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/annullare-scontrino"
-              className="text-primary hover:underline"
-            >
-              Annullare uno scontrino: quando si può e come fare
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="aliquote-iva" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -228,35 +229,7 @@ export default function AnnullareScontrinoPage() {
             </p>
           </div>
         </div>
-
-        {/* ─── Link correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/storico-ed-esportazione"
-              className="text-primary hover:underline"
-            >
-              Storico scontrini: filtri, ricerca ed esportazione
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="annullare-scontrino" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "API per sviluppatori | ScontrinoZero",
@@ -821,6 +822,7 @@ const idempotencyKey = crypto.randomUUID();`}</code>
             </tbody>
           </table>
         </div>
+        <RelatedHelpArticles slug="api" />
       </article>
     </section>
   );

--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Come passare da mensile ad annuale | ScontrinoZero Help",
@@ -145,26 +146,7 @@ export default function CambioPianoPage() {
           <em>Cronologia fatturazione</em>.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/piani-e-prezzi"
-              className="text-primary hover:underline"
-            >
-              Piani disponibili: Starter, Pro e self-hosted gratuito
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/fatture-e-ricevute"
-              className="text-primary hover:underline"
-            >
-              Dove trovare fatture e ricevute di pagamento
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="cambio-piano" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -195,34 +196,7 @@ export default function CassettoFiscalePage() {
           dall&apos;app.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/errori-ade"
-              className="text-primary hover:underline"
-            >
-              Errori comuni di accesso AdE e come risolverli
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/storico-ed-esportazione"
-              className="text-primary hover:underline"
-            >
-              Storico scontrini: filtri, ricerca ed esportazione
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="cassetto-fiscale" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
+++ b/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Chiusura giornaliera: è obbligatoria? | ScontrinoZero Help",
@@ -192,34 +193,7 @@ export default function ChiusuraGiornalieraPage() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/cassetto-fiscale"
-              className="text-primary hover:underline"
-            >
-              Dove verificare i corrispettivi nel cassetto fiscale
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/storico-ed-esportazione"
-              className="text-primary hover:underline"
-            >
-              Storico scontrini: filtri, ricerca ed esportazione
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="chiusura-giornaliera" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/come-collegare-ade/page.tsx
+++ b/src/app/(marketing)/help/come-collegare-ade/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -254,27 +255,7 @@ export default function ComeCollegareAde() {
           </a>
           {"."}
         </p>
-
-        {/* ─── Link correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/credenziali-fisconline"
-              className="text-primary hover:underline"
-            >
-              Credenziali Fisconline: dove trovarle e come verificarle
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="come-collegare-ade" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/contatto-assistenza/page.tsx
+++ b/src/app/(marketing)/help/contatto-assistenza/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Come contattare l'assistenza | ScontrinoZero Help",
@@ -129,26 +130,7 @@ export default function ContattoAssistenzaPage() {
           AdE, senza dover contattare il supporto.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/errori-ade"
-              className="text-primary hover:underline"
-            >
-              Errori comuni di accesso AdE e come risolverli
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/piani-e-prezzi"
-              className="text-primary hover:underline"
-            >
-              Piani disponibili: Starter, Pro e self-hosted gratuito
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="contatto-assistenza" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/credenziali-fisconline/page.tsx
+++ b/src/app/(marketing)/help/credenziali-fisconline/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -278,27 +279,7 @@ export default function CredenzialiPage() {
             </p>
           </div>
         </div>
-
-        {/* ─── Link correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="credenziali-fisconline" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/errori-ade/page.tsx
+++ b/src/app/(marketing)/help/errori-ade/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Errori comuni di accesso AdE e come risolverli | ScontrinoZero Help",
@@ -324,34 +325,7 @@ export default function ErroriAdePage() {
           parte dopo <code>/r/</code>).
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/credenziali-fisconline"
-              className="text-primary hover:underline"
-            >
-              Credenziali Fisconline: dove trovarle e come verificarle
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/sicurezza-credenziali"
-              className="text-primary hover:underline"
-            >
-              Sicurezza e privacy: come proteggiamo le tue credenziali
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="errori-ade" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/fatture-e-ricevute/page.tsx
+++ b/src/app/(marketing)/help/fatture-e-ricevute/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Dove trovare fatture e ricevute di pagamento | ScontrinoZero Help",
@@ -112,26 +113,7 @@ export default function FattureERicevutePage() {
           e va valutata con il tuo commercialista.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/piani-e-prezzi"
-              className="text-primary hover:underline"
-            >
-              Piani disponibili: Starter, Pro e self-hosted gratuito
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/cambio-piano"
-              className="text-primary hover:underline"
-            >
-              Come passare da mensile ad annuale
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="fatture-e-ricevute" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/installare-app/page.tsx
+++ b/src/app/(marketing)/help/installare-app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -286,26 +287,7 @@ export default function InstallareAppPage() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/prima-configurazione"
-              className="text-primary hover:underline"
-            >
-              Prima configurazione passo-passo
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="installare-app" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/intestazione-scontrino/page.tsx
+++ b/src/app/(marketing)/help/intestazione-scontrino/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -169,34 +170,7 @@ export default function IntestazioneScontrinoPage() {
           Questa funzione è pianificata per una release futura.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/prima-configurazione"
-              className="text-primary hover:underline"
-            >
-              Prima configurazione passo-passo (onboarding completo)
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/cassetto-fiscale"
-              className="text-primary hover:underline"
-            >
-              Dove verificare i corrispettivi nel cassetto fiscale
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="intestazione-scontrino" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/normativa-pos-2026/page.tsx
+++ b/src/app/(marketing)/help/normativa-pos-2026/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -319,34 +320,7 @@ export default function NormativaPos2026Page() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/prima-configurazione"
-              className="text-primary hover:underline"
-            >
-              Prima configurazione passo-passo (onboarding completo)
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/chiusura-giornaliera"
-              className="text-primary hover:underline"
-            >
-              Chiusura giornaliera: è obbligatoria?
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/regime-forfettario"
-              className="text-primary hover:underline"
-            >
-              Regime forfettario: configurazione IVA corretta
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="normativa-pos-2026" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -302,34 +303,7 @@ export default function PianiEPrezziPage() {
           e decidere alla scadenza.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/prima-configurazione"
-              className="text-primary hover:underline"
-            >
-              Prima configurazione passo-passo (onboarding completo)
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/storico-ed-esportazione"
-              className="text-primary hover:underline"
-            >
-              Storico scontrini: filtri, ricerca ed esportazione
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/sicurezza-credenziali"
-              className="text-primary hover:underline"
-            >
-              Sicurezza e privacy: come proteggiamo le tue credenziali
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="piani-e-prezzi" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
+++ b/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -204,34 +205,7 @@ export default function PosRtObbligoPage() {
           indicate per evitare sanzioni.
         </p>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/normativa-pos-2026"
-              className="text-primary hover:underline"
-            >
-              Nuova normativa POS 2026: cosa cambia per gli esercenti
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="pos-rt-obbligo" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/prima-configurazione/page.tsx
+++ b/src/app/(marketing)/help/prima-configurazione/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Prima configurazione passo-passo | ScontrinoZero Help",
@@ -290,50 +291,7 @@ export default function PrimaConfigurazioneePage() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/credenziali-fisconline"
-              className="text-primary hover:underline"
-            >
-              Credenziali Fisconline: dove trovarle e come verificarle
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/regime-forfettario"
-              className="text-primary hover:underline"
-            >
-              Regime forfettario: configurazione IVA corretta
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/installare-app"
-              className="text-primary hover:underline"
-            >
-              Come installare ScontrinoZero come app sul tuo dispositivo
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="prima-configurazione" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/primo-scontrino/page.tsx
+++ b/src/app/(marketing)/help/primo-scontrino/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Come emettere il primo scontrino elettronico | ScontrinoZero Help",
@@ -237,35 +238,7 @@ export default function PrimoScontrinoPage() {
             </p>
           </div>
         </div>
-
-        {/* ─── Link correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/annullare-scontrino"
-              className="text-primary hover:underline"
-            >
-              Annullare uno scontrino: quando si può e come fare
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/regime-forfettario"
-              className="text-primary hover:underline"
-            >
-              Regime forfettario: configurazione IVA corretta
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="primo-scontrino" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/regime-forfettario/page.tsx
+++ b/src/app/(marketing)/help/regime-forfettario/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title: "Regime forfettario: configurazione IVA corretta | ScontrinoZero Help",
@@ -255,35 +256,7 @@ export default function RegimeForfettarioPage() {
             </p>
           </div>
         </div>
-
-        {/* ─── Link correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/primo-scontrino"
-              className="text-primary hover:underline"
-            >
-              Come emettere il primo scontrino elettronico
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/annullare-scontrino"
-              className="text-primary hover:underline"
-            >
-              Annullare uno scontrino: quando si può e come fare
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="regime-forfettario" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
+++ b/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -257,34 +258,7 @@ export default function SicurezzaCredenzialiPage() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/credenziali-fisconline"
-              className="text-primary hover:underline"
-            >
-              Credenziali Fisconline: dove trovarle e come verificarle
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/come-collegare-ade"
-              className="text-primary hover:underline"
-            >
-              Come collegare ScontrinoZero all&apos;Agenzia delle Entrate
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/errori-ade"
-              className="text-primary hover:underline"
-            >
-              Errori comuni di accesso AdE e come risolverli
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="sicurezza-credenziali" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata: Metadata = {
   title:
@@ -209,34 +210,7 @@ export default function StoricoEdEsportazionePage() {
           </div>
         </div>
 
-        {/* ─── Articoli correlati ─── */}
-        <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <Link
-              href="/help/annullare-scontrino"
-              className="text-primary hover:underline"
-            >
-              Annullare uno scontrino: quando si può e come fare
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/cassetto-fiscale"
-              className="text-primary hover:underline"
-            >
-              Dove verificare i corrispettivi nel cassetto fiscale
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/help/piani-e-prezzi"
-              className="text-primary hover:underline"
-            >
-              Piani disponibili: Starter, Pro e self-hosted gratuito
-            </Link>
-          </li>
-        </ul>
+        <RelatedHelpArticles slug="storico-ed-esportazione" />
 
         {/* ─── Footer articolo ─── */}
         <div className="border-border mt-12 border-t pt-6">

--- a/src/components/help/related-articles.test.tsx
+++ b/src/components/help/related-articles.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RelatedHelpArticles } from "./related-articles";
+import { helpArticles } from "@/lib/help/articles";
+
+describe("RelatedHelpArticles", () => {
+  it("renders the 'Articoli correlati' heading", () => {
+    render(<RelatedHelpArticles slug="aliquote-iva" />);
+    expect(
+      screen.getByRole("heading", { name: /articoli correlati/i }),
+    ).toBeTruthy();
+  });
+
+  it("renders 3 related links to /help/<slug>", () => {
+    render(<RelatedHelpArticles slug="aliquote-iva" />);
+    const expected = helpArticles["aliquote-iva"].related;
+    for (const relSlug of expected) {
+      const link = screen.getByRole("link", {
+        name: helpArticles[relSlug].title,
+      });
+      expect(link.getAttribute("href")).toBe(`/help/${relSlug}`);
+    }
+  });
+
+  it("renders a CTA link to /register", () => {
+    render(<RelatedHelpArticles slug="primo-scontrino" />);
+    const cta = screen.getByRole("link", {
+      name: /crea l'account|crea l’account/i,
+    });
+    expect(cta.getAttribute("href")).toBe("/register");
+  });
+
+  it("throws for an unknown slug", () => {
+    expect(() => render(<RelatedHelpArticles slug="unknown" />)).toThrow();
+  });
+});

--- a/src/components/help/related-articles.tsx
+++ b/src/components/help/related-articles.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getRelatedArticles } from "@/lib/help/articles";
+
+interface RelatedHelpArticlesProps {
+  readonly slug: string;
+}
+
+export function RelatedHelpArticles({ slug }: RelatedHelpArticlesProps) {
+  const related = getRelatedArticles(slug);
+  return (
+    <>
+      <h2 className="mt-10 text-xl font-semibold">Articoli correlati</h2>
+      <ul className="mt-3 space-y-1 text-sm">
+        {related.map((article) => (
+          <li key={article.slug}>
+            <Link
+              href={`/help/${article.slug}`}
+              className="text-primary hover:underline"
+            >
+              {article.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <div className="bg-muted/40 border-border mt-8 rounded-lg border p-5 text-center">
+        <p className="text-sm font-semibold">Pronto a iniziare?</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          {"30 giorni di prova gratuita, senza carta di credito."}
+        </p>
+        <Button asChild className="mt-3">
+          <Link href="/register">
+            {"Crea l'account "}
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/lib/help/articles.test.ts
+++ b/src/lib/help/articles.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { helpArticles, getRelatedArticles, getHelpArticle } from "./articles";
+
+describe("helpArticles registry", () => {
+  it("contains at least 21 entries", () => {
+    expect(Object.keys(helpArticles).length).toBeGreaterThanOrEqual(21);
+  });
+
+  it("each entry's key matches its slug", () => {
+    for (const [key, article] of Object.entries(helpArticles)) {
+      expect(article.slug).toBe(key);
+    }
+  });
+
+  it("each entry has non-empty title and slug", () => {
+    for (const article of Object.values(helpArticles)) {
+      expect(article.slug.length).toBeGreaterThan(0);
+      expect(article.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each entry has exactly 3 related slugs", () => {
+    for (const article of Object.values(helpArticles)) {
+      expect(article.related).toHaveLength(3);
+    }
+  });
+
+  it("no entry references itself in related", () => {
+    for (const article of Object.values(helpArticles)) {
+      expect(article.related).not.toContain(article.slug);
+    }
+  });
+
+  it("every related slug exists in the registry", () => {
+    for (const article of Object.values(helpArticles)) {
+      for (const relSlug of article.related) {
+        expect(helpArticles[relSlug]).toBeDefined();
+      }
+    }
+  });
+
+  it("related slugs within one entry are unique", () => {
+    for (const article of Object.values(helpArticles)) {
+      const unique = new Set(article.related);
+      expect(unique.size).toBe(article.related.length);
+    }
+  });
+});
+
+describe("getRelatedArticles", () => {
+  it("returns 3 HelpArticle objects for a known slug", () => {
+    const result = getRelatedArticles("aliquote-iva");
+    expect(result).toHaveLength(3);
+    for (const article of result) {
+      expect(article.title).toBeTruthy();
+      expect(article.slug).toBeTruthy();
+    }
+  });
+
+  it("returned articles correspond to the registry's related slugs", () => {
+    const result = getRelatedArticles("primo-scontrino");
+    const expected = helpArticles["primo-scontrino"].related;
+    expect(result.map((a) => a.slug)).toEqual([...expected]);
+  });
+
+  it("throws on unknown slug", () => {
+    expect(() => getRelatedArticles("does-not-exist")).toThrow();
+  });
+});
+
+describe("getHelpArticle", () => {
+  it("returns the entry for a known slug", () => {
+    const article = getHelpArticle("regime-forfettario");
+    expect(article.slug).toBe("regime-forfettario");
+  });
+
+  it("throws on unknown slug", () => {
+    expect(() => getHelpArticle("nope")).toThrow();
+  });
+});

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -1,0 +1,142 @@
+export interface HelpArticle {
+  readonly slug: string;
+  readonly title: string;
+  readonly related: readonly [string, string, string];
+}
+
+export const helpArticles: Record<string, HelpArticle> = {
+  "aliquote-iva": {
+    slug: "aliquote-iva",
+    title: "Aliquote IVA, catalogo e metodi di pagamento",
+    related: ["regime-forfettario", "primo-scontrino", "annullare-scontrino"],
+  },
+  "annullare-scontrino": {
+    slug: "annullare-scontrino",
+    title: "Annullare uno scontrino: quando si può e come fare",
+    related: [
+      "primo-scontrino",
+      "storico-ed-esportazione",
+      "come-collegare-ade",
+    ],
+  },
+  api: {
+    slug: "api",
+    title: "API per sviluppatori",
+    related: [
+      "primo-scontrino",
+      "sicurezza-credenziali",
+      "contatto-assistenza",
+    ],
+  },
+  "cambio-piano": {
+    slug: "cambio-piano",
+    title: "Come passare da mensile ad annuale",
+    related: ["piani-e-prezzi", "fatture-e-ricevute", "contatto-assistenza"],
+  },
+  "cassetto-fiscale": {
+    slug: "cassetto-fiscale",
+    title: "Verificare i corrispettivi nel cassetto fiscale",
+    related: ["storico-ed-esportazione", "errori-ade", "primo-scontrino"],
+  },
+  "chiusura-giornaliera": {
+    slug: "chiusura-giornaliera",
+    title: "Chiusura giornaliera: è obbligatoria?",
+    related: ["cassetto-fiscale", "storico-ed-esportazione", "primo-scontrino"],
+  },
+  "come-collegare-ade": {
+    slug: "come-collegare-ade",
+    title: "Collegare ScontrinoZero all'Agenzia delle Entrate",
+    related: ["credenziali-fisconline", "errori-ade", "primo-scontrino"],
+  },
+  "contatto-assistenza": {
+    slug: "contatto-assistenza",
+    title: "Come contattare l'assistenza",
+    related: ["errori-ade", "sicurezza-credenziali", "piani-e-prezzi"],
+  },
+  "credenziali-fisconline": {
+    slug: "credenziali-fisconline",
+    title: "Credenziali Fisconline: dove trovarle e verificarle",
+    related: ["come-collegare-ade", "sicurezza-credenziali", "errori-ade"],
+  },
+  "errori-ade": {
+    slug: "errori-ade",
+    title: "Errori comuni di accesso AdE e come risolverli",
+    related: [
+      "come-collegare-ade",
+      "credenziali-fisconline",
+      "sicurezza-credenziali",
+    ],
+  },
+  "fatture-e-ricevute": {
+    slug: "fatture-e-ricevute",
+    title: "Dove trovare fatture e ricevute di pagamento",
+    related: ["cambio-piano", "piani-e-prezzi", "contatto-assistenza"],
+  },
+  "installare-app": {
+    slug: "installare-app",
+    title: "Installare ScontrinoZero come app sul dispositivo",
+    related: ["prima-configurazione", "primo-scontrino", "piani-e-prezzi"],
+  },
+  "intestazione-scontrino": {
+    slug: "intestazione-scontrino",
+    title: "Personalizzare intestazione e dati dello scontrino",
+    related: ["prima-configurazione", "come-collegare-ade", "primo-scontrino"],
+  },
+  "normativa-pos-2026": {
+    slug: "normativa-pos-2026",
+    title: "Collegamento POS-cassa 2026: cosa cambia",
+    related: ["pos-rt-obbligo", "chiusura-giornaliera", "regime-forfettario"],
+  },
+  "piani-e-prezzi": {
+    slug: "piani-e-prezzi",
+    title: "Piani disponibili: Starter, Pro e self-hosted",
+    related: ["prima-configurazione", "fatture-e-ricevute", "cambio-piano"],
+  },
+  "pos-rt-obbligo": {
+    slug: "pos-rt-obbligo",
+    title: "Collegamento POS-RT: obbligo e scadenze 2026",
+    related: ["normativa-pos-2026", "come-collegare-ade", "primo-scontrino"],
+  },
+  "prima-configurazione": {
+    slug: "prima-configurazione",
+    title: "Prima configurazione passo-passo",
+    related: ["come-collegare-ade", "primo-scontrino", "installare-app"],
+  },
+  "primo-scontrino": {
+    slug: "primo-scontrino",
+    title: "Come emettere il primo scontrino elettronico",
+    related: [
+      "come-collegare-ade",
+      "annullare-scontrino",
+      "regime-forfettario",
+    ],
+  },
+  "regime-forfettario": {
+    slug: "regime-forfettario",
+    title: "Regime forfettario: configurazione IVA corretta",
+    related: ["aliquote-iva", "primo-scontrino", "annullare-scontrino"],
+  },
+  "sicurezza-credenziali": {
+    slug: "sicurezza-credenziali",
+    title: "Sicurezza e privacy delle credenziali",
+    related: ["credenziali-fisconline", "errori-ade", "come-collegare-ade"],
+  },
+  "storico-ed-esportazione": {
+    slug: "storico-ed-esportazione",
+    title: "Storico scontrini: filtri, ricerca ed esportazione",
+    related: ["annullare-scontrino", "cassetto-fiscale", "piani-e-prezzi"],
+  },
+};
+
+export function getHelpArticle(slug: string): HelpArticle {
+  const article = helpArticles[slug];
+  if (!article) {
+    throw new Error(`Unknown help article slug: ${slug}`);
+  }
+  return article;
+}
+
+export function getRelatedArticles(slug: string): HelpArticle[] {
+  const article = getHelpArticle(slug);
+  return article.related.map((relSlug) => getHelpArticle(relSlug));
+}


### PR DESCRIPTION
- src/lib/help/articles.ts: registry single-source-of-truth con slug, title e tre related per articolo (21 entry); helper getHelpArticle() e getRelatedArticles() con throw su slug ignoti
- src/components/help/related-articles.tsx: <RelatedHelpArticles slug>
  che renderizza i 3 link correlati + card CTA verso /register
- Test (TDD): registry validato (12 expect: chiavi=slug, related len=3, no self-ref, slug esistenti, unicità) + componente (4 expect: heading, href corretti, CTA, throw su slug ignoto)
- Refactor: tutte le 21 pagine /help/<slug>/page.tsx ora usano il componente al posto di sezioni "Articoli correlati" ad-hoc; api/ ottiene la sezione che non aveva; rimossi commenti orfani

Parte della v1.2.8 SEO Foundations (Cantiere 4 — internal linking).