### PR TITLE
Add CSP Report-Only mode with violation logging endpoint

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import withSerwistInit from "@serwist/next";
-import { buildCspReportOnly } from "./src/lib/csp";
+import { buildCspReportOnly, buildReportingEndpoints } from "./src/lib/csp";
 
 const withSerwist = withSerwistInit({
   swSrc: "src/sw.ts",
@@ -58,8 +58,10 @@ const nextConfig: NextConfig = {
         value: buildCspReportOnly(),
       },
       {
+        // Reporting API richiede URL assoluto: i browser che prioritizzano
+        // `report-to` (Chrome) scartano silenziosamente endpoint relativi.
         key: "Reporting-Endpoints",
-        value: 'csp-endpoint="/api/csp-report"',
+        value: buildReportingEndpoints(allowedOrigin),
       },
     ];
     if (process.env.NODE_ENV === "production") {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import withSerwistInit from "@serwist/next";
+import { buildCspReportOnly } from "./src/lib/csp";
 
 const withSerwist = withSerwistInit({
   swSrc: "src/sw.ts",
@@ -36,11 +37,12 @@ const nextConfig: NextConfig = {
     const allowedOrigin =
       process.env.NEXT_PUBLIC_APP_URL ?? "https://app.scontrinozero.it";
 
-    // Baseline security headers applied to every response. CSP is intentionally
-    // *not* set here — a correct CSP needs to map every external origin
-    // (Sentry, Turnstile, Stripe, Resend, Supabase, fonts, …) and is rolled
-    // out in a dedicated release with a report-only phase first to avoid
-    // breaking production. See PLAN.md backlog (B14).
+    // Baseline security headers applied to every response.
+    //
+    // CSP è in fase Report-Only: la policy non blocca nulla, ma le violazioni
+    // vengono inviate a /api/csp-report (vedi src/lib/csp.ts e PLAN.md B14).
+    // Promozione a `Content-Security-Policy` enforce dopo ≥1 settimana con
+    // zero violazioni reali in produzione.
     const securityHeaders: { key: string; value: string }[] = [
       { key: "X-Content-Type-Options", value: "nosniff" },
       { key: "X-Frame-Options", value: "DENY" },
@@ -50,6 +52,14 @@ const nextConfig: NextConfig = {
       {
         key: "Permissions-Policy",
         value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+      },
+      {
+        key: "Content-Security-Policy-Report-Only",
+        value: buildCspReportOnly(),
+      },
+      {
+        key: "Reporting-Endpoints",
+        value: 'csp-endpoint="/api/csp-report"',
       },
     ];
     if (process.env.NODE_ENV === "production") {

--- a/src/app/api/csp-report/route.test.ts
+++ b/src/app/api/csp-report/route.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRateLimiterCheck, mockLoggerWarn } = vi.hoisted(() => ({
+  mockRateLimiterCheck: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockRateLimiterCheck };
+  }),
+  RATE_LIMIT_WINDOWS: { AUTH_15_MIN: 15 * 60 * 1000, HOURLY: 60 * 60 * 1000 },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: mockLoggerWarn },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimiterCheck.mockReturnValue({
+    success: true,
+    remaining: 59,
+    resetAt: Date.now() + 60_000,
+  });
+});
+
+function makeRequest(body: string, contentType: string): Request {
+  return new Request("https://scontrinozero.it/api/csp-report", {
+    method: "POST",
+    headers: {
+      "content-type": contentType,
+      "cf-connecting-ip": "203.0.113.10",
+    },
+    body,
+  });
+}
+
+describe("POST /api/csp-report", () => {
+  it("ritorna 204 e logga la violation legacy (application/csp-report)", async () => {
+    const { POST } = await import("./route");
+    const body = JSON.stringify({
+      "csp-report": {
+        "blocked-uri": "https://evil.example/script.js",
+        "document-uri": "https://scontrinozero.it/",
+        "violated-directive": "script-src",
+        "effective-directive": "script-src-elem",
+        "original-policy": "default-src 'self'",
+        disposition: "report",
+      },
+    });
+    const res = await POST(makeRequest(body, "application/csp-report"));
+    expect(res.status).toBe(204);
+    expect(mockLoggerWarn).toHaveBeenCalledOnce();
+    const [ctx, msg] = mockLoggerWarn.mock.calls[0];
+    expect(msg).toMatch(/csp/i);
+    expect(ctx).toMatchObject({
+      cspViolation: expect.objectContaining({
+        blockedUri: "https://evil.example/script.js",
+        violatedDirective: "script-src",
+      }),
+    });
+  });
+
+  it("ritorna 204 e logga la violation Reporting API (application/reports+json)", async () => {
+    const { POST } = await import("./route");
+    const body = JSON.stringify([
+      {
+        type: "csp-violation",
+        age: 0,
+        url: "https://scontrinozero.it/",
+        body: {
+          blockedURL: "https://evil.example/script.js",
+          documentURL: "https://scontrinozero.it/",
+          violatedDirective: "script-src",
+          effectiveDirective: "script-src-elem",
+          originalPolicy: "default-src 'self'",
+          disposition: "report",
+          statusCode: 200,
+        },
+      },
+    ]);
+    const res = await POST(makeRequest(body, "application/reports+json"));
+    expect(res.status).toBe(204);
+    expect(mockLoggerWarn).toHaveBeenCalledOnce();
+    const [ctx] = mockLoggerWarn.mock.calls[0];
+    expect(ctx.cspViolation).toMatchObject({
+      blockedUri: "https://evil.example/script.js",
+      violatedDirective: "script-src",
+    });
+  });
+
+  it("supporta più report nel body Reporting API (loggandoli tutti)", async () => {
+    const { POST } = await import("./route");
+    const body = JSON.stringify([
+      {
+        type: "csp-violation",
+        body: {
+          blockedURL: "https://a.example/",
+          violatedDirective: "img-src",
+        },
+      },
+      {
+        type: "csp-violation",
+        body: {
+          blockedURL: "https://b.example/",
+          violatedDirective: "script-src",
+        },
+      },
+    ]);
+    const res = await POST(makeRequest(body, "application/reports+json"));
+    expect(res.status).toBe(204);
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignora report non csp-violation nel batch Reporting API", async () => {
+    const { POST } = await import("./route");
+    const body = JSON.stringify([
+      {
+        type: "deprecation",
+        body: { id: "deprecated-feature" },
+      },
+      {
+        type: "csp-violation",
+        body: {
+          blockedURL: "https://a.example/",
+          violatedDirective: "img-src",
+        },
+      },
+    ]);
+    const res = await POST(makeRequest(body, "application/reports+json"));
+    expect(res.status).toBe(204);
+    expect(mockLoggerWarn).toHaveBeenCalledOnce();
+  });
+
+  it("ritorna 415 su content-type sconosciuto", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest("{}", "application/json"));
+    expect(res.status).toBe(415);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("ritorna 400 su JSON malformato", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest("not-json{{", "application/csp-report"));
+    expect(res.status).toBe(400);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("ritorna 413 su body > 8KB", async () => {
+    const { POST } = await import("./route");
+    const big = JSON.stringify({ "csp-report": { x: "a".repeat(10_000) } });
+    const res = await POST(makeRequest(big, "application/csp-report"));
+    expect(res.status).toBe(413);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("ritorna 429 quando il rate limit è superato", async () => {
+    mockRateLimiterCheck.mockReturnValue({
+      success: false,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+    });
+    const { POST } = await import("./route");
+    const body = JSON.stringify({ "csp-report": { "blocked-uri": "x" } });
+    const res = await POST(makeRequest(body, "application/csp-report"));
+    expect(res.status).toBe(429);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("non logga se la violation, dopo sanitizzazione, è vuota", async () => {
+    const { POST } = await import("./route");
+    // Tutti campi non-allowlist
+    const body = JSON.stringify({
+      "csp-report": { "source-file": "/x", "script-sample": "y" },
+    });
+    const res = await POST(makeRequest(body, "application/csp-report"));
+    expect(res.status).toBe(204);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("usa il rate-limit chiave per IP (CF-Connecting-IP)", async () => {
+    const { POST } = await import("./route");
+    const body = JSON.stringify({ "csp-report": { "blocked-uri": "x" } });
+    await POST(makeRequest(body, "application/csp-report"));
+    expect(mockRateLimiterCheck).toHaveBeenCalledWith(
+      expect.stringContaining("203.0.113.10"),
+    );
+  });
+});

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,67 @@
+import { sanitizeCspViolation } from "@/lib/csp";
+import { getClientIp } from "@/lib/get-client-ip";
+import { logger } from "@/lib/logger";
+import { RATE_LIMIT_WINDOWS, RateLimiter } from "@/lib/rate-limit";
+import { readJsonWithLimit } from "@/lib/request-utils";
+
+export const dynamic = "force-dynamic";
+
+const MAX_BODY_BYTES = 8 * 1024;
+
+// Rate limit conservativo: violazioni reali sono rare; un picco di richieste
+// indica abuso (uno script ostile che bombarda l'endpoint per riempire i log).
+const cspReportLimiter = new RateLimiter({
+  maxRequests: 60,
+  windowMs: RATE_LIMIT_WINDOWS.HOURLY / 60,
+});
+
+interface ReportingApiEntry {
+  readonly type?: string;
+  readonly body?: unknown;
+}
+
+function logViolation(violation: unknown, ip: string): void {
+  const sanitized = sanitizeCspViolation(violation);
+  if (Object.keys(sanitized).length === 0) return;
+  logger.warn({ cspViolation: sanitized, ip }, "CSP violation report received");
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const ip = getClientIp(req.headers);
+  const limit = cspReportLimiter.check(`csp-report:${ip}`);
+  if (!limit.success) {
+    return new Response(null, { status: 429 });
+  }
+
+  const ct = req.headers.get("content-type") ?? "";
+  const isLegacy = ct.includes("application/csp-report");
+  const isReportingApi = ct.includes("application/reports+json");
+  if (!isLegacy && !isReportingApi) {
+    return new Response(null, { status: 415 });
+  }
+
+  const result = await readJsonWithLimit(req, MAX_BODY_BYTES);
+  if (!result.ok) {
+    if ("tooLarge" in result) return new Response(null, { status: 413 });
+    return new Response(null, { status: 400 });
+  }
+
+  if (isLegacy) {
+    const data = result.data as { "csp-report"?: unknown };
+    logViolation(data?.["csp-report"], ip);
+    return new Response(null, { status: 204 });
+  }
+
+  // Reporting API: il body è un array di report eterogenei. Filtriamo i
+  // soli "csp-violation" — gli altri (deprecation, intervention) non ci
+  // interessano e non vanno loggati come CSP.
+  if (Array.isArray(result.data)) {
+    for (const entry of result.data as ReportingApiEntry[]) {
+      if (entry?.type === "csp-violation") {
+        logViolation(entry.body, ip);
+      }
+    }
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { buildCspReportOnly, sanitizeCspViolation } from "./csp";
+
+describe("buildCspReportOnly", () => {
+  const policy = buildCspReportOnly();
+
+  it("contiene default-src self", () => {
+    expect(policy).toMatch(/default-src 'self'/);
+  });
+
+  it("autorizza Cloudflare Turnstile come script-src e frame-src", () => {
+    expect(policy).toMatch(
+      /script-src[^;]*\bchallenges\.cloudflare\.com\b[^;]*;/,
+    );
+    expect(policy).toMatch(
+      /frame-src[^;]*\bhttps:\/\/challenges\.cloudflare\.com\b[^;]*;/,
+    );
+  });
+
+  it("autorizza Supabase REST e WebSocket in connect-src", () => {
+    expect(policy).toMatch(
+      /connect-src[^;]*\bhttps:\/\/\*\.supabase\.co\b[^;]*;/,
+    );
+    expect(policy).toMatch(
+      /connect-src[^;]*\bwss:\/\/\*\.supabase\.co\b[^;]*;/,
+    );
+  });
+
+  it("autorizza Sentry ingest in connect-src", () => {
+    expect(policy).toMatch(
+      /connect-src[^;]*\bhttps:\/\/\*\.ingest\.sentry\.io\b[^;]*;/,
+    );
+  });
+
+  it("permette inline + data: per immagini, font e style (Tailwind/Radix)", () => {
+    expect(policy).toMatch(/img-src[^;]*\bdata:[^;]*;/);
+    expect(policy).toMatch(/font-src[^;]*\bdata:[^;]*;/);
+    expect(policy).toMatch(/style-src[^;]*'unsafe-inline'[^;]*;/);
+  });
+
+  it("ammette unsafe-inline su script-src per i payload JSON-LD escaped", () => {
+    // Nota: temporaneo, da migrare a nonce-based in PR follow-up.
+    expect(policy).toMatch(/script-src[^;]*'unsafe-inline'[^;]*;/);
+  });
+
+  it("blocca completamente i frame ancestors e gli object", () => {
+    expect(policy).toMatch(/frame-ancestors 'none'/);
+    expect(policy).toMatch(/object-src 'none'/);
+  });
+
+  it("punta /api/csp-report come report-uri e dichiara report-to", () => {
+    expect(policy).toMatch(/report-uri \/api\/csp-report/);
+    expect(policy).toMatch(/report-to csp-endpoint/);
+  });
+
+  it("non contiene direttive vuote o separatori duplicati", () => {
+    // Consentite singole spaziature; nessun ";;" e nessun "; ;"
+    expect(policy).not.toMatch(/;\s*;/);
+    // Ogni segmento (split su ";") deve avere almeno 2 token: direttiva + valore
+    for (const segment of policy.split(";").map((s) => s.trim())) {
+      if (segment.length === 0) continue;
+      expect(segment.split(/\s+/).length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("è deterministico tra invocazioni successive (snapshot regression)", () => {
+    expect(buildCspReportOnly()).toBe(policy);
+  });
+});
+
+describe("sanitizeCspViolation", () => {
+  it("conserva solo i campi safe della legacy report", () => {
+    const raw = {
+      "blocked-uri": "https://evil.example/script.js",
+      "document-uri": "https://scontrinozero.it/dashboard",
+      "violated-directive": "script-src",
+      "effective-directive": "script-src-elem",
+      "original-policy": "default-src 'self'; ...",
+      referrer: "https://google.com",
+      disposition: "report",
+      "status-code": 200,
+      // campi non in allowlist — devono essere strippati
+      "source-file": "/etc/passwd",
+      "script-sample": "any private code here",
+      "line-number": 42,
+    };
+    const out = sanitizeCspViolation(raw);
+    expect(out).toEqual({
+      blockedUri: "https://evil.example/script.js",
+      documentUri: "https://scontrinozero.it/dashboard",
+      violatedDirective: "script-src",
+      effectiveDirective: "script-src-elem",
+      originalPolicy: "default-src 'self'; ...",
+      referrer: "https://google.com",
+      disposition: "report",
+      statusCode: 200,
+    });
+  });
+
+  it("conserva i campi safe della Reporting API (camelCase nativo)", () => {
+    const raw = {
+      blockedURL: "https://evil.example/script.js",
+      documentURL: "https://scontrinozero.it/",
+      violatedDirective: "script-src",
+      effectiveDirective: "script-src-elem",
+      originalPolicy: "default-src 'self'",
+      referrer: "",
+      disposition: "report",
+      statusCode: 200,
+      sourceFile: "/leak/me",
+      sample: "private",
+    };
+    const out = sanitizeCspViolation(raw);
+    expect(out.blockedUri).toBe("https://evil.example/script.js");
+    expect(out.documentUri).toBe("https://scontrinozero.it/");
+    expect(out).not.toHaveProperty("sourceFile");
+    expect(out).not.toHaveProperty("sample");
+  });
+
+  it("tronca URL > 1024 byte per evitare log bombing", () => {
+    const longUri = "https://evil.example/" + "a".repeat(2000);
+    const out = sanitizeCspViolation({ "blocked-uri": longUri });
+    expect(typeof out.blockedUri).toBe("string");
+    expect((out.blockedUri as string).length).toBeLessThanOrEqual(1024);
+  });
+
+  it("ritorna oggetto vuoto su input non-oggetto", () => {
+    expect(sanitizeCspViolation(null)).toEqual({});
+    expect(sanitizeCspViolation(undefined)).toEqual({});
+    expect(sanitizeCspViolation("string")).toEqual({});
+    expect(sanitizeCspViolation(42)).toEqual({});
+  });
+
+  it("scarta valori non-stringa/non-numero per chiavi stringa attese", () => {
+    const out = sanitizeCspViolation({
+      "blocked-uri": { malicious: "object" },
+      "violated-directive": ["array"],
+      "status-code": 200,
+    });
+    expect(out).not.toHaveProperty("blockedUri");
+    expect(out).not.toHaveProperty("violatedDirective");
+    expect(out.statusCode).toBe(200);
+  });
+});

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildCspReportOnly, sanitizeCspViolation } from "./csp";
+import {
+  buildCspReportOnly,
+  buildReportingEndpoints,
+  sanitizeCspViolation,
+} from "./csp";
 
 describe("buildCspReportOnly", () => {
   const policy = buildCspReportOnly();
@@ -65,6 +69,38 @@ describe("buildCspReportOnly", () => {
 
   it("è deterministico tra invocazioni successive (snapshot regression)", () => {
     expect(buildCspReportOnly()).toBe(policy);
+  });
+});
+
+describe("buildReportingEndpoints", () => {
+  it("usa URL assoluto come richiesto dalla Reporting API", () => {
+    const value = buildReportingEndpoints("https://app.scontrinozero.it");
+    expect(value).toBe(
+      'csp-endpoint="https://app.scontrinozero.it/api/csp-report"',
+    );
+  });
+
+  it("rimuove la trailing slash dalla base URL", () => {
+    const value = buildReportingEndpoints("https://app.scontrinozero.it/");
+    expect(value).toBe(
+      'csp-endpoint="https://app.scontrinozero.it/api/csp-report"',
+    );
+  });
+
+  it("supporta hostname sandbox e custom (self-hosted)", () => {
+    expect(buildReportingEndpoints("https://sandbox.scontrinozero.it")).toBe(
+      'csp-endpoint="https://sandbox.scontrinozero.it/api/csp-report"',
+    );
+    expect(buildReportingEndpoints("https://cassa.miosito.it")).toBe(
+      'csp-endpoint="https://cassa.miosito.it/api/csp-report"',
+    );
+  });
+
+  it("non concatena URL malformata se manca lo schema (caller deve passare absolute)", () => {
+    // Documenta il contratto: il caller (next.config.ts) è responsabile di
+    // passare un URL assoluto. La funzione non normalizza/valida lo schema.
+    const value = buildReportingEndpoints("scontrinozero.it");
+    expect(value).toBe('csp-endpoint="scontrinozero.it/api/csp-report"');
   });
 });
 

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -24,6 +24,8 @@ const SUPABASE_HOSTS = [
 const SENTRY_HOSTS = ["https://*.ingest.sentry.io"] as const;
 const TURNSTILE_HOSTS = ["https://challenges.cloudflare.com"] as const;
 
+const CSP_REPORT_PATH = "/api/csp-report";
+
 const DIRECTIVES: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
   ["default-src", ["'self'"]],
   ["script-src", ["'self'", "'unsafe-inline'", "challenges.cloudflare.com"]],
@@ -39,7 +41,11 @@ const DIRECTIVES: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
   ["base-uri", ["'self'"]],
   ["form-action", ["'self'"]],
   ["object-src", ["'none'"]],
-  ["report-uri", ["/api/csp-report"]],
+  // CSP3: report-uri ammette URL relativi, risolti rispetto al documento.
+  ["report-uri", [CSP_REPORT_PATH]],
+  // Reporting API: il token deve combaciare con una entry dell'header
+  // `Reporting-Endpoints` (vedi buildReportingEndpoints), che richiede URL
+  // assoluto.
   ["report-to", ["csp-endpoint"]],
 ];
 
@@ -53,6 +59,20 @@ export function buildCspReportOnly(): string {
   return DIRECTIVES.map(
     ([directive, sources]) => `${directive} ${sources.join(" ")}`,
   ).join("; ");
+}
+
+/**
+ * Costruisce il valore dell'header `Reporting-Endpoints`.
+ *
+ * La spec Reporting API richiede URL assoluti (potentially-trustworthy):
+ * un valore relativo viene parseato dal browser ma il delivery dei report
+ * fallisce silenziosamente. Chrome prioritizza `report-to` su `report-uri`,
+ * quindi senza URL assoluto le violation reports della maggioranza del
+ * traffico vanno perse.
+ */
+export function buildReportingEndpoints(appUrl: string): string {
+  const base = appUrl.endsWith("/") ? appUrl.slice(0, -1) : appUrl;
+  return `csp-endpoint="${base}${CSP_REPORT_PATH}"`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,136 @@
+/**
+ * Content-Security-Policy in modalità Report-Only.
+ *
+ * Strategia di rollout (vedi PLAN.md backlog B14):
+ *  1. Deploy con header `Content-Security-Policy-Report-Only` in produzione.
+ *  2. Raccolta violazioni reali via `/api/csp-report` per ≥ 1 settimana.
+ *  3. Promozione a `Content-Security-Policy` (enforce) in PR follow-up dopo
+ *     zero violation reali.
+ *
+ * Limitazioni note di questa fase:
+ *  - `script-src 'unsafe-inline'` è temporaneo: serve per i payload JSON-LD
+ *    inseriti via `dangerouslySetInnerHTML` in `src/components/json-ld.tsx`.
+ *    I contenuti sono già escaped (`safeJsonLd`), quindi sicuri. La migrazione
+ *    a nonce-based è scope di una PR successiva (richiede tocco di tutti gli
+ *    inserimenti `<JsonLd>` per ricevere il nonce dal middleware).
+ *  - `style-src 'unsafe-inline'` resta: Tailwind 4 inline + Radix UI portali
+ *    iniettano style runtime non isolabili senza nonce dinamico.
+ */
+
+const SUPABASE_HOSTS = [
+  "https://*.supabase.co",
+  "wss://*.supabase.co",
+] as const;
+const SENTRY_HOSTS = ["https://*.ingest.sentry.io"] as const;
+const TURNSTILE_HOSTS = ["https://challenges.cloudflare.com"] as const;
+
+const DIRECTIVES: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
+  ["default-src", ["'self'"]],
+  ["script-src", ["'self'", "'unsafe-inline'", "challenges.cloudflare.com"]],
+  ["style-src", ["'self'", "'unsafe-inline'"]],
+  ["img-src", ["'self'", "data:"]],
+  ["font-src", ["'self'", "data:"]],
+  [
+    "connect-src",
+    ["'self'", ...SUPABASE_HOSTS, ...SENTRY_HOSTS, ...TURNSTILE_HOSTS],
+  ],
+  ["frame-src", ["'self'", ...TURNSTILE_HOSTS]],
+  ["frame-ancestors", ["'none'"]],
+  ["base-uri", ["'self'"]],
+  ["form-action", ["'self'"]],
+  ["object-src", ["'none'"]],
+  ["report-uri", ["/api/csp-report"]],
+  ["report-to", ["csp-endpoint"]],
+];
+
+/**
+ * Costruisce la stringa CSP report-only deterministica.
+ *
+ * Output esempio:
+ *   default-src 'self'; script-src 'self' 'unsafe-inline' challenges.cloudflare.com; ...
+ */
+export function buildCspReportOnly(): string {
+  return DIRECTIVES.map(
+    ([directive, sources]) => `${directive} ${sources.join(" ")}`,
+  ).join("; ");
+}
+
+// ---------------------------------------------------------------------------
+// Sanitizzazione violation report
+// ---------------------------------------------------------------------------
+
+const MAX_FIELD_LENGTH = 1024;
+
+/**
+ * Mapping da chiavi sorgente (legacy `csp-report` + Reporting API moderna)
+ * verso chiavi camelCase normalizzate in output.
+ *
+ * Allowlist esplicita: tutto ciò che non è qui dentro viene scartato. Evita
+ * di propagare campi rumorosi o sensibili (`source-file`, `script-sample`,
+ * `line-number`, ecc.) nei log strutturati e in Sentry.
+ */
+const FIELD_ALIASES: Record<string, "string" | "number"> = {
+  // legacy "csp-report" formato Chrome/Firefox/Safari
+  "blocked-uri": "string",
+  "document-uri": "string",
+  "violated-directive": "string",
+  "effective-directive": "string",
+  "original-policy": "string",
+  referrer: "string",
+  disposition: "string",
+  "status-code": "number",
+  // Reporting API (camelCase / URL form)
+  blockedURL: "string",
+  documentURL: "string",
+  violatedDirective: "string",
+  effectiveDirective: "string",
+  originalPolicy: "string",
+  statusCode: "number",
+};
+
+const OUTPUT_KEYS: Record<string, string> = {
+  "blocked-uri": "blockedUri",
+  "document-uri": "documentUri",
+  "violated-directive": "violatedDirective",
+  "effective-directive": "effectiveDirective",
+  "original-policy": "originalPolicy",
+  referrer: "referrer",
+  disposition: "disposition",
+  "status-code": "statusCode",
+  blockedURL: "blockedUri",
+  documentURL: "documentUri",
+  violatedDirective: "violatedDirective",
+  effectiveDirective: "effectiveDirective",
+  originalPolicy: "originalPolicy",
+  statusCode: "statusCode",
+};
+
+function truncate(value: string): string {
+  return value.length > MAX_FIELD_LENGTH
+    ? value.slice(0, MAX_FIELD_LENGTH)
+    : value;
+}
+
+/**
+ * Estrae i campi safe da una violation report (legacy o Reporting API),
+ * scartando tutto ciò che non è in allowlist e troncando le stringhe lunghe.
+ */
+export function sanitizeCspViolation(input: unknown): Record<string, unknown> {
+  if (typeof input !== "object" || input === null) return {};
+  const raw = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  for (const [sourceKey, expectedType] of Object.entries(FIELD_ALIASES)) {
+    if (!(sourceKey in raw)) continue;
+    const value = raw[sourceKey];
+    const outKey = OUTPUT_KEYS[sourceKey];
+    if (expectedType === "string" && typeof value === "string") {
+      out[outKey] = truncate(value);
+    } else if (expectedType === "number" && typeof value === "number") {
+      out[outKey] = value;
+    }
+    // altri tipi (oggetti, array, boolean) sono scartati silenziosamente
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary
Implements Content-Security-Policy in Report-Only mode with a dedicated endpoint to collect and log CSP violations. This is the first phase of the CSP rollout strategy (see PLAN.md B14), allowing real-world violation monitoring before enforcing the policy in production.

## Key Changes

- **CSP Policy Definition** (`src/lib/csp.ts`):
  - `buildCspReportOnly()`: Generates a deterministic CSP report-only policy string covering all external dependencies (Supabase, Sentry, Cloudflare Turnstile)
  - `sanitizeCspViolation()`: Sanitizes violation reports by allowlisting safe fields and truncating long URLs to prevent log bombing
  - Supports both legacy `csp-report` format and modern Reporting API format

- **CSP Report Endpoint** (`src/app/api/csp-report/route.ts`):
  - POST handler accepting both `application/csp-report` (legacy) and `application/reports+json` (Reporting API) content types
  - Rate limiting (60 requests/minute per IP) to prevent abuse
  - Request size validation (max 8KB)
  - Filters Reporting API batches to log only `csp-violation` entries, ignoring deprecation/intervention reports
  - Returns 204 on success, 415 on unsupported content-type, 400 on malformed JSON, 413 on oversized body, 429 on rate limit exceeded

- **Security Headers** (`next.config.ts`):
  - Added `Content-Security-Policy-Report-Only` header with the generated policy
  - Added `Reporting-Endpoints` header to direct violations to `/api/csp-report`

- **Comprehensive Test Coverage**:
  - `src/lib/csp.test.ts`: Tests for policy generation and violation sanitization
  - `src/app/api/csp-report/route.test.ts`: Tests for endpoint behavior, error handling, rate limiting, and both report formats

## Implementation Notes

- **Temporary `unsafe-inline` on script-src**: Required for JSON-LD payloads in `src/components/json-ld.tsx`. Content is already escaped (`safeJsonLd`). Migration to nonce-based approach is deferred to a follow-up PR.
- **Unsafe-inline on style-src**: Retained for Tailwind 4 inline styles and Radix UI portal injections; dynamic nonce approach is out of scope for this phase.
- **Rollout Strategy**: After ≥1 week of zero real violations in production, the policy will be promoted from Report-Only to enforced `Content-Security-Policy` header in a follow-up PR.

https://claude.ai/code/session_01TtBZ6hTya2CCzGxaLsmPcn