### PR TITLE
Remove NCC/taxi category from platform

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -25,7 +25,6 @@ import {
   Scissors,
   Wrench,
   BedDouble,
-  Car,
   Percent,
   Briefcase,
 } from "lucide-react";
@@ -273,13 +272,6 @@ export default function Home() {
                 title: "B&B e strutture ricettive",
                 description:
                   "Ideale per attività stagionali che non vogliono un registratore fisso.",
-              },
-              {
-                icon: Car,
-                slug: "ncc-taxi",
-                title: "NCC e taxi",
-                description:
-                  "Zero hardware aggiuntivo: basta lo smartphone che già usi ogni giorno.",
               },
               {
                 icon: Percent,

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -5,7 +5,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(40);
+    expect(result).toHaveLength(39);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -33,7 +33,6 @@ describe("sitemap", () => {
       "https://scontrinozero.it/per/parrucchieri-estetisti",
       "https://scontrinozero.it/per/artigiani",
       "https://scontrinozero.it/per/b-and-b",
-      "https://scontrinozero.it/per/ncc-taxi",
       "https://scontrinozero.it/per/regime-forfettario",
       "https://scontrinozero.it/per/professionisti",
     ];
@@ -47,39 +46,39 @@ describe("sitemap", () => {
     }
 
     // Legal
-    expect(result[10]).toMatchObject({
+    expect(result[9]).toMatchObject({
       url: "https://scontrinozero.it/privacy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[11]).toMatchObject({
+    expect(result[10]).toMatchObject({
       url: "https://scontrinozero.it/privacy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[12]).toMatchObject({
+    expect(result[11]).toMatchObject({
       url: "https://scontrinozero.it/termini",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[13]).toMatchObject({
+    expect(result[12]).toMatchObject({
       url: "https://scontrinozero.it/termini/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[14]).toMatchObject({
+    expect(result[13]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[15]).toMatchObject({
+    expect(result[14]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
 
     // Help center hub
-    expect(result[16]).toMatchObject({
+    expect(result[15]).toMatchObject({
       url: "https://scontrinozero.it/help",
       changeFrequency: "monthly",
       priority: 0.6,
@@ -115,12 +114,12 @@ describe("sitemap", () => {
     }
 
     // Auth pages (last two)
-    expect(result[38]).toMatchObject({
+    expect(result[37]).toMatchObject({
       url: "https://scontrinozero.it/login",
       changeFrequency: "yearly",
       priority: 0.5,
     });
-    expect(result[39]).toMatchObject({
+    expect(result[38]).toMatchObject({
       url: "https://scontrinozero.it/register",
       changeFrequency: "yearly",
       priority: 0.5,
@@ -138,8 +137,8 @@ describe("sitemap", () => {
     expect(result[1].url).toBe("https://test.scontrinozero.it/prezzi");
     expect(result[2].url).toBe("https://test.scontrinozero.it/funzionalita");
     expect(result[3].url).toBe("https://test.scontrinozero.it/per/ambulanti");
-    expect(result[10].url).toBe("https://test.scontrinozero.it/privacy");
-    expect(result[16].url).toBe("https://test.scontrinozero.it/help");
+    expect(result[9].url).toBe("https://test.scontrinozero.it/privacy");
+    expect(result[15].url).toBe("https://test.scontrinozero.it/help");
 
     vi.unstubAllEnvs();
   });

--- a/src/lib/per/categories.test.ts
+++ b/src/lib/per/categories.test.ts
@@ -7,8 +7,8 @@ import {
 } from "./categories";
 
 describe("categorySlugs", () => {
-  it("contains exactly 7 slugs", () => {
-    expect(categorySlugs).toHaveLength(7);
+  it("contains exactly 6 slugs", () => {
+    expect(categorySlugs).toHaveLength(6);
   });
 
   it("contains the expected slugs", () => {
@@ -18,7 +18,6 @@ describe("categorySlugs", () => {
         "parrucchieri-estetisti",
         "artigiani",
         "b-and-b",
-        "ncc-taxi",
         "regime-forfettario",
         "professionisti",
       ]),
@@ -36,7 +35,6 @@ describe("categories dictionary", () => {
     "parrucchieri-estetisti",
     "artigiani",
     "b-and-b",
-    "ncc-taxi",
     "regime-forfettario",
     "professionisti",
   ] as const) {

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -22,7 +22,6 @@ export type CategorySlug =
   | "parrucchieri-estetisti"
   | "artigiani"
   | "b-and-b"
-  | "ncc-taxi"
   | "regime-forfettario"
   | "professionisti";
 
@@ -31,7 +30,6 @@ export const categorySlugs: readonly CategorySlug[] = [
   "parrucchieri-estetisti",
   "artigiani",
   "b-and-b",
-  "ncc-taxi",
   "regime-forfettario",
   "professionisti",
 ];
@@ -212,50 +210,6 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       },
     ],
     relatedHelp: ["primo-scontrino", "aliquote-iva", "intestazione-scontrino"],
-  },
-  "ncc-taxi": {
-    slug: "ncc-taxi",
-    title: "Scontrino elettronico per NCC e taxi",
-    metaTitle: "Scontrino elettronico per NCC e taxi | ScontrinoZero",
-    metaDescription:
-      "Emetti lo scontrino al passeggero direttamente dallo smartphone, a fine corsa. Senza tassametro fiscale aggiuntivo. Da €2,50/mese, prova 30 giorni.",
-    heroSubtitle:
-      "Emetti lo scontrino a fine corsa direttamente dal telefono che usi già per il navigatore. Niente cassetto fiscale aggiuntivo in vettura.",
-    audience: "noleggiatori con conducente (NCC), tassisti, autisti turistici",
-    useCase:
-      "Gli NCC e i taxi sono obbligati a rilasciare lo scontrino al passeggero per la corsa effettuata. ScontrinoZero ti permette di emetterlo dal telefono al termine della corsa, con l'importo già calcolato. Il passeggero riceve il documento via link o QR. Nessun hardware in più rispetto a quello che hai già in vettura.",
-    obligations: [
-      "Emissione del Documento Commerciale Online per la corsa effettuata, su richiesta del passeggero o automaticamente per importi rilevanti.",
-      "Applicazione dell'aliquota IVA 10% per il trasporto urbano e suburbano di persone (DPR 633/72 Tab. A, parte III, n. 127-novies).",
-      "Trasmissione corrispettivi all'Agenzia delle Entrate entro 12 giorni.",
-      "Per gli NCC: rispetto della disciplina specifica L. 21/1992 e successive modifiche.",
-    ],
-    benefits: [
-      "Emissione veloce: importo, IVA al 10% pre-configurato, scontrino in pochi secondi.",
-      "Pagamento misto contanti/POS gestito in un'unica transazione.",
-      "Funziona sul telefono che già usi per il navigatore e l'app di prenotazione.",
-      "Storico corse consultabile e ricercabile; export CSV in arrivo sul piano Pro.",
-    ],
-    faq: [
-      {
-        question:
-          "Va bene anche per chi lavora con piattaforme tipo Uber o Bolt?",
-        answer:
-          'Per le corse intermediate da piattaforme la fatturazione segue regole specifiche definite dal contratto con la piattaforma stessa. Per le corse "private" effettuate al di fuori della piattaforma, ScontrinoZero è la soluzione naturale.',
-      },
-      {
-        question: "L'aliquota 10% si applica a tutte le corse?",
-        answer:
-          "Si applica al trasporto urbano e suburbano di persone. Per altre prestazioni (es. tour turistici, transfer aeroportuali extraurbani) verifica con il commercialista l'aliquota applicabile.",
-      },
-      {
-        question:
-          "Posso emettere lo scontrino se il passeggero paga in contanti?",
-        answer:
-          "Sì. ScontrinoZero gestisce pagamenti in contanti, con carta o misti. L'importante è che lo scontrino sia emesso a conclusione della corsa.",
-      },
-    ],
-    relatedHelp: ["primo-scontrino", "aliquote-iva", "installare-app"],
   },
   "regime-forfettario": {
     slug: "regime-forfettario",


### PR DESCRIPTION
## Summary
Removes the "ncc-taxi" category from the ScontrinoZero platform, including all related configuration, content, and UI references.

## Changes
- **Category definition** (`src/lib/per/categories.ts`):
  - Removed `"ncc-taxi"` from the `CategorySlug` type union
  - Removed `"ncc-taxi"` from the `categorySlugs` array
  - Removed the entire `"ncc-taxi"` category object (50 lines) containing title, meta tags, hero subtitle, audience, use cases, obligations, benefits, FAQs, and related help links

- **Homepage UI** (`src/app/(marketing)/page.tsx`):
  - Removed the NCC/taxi card from the category showcase grid
  - Removed the `Car` icon import (no longer needed)

- **Tests**:
  - Updated `src/lib/per/categories.test.ts`: adjusted expected slug count from 7 to 6, removed `"ncc-taxi"` from expected slugs array
  - Updated `src/app/sitemap.test.ts`: adjusted total sitemap length from 40 to 39 entries, removed the NCC/taxi URL from expected sitemap entries, updated all subsequent test indices to account for the removed entry

## Impact
- Reduces the number of supported categories from 7 to 6
- Removes one URL from the sitemap
- No breaking changes to remaining categories or functionality

https://claude.ai/code/session_017i8XKCFm1NVvvLhBpvB6Uo