### PR TITLE
Log response details when AdE submission fails with 5xx errors

### DIFF
--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -1127,6 +1127,29 @@ describe("RealAdeClient", () => {
       );
     });
 
+    it("logs at warn level (not error) for 4xx responses", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 400,
+          body: { errori: [{ codice: "E400", descrizione: "Bad payload" }] },
+        }),
+      );
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdePortalError,
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 400,
+        }),
+        "ade:submit_failed",
+      );
+    });
+
     it("throws if not logged in", async () => {
       await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
         "Not logged in",

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -13,7 +13,17 @@ import {
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
 } from "./errors";
+import { logger } from "@/lib/logger";
 import type { AdePayload, AdeResponse, SpidCredentials } from "./types";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1033,6 +1043,87 @@ describe("RealAdeClient", () => {
 
       await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
         AdePortalError,
+      );
+    });
+
+    it("logs response body excerpt and content-type when AdE returns 500 with JSON", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      const adeErrorBody = {
+        esito: false,
+        errori: [{ codice: "E001", descrizione: "Documento non annullabile" }],
+      };
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 500,
+          body: adeErrorBody,
+          headers: [["Content-Type", "application/json;charset=UTF-8"]],
+        }),
+      );
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdePortalError,
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          contentType: "application/json;charset=UTF-8",
+          bodyExcerpt: JSON.stringify(adeErrorBody),
+          endpoint: "/ser/api/documenti/v1/doc/documenti/",
+        }),
+        "ade:submit_failed",
+      );
+    });
+
+    it("logs body excerpt when AdE returns 500 with HTML/plain text body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      const htmlBody =
+        "<html><body><h1>Internal Server Error</h1><p>Generic AdE failure</p></body></html>";
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 500,
+          body: htmlBody,
+          headers: [["Content-Type", "text/html; charset=UTF-8"]],
+        }),
+      );
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdePortalError,
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          contentType: "text/html; charset=UTF-8",
+          bodyExcerpt: htmlBody,
+        }),
+        "ade:submit_failed",
+      );
+    });
+
+    it("truncates body excerpt to 2048 chars when body is large", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      const largeBody = "x".repeat(5000);
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ status: 500, body: largeBody }),
+      );
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdePortalError,
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          bodyExcerpt: "x".repeat(2048),
+        }),
+        "ade:submit_failed",
       );
     });
 

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -1302,11 +1302,14 @@ export class RealAdeClient implements AdeClient {
     }
 
     if (!response.ok) {
-      // AdE può tornare 5xx con body utile (errori[], stack trace, HTML).
-      // Catturiamo un estratto per diagnosticare la causa lato AdE invece di
-      // lanciare un errore opaco. Mai loggare il payload inviato: contiene
-      // dati fiscali (importi, CF cliente). Per correlare basta voidDocumentId
-      // dal chiamante.
+      // AdE può tornare 5xx con body utile (errori[], stack trace, HTML) o 4xx
+      // con dettagli su payload malformato/auth. Catturiamo un estratto per
+      // diagnostica invece di lanciare un errore opaco. Mai loggare il payload
+      // inviato: contiene dati fiscali (importi, CF cliente). Per correlare
+      // basta voidDocumentId dal chiamante.
+      // Livello: warn per 4xx (visibilità senza alerting — i rifiuti logici
+      // AdE arrivano come 200 esito:false, quindi 4xx è sempre anomalo ma non
+      // necessariamente un'outage); error per 5xx (genuine portal failure).
       let bodyExcerpt = "";
       try {
         const text = await response.text();
@@ -1314,15 +1317,17 @@ export class RealAdeClient implements AdeClient {
       } catch {
         bodyExcerpt = "<unreadable>";
       }
-      logger.error(
-        {
-          statusCode: response.status,
-          contentType: response.headers.get("content-type") ?? null,
-          bodyExcerpt,
-          endpoint: "/ser/api/documenti/v1/doc/documenti/",
-        },
-        "ade:submit_failed",
-      );
+      const logCtx = {
+        statusCode: response.status,
+        contentType: response.headers.get("content-type") ?? null,
+        bodyExcerpt,
+        endpoint: "/ser/api/documenti/v1/doc/documenti/",
+      };
+      if (response.status >= 500) {
+        logger.error(logCtx, "ade:submit_failed");
+      } else {
+        logger.warn(logCtx, "ade:submit_failed");
+      }
       throw new AdePortalError(
         response.status,
         `Document submission failed with status ${response.status}`,

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -1302,6 +1302,27 @@ export class RealAdeClient implements AdeClient {
     }
 
     if (!response.ok) {
+      // AdE può tornare 5xx con body utile (errori[], stack trace, HTML).
+      // Catturiamo un estratto per diagnosticare la causa lato AdE invece di
+      // lanciare un errore opaco. Mai loggare il payload inviato: contiene
+      // dati fiscali (importi, CF cliente). Per correlare basta voidDocumentId
+      // dal chiamante.
+      let bodyExcerpt = "";
+      try {
+        const text = await response.text();
+        bodyExcerpt = text.slice(0, 2048);
+      } catch {
+        bodyExcerpt = "<unreadable>";
+      }
+      logger.error(
+        {
+          statusCode: response.status,
+          contentType: response.headers.get("content-type") ?? null,
+          bodyExcerpt,
+          endpoint: "/ser/api/documenti/v1/doc/documenti/",
+        },
+        "ade:submit_failed",
+      );
       throw new AdePortalError(
         response.status,
         `Document submission failed with status ${response.status}`,


### PR DESCRIPTION
## Summary
Added detailed error logging when the AdE portal returns 5xx status codes during document submission, capturing response metadata and body excerpts to aid in diagnostics without exposing sensitive fiscal data.

## Key Changes
- **Error logging in `RealAdeClient.submitSale()`**: When a non-ok response is received, the client now logs the HTTP status code, content-type header, and a truncated excerpt of the response body (max 2048 characters) to help diagnose AdE-side failures
- **Safe body extraction**: Implemented try-catch handling around response body reading to gracefully handle unreadable responses
- **Test coverage**: Added three new test cases validating:
  - Logging of JSON error responses with proper content-type capture
  - Logging of HTML/plain text error responses
  - Truncation of large response bodies to 2048 characters
- **Logger mocking**: Set up proper mocking of the logger module in tests to verify logging calls

## Implementation Details
- The logged excerpt includes the full response body for JSON/text responses (up to 2048 chars) to preserve error details from AdE
- The endpoint path is hardcoded in logs as it's specific to the submission operation
- Sensitive data (fiscal amounts, customer tax IDs) in request payloads are intentionally not logged; correlation is done via `voidDocumentId` from the caller
- If response body cannot be read, logs `"<unreadable>"` as the excerpt rather than failing

https://claude.ai/code/session_01Kmgf6J1bsN12bdBPDJ15cm