### PR TITLE
docs(readme): allinea badge versione a v1.2.11 prima del tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ La versione self-hosted include tutte le funzionalità della versione SaaS; il v
 
 ## Stato del progetto
 
-🚀 **v1.2.13 — in produzione su [scontrinozero.it](https://scontrinozero.it)**
+🚀 **v1.2.11 — in produzione su [scontrinozero.it](https://scontrinozero.it)**
 
 Roadmap dettagliata in [`PLAN.md`](./PLAN.md). Lavoro in corso su SEO foundations (v1.2.8 → v1.2.15) e lancio open source.
 


### PR DESCRIPTION
package.json/package-lock.json/CLAUDE.md/PLAN.md sono già su v1.2.11;
README riportava ancora v1.2.13 (riferimento a release "logica" pre-consolidamento).