### PR TITLE
feat(db): statement timeout + 503 retryable foundation (B13 fase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12193,9 +12193,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "yaml": ">=2.8.3",
     "picomatch": "4.0.4",
     "express-rate-limit": "^8.5.1",
+    "fast-uri": "^3.1.2",
     "micromatch": {
       "picomatch": "2.3.2"
     },

--- a/src/app/api/v1/receipts/[id]/route.test.ts
+++ b/src/app/api/v1/receipts/[id]/route.test.ts
@@ -14,6 +14,9 @@ const {
   mockSelectLinesWhere,
   mockSelectLinesFrom,
   mockSelect,
+  mockTransaction,
+  mockTxExecute,
+  mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockAuthenticateApiKey: vi.fn(),
   mockIsApiKeyAuthError: vi.fn(),
@@ -25,6 +28,9 @@ const {
   mockSelectLinesWhere: vi.fn(),
   mockSelectLinesFrom: vi.fn(),
   mockSelect: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockTxExecute: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }));
 
 vi.mock("@/lib/api-auth", () => ({
@@ -37,7 +43,13 @@ vi.mock("@/lib/plans", () => ({
 }));
 
 vi.mock("@/db", () => ({
-  getDb: vi.fn().mockReturnValue({ select: mockSelect }),
+  getDb: vi
+    .fn()
+    .mockReturnValue({ select: mockSelect, transaction: mockTransaction }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: mockLoggerWarn, error: vi.fn() },
 }));
 
 vi.mock("@/db/schema", () => ({
@@ -48,6 +60,7 @@ vi.mock("@/db/schema", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((col, val) => ({ col, val })),
   and: vi.fn((...args) => args),
+  sql: { raw: vi.fn((s) => ({ raw: s })) },
   asc: vi.fn((col) => ({ col, direction: "asc" })),
 }));
 
@@ -118,6 +131,15 @@ describe("GET /api/v1/receipts/[id]", () => {
     mockIsApiKeyAuthError.mockReturnValue(false);
     mockAuthenticateApiKey.mockResolvedValue(FAKE_AUTH);
     mockCanUseApi.mockReturnValue(true);
+
+    // withStatementTimeout(timeoutMs, fn) calls db.transaction(cb) where cb
+    // does `tx.execute(SET LOCAL ...)` then `fn(tx)`. Wire the mock so the
+    // tx object exposes the same `select` chain the existing setup helpers
+    // configure on the parent db mock.
+    mockTransaction.mockImplementation(async (cb) =>
+      cb({ execute: mockTxExecute, select: mockSelect }),
+    );
+    mockTxExecute.mockResolvedValue(undefined);
 
     setupDocMock(FAKE_DOC);
     setupLinesMock([FAKE_LINE]);
@@ -227,6 +249,10 @@ describe("GET /api/v1/receipts/[id]", () => {
     mockIsApiKeyAuthError.mockReturnValue(false);
     mockAuthenticateApiKey.mockResolvedValue(FAKE_AUTH);
     mockCanUseApi.mockReturnValue(true);
+    mockTransaction.mockImplementation(async (cb) =>
+      cb({ execute: mockTxExecute, select: mockSelect }),
+    );
+    mockTxExecute.mockResolvedValue(undefined);
     setupDocMock(null);
 
     const res = await GET(
@@ -234,5 +260,41 @@ describe("GET /api/v1/receipts/[id]", () => {
       makeParams("00000000-0000-0000-0000-000000000000"),
     );
     expect(res.status).toBe(404);
+  });
+
+  it("ritorna 503 con Retry-After su statement timeout DB (Postgres 57014)", async () => {
+    const timeoutErr = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    mockTransaction.mockImplementationOnce(async () => {
+      throw timeoutErr;
+    });
+
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("5");
+    const body = await res.json();
+    expect(body.code).toBe("DB_TIMEOUT");
+
+    expect(mockLoggerWarn).toHaveBeenCalledOnce();
+    const [ctx, msg] = mockLoggerWarn.mock.calls[0];
+    expect(msg).toMatch(/timeout/i);
+    expect(ctx.path).toBe("GET /api/v1/receipts/[id]");
+    expect(ctx.statusCode).toBe(503);
+  });
+
+  it("propaga errori DB non-timeout (status default Next.js, non 503)", async () => {
+    const otherErr = Object.assign(new Error("unique violation"), {
+      code: "23505",
+    });
+    mockTransaction.mockImplementationOnce(async () => {
+      throw otherErr;
+    });
+
+    await expect(GET(makeRequest(), makeParams())).rejects.toMatchObject({
+      code: "23505",
+    });
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/v1/receipts/[id]/route.ts
+++ b/src/app/api/v1/receipts/[id]/route.ts
@@ -1,13 +1,20 @@
 import { and, asc, eq } from "drizzle-orm";
-import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
+import { dbTimeoutResponse, isStatementTimeoutError } from "@/lib/api-errors";
+import { withStatementTimeout } from "@/lib/db-timeout";
 import { isValidUuid } from "@/lib/uuid";
+import { logger } from "@/lib/logger";
 import {
   requireBusinessApiAuth,
   corsOptionsResponse,
   withCors,
 } from "@/lib/api-v1-helpers";
 import { calcDocTotal } from "@/lib/receipts/document-lines";
+
+// Single-doc read: 2 indexed SELECT, atteso < 50ms p99. 3s di budget cattura
+// solo gli stalli reali (DB sovraccarico, lock attesi) senza falsi positivi.
+const STATEMENT_TIMEOUT_MS = 3000;
+const ROUTE = "GET /api/v1/receipts/[id]";
 
 export function OPTIONS(): Response {
   return corsOptionsResponse("GET, OPTIONS");
@@ -30,40 +37,59 @@ export async function GET(
     );
   }
 
-  const db = getDb();
-  const [doc] = await db
-    .select({
-      id: commercialDocuments.id,
-      kind: commercialDocuments.kind,
-      status: commercialDocuments.status,
-      idempotencyKey: commercialDocuments.idempotencyKey,
-      adeTransactionId: commercialDocuments.adeTransactionId,
-      adeProgressive: commercialDocuments.adeProgressive,
-      createdAt: commercialDocuments.createdAt,
-      lotteryCode: commercialDocuments.lotteryCode,
-      voidedDocumentId: commercialDocuments.voidedDocumentId,
-      publicRequest: commercialDocuments.publicRequest,
-    })
-    .from(commercialDocuments)
-    .where(
-      and(
-        eq(commercialDocuments.id, id),
-        eq(commercialDocuments.businessId, auth.businessId),
-      ),
-    )
-    .limit(1);
+  let result;
+  try {
+    result = await withStatementTimeout(STATEMENT_TIMEOUT_MS, async (tx) => {
+      const [doc] = await tx
+        .select({
+          id: commercialDocuments.id,
+          kind: commercialDocuments.kind,
+          status: commercialDocuments.status,
+          idempotencyKey: commercialDocuments.idempotencyKey,
+          adeTransactionId: commercialDocuments.adeTransactionId,
+          adeProgressive: commercialDocuments.adeProgressive,
+          createdAt: commercialDocuments.createdAt,
+          lotteryCode: commercialDocuments.lotteryCode,
+          voidedDocumentId: commercialDocuments.voidedDocumentId,
+          publicRequest: commercialDocuments.publicRequest,
+        })
+        .from(commercialDocuments)
+        .where(
+          and(
+            eq(commercialDocuments.id, id),
+            eq(commercialDocuments.businessId, auth.businessId),
+          ),
+        )
+        .limit(1);
 
-  if (!doc) {
+      if (!doc) return null;
+
+      const lines = await tx
+        .select()
+        .from(commercialDocumentLines)
+        .where(eq(commercialDocumentLines.documentId, doc.id))
+        .orderBy(asc(commercialDocumentLines.lineIndex));
+
+      return { doc, lines };
+    });
+  } catch (err) {
+    if (isStatementTimeoutError(err)) {
+      logger.warn(
+        { err, path: ROUTE, statusCode: 503 },
+        "DB statement timeout",
+      );
+      return withCors(dbTimeoutResponse());
+    }
+    throw err;
+  }
+
+  if (!result) {
     return withCors(
       Response.json({ error: "Documento non trovato." }, { status: 404 }),
     );
   }
 
-  const lines = await db
-    .select()
-    .from(commercialDocumentLines)
-    .where(eq(commercialDocumentLines.documentId, doc.id))
-    .orderBy(asc(commercialDocumentLines.lineIndex));
+  const { doc, lines } = result;
 
   const total = calcDocTotal(lines);
 

--- a/src/db/index.test.ts
+++ b/src/db/index.test.ts
@@ -49,6 +49,9 @@ describe("db initialization", () => {
     expect(dbModule.getDb()).toBe(drizzleDb);
     expect(postgres).toHaveBeenCalledWith(process.env.DATABASE_URL, {
       prepare: false,
+      max: 10,
+      connect_timeout: 10,
+      idle_timeout: 30,
     });
     expect(drizzle).toHaveBeenCalledWith({
       client: postgresClient,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -16,7 +16,21 @@ export function getDb() {
   }
 
   const client = postgres(databaseUrl, {
-    prepare: false, // Required for Supabase transaction pooler
+    // Required for Supabase transaction pooler — prepared statements are
+    // unsupported there because every transaction can land on a different
+    // backend connection.
+    prepare: false,
+    // Cap the pool to avoid exhausting Supabase free-tier connection limits
+    // (default 60 inbound). 10 sockets × N container instances must stay
+    // well under that ceiling. Bump only after observing saturation in logs.
+    max: 10,
+    // Surface "DB unreachable" within ~10s instead of letting requests hang
+    // on TCP connect — the API route can return a 5xx fast and let the
+    // orchestrator decide whether to take this instance out of rotation.
+    connect_timeout: 10,
+    // Reclaim sockets that have been idle ≥ 30s. Keeps the pool small under
+    // bursty traffic without paying the connect cost on every request.
+    idle_timeout: 30,
   });
 
   cachedDb = drizzle({ client, schema });

--- a/src/lib/api-errors.test.ts
+++ b/src/lib/api-errors.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { dbTimeoutResponse, isStatementTimeoutError } from "./api-errors";
+
+describe("isStatementTimeoutError", () => {
+  it("riconosce un PostgresError con code 57014", () => {
+    const err = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      {
+        code: "57014",
+      },
+    );
+    expect(isStatementTimeoutError(err)).toBe(true);
+  });
+
+  it("ignora un Error senza code", () => {
+    expect(isStatementTimeoutError(new Error("boom"))).toBe(false);
+  });
+
+  it("ignora un PostgresError con code diverso", () => {
+    const err = Object.assign(new Error("unique violation"), { code: "23505" });
+    expect(isStatementTimeoutError(err)).toBe(false);
+  });
+
+  it("ignora valori non-Error / non-oggetto", () => {
+    expect(isStatementTimeoutError(null)).toBe(false);
+    expect(isStatementTimeoutError(undefined)).toBe(false);
+    expect(isStatementTimeoutError("57014")).toBe(false);
+    expect(isStatementTimeoutError(57014)).toBe(false);
+    expect(isStatementTimeoutError({ code: 57014 })).toBe(false); // numero, non stringa
+  });
+
+  it("riconosce oggetti plain con code 57014 (errori postgres-js non sono Error)", () => {
+    // postgres-js lancia oggetti `PostgresError` che ereditano da Error;
+    // accettiamo anche oggetti plain con la stessa shape per robustezza.
+    expect(isStatementTimeoutError({ code: "57014" })).toBe(true);
+  });
+});
+
+describe("dbTimeoutResponse", () => {
+  it("ritorna un Response 503 con body JSON canonico", async () => {
+    const res = dbTimeoutResponse();
+    expect(res.status).toBe(503);
+    expect(res.headers.get("content-type")).toMatch(/json/i);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: expect.any(String) });
+  });
+
+  it("imposta header Retry-After con un valore intero in secondi", () => {
+    const res = dbTimeoutResponse();
+    const retry = res.headers.get("retry-after");
+    expect(retry).not.toBeNull();
+    expect(retry).toMatch(/^\d+$/);
+    expect(Number(retry)).toBeGreaterThan(0);
+  });
+
+  it("usa un error code machine-readable nel body", async () => {
+    const body = (await dbTimeoutResponse().json()) as { code?: string };
+    expect(body.code).toBe("DB_TIMEOUT");
+  });
+});

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Discriminante per gli errori di statement timeout di Postgres.
+ *
+ * Postgres ritorna SQLSTATE `57014` (`query_canceled`) quando una query
+ * eccede `statement_timeout` o riceve un cancel esplicito. È l'unico signal
+ * affidabile di "è stato il timeout" — il messaggio testuale può variare
+ * tra versioni di Postgres e localizzazioni.
+ *
+ * Accetta sia istanze Error (PostgresError di postgres-js eredita da Error)
+ * sia oggetti plain con la stessa shape, per robustezza ai mock di test.
+ */
+export function isStatementTimeoutError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  return code === "57014";
+}
+
+const RETRY_AFTER_SECONDS = 5;
+
+/**
+ * Risposta canonica per un timeout DB lato server.
+ *
+ * 503 (non 500): comunica al client che il fallimento è transient e ritentabile.
+ * `Retry-After` indica il backoff suggerito; il body include un `code`
+ * machine-readable distinto dagli errori logici, così il client può
+ * discriminare retry automatici da errori permanenti senza parsing del testo.
+ */
+export function dbTimeoutResponse(): Response {
+  return Response.json(
+    {
+      code: "DB_TIMEOUT",
+      error:
+        "Servizio temporaneamente sovraccarico, riprova tra qualche istante.",
+    },
+    {
+      status: 503,
+      headers: { "Retry-After": String(RETRY_AFTER_SECONDS) },
+    },
+  );
+}

--- a/src/lib/db-timeout.test.ts
+++ b/src/lib/db-timeout.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockTransaction, mockTxExecute } = vi.hoisted(() => ({
+  mockTransaction: vi.fn(),
+  mockTxExecute: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({ transaction: mockTransaction }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTransaction.mockImplementation(async (fn) =>
+    fn({ execute: mockTxExecute }),
+  );
+  mockTxExecute.mockResolvedValue(undefined);
+});
+
+describe("withStatementTimeout", () => {
+  it("avvolge la callback in db.transaction()", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    await withStatementTimeout(5000, async () => "ok");
+    expect(mockTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("imposta SET LOCAL statement_timeout come primo statement", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    await withStatementTimeout(5000, async () => "ok");
+    // Il primo execute della transazione è il SET LOCAL.
+    expect(mockTxExecute).toHaveBeenCalledTimes(1);
+    const firstCall = mockTxExecute.mock.calls[0][0];
+    // Il SQL fragment di Drizzle ha una proprietà `queryChunks` interna; il
+    // toString o i chunks contengono il timeout numerico.
+    const stringified = JSON.stringify(firstCall);
+    expect(stringified).toContain("5000");
+    expect(stringified.toLowerCase()).toContain("statement_timeout");
+  });
+
+  it("propaga il valore di ritorno della callback", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    const result = await withStatementTimeout(3000, async () => ({ ok: true }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("passa la tx alla callback", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    let received: unknown = null;
+    await withStatementTimeout(3000, async (tx) => {
+      received = tx;
+      return null;
+    });
+    expect(received).toBeDefined();
+    expect(received).toHaveProperty("execute");
+  });
+
+  it("rifiuta timeout non positivi (guard contro misconfig)", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    await expect(withStatementTimeout(0, async () => null)).rejects.toThrow(
+      /positive/i,
+    );
+    await expect(withStatementTimeout(-1, async () => null)).rejects.toThrow(
+      /positive/i,
+    );
+  });
+
+  it("rifiuta timeout non interi (statement_timeout vuole un intero)", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    await expect(withStatementTimeout(1.5, async () => null)).rejects.toThrow(
+      /integer/i,
+    );
+  });
+
+  it("propaga errori della callback", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    mockTransaction.mockImplementation(async (fn) =>
+      fn({ execute: mockTxExecute }),
+    );
+    await expect(
+      withStatementTimeout(1000, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("propaga errori statement_timeout (Postgres code 57014)", async () => {
+    const { withStatementTimeout } = await import("./db-timeout");
+    const pgErr = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      {
+        code: "57014",
+      },
+    );
+    mockTransaction.mockImplementation(async () => {
+      throw pgErr;
+    });
+    await expect(
+      withStatementTimeout(1000, async () => "never"),
+    ).rejects.toMatchObject({ code: "57014" });
+  });
+});

--- a/src/lib/db-timeout.ts
+++ b/src/lib/db-timeout.ts
@@ -1,0 +1,46 @@
+import { sql } from "drizzle-orm";
+import { getDb } from "@/db";
+
+type DrizzleDb = ReturnType<typeof getDb>;
+type DrizzleTx = Parameters<Parameters<DrizzleDb["transaction"]>[0]>[0];
+
+/**
+ * Esegue `fn` dentro una transazione preceduta da
+ * `SET LOCAL statement_timeout = <ms>`.
+ *
+ * Pattern già provato nella readiness probe (`/api/health/ready`):
+ * Postgres aborta lo statement con error code `57014` se eccede il budget e
+ * recupera la connessione dal pool. `SET LOCAL` resta scoped alla transazione
+ * — sicuro anche con il transaction pooler di Supabase, dove le sessioni non
+ * sono persistenti tra transazioni.
+ *
+ * `timeoutMs` deve essere un intero positivo: Postgres rifiuta valori non
+ * interi e un valore <= 0 disabiliterebbe il timeout — bug più che feature.
+ *
+ * Drizzle non propaga `AbortSignal` attraverso il query builder, perciò
+ * `SET LOCAL statement_timeout` è l'unico meccanismo affidabile per imporre
+ * un budget di latenza dal lato applicativo.
+ */
+export async function withStatementTimeout<T>(
+  timeoutMs: number,
+  fn: (tx: DrizzleTx) => Promise<T>,
+): Promise<T> {
+  if (!Number.isInteger(timeoutMs)) {
+    throw new TypeError(
+      `withStatementTimeout: timeoutMs must be an integer, got ${timeoutMs}`,
+    );
+  }
+  if (timeoutMs <= 0) {
+    throw new RangeError(
+      `withStatementTimeout: timeoutMs must be positive, got ${timeoutMs}`,
+    );
+  }
+
+  const db = getDb();
+  return db.transaction(async (tx) => {
+    // sql.raw è sicuro qui: timeoutMs è un intero validato sopra, non
+    // c'è nessun input utente nella query.
+    await tx.execute(sql.raw(`SET LOCAL statement_timeout = ${timeoutMs}`));
+    return fn(tx);
+  });
+}

--- a/tests/unit/api-v1-receipt-get.test.ts
+++ b/tests/unit/api-v1-receipt-get.test.ts
@@ -16,6 +16,8 @@ const {
   mockLinesWhere,
   mockLinesFrom,
   mockSelect,
+  mockTransaction,
+  mockTxExecute,
 } = vi.hoisted(() => ({
   mockAuthenticateApiKey: vi.fn(),
   mockIsApiKeyAuthError: vi.fn(),
@@ -28,6 +30,8 @@ const {
   mockLinesWhere: vi.fn(),
   mockLinesFrom: vi.fn(),
   mockSelect: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockTxExecute: vi.fn(),
 }));
 
 vi.mock("@/lib/api-auth", () => ({
@@ -52,6 +56,7 @@ vi.mock("drizzle-orm", () => ({
   and: vi.fn(),
   eq: vi.fn(),
   asc: vi.fn(),
+  sql: { raw: vi.fn((s) => ({ raw: s })) },
 }));
 
 // --- Helpers ---
@@ -93,7 +98,18 @@ describe("GET /api/v1/receipts/[id]", () => {
     mockSelect
       .mockReturnValueOnce({ from: mockFrom })
       .mockReturnValueOnce({ from: mockLinesFrom });
-    mockGetDb.mockReturnValue({ select: mockSelect });
+
+    // withStatementTimeout wraps queries in db.transaction(cb) — wire the
+    // tx callback to expose the same select chain configured above.
+    mockTransaction.mockImplementation(async (cb) =>
+      cb({ execute: mockTxExecute, select: mockSelect }),
+    );
+    mockTxExecute.mockResolvedValue(undefined);
+
+    mockGetDb.mockReturnValue({
+      select: mockSelect,
+      transaction: mockTransaction,
+    });
   });
 
   describe("UUID validation", () => {


### PR DESCRIPTION
Pone le basi per il backlog B13 (DB query timeouts) con scope contenuto:
foundation + applicazione mirata a una sola route come proof-of-concept.

Foundation
- `src/db/index.ts`: postgres-js client ora configurato con `max: 10`,
  `connect_timeout: 10s`, `idle_timeout: 30s`. Cap conservativo per non
  saturare le 60 connessioni inbound del free tier Supabase; alzare solo
  se osserviamo saturazione nei log.
- `src/lib/db-timeout.ts`: helper `withStatementTimeout(timeoutMs, fn)`
  che avvolge la callback in `db.transaction()` preceduta da
  `SET LOCAL statement_timeout`. Pattern già provato in
  `/api/health/ready`. Drizzle non propaga AbortSignal, perciò questa è
  l'unica via per imporre un budget di latenza dal lato applicativo.
  Validazione di `timeoutMs` come intero positivo.
- `src/lib/api-errors.ts`: `isStatementTimeoutError(err)` discrimina su
  SQLSTATE 57014 (`query_canceled` di Postgres). `dbTimeoutResponse()`
  ritorna 503 + `Retry-After: 5` + body `{ code: "DB_TIMEOUT" }` —
  machine-readable, distinto dagli errori logici.

Applicazione mirata
- `GET /api/v1/receipts/[id]`: query doc + lines ora dentro
  `withStatementTimeout(3000, ...)`. 3s di budget cattura solo gli stalli
  reali (DB sovraccarico, lock attesi) senza falsi positivi su due SELECT
  indicizzate. Su 57014: `logger.warn` strutturato + 503 retryable.
  Errori non-timeout passano oltre alla error boundary di Next.js.

Test
- 16 nuovi test (8 db-timeout + 8 api-errors), 100% coverage sui nuovi file.
- Aggiornato test snapshot del client postgres-js (nuove opzioni pool).
- Aggiornati 2 test file della route per il nuovo pattern transaction.
- Aggiunto test 503 con `Retry-After` + log warn strutturato + test che
  verifica passthrough di errori DB non-timeout.
- Suite completa: 1693 test verdi.

Refs PLAN.md backlog B13. Phase 2 (apply a list/PDF/emit/void) in PR
follow-up dopo merge di questa.