### PR TITLE
ci: silence lint warnings and Node 20 deprecation notices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gitleaks-action v2 is still pinned to Node 20. Opt into Node 24 to
+          # silence the deprecation warning until upstream ships a Node 24 build.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
   # Audit dipendenze — gira anche su modifiche al solo lockfile
   audit:
@@ -181,6 +184,6 @@ jobs:
         with:
           name: next-build
           path: |
-            .next/
-            !.next/cache
+            .next/**
+            !.next/cache/**
           retention-days: 1

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,18 @@ const eslintConfig = defineConfig([
     plugins: { prettier: prettierPlugin },
     rules: {
       "prettier/prettier": "error",
+      // Honor the `_` prefix convention for intentionally unused variables/args.
+      // Required when an interface or signature forces a parameter name (e.g.
+      // route handlers `GET(_req)`, mock client `submitSale(_payload)`).
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
     },
   },
   prettierConfig,

--- a/src/lib/ade/mapper.test.ts
+++ b/src/lib/ade/mapper.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import type { AdeCedentePrestatore, AdeDocumentDetail } from "./types";
 import type {
-  PaymentRequest,
   SaleDocumentRequest,
   SaleLineRequest,
   VoidRequest,

--- a/src/lib/api-keys.test.ts
+++ b/src/lib/api-keys.test.ts
@@ -95,7 +95,6 @@ describe("isValidApiKeyFormat", () => {
 
   it("accetta body con tutti i caratteri base64url validi", () => {
     // base64url: A-Z, a-z, 0-9, -, _
-    const body = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwx01"; // 50 — no, must be 48
     const body48 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwx".slice(
       0,
       48,

--- a/src/server/account-actions.test.ts
+++ b/src/server/account-actions.test.ts
@@ -10,7 +10,6 @@ vi.mock("@/lib/server-auth", () => ({
   getAuthenticatedUser: () => mockGetAuthenticatedUser(),
 }));
 
-const mockDeleteWhere = vi.fn();
 const mockDeleteReturning = vi.fn();
 vi.mock("@/db", () => ({
   getDb: vi.fn().mockReturnValue({

--- a/tests/unit/scripts-rotate-encryption-key.test.ts
+++ b/tests/unit/scripts-rotate-encryption-key.test.ts
@@ -135,7 +135,6 @@ describe("rotateEncryptionKey", () => {
     const oldKeyHex = makeKeyHex();
     const newKeyHex = makeKeyHex();
     const oldKeyBuf = Buffer.from(oldKeyHex, "hex");
-    const newKeyBuf = Buffer.from(newKeyHex, "hex");
 
     const row1 = makeRow("id-1", 1, oldKeyBuf, "CF001", "pass001", "1111");
     const row2 = makeRow("id-2", 1, oldKeyBuf, "CF002", "pass002", "2222");

--- a/tests/unit/server-storico-actions.test.ts
+++ b/tests/unit/server-storico-actions.test.ts
@@ -14,9 +14,6 @@ const {
   mockDocsWhere,
   mockDocsFrom,
   mockCountFrom,
-  mockLinesOrderBy,
-  mockLinesWhere,
-  mockLinesFrom,
   mockSelect,
 } = vi.hoisted(() => ({
   mockGetAuthenticatedUser: vi.fn(),
@@ -29,9 +26,6 @@ const {
   mockDocsWhere: vi.fn(),
   mockDocsFrom: vi.fn(),
   mockCountFrom: vi.fn(),
-  mockLinesOrderBy: vi.fn(),
-  mockLinesWhere: vi.fn(),
-  mockLinesFrom: vi.fn(),
   mockSelect: vi.fn(),
 }));
 


### PR DESCRIPTION
- ESLint: honor the `_` prefix convention for intentionally unused
  vars/args (required for signatures forced by interfaces, e.g.
  route handlers `GET(_req)` and mock client `submitSale(_payload)`).
- Remove stray unused imports/locals not covered by the convention.
- Gitleaks: opt in to Node 24 via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
  to silence the runner deprecation warning until upstream ships a
  Node 24 build.
- upload-artifact: use explicit `.next/**` / `!.next/cache/**` globs
  so the build output is uploaded reliably under v7 path semantics.