### PR TITLE
docs(plan): allinea v1.3.0 a Analytics Pro + Export CSV async via email

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -10,7 +10,7 @@ La versione pubblicata corrente Ã¨ in `package.json`. Lo storico delle release Ã
 
 | Versione     | Descrizione                                                                                                                  |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| **v1.3.0**   | Analytics dashboard Pro (KPI + sparkline + breakdown) + Export CSV scontrini Pro asincrono via email                         |
+| **v1.3.0**   | Analytics dashboard Pro (KPI + sparkline + breakdown) + Export CSV scontrini Pro (download diretto streaming)                |
 | **v1.4.0**   | Coupon/promo codes, referral program, Stripe Customer Portal polish                                                          |
 | **v1.5.0**   | Email scontrino al cliente (PDF allegato via Resend)                                                                         |
 | **v1.7.0**   | Catalogo: modifica prodotto + sync AdE (HAR: aggiungi/modifica/elimina)                                                      |

--- a/PLAN.md
+++ b/PLAN.md
@@ -10,10 +10,9 @@ La versione pubblicata corrente Ã¨ in `package.json`. Lo storico delle release Ã
 
 | Versione     | Descrizione                                                                                                                  |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| **v1.3.0**   | Analytics dashboard, export CSV, coupon/promo                                                                                |
+| **v1.3.0**   | Analytics dashboard Pro (KPI + sparkline + breakdown) + Export CSV scontrini Pro asincrono via email                         |
 | **v1.4.0**   | Coupon/promo codes, referral program, Stripe Customer Portal polish                                                          |
 | **v1.5.0**   | Email scontrino al cliente (PDF allegato via Resend)                                                                         |
-| **v1.6.0**   | Dashboard analytics: totale giornaliero, sparkline revenue, export CSV                                                       |
 | **v1.7.0**   | Catalogo: modifica prodotto + sync AdE (HAR: aggiungi/modifica/elimina)                                                      |
 | **v1.8.0**   | AdE auth multi-metodo: SPID e CIE selezionabili in onboarding + settings; cookie jar cifrato, re-auth on 401                 |
 | **v1.9.0**   | CSV import prodotti, barcode scanner (BarcodeDetector API), Umami analytics                                                  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.5",
         "react-hook-form": "^7.75.0",
+        "recharts": "^3.8.1",
         "resend": "^6.12.2",
         "serwist": "^9.5.7",
         "sonner": "^2.0.7",
@@ -5513,6 +5514,42 @@
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.13",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
@@ -6966,7 +7003,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -7633,6 +7669,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -7775,6 +7874,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -9786,6 +9891,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -9919,6 +10145,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -11170,6 +11402,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -11770,7 +12012,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -12821,6 +13062,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12893,6 +13144,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -16260,8 +16520,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -16358,6 +16640,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -16370,6 +16682,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -16447,6 +16774,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resend": {
       "version": "6.12.2",
@@ -17955,7 +18288,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -18597,6 +18929,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.5",
     "react-hook-form": "^7.75.0",
+    "recharts": "^3.8.1",
     "resend": "^6.12.2",
     "serwist": "^9.5.7",
     "sonner": "^2.0.7",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -72,6 +72,9 @@ sonar.coverage.exclusions=\
   src/components/cassa/receipt-success.tsx,\
   src/components/storico/storico-client.tsx,\
   src/components/storico/void-receipt-dialog.tsx,\
+  src/components/analytics/analytics-client.tsx,\
+  src/components/analytics/revenue-sparkline.tsx,\
+  src/components/analytics/payment-breakdown.tsx,\
   src/components/providers.tsx,\
   src/app/r/**/page.tsx,\
   src/components/billing/checkout-button.tsx,\

--- a/src/app/api/export/receipts/route.test.ts
+++ b/src/app/api/export/receipts/route.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetUser,
+  mockAssertProPlan,
+  mockRateLimiterCheck,
+  mockSelect,
+  mockBuildReceiptsCsvStream,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockAssertProPlan: vi.fn(),
+  mockRateLimiterCheck: vi.fn(),
+  mockSelect: vi.fn(),
+  mockBuildReceiptsCsvStream: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/lib/plans", () => ({
+  assertProPlan: mockAssertProPlan,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockRateLimiterCheck };
+  }),
+  RATE_LIMIT_WINDOWS: { AUTH_15_MIN: 900_000, HOURLY: 3_600_000 },
+}));
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({ select: mockSelect }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  profiles: { id: "p_id", authUserId: "p_auth" },
+  businesses: { id: "b_id", profileId: "b_profile" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (a: unknown, b: unknown) => ({ _eq: [a, b] }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/receipts/csv-export", () => ({
+  buildReceiptsCsvStream: mockBuildReceiptsCsvStream,
+}));
+
+import { GET } from "./route";
+
+// --- Helpers ---
+
+function makeSelectBuilder(result: unknown[]) {
+  const builder = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn().mockResolvedValue(result),
+  };
+  builder.from.mockReturnValue(builder);
+  builder.innerJoin.mockReturnValue(builder);
+  builder.where.mockReturnValue(builder);
+  return builder;
+}
+
+function makeRequest(qs = ""): Request {
+  return new Request(`http://localhost/api/export/receipts${qs}`);
+}
+
+function makeFakeStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode("hello"));
+      c.close();
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  mockAssertProPlan.mockResolvedValue({ ok: true, plan: "pro" });
+  mockRateLimiterCheck.mockReturnValue({
+    success: true,
+    remaining: 9,
+    resetAt: 0,
+  });
+  mockSelect.mockReturnValue(makeSelectBuilder([{ id: "biz-1" }]));
+  mockBuildReceiptsCsvStream.mockReturnValue(makeFakeStream());
+});
+
+describe("GET /api/export/receipts", () => {
+  it("restituisce 401 se non autenticato", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockAssertProPlan.mockResolvedValue({
+      ok: false,
+      status: 401,
+      error: "Non autenticato.",
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("restituisce 403 se il piano non e' Pro", async () => {
+    mockAssertProPlan.mockResolvedValue({
+      ok: false,
+      status: 403,
+      error: "Funzionalità riservata al piano Pro.",
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("restituisce 429 se rate limit superato", async () => {
+    mockRateLimiterCheck.mockReturnValue({
+      success: false,
+      remaining: 0,
+      resetAt: 0,
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+    expect(mockBuildReceiptsCsvStream).not.toHaveBeenCalled();
+  });
+
+  it("restituisce 404 se l'utente non ha un business", async () => {
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("restituisce 400 se la data 'from' non e' yyyy-MM-dd", async () => {
+    const res = await GET(makeRequest("?from=2026/01/01"));
+    expect(res.status).toBe(400);
+  });
+
+  it("restituisce 400 se status non e' tra i valori ammessi", async () => {
+    const res = await GET(makeRequest("?status=PENDING"));
+    expect(res.status).toBe(400);
+  });
+
+  it("restituisce 400 se dateFrom > dateTo", async () => {
+    const res = await GET(makeRequest("?from=2026-05-19&to=2026-01-01"));
+    expect(res.status).toBe(400);
+  });
+
+  it("restituisce 200 con header text/csv per il piano Pro", async () => {
+    const res = await GET(makeRequest("?from=2026-01-01&to=2026-05-19"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+    expect(res.headers.get("Content-Disposition")).toContain(
+      'filename="scontrini-2026-01-01-2026-05-19.csv"',
+    );
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("passa businessId, dateFrom e dateTo (exclusive) a buildReceiptsCsvStream", async () => {
+    await GET(makeRequest("?from=2026-01-01&to=2026-05-19&status=ACCEPTED"));
+    expect(mockBuildReceiptsCsvStream).toHaveBeenCalledWith({
+      businessId: "biz-1",
+      status: "ACCEPTED",
+      dateFrom: new Date("2026-01-01T00:00:00.000Z"),
+      // dateTo viene convertito in upper bound exclusive (giorno successivo)
+      dateTo: new Date("2026-05-20T00:00:00.000Z"),
+    });
+  });
+
+  it("passa null per i filtri opzionali assenti", async () => {
+    await GET(makeRequest());
+    expect(mockBuildReceiptsCsvStream).toHaveBeenCalledWith({
+      businessId: "biz-1",
+      status: null,
+      dateFrom: null,
+      dateTo: null,
+    });
+  });
+
+  it("usa rate limit key per-user (csv:<userId>)", async () => {
+    await GET(makeRequest());
+    expect(mockRateLimiterCheck).toHaveBeenCalledWith("csv:user-1");
+  });
+});

--- a/src/app/api/export/receipts/route.ts
+++ b/src/app/api/export/receipts/route.ts
@@ -1,0 +1,131 @@
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb } from "@/db";
+import { businesses, profiles } from "@/db/schema";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { assertProPlan } from "@/lib/plans";
+import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+import { parseStrictIsoDateUtc } from "@/lib/date-utils";
+import {
+  buildReceiptsCsvStream,
+  type ReceiptStatusFilter,
+} from "@/lib/receipts/csv-export";
+
+const csvExportLimiter = new RateLimiter({
+  maxRequests: 10,
+  windowMs: RATE_LIMIT_WINDOWS.HOURLY,
+});
+
+const STATUS_VALUES = ["ACCEPTED", "VOID_ACCEPTED"] as const;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+const querySchema = z.object({
+  from: z
+    .string()
+    .regex(ISO_DATE, "Formato data 'from' non valido (yyyy-MM-dd).")
+    .optional(),
+  to: z
+    .string()
+    .regex(ISO_DATE, "Formato data 'to' non valido (yyyy-MM-dd).")
+    .optional(),
+  status: z.enum(STATUS_VALUES).optional(),
+});
+
+function errorJson(status: number, error: string): Response {
+  return Response.json({ error }, { status });
+}
+
+function buildFilename(
+  from: string | undefined,
+  to: string | undefined,
+): string {
+  const start = from ?? "tutti";
+  const end = to ?? "tutti";
+  return `scontrini-${start}-${end}.csv`;
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse({
+    from: url.searchParams.get("from") ?? undefined,
+    to: url.searchParams.get("to") ?? undefined,
+    status: url.searchParams.get("status") ?? undefined,
+  });
+  if (!parsed.success) {
+    return errorJson(
+      400,
+      parsed.error.issues[0]?.message ?? "Parametri non validi.",
+    );
+  }
+  const { from, to, status } = parsed.data;
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const proCheck = await assertProPlan(user?.id ?? null);
+  if (!proCheck.ok) {
+    return errorJson(proCheck.status, proCheck.error);
+  }
+  // user is guaranteed non-null here (assertProPlan returns 401 otherwise)
+  const userId = user!.id;
+
+  const rate = csvExportLimiter.check(`csv:${userId}`);
+  if (!rate.success) {
+    logger.warn({ userId }, "CSV export rate limit exceeded");
+    return errorJson(429, "Troppe esportazioni. Riprova tra qualche minuto.");
+  }
+
+  const db = getDb();
+  const [biz] = await db
+    .select({ id: businesses.id })
+    .from(profiles)
+    .innerJoin(businesses, eq(businesses.profileId, profiles.id))
+    .where(eq(profiles.authUserId, userId))
+    .limit(1);
+
+  if (!biz) {
+    return errorJson(404, "Business non trovato.");
+  }
+
+  const dateFrom = from ? parseStrictIsoDateUtc(from) : null;
+  if (from && !dateFrom) {
+    return errorJson(400, "Formato data 'from' non valido (yyyy-MM-dd).");
+  }
+  const dateTo = to ? parseStrictIsoDateUtc(to) : null;
+  if (to && !dateTo) {
+    return errorJson(400, "Formato data 'to' non valido (yyyy-MM-dd).");
+  }
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    return errorJson(
+      400,
+      "La data di inizio non può essere successiva alla data di fine.",
+    );
+  }
+
+  // dateTo is inclusive in user-facing semantics; convert to exclusive
+  // upper bound (start of next day) for the SQL filter.
+  let dateToExclusive: Date | null = null;
+  if (dateTo) {
+    dateToExclusive = new Date(dateTo);
+    dateToExclusive.setUTCDate(dateToExclusive.getUTCDate() + 1);
+  }
+
+  const stream = buildReceiptsCsvStream({
+    businessId: biz.id,
+    status: (status as ReceiptStatusFilter | undefined) ?? null,
+    dateFrom,
+    dateTo: dateToExclusive,
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${buildFilename(from, to)}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/export/receipts/route.ts
+++ b/src/app/api/export/receipts/route.ts
@@ -36,13 +36,8 @@ function errorJson(status: number, error: string): Response {
   return Response.json({ error }, { status });
 }
 
-function buildFilename(
-  from: string | undefined,
-  to: string | undefined,
-): string {
-  const start = from ?? "tutti";
-  const end = to ?? "tutti";
-  return `scontrini-${start}-${end}.csv`;
+function buildFilename(from: string = "tutti", to: string = "tutti"): string {
+  return `scontrini-${from}-${to}.csv`;
 }
 
 export async function GET(req: Request): Promise<Response> {

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -1,15 +1,74 @@
-import { BarChart2 } from "lucide-react";
+import { redirect } from "next/navigation";
+import { getOnboardingStatus } from "@/server/onboarding-actions";
+import {
+  type AnalyticsKpis,
+  type PaymentBreakdownEntry,
+  type RevenuePoint,
+  getAnalyticsKpis,
+  getPaymentBreakdown,
+  getRevenueTimeseries,
+} from "@/server/analytics-actions";
+import { AnalyticsClient } from "@/components/analytics/analytics-client";
+import { ProFeatureGate } from "@/components/billing/pro-feature-gate";
+import { getAuthenticatedUser } from "@/lib/server-auth";
+import { getPlan } from "@/lib/plans";
 
-export default function AnalyticsPage() {
+const ZERO_KPIS: AnalyticsKpis = {
+  revenueCents: 0,
+  count: 0,
+  aovCents: 0,
+  voidCount: 0,
+};
+
+export default async function AnalyticsPage() {
+  const status = await getOnboardingStatus();
+  if (!status.businessId) redirect("/onboarding");
+
+  const user = await getAuthenticatedUser();
+  const planInfo = await getPlan(user.id);
+
+  if (planInfo.plan !== "pro" && planInfo.plan !== "unlimited") {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold">Analytics</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Andamento ricavi e scontrini per il periodo selezionato.
+          </p>
+        </div>
+        <ProFeatureGate
+          plan={planInfo.plan}
+          title="Analytics avanzata · Pro"
+          description="Dashboard con KPI, andamento ricavi e ripartizione metodi di pagamento. Passa a Pro per attivarla."
+        >
+          <div />
+        </ProFeatureGate>
+      </div>
+    );
+  }
+
+  const businessId = status.businessId;
+  const [kpis, timeseries, breakdown] = await Promise.all([
+    getAnalyticsKpis(businessId, "30d"),
+    getRevenueTimeseries(businessId, "30d"),
+    getPaymentBreakdown(businessId, "30d"),
+  ]);
+
+  const safeKpis: AnalyticsKpis = "error" in kpis ? ZERO_KPIS : kpis;
+  const safeTimeseries: RevenuePoint[] = Array.isArray(timeseries)
+    ? timeseries
+    : [];
+  const safeBreakdown: PaymentBreakdownEntry[] = Array.isArray(breakdown)
+    ? breakdown
+    : [];
+
   return (
-    <div className="flex flex-col items-center justify-center py-20 text-center">
-      <BarChart2 className="text-muted-foreground mb-4 h-12 w-12" />
-      <h1 className="text-2xl font-bold">Analytics</h1>
-      <p className="text-muted-foreground mt-2 max-w-sm text-sm">
-        {
-          "La dashboard analytics è in arrivo. Potrai visualizzare l'andamento delle vendite, i totali giornalieri e molto altro."
-        }
-      </p>
-    </div>
+    <AnalyticsClient
+      businessId={businessId}
+      initialRange="30d"
+      initialKpis={safeKpis}
+      initialTimeseries={safeTimeseries}
+      initialBreakdown={safeBreakdown}
+    />
   );
 }

--- a/src/app/dashboard/storico/export-csv-button.test.tsx
+++ b/src/app/dashboard/storico/export-csv-button.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExportCsvButton } from "./export-csv-button";
+
+describe("ExportCsvButton", () => {
+  it("renders an enabled download link for the pro plan", () => {
+    render(
+      <ExportCsvButton
+        plan="pro"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /esporta csv/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/api/export/receipts?from=2026-01-01&to=2026-05-19",
+    );
+    expect(link).toHaveAttribute("download");
+  });
+
+  it("includes the status filter in the URL when set", () => {
+    render(
+      <ExportCsvButton
+        plan="pro"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status="VOID_ACCEPTED"
+      />,
+    );
+    const link = screen.getByRole("link", { name: /esporta csv/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/api/export/receipts?from=2026-01-01&to=2026-05-19&status=VOID_ACCEPTED",
+    );
+  });
+
+  it("renders an upsell link to settings#billing for non-Pro plans", () => {
+    render(
+      <ExportCsvButton
+        plan="starter"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /esporta csv/i });
+    expect(link).toHaveAttribute("href", "/dashboard/settings#billing");
+    expect(link).not.toHaveAttribute("download");
+  });
+
+  it("marks the upsell link with title to hint the Pro requirement", () => {
+    render(
+      <ExportCsvButton
+        plan="trial"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /esporta csv/i });
+    expect(link.getAttribute("title")?.toLowerCase()).toContain("pro");
+  });
+
+  it("renders the upsell link for unlimited treated as pro (same behaviour)", () => {
+    render(
+      <ExportCsvButton
+        plan="unlimited"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /esporta csv/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/api/export/receipts?from=2026-01-01&to=2026-05-19",
+    );
+  });
+});

--- a/src/app/dashboard/storico/export-csv-button.tsx
+++ b/src/app/dashboard/storico/export-csv-button.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { canUsePro, type Plan } from "@/lib/plans";
+import { canUsePro, type Plan } from "@/lib/plans-shared";
 
 interface ExportCsvButtonProps {
   readonly plan: Plan;

--- a/src/app/dashboard/storico/export-csv-button.tsx
+++ b/src/app/dashboard/storico/export-csv-button.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { canUsePro, type Plan } from "@/lib/plans";
+
+interface ExportCsvButtonProps {
+  readonly plan: Plan;
+  readonly dateFrom: string;
+  readonly dateTo: string;
+  readonly status: "ACCEPTED" | "VOID_ACCEPTED" | null;
+}
+
+function buildExportUrl(props: ExportCsvButtonProps): string {
+  const params = new URLSearchParams();
+  params.set("from", props.dateFrom);
+  params.set("to", props.dateTo);
+  if (props.status) params.set("status", props.status);
+  return `/api/export/receipts?${params.toString()}`;
+}
+
+export function ExportCsvButton(props: ExportCsvButtonProps) {
+  if (canUsePro(props.plan)) {
+    return (
+      <Button asChild variant="outline">
+        <a href={buildExportUrl(props)} download>
+          <Download className="size-4" aria-hidden />
+          Esporta CSV
+        </a>
+      </Button>
+    );
+  }
+
+  return (
+    <Button asChild variant="outline">
+      <Link
+        href="/dashboard/settings#billing"
+        title="Esportazione CSV disponibile sul piano Pro"
+      >
+        <Download className="size-4" aria-hidden />
+        Esporta CSV
+      </Link>
+    </Button>
+  );
+}

--- a/src/app/dashboard/storico/page.tsx
+++ b/src/app/dashboard/storico/page.tsx
@@ -3,6 +3,8 @@ import { getOnboardingStatus } from "@/server/onboarding-actions";
 import { searchReceipts } from "@/server/storico-actions";
 import { StoricoClient } from "@/components/storico/storico-client";
 import { STORICO_PAGE_SIZE, type StatusFilter } from "@/types/storico";
+import { getAuthenticatedUser } from "@/lib/server-auth";
+import { getPlan } from "@/lib/plans";
 
 const STATUS_VALUES = new Set<StatusFilter>(["ACCEPTED", "VOID_ACCEPTED", ""]);
 
@@ -44,13 +46,17 @@ export default async function StoricoPage({
   const dateTo = al ?? todayStr;
   const statusParam = parseStatus(stato);
 
-  const initialResult = await searchReceipts(status.businessId, {
-    dateFrom,
-    dateTo,
-    ...(statusParam ? { status: statusParam } : {}),
-    page: 1,
-    pageSize: STORICO_PAGE_SIZE,
-  });
+  const [initialResult, user] = await Promise.all([
+    searchReceipts(status.businessId, {
+      dateFrom,
+      dateTo,
+      ...(statusParam ? { status: statusParam } : {}),
+      page: 1,
+      pageSize: STORICO_PAGE_SIZE,
+    }),
+    getAuthenticatedUser(),
+  ]);
+  const planInfo = await getPlan(user.id);
 
   return (
     <StoricoClient
@@ -60,6 +66,7 @@ export default async function StoricoPage({
       initialDateFrom={dateFrom}
       initialDateTo={dateTo}
       initialStatus={statusParam}
+      plan={planInfo.plan}
     />
   );
 }

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useState, useTransition } from "react";
+import {
+  type AnalyticsKpis,
+  type AnalyticsRange,
+  type PaymentBreakdownEntry,
+  type RevenuePoint,
+  getAnalyticsKpis,
+  getPaymentBreakdown,
+  getRevenueTimeseries,
+} from "@/server/analytics-actions";
+import { KpiCards } from "./kpi-cards";
+import { PaymentBreakdown } from "./payment-breakdown";
+import { RevenueSparkline } from "./revenue-sparkline";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AnalyticsClientProps {
+  readonly businessId: string;
+  readonly initialRange: AnalyticsRange;
+  readonly initialKpis: AnalyticsKpis;
+  readonly initialTimeseries: RevenuePoint[];
+  readonly initialBreakdown: PaymentBreakdownEntry[];
+}
+
+const ZERO_KPIS: AnalyticsKpis = {
+  revenueCents: 0,
+  count: 0,
+  aovCents: 0,
+  voidCount: 0,
+};
+
+export function AnalyticsClient({
+  businessId,
+  initialRange,
+  initialKpis,
+  initialTimeseries,
+  initialBreakdown,
+}: AnalyticsClientProps) {
+  const [range, setRange] = useState<AnalyticsRange>(initialRange);
+  const [kpis, setKpis] = useState<AnalyticsKpis>(initialKpis);
+  const [timeseries, setTimeseries] =
+    useState<RevenuePoint[]>(initialTimeseries);
+  const [breakdown, setBreakdown] =
+    useState<PaymentBreakdownEntry[]>(initialBreakdown);
+  const [isPending, startTransition] = useTransition();
+
+  function handleRangeChange(next: string) {
+    if (next !== "7d" && next !== "30d" && next !== "90d") return;
+    const nextRange = next;
+    setRange(nextRange);
+    startTransition(async () => {
+      const [k, t, b] = await Promise.all([
+        getAnalyticsKpis(businessId, nextRange),
+        getRevenueTimeseries(businessId, nextRange),
+        getPaymentBreakdown(businessId, nextRange),
+      ]);
+      setKpis("error" in k ? ZERO_KPIS : k);
+      setTimeseries(Array.isArray(t) ? t : []);
+      setBreakdown(Array.isArray(b) ? b : []);
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">Analytics</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Andamento ricavi e scontrini per il periodo selezionato.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {isPending && (
+            <Loader2 className="text-muted-foreground size-4 animate-spin" />
+          )}
+          <Select value={range} onValueChange={handleRangeChange}>
+            <SelectTrigger className="h-9 w-[160px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7d">Ultimi 7 giorni</SelectItem>
+              <SelectItem value="30d">Ultimi 30 giorni</SelectItem>
+              <SelectItem value="90d">Ultimi 90 giorni</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <KpiCards kpis={kpis} />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Ricavi giornalieri</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <RevenueSparkline data={timeseries} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Metodi di pagamento</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PaymentBreakdown data={breakdown} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/analytics/kpi-cards.test.tsx
+++ b/src/components/analytics/kpi-cards.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { KpiCards } from "./kpi-cards";
+
+describe("KpiCards", () => {
+  it("formats currency values with euro and Italian locale", () => {
+    render(
+      <KpiCards
+        kpis={{
+          revenueCents: 123456,
+          count: 42,
+          aovCents: 2938,
+          voidCount: 3,
+        }}
+      />,
+    );
+    // Tollera Node senza ICU full (no separatore migliaia: "1234,56 €") e
+    // ambienti browser/CI con ICU completo ("1.234,56 €").
+    expect(screen.getByText(/1\.?234,56/)).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText(/29,38/)).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders em-dash for empty datasets instead of NaN €", () => {
+    render(
+      <KpiCards
+        kpis={{ revenueCents: 0, count: 0, aovCents: 0, voidCount: 0 }}
+      />,
+    );
+    // Three monetary cards (revenue, AOV) + two counts; the dash placeholder
+    // applies to the AOV when count is 0 to avoid showing "0,00 €" as if it
+    // were a meaningful number.
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("renders all four KPI titles", () => {
+    render(
+      <KpiCards
+        kpis={{ revenueCents: 0, count: 0, aovCents: 0, voidCount: 0 }}
+      />,
+    );
+    expect(screen.getByText(/ricavi/i)).toBeInTheDocument();
+    expect(screen.getByText(/scontrini emessi/i)).toBeInTheDocument();
+    expect(screen.getByText(/scontrino medio/i)).toBeInTheDocument();
+    expect(screen.getByText(/scontrini annullati/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/analytics/kpi-cards.tsx
+++ b/src/components/analytics/kpi-cards.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils";
+import type { AnalyticsKpis } from "@/server/analytics-actions";
+
+interface KpiCardsProps {
+  readonly kpis: AnalyticsKpis;
+}
+
+function fromCents(cents: number): number {
+  return cents / 100;
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("it-IT").format(value);
+}
+
+interface KpiCardProps {
+  readonly title: string;
+  readonly value: string;
+}
+
+function KpiCard({ title, value }: KpiCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {title}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-semibold">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function KpiCards({ kpis }: KpiCardsProps) {
+  const revenueLabel =
+    kpis.count === 0 ? "—" : formatCurrency(fromCents(kpis.revenueCents));
+  const countLabel = kpis.count === 0 ? "—" : formatCount(kpis.count);
+  const aovLabel =
+    kpis.count === 0 ? "—" : formatCurrency(fromCents(kpis.aovCents));
+  const voidLabel = formatCount(kpis.voidCount);
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <KpiCard title="Ricavi" value={revenueLabel} />
+      <KpiCard title="Scontrini emessi" value={countLabel} />
+      <KpiCard title="Scontrino medio" value={aovLabel} />
+      <KpiCard title="Scontrini annullati" value={voidLabel} />
+    </div>
+  );
+}

--- a/src/components/analytics/payment-breakdown.tsx
+++ b/src/components/analytics/payment-breakdown.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { formatCurrency } from "@/lib/utils";
+import type { PaymentBreakdownEntry } from "@/server/analytics-actions";
+
+const METHOD_LABELS: Record<string, string> = {
+  PC: "Contanti",
+  PE: "Elettronico",
+  other: "Altro",
+};
+
+interface PaymentBreakdownProps {
+  readonly data: readonly PaymentBreakdownEntry[];
+}
+
+export function PaymentBreakdown({ data }: PaymentBreakdownProps) {
+  const chartData = data.map((e) => ({
+    method: METHOD_LABELS[e.method] ?? e.method,
+    revenue: e.revenueCents / 100,
+    count: e.count,
+  }));
+
+  if (chartData.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-[220px] items-center justify-center text-sm">
+        Nessuno scontrino nel periodo selezionato.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[220px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={chartData}
+          margin={{ top: 10, right: 12, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis
+            dataKey="method"
+            stroke="currentColor"
+            fontSize={11}
+            tickLine={false}
+            axisLine={false}
+          />
+          <YAxis
+            tickFormatter={(value) => `${Math.round(value)}€`}
+            stroke="currentColor"
+            fontSize={11}
+            tickLine={false}
+            axisLine={false}
+            width={48}
+          />
+          <Tooltip
+            formatter={(value) => [
+              typeof value === "number" ? formatCurrency(value) : String(value),
+              "Ricavi",
+            ]}
+            contentStyle={{
+              borderRadius: 8,
+              border: "1px solid rgba(0,0,0,0.08)",
+              fontSize: 12,
+            }}
+          />
+          <Bar
+            dataKey="revenue"
+            fill="hsl(var(--primary, 220 90% 56%))"
+            radius={[4, 4, 0, 0]}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/analytics/revenue-sparkline.tsx
+++ b/src/components/analytics/revenue-sparkline.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import type { RevenuePoint } from "@/server/analytics-actions";
+
+interface RevenueSparklineProps {
+  readonly data: readonly RevenuePoint[];
+}
+
+export function RevenueSparkline({ data }: RevenueSparklineProps) {
+  const chartData = data.map((p) => ({
+    date: p.date,
+    revenue: p.revenueCents / 100,
+  }));
+
+  return (
+    <div className="h-[220px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart
+          data={chartData}
+          margin={{ top: 10, right: 12, left: 0, bottom: 0 }}
+        >
+          <XAxis
+            dataKey="date"
+            tickFormatter={(value) => formatDate(value, "2-digit")}
+            stroke="currentColor"
+            fontSize={11}
+            tickLine={false}
+            axisLine={false}
+            minTickGap={24}
+          />
+          <YAxis
+            tickFormatter={(value) => `${Math.round(value)}€`}
+            stroke="currentColor"
+            fontSize={11}
+            tickLine={false}
+            axisLine={false}
+            width={48}
+          />
+          <Tooltip
+            labelFormatter={(value) =>
+              typeof value === "string"
+                ? formatDate(value)
+                : String(value ?? "")
+            }
+            formatter={(value) => [
+              typeof value === "number" ? formatCurrency(value) : String(value),
+              "Ricavi",
+            ]}
+            contentStyle={{
+              borderRadius: 8,
+              border: "1px solid rgba(0,0,0,0.08)",
+              fontSize: 12,
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="revenue"
+            stroke="hsl(var(--primary, 220 90% 56%))"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/billing/pro-feature-gate.test.tsx
+++ b/src/components/billing/pro-feature-gate.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProFeatureGate } from "./pro-feature-gate";
+
+describe("ProFeatureGate", () => {
+  it("renders children when plan is pro", () => {
+    render(
+      <ProFeatureGate plan="pro">
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(screen.getByText("protected content")).toBeInTheDocument();
+  });
+
+  it("renders children when plan is unlimited", () => {
+    render(
+      <ProFeatureGate plan="unlimited">
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(screen.getByText("protected content")).toBeInTheDocument();
+  });
+
+  it("renders upsell card when plan is starter", () => {
+    render(
+      <ProFeatureGate plan="starter">
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    expect(screen.getByText("Disponibile sul piano Pro")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /passa a pro/i });
+    expect(link).toHaveAttribute("href", "/dashboard/settings#billing");
+  });
+
+  it("renders upsell card when plan is trial", () => {
+    render(
+      <ProFeatureGate plan="trial">
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /passa a pro/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders upsell card for developer plans (Pro feature gate is plan-Pro only)", () => {
+    render(
+      <ProFeatureGate plan="developer_indie">
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /passa a pro/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the custom title when provided", () => {
+    render(
+      <ProFeatureGate plan="starter" title="Analytics avanzata">
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(screen.getByText("Analytics avanzata")).toBeInTheDocument();
+  });
+
+  it("uses the custom description when provided", () => {
+    render(
+      <ProFeatureGate
+        plan="starter"
+        description="Sblocca i grafici per i tuoi scontrini."
+      >
+        <div>protected content</div>
+      </ProFeatureGate>,
+    );
+    expect(
+      screen.getByText("Sblocca i grafici per i tuoi scontrini."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/billing/pro-feature-gate.tsx
+++ b/src/components/billing/pro-feature-gate.tsx
@@ -8,7 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { canUsePro, type Plan } from "@/lib/plans";
+import { canUsePro, type Plan } from "@/lib/plans-shared";
 
 interface ProFeatureGateProps {
   readonly plan: Plan;

--- a/src/components/billing/pro-feature-gate.tsx
+++ b/src/components/billing/pro-feature-gate.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { canUsePro, type Plan } from "@/lib/plans";
+
+interface ProFeatureGateProps {
+  readonly plan: Plan;
+  readonly children: React.ReactNode;
+  readonly title?: string;
+  readonly description?: string;
+}
+
+const DEFAULT_TITLE = "Disponibile sul piano Pro";
+const DEFAULT_DESCRIPTION =
+  "Questa funzionalità è inclusa nel piano Pro. Passa a Pro per sbloccarla.";
+
+export function ProFeatureGate({
+  plan,
+  children,
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+}: ProFeatureGateProps) {
+  if (canUsePro(plan)) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="size-4" aria-hidden />
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button asChild>
+          <Link href="/dashboard/settings#billing">Passa a Pro</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/storico/storico-client.tsx
+++ b/src/components/storico/storico-client.tsx
@@ -7,8 +7,10 @@ import { format } from "date-fns";
 import type { DateRange } from "react-day-picker";
 import { searchReceipts } from "@/server/storico-actions";
 import { VoidReceiptDialog } from "./void-receipt-dialog";
+import { ExportCsvButton } from "@/app/dashboard/storico/export-csv-button";
 import { Button } from "@/components/ui/button";
 import { DateRangePicker } from "@/components/ui/date-range-picker";
+import type { Plan } from "@/lib/plans";
 import {
   Select,
   SelectContent,
@@ -84,6 +86,7 @@ interface StoricoClientProps {
   readonly initialDateFrom?: string;
   readonly initialDateTo?: string;
   readonly initialStatus?: StatusFilter;
+  readonly plan: Plan;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +100,7 @@ export function StoricoClient({
   initialDateFrom,
   initialDateTo,
   initialStatus,
+  plan,
 }: StoricoClientProps) {
   const router = useRouter();
   const today = new Date();
@@ -248,6 +252,20 @@ export function StoricoClient({
           {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {isPending ? "Ricerca…" : "Cerca"}
         </Button>
+        <ExportCsvButton
+          plan={plan}
+          dateFrom={
+            dateRange?.from
+              ? format(dateRange.from, "yyyy-MM-dd")
+              : format(sevenDaysAgo, "yyyy-MM-dd")
+          }
+          dateTo={
+            dateRange?.to
+              ? format(dateRange.to, "yyyy-MM-dd")
+              : format(today, "yyyy-MM-dd")
+          }
+          status={statusFilter === "" ? null : statusFilter}
+        />
       </form>
 
       {/* Table */}

--- a/src/components/storico/storico-client.tsx
+++ b/src/components/storico/storico-client.tsx
@@ -10,7 +10,7 @@ import { VoidReceiptDialog } from "./void-receipt-dialog";
 import { ExportCsvButton } from "@/app/dashboard/storico/export-csv-button";
 import { Button } from "@/components/ui/button";
 import { DateRangePicker } from "@/components/ui/date-range-picker";
-import type { Plan } from "@/lib/plans";
+import type { Plan } from "@/lib/plans-shared";
 import {
   Select,
   SelectContent,

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { CSV_BOM, escapeCsvField, rowToCsv, rowsToCsv } from "./csv";
+
+describe("escapeCsvField", () => {
+  it("returns the string as-is when no special chars are present", () => {
+    expect(escapeCsvField("ciao")).toBe("ciao");
+  });
+
+  it("wraps a value containing a comma in double quotes", () => {
+    expect(escapeCsvField("a,b")).toBe('"a,b"');
+  });
+
+  it("wraps a value containing a double quote and doubles the quote (RFC 4180)", () => {
+    expect(escapeCsvField('a"b')).toBe('"a""b"');
+  });
+
+  it("wraps a value containing CR/LF in double quotes", () => {
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+    expect(escapeCsvField("line1\rline2")).toBe('"line1\rline2"');
+    expect(escapeCsvField("line1\r\nline2")).toBe('"line1\r\nline2"');
+  });
+
+  it("returns empty string for null", () => {
+    expect(escapeCsvField(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(escapeCsvField(undefined)).toBe("");
+  });
+
+  it("converts numbers to strings", () => {
+    expect(escapeCsvField(42)).toBe("42");
+    expect(escapeCsvField(3.14)).toBe("3.14");
+  });
+
+  it("converts booleans to strings", () => {
+    expect(escapeCsvField(true)).toBe("true");
+    expect(escapeCsvField(false)).toBe("false");
+  });
+
+  it("converts Date to ISO string", () => {
+    expect(escapeCsvField(new Date("2026-05-19T12:34:56Z"))).toBe(
+      "2026-05-19T12:34:56.000Z",
+    );
+  });
+
+  it("guards against CSV formula injection by prefixing dangerous leaders with apostrophe", () => {
+    expect(escapeCsvField("=cmd|' /C calc'!A0")).toBe("'=cmd|' /C calc'!A0");
+    expect(escapeCsvField("+1+1")).toBe("'+1+1");
+    expect(escapeCsvField("-2+3")).toBe("'-2+3");
+    expect(escapeCsvField("@SUM(A1)")).toBe("'@SUM(A1)");
+    expect(escapeCsvField("\tcmd")).toBe("'\tcmd");
+  });
+
+  it("does not treat a comma-containing value starting with = as exempt from quoting", () => {
+    expect(escapeCsvField("=A1,B1")).toBe('"\'=A1,B1"');
+  });
+
+  it("does not escape a regular value starting with a number", () => {
+    expect(escapeCsvField("12345")).toBe("12345");
+  });
+});
+
+describe("rowToCsv", () => {
+  it("joins fields with comma and terminates with CRLF (RFC 4180)", () => {
+    expect(rowToCsv(["a", "b", "c"])).toBe("a,b,c\r\n");
+  });
+
+  it("escapes each field independently", () => {
+    expect(rowToCsv(["a,b", 'c"d', "ok"])).toBe('"a,b","c""d",ok\r\n');
+  });
+
+  it("handles null and undefined values as empty fields", () => {
+    expect(rowToCsv(["a", null, undefined, "b"])).toBe("a,,,b\r\n");
+  });
+
+  it("emits empty row when given an empty array", () => {
+    expect(rowToCsv([])).toBe("\r\n");
+  });
+});
+
+describe("rowsToCsv", () => {
+  it("concatenates multiple rows with CRLF separators", () => {
+    expect(
+      rowsToCsv([
+        ["h1", "h2"],
+        ["v1", "v2"],
+      ]),
+    ).toBe("h1,h2\r\nv1,v2\r\n");
+  });
+
+  it("returns empty string when given no rows", () => {
+    expect(rowsToCsv([])).toBe("");
+  });
+});
+
+describe("CSV_BOM", () => {
+  it("is the UTF-8 BOM character (U+FEFF) for Excel italiano compatibility", () => {
+    expect(CSV_BOM).toBe("﻿");
+    expect(CSV_BOM).toHaveLength(1);
+  });
+});

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -7,22 +7,44 @@ export const CSV_BOM = "﻿";
 const FORMULA_LEADERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
 
 /**
+ * Tipi accettati come singolo campo CSV. Restringere a primitivi + Date
+ * evita di affidarsi al `[object Object]` di `String(any)`, che e' quasi
+ * sempre un bug del caller.
+ */
+export type CsvFieldValue =
+  | string
+  | number
+  | boolean
+  | bigint
+  | Date
+  | null
+  | undefined;
+
+/**
  * Restituisce true se il campo deve essere wrappato in virgolette doppie
  * (contiene virgola, virgolette doppie, CR o LF).
  */
 function needsQuoting(value: string): boolean {
-  for (let i = 0; i < value.length; i++) {
-    const c = value[i];
+  for (const c of value) {
     if (c === "," || c === '"' || c === "\n" || c === "\r") return true;
   }
   return false;
+}
+
+function valueToString(
+  value: Exclude<CsvFieldValue, null | undefined>,
+): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  // number / boolean / bigint — tutte hanno toString() ben definita.
+  return String(value);
 }
 
 /**
  * Escape conforme RFC 4180 di un singolo campo CSV.
  *
  * - null/undefined → stringa vuota
- * - numeri/booleani/Date → toString / toISOString
+ * - numeri/booleani/bigint/Date → toString / toISOString
  * - virgola, doppia quote, newline → wrap in `"..."`
  * - doppia quote interna raddoppiata
  *
@@ -31,22 +53,17 @@ function needsQuoting(value: string): boolean {
  * viene anteposto un apostrofo che neutralizza l'interpretazione come
  * formula senza alterare la lettura visiva in molti tool.
  */
-export function escapeCsvField(value: unknown): string {
+export function escapeCsvField(value: CsvFieldValue): string {
   if (value === null || value === undefined) return "";
 
-  let str: string;
-  if (value instanceof Date) {
-    str = value.toISOString();
-  } else {
-    str = String(value);
-  }
+  let str = valueToString(value);
 
   if (str.length > 0 && FORMULA_LEADERS.has(str[0])) {
     str = `'${str}`;
   }
 
   if (needsQuoting(str)) {
-    return `"${str.replace(/"/g, '""')}"`;
+    return `"${str.replaceAll('"', '""')}"`;
   }
   return str;
 }
@@ -55,7 +72,7 @@ export function escapeCsvField(value: unknown): string {
  * Costruisce una singola riga CSV (campi separati da virgola, terminatore CRLF
  * come da RFC 4180).
  */
-export function rowToCsv(fields: readonly unknown[]): string {
+export function rowToCsv(fields: readonly CsvFieldValue[]): string {
   return fields.map(escapeCsvField).join(",") + "\r\n";
 }
 
@@ -64,7 +81,7 @@ export function rowToCsv(fields: readonly unknown[]): string {
  * `rowToCsv` riga-per-riga in streaming, evitando di costruire la stringa
  * intera in memoria.
  */
-export function rowsToCsv(rows: readonly (readonly unknown[])[]): string {
+export function rowsToCsv(rows: readonly (readonly CsvFieldValue[])[]): string {
   let out = "";
   for (const row of rows) out += rowToCsv(row);
   return out;

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,71 @@
+/**
+ * UTF-8 Byte Order Mark. Excel italiano richiede il BOM all'inizio del file
+ * per riconoscere l'encoding e applicare la virgola come separatore decimale.
+ */
+export const CSV_BOM = "﻿";
+
+const FORMULA_LEADERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
+
+/**
+ * Restituisce true se il campo deve essere wrappato in virgolette doppie
+ * (contiene virgola, virgolette doppie, CR o LF).
+ */
+function needsQuoting(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const c = value[i];
+    if (c === "," || c === '"' || c === "\n" || c === "\r") return true;
+  }
+  return false;
+}
+
+/**
+ * Escape conforme RFC 4180 di un singolo campo CSV.
+ *
+ * - null/undefined → stringa vuota
+ * - numeri/booleani/Date → toString / toISOString
+ * - virgola, doppia quote, newline → wrap in `"..."`
+ * - doppia quote interna raddoppiata
+ *
+ * Protegge anche da CSV formula injection (Excel/LibreOffice eseguono
+ * formule se il campo inizia con `=`, `+`, `-`, `@`, TAB, CR): in quel caso
+ * viene anteposto un apostrofo che neutralizza l'interpretazione come
+ * formula senza alterare la lettura visiva in molti tool.
+ */
+export function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) return "";
+
+  let str: string;
+  if (value instanceof Date) {
+    str = value.toISOString();
+  } else {
+    str = String(value);
+  }
+
+  if (str.length > 0 && FORMULA_LEADERS.has(str[0])) {
+    str = `'${str}`;
+  }
+
+  if (needsQuoting(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Costruisce una singola riga CSV (campi separati da virgola, terminatore CRLF
+ * come da RFC 4180).
+ */
+export function rowToCsv(fields: readonly unknown[]): string {
+  return fields.map(escapeCsvField).join(",") + "\r\n";
+}
+
+/**
+ * Concatena multiple righe CSV. Per export di grandi dimensioni preferire
+ * `rowToCsv` riga-per-riga in streaming, evitando di costruire la stringa
+ * intera in memoria.
+ */
+export function rowsToCsv(rows: readonly (readonly unknown[])[]): string {
+  let out = "";
+  for (const row of rows) out += rowToCsv(row);
+  return out;
+}

--- a/src/lib/plans-shared.ts
+++ b/src/lib/plans-shared.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure plan helpers + types — safe to import from client components.
+ *
+ * Tieni qui SOLO codice senza dipendenze server (no `getDb`, no Drizzle).
+ * Tutto cio' che riguarda la lettura del piano dal DB sta in `plans.ts`,
+ * che importa da questo file e re-esporta i symbol pure per i caller server.
+ *
+ * Motivo: client component bundler analizza ogni modulo che incontra; se
+ * `plans.ts` viene tirato dentro perche' un client usa `canUsePro`, Next
+ * tenta di bundler-izzare anche `getDb` -> postgres -> module-not-found.
+ */
+
+export type Plan =
+  | "trial"
+  | "starter"
+  | "pro"
+  | "unlimited"
+  | "developer_indie"
+  | "developer_business"
+  | "developer_scale";
+
+/** Durata del trial in giorni */
+export const TRIAL_DAYS = 30;
+
+/** Numero massimo di prodotti nel catalogo per piano Starter e trial */
+export const STARTER_CATALOG_LIMIT = 5;
+
+/**
+ * Ritorna true se il trial è scaduto (> TRIAL_DAYS giorni fa).
+ * Se trialStartedAt è null, considera il trial come scaduto.
+ */
+export function isTrialExpired(trialStartedAt: Date | null): boolean {
+  if (!trialStartedAt) return true;
+  const expiryMs = trialStartedAt.getTime() + TRIAL_DAYS * 24 * 60 * 60 * 1000;
+  return Date.now() >= expiryMs;
+}
+
+/**
+ * Ritorna true se l'utente può emettere scontrini.
+ * - trial non scaduto → ✅
+ * - starter / pro / unlimited → ✅
+ * - trial scaduto → ❌ (sola lettura)
+ */
+export function canEmit(plan: Plan, trialStartedAt: Date | null): boolean {
+  if (plan === "trial") return !isTrialExpired(trialStartedAt);
+  return true;
+}
+
+/**
+ * Ritorna true se l'utente ha accesso alle feature Pro (analytics avanzata,
+ * export CSV, AdE sync, supporto prioritario).
+ */
+export function canUsePro(plan: Plan): boolean {
+  return plan === "pro" || plan === "unlimited";
+}
+
+/**
+ * Ritorna true se il piano è un piano developer (Fase B: Partner API).
+ */
+export function isDeveloperPlan(plan: Plan): boolean {
+  return (
+    plan === "developer_indie" ||
+    plan === "developer_business" ||
+    plan === "developer_scale"
+  );
+}
+
+/**
+ * Ritorna true se il piano ha accesso alla Developer API.
+ * - Pro e Unlimited: accesso API come feature inclusa nel piano
+ * - Developer plans: accesso API con limiti mensili per volume
+ */
+export function canUseApi(plan: Plan): boolean {
+  return canUsePro(plan) || isDeveloperPlan(plan);
+}
+
+/**
+ * Numero massimo di API key attive (non revocate) per piano.
+ * null = nessun limite.
+ * Starter/trial non hanno accesso API (canUseApi = false), quindi non
+ * hanno una entry qui. I piani Developer sono gestiti nella Fase B.
+ */
+export const API_KEY_LIMITS: Partial<Record<Plan, number>> = {
+  pro: 3,
+};
+
+/**
+ * Ritorna il limite di API key attive per il piano dato.
+ * null significa nessun limite applicato (es. Unlimited, piani Developer).
+ */
+export function getApiKeyLimit(plan: Plan): number | null {
+  return API_KEY_LIMITS[plan] ?? null;
+}
+
+/**
+ * Limite mensile di scontrini emettibili via API per i piani developer.
+ * null = nessun limite (piani non-developer con accesso API).
+ */
+export const DEVELOPER_MONTHLY_LIMITS: Partial<Record<Plan, number>> = {
+  developer_indie: 300,
+  developer_business: 1500,
+  developer_scale: 5000,
+};
+
+/**
+ * Ritorna true se l'utente può aggiungere un prodotto al catalogo.
+ * - pro / unlimited → sempre true
+ * - starter / trial (non scaduto) → solo se currentCount < STARTER_CATALOG_LIMIT
+ * - trial scaduto → false
+ */
+export function canAddCatalogItem(
+  plan: Plan,
+  trialStartedAt: Date | null,
+  currentCount: number,
+): boolean {
+  if (plan === "pro" || plan === "unlimited" || isDeveloperPlan(plan))
+    return true;
+  if (plan === "trial" && isTrialExpired(trialStartedAt)) return false;
+  return currentCount < STARTER_CATALOG_LIMIT;
+}

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -27,6 +27,7 @@ import {
   DEVELOPER_MONTHLY_LIMITS,
   STARTER_CATALOG_LIMIT,
   TRIAL_DAYS,
+  assertProPlan,
   canAddCatalogItem,
   canEmit,
   canUseApi,
@@ -290,5 +291,101 @@ describe("getPlan", () => {
     await expect(getPlan("user-not-found")).rejects.toThrow(
       "Profilo non trovato",
     );
+  });
+});
+
+describe("assertProPlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDb.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockSelectWhere });
+    mockSelectWhere.mockReturnValue({ limit: mockLimit });
+  });
+
+  it("returns 401 when authUserId is null", async () => {
+    const result = await assertProPlan(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toContain("Non autenticato");
+    }
+  });
+
+  it("returns 401 when authUserId is an empty string", async () => {
+    const result = await assertProPlan("");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it("returns 401 when the profile does not exist", async () => {
+    mockLimit.mockResolvedValue([]);
+    const result = await assertProPlan("user-no-profile");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it("returns 403 for the starter plan", async () => {
+    mockLimit.mockResolvedValue([
+      { plan: "starter", trialStartedAt: null, planExpiresAt: null },
+    ]);
+    const result = await assertProPlan("user-starter");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.error).toContain("Pro");
+    }
+  });
+
+  it("returns 403 for the trial plan", async () => {
+    mockLimit.mockResolvedValue([
+      { plan: "trial", trialStartedAt: new Date(), planExpiresAt: null },
+    ]);
+    const result = await assertProPlan("user-trial");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+    }
+  });
+
+  it("returns 403 for developer plans (Pro feature gate is plan-Pro only)", async () => {
+    mockLimit.mockResolvedValue([
+      {
+        plan: "developer_indie",
+        trialStartedAt: null,
+        planExpiresAt: null,
+      },
+    ]);
+    const result = await assertProPlan("user-dev");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+    }
+  });
+
+  it("returns ok=true for pro plan", async () => {
+    mockLimit.mockResolvedValue([
+      { plan: "pro", trialStartedAt: null, planExpiresAt: null },
+    ]);
+    const result = await assertProPlan("user-pro");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.plan).toBe("pro");
+    }
+  });
+
+  it("returns ok=true for unlimited plan", async () => {
+    mockLimit.mockResolvedValue([
+      { plan: "unlimited", trialStartedAt: null, planExpiresAt: null },
+    ]);
+    const result = await assertProPlan("user-unlimited");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.plan).toBe("unlimited");
+    }
   });
 });

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -88,6 +88,46 @@ export function canUsePro(plan: Plan): boolean {
   return plan === "pro" || plan === "unlimited";
 }
 
+export type AssertProPlanResult =
+  | { ok: true; plan: Plan }
+  | { ok: false; status: 401 | 403; error: string };
+
+/**
+ * Gate per route handler che proteggono una feature Pro.
+ * - authUserId null/empty → 401
+ * - profilo non trovato → 401
+ * - piano non Pro/Unlimited → 403
+ * - piano Pro/Unlimited → ok
+ *
+ * Da usare nelle route handler dove si vuole rispondere con uno status HTTP
+ * preciso senza try/catch. Per le server actions usare direttamente getPlan +
+ * canUsePro (i pattern esistenti).
+ */
+export async function assertProPlan(
+  authUserId: string | null,
+): Promise<AssertProPlanResult> {
+  if (!authUserId) {
+    return { ok: false, status: 401, error: "Non autenticato." };
+  }
+
+  let info: PlanInfo;
+  try {
+    info = await getPlan(authUserId);
+  } catch {
+    return { ok: false, status: 401, error: "Non autenticato." };
+  }
+
+  if (!canUsePro(info.plan)) {
+    return {
+      ok: false,
+      status: 403,
+      error: "Funzionalità riservata al piano Pro.",
+    };
+  }
+
+  return { ok: true, plan: info.plan };
+}
+
 /**
  * Ritorna true se il piano è un piano developer (Fase B: Partner API).
  */

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,15 +1,25 @@
 import { eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { profiles } from "@/db/schema";
+import { canUsePro, type Plan } from "@/lib/plans-shared";
 
-export type Plan =
-  | "trial"
-  | "starter"
-  | "pro"
-  | "unlimited"
-  | "developer_indie"
-  | "developer_business"
-  | "developer_scale";
+// Re-export pure helpers so existing server callers can keep importing from
+// "@/lib/plans". I client component MUST import from "@/lib/plans-shared"
+// (questo file importa @/db, server-only).
+export {
+  API_KEY_LIMITS,
+  DEVELOPER_MONTHLY_LIMITS,
+  STARTER_CATALOG_LIMIT,
+  TRIAL_DAYS,
+  canAddCatalogItem,
+  canEmit,
+  canUseApi,
+  canUsePro,
+  getApiKeyLimit,
+  isDeveloperPlan,
+  isTrialExpired,
+} from "@/lib/plans-shared";
+export type { Plan } from "@/lib/plans-shared";
 
 export type PlanInfo = {
   plan: Plan;
@@ -17,14 +27,8 @@ export type PlanInfo = {
   planExpiresAt: Date | null;
 };
 
-/** Durata del trial in giorni */
-export const TRIAL_DAYS = 30;
-
-/** Numero massimo di prodotti nel catalogo per piano Starter e trial */
-export const STARTER_CATALOG_LIMIT = 5;
-
 // ---------------------------------------------------------------------------
-// DB query
+// DB query (server-only)
 // ---------------------------------------------------------------------------
 
 /**
@@ -53,39 +57,6 @@ export async function getPlan(authUserId: string): Promise<PlanInfo> {
     trialStartedAt: profile.trialStartedAt ?? null,
     planExpiresAt: profile.planExpiresAt ?? null,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Pure helper functions
-// ---------------------------------------------------------------------------
-
-/**
- * Ritorna true se il trial è scaduto (> TRIAL_DAYS giorni fa).
- * Se trialStartedAt è null, considera il trial come scaduto.
- */
-export function isTrialExpired(trialStartedAt: Date | null): boolean {
-  if (!trialStartedAt) return true;
-  const expiryMs = trialStartedAt.getTime() + TRIAL_DAYS * 24 * 60 * 60 * 1000;
-  return Date.now() >= expiryMs;
-}
-
-/**
- * Ritorna true se l'utente può emettere scontrini.
- * - trial non scaduto → ✅
- * - starter / pro / unlimited → ✅
- * - trial scaduto → ❌ (sola lettura)
- */
-export function canEmit(plan: Plan, trialStartedAt: Date | null): boolean {
-  if (plan === "trial") return !isTrialExpired(trialStartedAt);
-  return true;
-}
-
-/**
- * Ritorna true se l'utente ha accesso alle feature Pro (analytics avanzata,
- * export CSV, AdE sync, supporto prioritario).
- */
-export function canUsePro(plan: Plan): boolean {
-  return plan === "pro" || plan === "unlimited";
 }
 
 export type AssertProPlanResult =
@@ -126,69 +97,4 @@ export async function assertProPlan(
   }
 
   return { ok: true, plan: info.plan };
-}
-
-/**
- * Ritorna true se il piano è un piano developer (Fase B: Partner API).
- */
-export function isDeveloperPlan(plan: Plan): boolean {
-  return (
-    plan === "developer_indie" ||
-    plan === "developer_business" ||
-    plan === "developer_scale"
-  );
-}
-
-/**
- * Ritorna true se il piano ha accesso alla Developer API.
- * - Pro e Unlimited: accesso API come feature inclusa nel piano
- * - Developer plans: accesso API con limiti mensili per volume
- */
-export function canUseApi(plan: Plan): boolean {
-  return canUsePro(plan) || isDeveloperPlan(plan);
-}
-
-/**
- * Numero massimo di API key attive (non revocate) per piano.
- * null = nessun limite.
- * Starter/trial non hanno accesso API (canUseApi = false), quindi non
- * hanno una entry qui. I piani Developer sono gestiti nella Fase B.
- */
-export const API_KEY_LIMITS: Partial<Record<Plan, number>> = {
-  pro: 3,
-};
-
-/**
- * Ritorna il limite di API key attive per il piano dato.
- * null significa nessun limite applicato (es. Unlimited, piani Developer).
- */
-export function getApiKeyLimit(plan: Plan): number | null {
-  return API_KEY_LIMITS[plan] ?? null;
-}
-
-/**
- * Limite mensile di scontrini emettibili via API per i piani developer.
- * null = nessun limite (piani non-developer con accesso API).
- */
-export const DEVELOPER_MONTHLY_LIMITS: Partial<Record<Plan, number>> = {
-  developer_indie: 300,
-  developer_business: 1500,
-  developer_scale: 5000,
-};
-
-/**
- * Ritorna true se l'utente può aggiungere un prodotto al catalogo.
- * - pro / unlimited → sempre true
- * - starter / trial (non scaduto) → solo se currentCount < STARTER_CATALOG_LIMIT
- * - trial scaduto → false
- */
-export function canAddCatalogItem(
-  plan: Plan,
-  trialStartedAt: Date | null,
-  currentCount: number,
-): boolean {
-  if (plan === "pro" || plan === "unlimited" || isDeveloperPlan(plan))
-    return true;
-  if (plan === "trial" && isTrialExpired(trialStartedAt)) return false;
-  return currentCount < STARTER_CATALOG_LIMIT;
 }

--- a/src/lib/receipts/csv-export.test.ts
+++ b/src/lib/receipts/csv-export.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetDb,
+  mockFetchLinesByDocIds,
+  mockGroupLinesByDocId,
+  mockCalcDocTotal,
+} = vi.hoisted(() => ({
+  mockGetDb: vi.fn(),
+  mockFetchLinesByDocIds: vi.fn(),
+  mockGroupLinesByDocId: vi.fn(),
+  mockCalcDocTotal: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({ getDb: mockGetDb }));
+vi.mock("@/db/schema", () => ({
+  commercialDocuments: {
+    id: "id",
+    businessId: "business_id",
+    kind: "kind",
+    status: "status",
+    createdAt: "created_at",
+    adeProgressive: "ade_progressive",
+    adeTransactionId: "ade_transaction_id",
+    lotteryCode: "lottery_code",
+    voidedDocumentId: "voided_document_id",
+    publicRequest: "public_request",
+  },
+}));
+
+vi.mock("@/lib/receipts/document-lines", () => ({
+  fetchLinesByDocIds: mockFetchLinesByDocIds,
+  groupLinesByDocId: mockGroupLinesByDocId,
+  calcDocTotal: mockCalcDocTotal,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ _and: args }),
+  desc: (col: unknown) => ({ _desc: col }),
+  eq: (a: unknown, b: unknown) => ({ _eq: [a, b] }),
+  gte: (a: unknown, b: unknown) => ({ _gte: [a, b] }),
+  inArray: (a: unknown, b: unknown) => ({ _inArray: [a, b] }),
+  lt: (a: unknown, b: unknown) => ({ _lt: [a, b] }),
+}));
+
+import {
+  RECEIPT_CSV_HEADERS,
+  buildReceiptsCsvStream,
+  formatReceiptRow,
+  type ReceiptDocRow,
+} from "./csv-export";
+
+function doc(overrides: Partial<ReceiptDocRow> = {}): ReceiptDocRow {
+  return {
+    id: "doc-1",
+    kind: "SALE",
+    status: "ACCEPTED",
+    createdAt: new Date("2026-05-19T12:34:56.789Z"),
+    adeProgressive: "00042",
+    adeTransactionId: "tx-12345",
+    lotteryCode: null,
+    voidedDocumentId: null,
+    publicRequest: { paymentMethod: "PC" },
+    ...overrides,
+  };
+}
+
+describe("RECEIPT_CSV_HEADERS", () => {
+  it("has the expected Italian column names", () => {
+    expect(RECEIPT_CSV_HEADERS).toEqual([
+      "id",
+      "numero_ade",
+      "data_emissione",
+      "tipo",
+      "stato",
+      "totale",
+      "metodo_pagamento",
+      "codice_lotteria",
+      "id_transazione_ade",
+      "id_documento_annullato",
+    ]);
+  });
+});
+
+describe("formatReceiptRow", () => {
+  it("formats a fully populated SALE document", () => {
+    const row = formatReceiptRow(doc(), 12.34);
+    expect(row).toEqual([
+      "doc-1",
+      "00042",
+      "2026-05-19T12:34:56.789Z",
+      "SALE",
+      "ACCEPTED",
+      "12,34",
+      "PC",
+      "",
+      "tx-12345",
+      "",
+    ]);
+  });
+
+  it("uses Italian comma as decimal separator for the total", () => {
+    expect(formatReceiptRow(doc(), 1234.5)[5]).toBe("1234,50");
+    expect(formatReceiptRow(doc(), 0)[5]).toBe("0,00");
+    expect(formatReceiptRow(doc(), 0.05)[5]).toBe("0,05");
+  });
+
+  it("emits empty strings for nullable fields", () => {
+    const row = formatReceiptRow(
+      doc({
+        adeProgressive: null,
+        adeTransactionId: null,
+        lotteryCode: null,
+        voidedDocumentId: null,
+        publicRequest: null,
+      }),
+      0,
+    );
+    expect(row[1]).toBe(""); // numero_ade
+    expect(row[6]).toBe(""); // metodo_pagamento
+    expect(row[7]).toBe(""); // codice_lotteria
+    expect(row[8]).toBe(""); // id_transazione_ade
+    expect(row[9]).toBe(""); // id_documento_annullato
+  });
+
+  it("emits lotteryCode when present", () => {
+    const row = formatReceiptRow(doc({ lotteryCode: "ABCDEFGH" }), 0);
+    expect(row[7]).toBe("ABCDEFGH");
+  });
+
+  it("emits voidedDocumentId for VOID_ACCEPTED states", () => {
+    const row = formatReceiptRow(
+      doc({ status: "VOID_ACCEPTED", voidedDocumentId: "doc-original" }),
+      0,
+    );
+    expect(row[4]).toBe("VOID_ACCEPTED");
+    expect(row[9]).toBe("doc-original");
+  });
+
+  it("extracts paymentMethod from publicRequest jsonb", () => {
+    expect(
+      formatReceiptRow(doc({ publicRequest: { paymentMethod: "PE" } }), 0)[6],
+    ).toBe("PE");
+    expect(
+      formatReceiptRow(doc({ publicRequest: { paymentMethod: null } }), 0)[6],
+    ).toBe("");
+    expect(
+      formatReceiptRow(
+        doc({ publicRequest: "not-an-object" as unknown as null }),
+        0,
+      )[6],
+    ).toBe("");
+  });
+});
+
+describe("buildReceiptsCsvStream", () => {
+  function setupDbMock(docs: ReceiptDocRow[]) {
+    const limit = vi.fn().mockImplementation(() => {
+      // First call returns the docs; subsequent calls return empty (loop exit).
+      limit.mockResolvedValue([]);
+      return Promise.resolve(docs);
+    });
+    const offset = vi.fn().mockReturnValue({ then: undefined });
+    const order = vi.fn();
+    const where = vi.fn();
+    const from = vi.fn();
+    const select = vi.fn();
+
+    select.mockReturnValue({ from });
+    from.mockReturnValue({ where });
+    where.mockReturnValue({ orderBy: order });
+    order.mockReturnValue({ limit: () => ({ offset: offset }) });
+    offset.mockImplementation((n: number) => {
+      return n === 0 ? Promise.resolve(docs) : Promise.resolve([]);
+    });
+
+    mockGetDb.mockReturnValue({ select });
+  }
+
+  async function streamToString(
+    stream: ReadableStream<Uint8Array>,
+  ): Promise<string> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder("utf-8", { ignoreBOM: true });
+    let out = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) out += decoder.decode(value, { stream: true });
+    }
+    out += decoder.decode();
+    return out;
+  }
+
+  it("emits BOM + header row when there are no documents", async () => {
+    setupDbMock([]);
+    const stream = buildReceiptsCsvStream({
+      businessId: "biz-1",
+      status: null,
+      dateFrom: null,
+      dateTo: null,
+    });
+    const body = await streamToString(stream);
+    expect(body.charCodeAt(0)).toBe(0xfeff); // BOM
+    expect(body).toContain("id,numero_ade,data_emissione");
+    expect(body.trim().split("\r\n")).toHaveLength(1);
+  });
+
+  it("streams one CSV row per document, with totals computed from lines", async () => {
+    const documents = [doc({ id: "d1" }), doc({ id: "d2" })];
+    setupDbMock(documents);
+
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      { documentId: "d2", grossUnitPrice: "5.00", quantity: "2" },
+    ]);
+    mockGroupLinesByDocId.mockReturnValue(
+      new Map([
+        ["d1", [{ documentId: "d1", grossUnitPrice: "10.00", quantity: "1" }]],
+        ["d2", [{ documentId: "d2", grossUnitPrice: "5.00", quantity: "2" }]],
+      ]),
+    );
+    mockCalcDocTotal.mockImplementation((lines: unknown[]) =>
+      lines[0] && (lines[0] as { documentId: string }).documentId === "d1"
+        ? 10
+        : 10,
+    );
+
+    const stream = buildReceiptsCsvStream({
+      businessId: "biz-1",
+      status: null,
+      dateFrom: null,
+      dateTo: null,
+    });
+    const body = await streamToString(stream);
+
+    const lines = body.split("\r\n").filter(Boolean);
+    expect(lines).toHaveLength(3); // header + 2 rows
+    expect(lines[1]).toContain("d1");
+    expect(lines[2]).toContain("d2");
+  });
+
+  it("propagates DB errors via stream.error so callers can detect failure", async () => {
+    const limit = vi.fn();
+    const order = vi.fn();
+    const where = vi.fn();
+    const from = vi.fn();
+    const select = vi.fn();
+
+    select.mockReturnValue({ from });
+    from.mockReturnValue({ where });
+    where.mockReturnValue({ orderBy: order });
+    order.mockReturnValue({
+      limit: () => ({
+        offset: () => Promise.reject(new Error("db down")),
+      }),
+    });
+    mockGetDb.mockReturnValue({ select });
+
+    const stream = buildReceiptsCsvStream({
+      businessId: "biz-1",
+      status: null,
+      dateFrom: null,
+      dateTo: null,
+    });
+
+    await expect(streamToString(stream)).rejects.toThrow("db down");
+    // Reference unused vars to satisfy strict mode
+    expect(limit).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/lib/receipts/csv-export.ts
+++ b/src/lib/receipts/csv-export.ts
@@ -1,0 +1,181 @@
+import { and, desc, eq, gte, inArray, lt } from "drizzle-orm";
+import { getDb } from "@/db";
+import { commercialDocuments } from "@/db/schema";
+import {
+  calcDocTotal,
+  fetchLinesByDocIds,
+  groupLinesByDocId,
+} from "@/lib/receipts/document-lines";
+import { CSV_BOM, rowToCsv } from "@/lib/csv";
+
+/**
+ * Batch size per la cursor query. 500 e' un compromesso fra memoria
+ * (peak ~500 docs + lines in RAM) e roundtrip DB (per 50k scontrini
+ * sono 100 query — accettabili).
+ */
+const BATCH_SIZE = 500;
+
+export const RECEIPT_CSV_HEADERS = [
+  "id",
+  "numero_ade",
+  "data_emissione",
+  "tipo",
+  "stato",
+  "totale",
+  "metodo_pagamento",
+  "codice_lotteria",
+  "id_transazione_ade",
+  "id_documento_annullato",
+] as const;
+
+export type ReceiptStatusFilter = "ACCEPTED" | "VOID_ACCEPTED";
+
+export type ReceiptDocRow = {
+  id: string;
+  kind: string;
+  status: string;
+  createdAt: Date;
+  adeProgressive: string | null;
+  adeTransactionId: string | null;
+  lotteryCode: string | null;
+  voidedDocumentId: string | null;
+  publicRequest: unknown;
+};
+
+export type BuildCsvStreamParams = {
+  businessId: string;
+  status: ReceiptStatusFilter | null;
+  dateFrom: Date | null;
+  dateTo: Date | null;
+};
+
+function extractPaymentMethod(publicRequest: unknown): string {
+  if (
+    publicRequest !== null &&
+    typeof publicRequest === "object" &&
+    "paymentMethod" in publicRequest
+  ) {
+    const pm = (publicRequest as { paymentMethod?: unknown }).paymentMethod;
+    if (typeof pm === "string") return pm;
+  }
+  return "";
+}
+
+function formatItalianAmount(amount: number): string {
+  return amount.toFixed(2).replace(".", ",");
+}
+
+/**
+ * Formatta una riga CSV per uno scontrino. Pure function — riusabile dai test
+ * senza mock DB.
+ */
+export function formatReceiptRow(doc: ReceiptDocRow, total: number): string[] {
+  return [
+    doc.id,
+    doc.adeProgressive ?? "",
+    doc.createdAt.toISOString(),
+    doc.kind,
+    doc.status,
+    formatItalianAmount(total),
+    extractPaymentMethod(doc.publicRequest),
+    doc.lotteryCode ?? "",
+    doc.adeTransactionId ?? "",
+    doc.voidedDocumentId ?? "",
+  ];
+}
+
+function buildConditions(params: BuildCsvStreamParams) {
+  const conditions = [
+    eq(commercialDocuments.businessId, params.businessId),
+    eq(commercialDocuments.kind, "SALE"),
+  ];
+
+  if (params.dateFrom) {
+    conditions.push(gte(commercialDocuments.createdAt, params.dateFrom));
+  }
+  if (params.dateTo) {
+    conditions.push(lt(commercialDocuments.createdAt, params.dateTo));
+  }
+  if (params.status) {
+    conditions.push(eq(commercialDocuments.status, params.status));
+  } else {
+    conditions.push(
+      inArray(commercialDocuments.status, ["ACCEPTED", "VOID_ACCEPTED"]),
+    );
+  }
+  return conditions;
+}
+
+async function fetchDocsBatch(
+  params: BuildCsvStreamParams,
+  offset: number,
+): Promise<ReceiptDocRow[]> {
+  const db = getDb();
+  const conditions = buildConditions(params);
+  const rows = await db
+    .select({
+      id: commercialDocuments.id,
+      kind: commercialDocuments.kind,
+      status: commercialDocuments.status,
+      createdAt: commercialDocuments.createdAt,
+      adeProgressive: commercialDocuments.adeProgressive,
+      adeTransactionId: commercialDocuments.adeTransactionId,
+      lotteryCode: commercialDocuments.lotteryCode,
+      voidedDocumentId: commercialDocuments.voidedDocumentId,
+      publicRequest: commercialDocuments.publicRequest,
+    })
+    .from(commercialDocuments)
+    .where(and(...conditions))
+    .orderBy(desc(commercialDocuments.createdAt))
+    .limit(BATCH_SIZE)
+    .offset(offset);
+  return rows as ReceiptDocRow[];
+}
+
+/**
+ * Costruisce un ReadableStream<Uint8Array> con il CSV completo degli scontrini
+ * filtrati. Emette in streaming: header riga 1, poi una riga per documento,
+ * con totale calcolato dalle righe.
+ *
+ * Lo stream usa una cursor query (LIMIT/OFFSET) per evitare di tenere tutti
+ * i documenti + lines in memoria contemporaneamente. Errori DB sono
+ * propagati via `controller.error()` cosi' il client riceve un download
+ * troncato (segnale che qualcosa e' andato storto).
+ */
+export function buildReceiptsCsvStream(
+  params: BuildCsvStreamParams,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        controller.enqueue(encoder.encode(CSV_BOM));
+        controller.enqueue(encoder.encode(rowToCsv(RECEIPT_CSV_HEADERS)));
+
+        let offset = 0;
+        while (true) {
+          const docs = await fetchDocsBatch(params, offset);
+          if (docs.length === 0) break;
+
+          const lines = await fetchLinesByDocIds(docs.map((d) => d.id));
+          const byDoc = groupLinesByDocId(lines);
+
+          for (const doc of docs) {
+            const total = calcDocTotal(byDoc.get(doc.id) ?? []);
+            controller.enqueue(
+              encoder.encode(rowToCsv(formatReceiptRow(doc, total))),
+            );
+          }
+
+          if (docs.length < BATCH_SIZE) break;
+          offset += BATCH_SIZE;
+        }
+
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+}

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -79,8 +79,10 @@ vi.mock("@/lib/logger", () => ({
 
 import {
   fillMissingDays,
+  formatRomeDay,
   normalizePaymentMethod,
   rangeToBounds,
+  romeMidnightUtc,
 } from "./analytics-helpers";
 import {
   getAnalyticsKpis,
@@ -115,20 +117,53 @@ beforeEach(() => {
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-describe("rangeToBounds", () => {
-  it("returns a [from, to) interval of the requested length in days", () => {
-    const { from, to } = rangeToBounds("30d", new Date("2026-05-19T12:00:00Z"));
-    expect(to.toISOString()).toBe("2026-05-20T00:00:00.000Z");
-    expect(from.toISOString()).toBe("2026-04-20T00:00:00.000Z");
+describe("formatRomeDay", () => {
+  it("returns the Italian fiscal day for an instant in CEST (summer)", () => {
+    // 19 maggio 2026 alle 00:30 Europe/Rome = 18 maggio 22:30 UTC (CEST = UTC+2)
+    expect(formatRomeDay(new Date("2026-05-18T22:30:00Z"))).toBe("2026-05-19");
   });
 
-  it("supports 7d and 90d ranges", () => {
-    const ref = new Date("2026-05-19T00:00:00Z");
-    expect(rangeToBounds("7d", ref).from.toISOString()).toBe(
-      "2026-05-13T00:00:00.000Z",
+  it("returns the Italian fiscal day for an instant in CET (winter)", () => {
+    // 15 gennaio 2026 alle 00:30 Europe/Rome = 14 gennaio 23:30 UTC (CET = UTC+1)
+    expect(formatRomeDay(new Date("2026-01-14T23:30:00Z"))).toBe("2026-01-15");
+  });
+});
+
+describe("romeMidnightUtc", () => {
+  it("returns the UTC instant of Rome midnight in CEST (summer = UTC+2)", () => {
+    expect(romeMidnightUtc("2026-05-20").toISOString()).toBe(
+      "2026-05-19T22:00:00.000Z",
     );
+  });
+
+  it("returns the UTC instant of Rome midnight in CET (winter = UTC+1)", () => {
+    expect(romeMidnightUtc("2026-02-19").toISOString()).toBe(
+      "2026-02-18T23:00:00.000Z",
+    );
+  });
+});
+
+describe("rangeToBounds", () => {
+  it("anchors [from, to) to Europe/Rome midnights for the requested length", () => {
+    // Reference 12:00 UTC del 19 maggio = 14:00 Rome → Rome day "2026-05-19"
+    const { from, to } = rangeToBounds("30d", new Date("2026-05-19T12:00:00Z"));
+    // `to` = mezzanotte Rome del 2026-05-20 (giorno dopo, exclusive) → 22:00Z (CEST)
+    expect(to.toISOString()).toBe("2026-05-19T22:00:00.000Z");
+    expect(formatRomeDay(to)).toBe("2026-05-20");
+    // `from` = mezzanotte Rome del 2026-04-20 → 22:00Z (CEST)
+    expect(from.toISOString()).toBe("2026-04-19T22:00:00.000Z");
+    expect(formatRomeDay(from)).toBe("2026-04-20");
+  });
+
+  it("supports 7d and 90d ranges and crosses DST boundaries correctly", () => {
+    const ref = new Date("2026-05-19T00:00:00Z"); // Rome day "2026-05-19"
+    // 7d → fromDay = 2026-05-13 (CEST) → 22:00Z del 12 maggio
+    expect(rangeToBounds("7d", ref).from.toISOString()).toBe(
+      "2026-05-12T22:00:00.000Z",
+    );
+    // 90d → fromDay = 2026-02-19 (CET — gli orologi italiani sono ancora su UTC+1)
     expect(rangeToBounds("90d", ref).from.toISOString()).toBe(
-      "2026-02-19T00:00:00.000Z",
+      "2026-02-18T23:00:00.000Z",
     );
   });
 });
@@ -152,15 +187,16 @@ describe("normalizePaymentMethod", () => {
 });
 
 describe("fillMissingDays", () => {
-  it("fills gaps with zero revenue across the full date range", () => {
+  it("fills gaps with zero revenue across the full Rome calendar range", () => {
     const data = new Map([
       ["2026-05-17", 1000],
       ["2026-05-19", 2500],
     ]);
+    // Bounds = mezzanotte Rome del 17 e del 20 maggio 2026 (CEST → 22:00Z giorno prima).
     const out = fillMissingDays(
       data,
-      new Date("2026-05-17T00:00:00Z"),
-      new Date("2026-05-20T00:00:00Z"),
+      romeMidnightUtc("2026-05-17"),
+      romeMidnightUtc("2026-05-20"),
     );
     expect(out).toEqual([
       { date: "2026-05-17", revenueCents: 1000 },
@@ -170,13 +206,8 @@ describe("fillMissingDays", () => {
   });
 
   it("returns an empty array when from >= to", () => {
-    expect(
-      fillMissingDays(
-        new Map(),
-        new Date("2026-05-19T00:00:00Z"),
-        new Date("2026-05-19T00:00:00Z"),
-      ),
-    ).toEqual([]);
+    const midnight = romeMidnightUtc("2026-05-19");
+    expect(fillMissingDays(new Map(), midnight, midnight)).toEqual([]);
   });
 });
 
@@ -261,7 +292,35 @@ describe("getAnalyticsKpis", () => {
 });
 
 describe("getRevenueTimeseries", () => {
-  it("groups revenue by UTC day and fills gaps with zero", async () => {
+  it("buckets a midnight-Rome receipt by the correct fiscal day (DST fix)", async () => {
+    // 2026-05-18T22:30Z = 00:30 Rome del 19 maggio (CEST). Deve finire
+    // nel bucket "2026-05-19" (giorno fiscale), non in "2026-05-18".
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        {
+          id: "d1",
+          status: "ACCEPTED",
+          createdAt: new Date("2026-05-18T22:30:00Z"),
+        },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+    ]);
+
+    const res = await getRevenueTimeseries(
+      "biz-1",
+      "7d",
+      new Date("2026-05-19T12:00:00Z"),
+    );
+
+    if (!Array.isArray(res)) throw new Error("Expected array");
+    const byDate = Object.fromEntries(res.map((p) => [p.date, p.revenueCents]));
+    expect(byDate["2026-05-19"]).toBe(1000);
+    expect(byDate["2026-05-18"]).toBe(0);
+  });
+
+  it("groups revenue by Italian fiscal day and fills gaps with zero", async () => {
     mockSelect.mockReturnValue(
       makeSelectBuilder([
         {

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -1,0 +1,382 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetAuthenticatedUser,
+  mockCheckBusinessOwnership,
+  mockGetPlan,
+  mockSelect,
+  mockFetchLinesByDocIds,
+} = vi.hoisted(() => ({
+  mockGetAuthenticatedUser: vi.fn(),
+  mockCheckBusinessOwnership: vi.fn(),
+  mockGetPlan: vi.fn(),
+  mockSelect: vi.fn(),
+  mockFetchLinesByDocIds: vi.fn(),
+}));
+
+vi.mock("@/lib/server-auth", () => ({
+  getAuthenticatedUser: mockGetAuthenticatedUser,
+  checkBusinessOwnership: mockCheckBusinessOwnership,
+}));
+
+vi.mock("@/lib/plans", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/plans")>("@/lib/plans");
+  return {
+    ...actual,
+    getPlan: mockGetPlan,
+  };
+});
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({ select: mockSelect }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  commercialDocuments: {
+    id: "id",
+    businessId: "business_id",
+    kind: "kind",
+    status: "status",
+    createdAt: "created_at",
+    publicRequest: "public_request",
+  },
+}));
+
+vi.mock("@/lib/receipts/document-lines", () => ({
+  fetchLinesByDocIds: mockFetchLinesByDocIds,
+  groupLinesByDocId: (lines: { documentId: string }[]) => {
+    const m = new Map<string, typeof lines>();
+    for (const l of lines) {
+      const arr = m.get(l.documentId) ?? [];
+      arr.push(l);
+      m.set(l.documentId, arr);
+    }
+    return m;
+  },
+  calcDocTotal: (
+    lines: { grossUnitPrice: string; quantity: string }[],
+  ): number =>
+    lines.reduce(
+      (s, l) =>
+        s + Number.parseFloat(l.grossUnitPrice) * Number.parseFloat(l.quantity),
+      0,
+    ),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ _and: args }),
+  eq: (a: unknown, b: unknown) => ({ _eq: [a, b] }),
+  gte: (a: unknown, b: unknown) => ({ _gte: [a, b] }),
+  lt: (a: unknown, b: unknown) => ({ _lt: [a, b] }),
+  inArray: (a: unknown, b: unknown) => ({ _inArray: [a, b] }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  fillMissingDays,
+  normalizePaymentMethod,
+  rangeToBounds,
+} from "./analytics-helpers";
+import {
+  getAnalyticsKpis,
+  getPaymentBreakdown,
+  getRevenueTimeseries,
+} from "./analytics-actions";
+
+// --- Helpers ---
+
+function makeSelectBuilder(result: unknown[]) {
+  const builder = {
+    from: vi.fn(),
+    where: vi.fn(),
+  };
+  builder.from.mockReturnValue(builder);
+  builder.where.mockReturnValue(Promise.resolve(result));
+  return builder;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthenticatedUser.mockResolvedValue({ id: "user-1" });
+  mockCheckBusinessOwnership.mockResolvedValue(null);
+  mockGetPlan.mockResolvedValue({
+    plan: "pro",
+    trialStartedAt: null,
+    planExpiresAt: null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("rangeToBounds", () => {
+  it("returns a [from, to) interval of the requested length in days", () => {
+    const { from, to } = rangeToBounds("30d", new Date("2026-05-19T12:00:00Z"));
+    expect(to.toISOString()).toBe("2026-05-20T00:00:00.000Z");
+    expect(from.toISOString()).toBe("2026-04-20T00:00:00.000Z");
+  });
+
+  it("supports 7d and 90d ranges", () => {
+    const ref = new Date("2026-05-19T00:00:00Z");
+    expect(rangeToBounds("7d", ref).from.toISOString()).toBe(
+      "2026-05-13T00:00:00.000Z",
+    );
+    expect(rangeToBounds("90d", ref).from.toISOString()).toBe(
+      "2026-02-19T00:00:00.000Z",
+    );
+  });
+});
+
+describe("normalizePaymentMethod", () => {
+  it("maps known codes to canonical labels", () => {
+    expect(normalizePaymentMethod("PC")).toBe("PC");
+    expect(normalizePaymentMethod("PE")).toBe("PE");
+  });
+
+  it("maps null/empty/non-string to 'other'", () => {
+    expect(normalizePaymentMethod(null)).toBe("other");
+    expect(normalizePaymentMethod("")).toBe("other");
+    expect(normalizePaymentMethod(undefined)).toBe("other");
+    expect(normalizePaymentMethod(42 as unknown as string)).toBe("other");
+  });
+
+  it("maps any unrecognised string to 'other'", () => {
+    expect(normalizePaymentMethod("UNKNOWN")).toBe("other");
+  });
+});
+
+describe("fillMissingDays", () => {
+  it("fills gaps with zero revenue across the full date range", () => {
+    const data = new Map([
+      ["2026-05-17", 1000],
+      ["2026-05-19", 2500],
+    ]);
+    const out = fillMissingDays(
+      data,
+      new Date("2026-05-17T00:00:00Z"),
+      new Date("2026-05-20T00:00:00Z"),
+    );
+    expect(out).toEqual([
+      { date: "2026-05-17", revenueCents: 1000 },
+      { date: "2026-05-18", revenueCents: 0 },
+      { date: "2026-05-19", revenueCents: 2500 },
+    ]);
+  });
+
+  it("returns an empty array when from >= to", () => {
+    expect(
+      fillMissingDays(
+        new Map(),
+        new Date("2026-05-19T00:00:00Z"),
+        new Date("2026-05-19T00:00:00Z"),
+      ),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server actions
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsKpis", () => {
+  it("returns an error when ownership check fails", async () => {
+    mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
+    const res = await getAnalyticsKpis("biz-1", "30d");
+    expect(res).toEqual({ error: "Non autorizzato." });
+  });
+
+  it("returns an error when the plan is not Pro", async () => {
+    mockGetPlan.mockResolvedValue({
+      plan: "starter",
+      trialStartedAt: null,
+      planExpiresAt: null,
+    });
+    const res = await getAnalyticsKpis("biz-1", "30d");
+    expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
+  });
+
+  it("returns an error for an invalid range", async () => {
+    const res = await getAnalyticsKpis("biz-1", "1y" as unknown as "30d");
+    expect(res).toMatchObject({ error: expect.any(String) });
+  });
+
+  it("returns 0/0/0/0 when there are no documents in the range", async () => {
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockFetchLinesByDocIds.mockResolvedValue([]);
+    const res = await getAnalyticsKpis("biz-1", "30d");
+    expect(res).toEqual({
+      revenueCents: 0,
+      count: 0,
+      aovCents: 0,
+      voidCount: 0,
+    });
+  });
+
+  it("computes revenue (cents), count, AOV, and voidCount", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { id: "d1", status: "ACCEPTED", createdAt: new Date() },
+        { id: "d2", status: "ACCEPTED", createdAt: new Date() },
+        { id: "d3", status: "VOID_ACCEPTED", createdAt: new Date() },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      { documentId: "d2", grossUnitPrice: "5.00", quantity: "2" },
+      { documentId: "d3", grossUnitPrice: "99.00", quantity: "1" },
+    ]);
+    const res = await getAnalyticsKpis("biz-1", "30d");
+    expect(res).toEqual({
+      // 10 + 10 = 20.00 → 2000 cents (void excluded from revenue)
+      revenueCents: 2000,
+      count: 2,
+      aovCents: 1000,
+      voidCount: 1,
+    });
+  });
+
+  it("does not divide by zero when computing AOV", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { id: "d1", status: "VOID_ACCEPTED", createdAt: new Date() },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+    ]);
+    const res = await getAnalyticsKpis("biz-1", "30d");
+    expect(res).toEqual({
+      revenueCents: 0,
+      count: 0,
+      aovCents: 0,
+      voidCount: 1,
+    });
+  });
+});
+
+describe("getRevenueTimeseries", () => {
+  it("groups revenue by UTC day and fills gaps with zero", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        {
+          id: "d1",
+          status: "ACCEPTED",
+          createdAt: new Date("2026-05-17T10:00:00Z"),
+        },
+        {
+          id: "d2",
+          status: "ACCEPTED",
+          createdAt: new Date("2026-05-19T09:00:00Z"),
+        },
+        {
+          id: "d3",
+          status: "ACCEPTED",
+          createdAt: new Date("2026-05-19T11:00:00Z"),
+        },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      { documentId: "d2", grossUnitPrice: "5.00", quantity: "1" },
+      { documentId: "d3", grossUnitPrice: "5.00", quantity: "1" },
+    ]);
+
+    const res = await getRevenueTimeseries(
+      "biz-1",
+      "7d",
+      new Date("2026-05-19T12:00:00Z"),
+    );
+
+    expect(Array.isArray(res)).toBe(true);
+    if (!Array.isArray(res)) return;
+    expect(res).toHaveLength(7);
+    const byDate = Object.fromEntries(res.map((p) => [p.date, p.revenueCents]));
+    expect(byDate["2026-05-17"]).toBe(1000);
+    expect(byDate["2026-05-18"]).toBe(0);
+    expect(byDate["2026-05-19"]).toBe(1000);
+  });
+
+  it("excludes VOID_ACCEPTED documents from the timeseries", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        {
+          id: "d1",
+          status: "VOID_ACCEPTED",
+          createdAt: new Date("2026-05-19T09:00:00Z"),
+        },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "100.00", quantity: "1" },
+    ]);
+    const res = await getRevenueTimeseries(
+      "biz-1",
+      "7d",
+      new Date("2026-05-19T12:00:00Z"),
+    );
+    if (!Array.isArray(res)) throw new Error("Expected array");
+    expect(res.every((p) => p.revenueCents === 0)).toBe(true);
+  });
+});
+
+describe("getPaymentBreakdown", () => {
+  it("groups ACCEPTED documents by paymentMethod with cents totals", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        {
+          id: "d1",
+          status: "ACCEPTED",
+          publicRequest: { paymentMethod: "PC" },
+        },
+        {
+          id: "d2",
+          status: "ACCEPTED",
+          publicRequest: { paymentMethod: "PE" },
+        },
+        {
+          id: "d3",
+          status: "ACCEPTED",
+          publicRequest: { paymentMethod: "PC" },
+        },
+        { id: "d4", status: "ACCEPTED", publicRequest: null },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      { documentId: "d2", grossUnitPrice: "20.00", quantity: "1" },
+      { documentId: "d3", grossUnitPrice: "5.00", quantity: "2" },
+      { documentId: "d4", grossUnitPrice: "1.00", quantity: "1" },
+    ]);
+    const res = await getPaymentBreakdown("biz-1", "30d");
+    if (!Array.isArray(res)) throw new Error("Expected array");
+    const byMethod = Object.fromEntries(res.map((e) => [e.method, e]));
+    expect(byMethod.PC).toEqual({ method: "PC", count: 2, revenueCents: 2000 });
+    expect(byMethod.PE).toEqual({ method: "PE", count: 1, revenueCents: 2000 });
+    expect(byMethod.other).toEqual({
+      method: "other",
+      count: 1,
+      revenueCents: 100,
+    });
+  });
+
+  it("excludes VOID_ACCEPTED documents from the breakdown", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        {
+          id: "d1",
+          status: "VOID_ACCEPTED",
+          publicRequest: { paymentMethod: "PC" },
+        },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([]);
+    const res = await getPaymentBreakdown("biz-1", "30d");
+    expect(res).toEqual([]);
+  });
+});

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -1,0 +1,219 @@
+"use server";
+
+import { and, eq, gte, inArray, lt } from "drizzle-orm";
+import { getDb } from "@/db";
+import { commercialDocuments } from "@/db/schema";
+import {
+  checkBusinessOwnership,
+  getAuthenticatedUser,
+} from "@/lib/server-auth";
+import { canUsePro, getPlan } from "@/lib/plans";
+import {
+  calcDocTotal,
+  fetchLinesByDocIds,
+  groupLinesByDocId,
+} from "@/lib/receipts/document-lines";
+import { logger } from "@/lib/logger";
+import {
+  type AnalyticsKpis,
+  type AnalyticsRange,
+  type PaymentBreakdownEntry,
+  type RevenuePoint,
+  VALID_RANGES,
+  fillMissingDays,
+  normalizePaymentMethod,
+  rangeToBounds,
+  toCents,
+} from "./analytics-helpers";
+
+export type {
+  AnalyticsKpis,
+  AnalyticsRange,
+  PaymentBreakdownEntry,
+  RevenuePoint,
+} from "./analytics-helpers";
+
+// ---------------------------------------------------------------------------
+// Authorization
+// ---------------------------------------------------------------------------
+
+type AuthOk = { ok: true; userId: string };
+type AuthFail = { ok: false; error: string };
+
+async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
+  let user;
+  try {
+    user = await getAuthenticatedUser();
+  } catch {
+    return { ok: false, error: "Non autenticato." };
+  }
+  const ownershipError = await checkBusinessOwnership(user.id, businessId);
+  if (ownershipError) {
+    logger.warn(
+      { userId: user.id, businessId },
+      "analytics: ownership check failed",
+    );
+    return { ok: false, error: ownershipError.error };
+  }
+  const planInfo = await getPlan(user.id);
+  if (!canUsePro(planInfo.plan)) {
+    return { ok: false, error: "Funzionalità riservata al piano Pro." };
+  }
+  return { ok: true, userId: user.id };
+}
+
+async function validateRange(
+  range: AnalyticsRange,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!VALID_RANGES.has(range)) {
+    return { ok: false, error: "Range non valido." };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+type DocRow = {
+  id: string;
+  status: string;
+  createdAt: Date;
+  publicRequest?: unknown;
+};
+
+async function fetchSaleDocsInRange(
+  businessId: string,
+  from: Date,
+  to: Date,
+  options: { includePublicRequest?: boolean } = {},
+): Promise<DocRow[]> {
+  const db = getDb();
+  const baseSelection = {
+    id: commercialDocuments.id,
+    status: commercialDocuments.status,
+    createdAt: commercialDocuments.createdAt,
+  };
+  const selection = options.includePublicRequest
+    ? { ...baseSelection, publicRequest: commercialDocuments.publicRequest }
+    : baseSelection;
+  const rows = await db
+    .select(selection)
+    .from(commercialDocuments)
+    .where(
+      and(
+        eq(commercialDocuments.businessId, businessId),
+        eq(commercialDocuments.kind, "SALE"),
+        inArray(commercialDocuments.status, ["ACCEPTED", "VOID_ACCEPTED"]),
+        gte(commercialDocuments.createdAt, from),
+        lt(commercialDocuments.createdAt, to),
+      ),
+    );
+  return rows as DocRow[];
+}
+
+async function computeTotalsByDoc(
+  docs: { id: string }[],
+): Promise<Map<string, number>> {
+  if (docs.length === 0) return new Map();
+  const lines = await fetchLinesByDocIds(docs.map((d) => d.id));
+  const grouped = groupLinesByDocId(lines);
+  const totalsByDoc = new Map<string, number>();
+  for (const doc of docs) {
+    totalsByDoc.set(doc.id, calcDocTotal(grouped.get(doc.id) ?? []));
+  }
+  return totalsByDoc;
+}
+
+// ---------------------------------------------------------------------------
+// Server actions
+// ---------------------------------------------------------------------------
+
+export async function getAnalyticsKpis(
+  businessId: string,
+  range: AnalyticsRange,
+): Promise<AnalyticsKpis | { error: string }> {
+  const rangeCheck = await validateRange(range);
+  if (!rangeCheck.ok) return { error: rangeCheck.error };
+  const auth = await authorizePro(businessId);
+  if (!auth.ok) return { error: auth.error };
+
+  const { from, to } = rangeToBounds(range);
+  const docs = await fetchSaleDocsInRange(businessId, from, to);
+  const totalsByDoc = await computeTotalsByDoc(docs);
+
+  let revenueCents = 0;
+  let count = 0;
+  let voidCount = 0;
+  for (const doc of docs) {
+    if (doc.status === "ACCEPTED") {
+      count++;
+      revenueCents += toCents(totalsByDoc.get(doc.id) ?? 0);
+    } else if (doc.status === "VOID_ACCEPTED") {
+      voidCount++;
+    }
+  }
+  const aovCents = count === 0 ? 0 : Math.round(revenueCents / count);
+
+  return { revenueCents, count, aovCents, voidCount };
+}
+
+export async function getRevenueTimeseries(
+  businessId: string,
+  range: AnalyticsRange,
+  reference: Date = new Date(),
+): Promise<RevenuePoint[] | { error: string }> {
+  const rangeCheck = await validateRange(range);
+  if (!rangeCheck.ok) return { error: rangeCheck.error };
+  const auth = await authorizePro(businessId);
+  if (!auth.ok) return { error: auth.error };
+
+  const { from, to } = rangeToBounds(range, reference);
+  const docs = await fetchSaleDocsInRange(businessId, from, to);
+  const totalsByDoc = await computeTotalsByDoc(docs);
+
+  const byDay = new Map<string, number>();
+  for (const doc of docs) {
+    if (doc.status !== "ACCEPTED") continue;
+    const key = doc.createdAt.toISOString().slice(0, 10);
+    byDay.set(
+      key,
+      (byDay.get(key) ?? 0) + toCents(totalsByDoc.get(doc.id) ?? 0),
+    );
+  }
+  return fillMissingDays(byDay, from, to);
+}
+
+export async function getPaymentBreakdown(
+  businessId: string,
+  range: AnalyticsRange,
+): Promise<PaymentBreakdownEntry[] | { error: string }> {
+  const rangeCheck = await validateRange(range);
+  if (!rangeCheck.ok) return { error: rangeCheck.error };
+  const auth = await authorizePro(businessId);
+  if (!auth.ok) return { error: auth.error };
+
+  const { from, to } = rangeToBounds(range);
+  const docs = await fetchSaleDocsInRange(businessId, from, to, {
+    includePublicRequest: true,
+  });
+  const totalsByDoc = await computeTotalsByDoc(docs);
+
+  const byMethod = new Map<string, { count: number; revenueCents: number }>();
+  for (const doc of docs) {
+    if (doc.status !== "ACCEPTED") continue;
+    const method = normalizePaymentMethod(
+      doc.publicRequest && typeof doc.publicRequest === "object"
+        ? (doc.publicRequest as { paymentMethod?: unknown }).paymentMethod
+        : null,
+    );
+    const entry = byMethod.get(method) ?? { count: 0, revenueCents: 0 };
+    entry.count++;
+    entry.revenueCents += toCents(totalsByDoc.get(doc.id) ?? 0);
+    byMethod.set(method, entry);
+  }
+  return Array.from(byMethod.entries()).map(([method, agg]) => ({
+    method,
+    ...agg,
+  }));
+}

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -21,6 +21,7 @@ import {
   type RevenuePoint,
   VALID_RANGES,
   fillMissingDays,
+  formatRomeDay,
   normalizePaymentMethod,
   rangeToBounds,
   toCents,
@@ -175,7 +176,10 @@ export async function getRevenueTimeseries(
   const byDay = new Map<string, number>();
   for (const doc of docs) {
     if (doc.status !== "ACCEPTED") continue;
-    const key = doc.createdAt.toISOString().slice(0, 10);
+    // Bucket per giorno fiscale italiano (Europe/Rome), non UTC: uno
+    // scontrino emesso alle 00:30 ora locale del 19 maggio deve apparire
+    // nel giorno "2026-05-19", anche se internamente e' 22:30Z del 18.
+    const key = formatRomeDay(doc.createdAt);
     byDay.set(
       key,
       (byDay.get(key) ?? 0) + toCents(totalsByDoc.get(doc.id) ?? 0),

--- a/src/server/analytics-helpers.ts
+++ b/src/server/analytics-helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers per le server actions di analytics. NO "use server" — questo
+ * file e' importabile sia da modulo server-action sia direttamente dai test
+ * con tutte le funzioni esportate (anche quelle sync).
+ */
+
+export type AnalyticsRange = "7d" | "30d" | "90d";
+
+export type AnalyticsKpis = {
+  /** Totale ricavi (solo SALE ACCEPTED) espresso in centesimi. */
+  revenueCents: number;
+  /** Numero scontrini SALE ACCEPTED. */
+  count: number;
+  /** Average Order Value in centesimi. Ritorna 0 se count == 0. */
+  aovCents: number;
+  /** Numero scontrini annullati (SALE con status VOID_ACCEPTED). */
+  voidCount: number;
+};
+
+export type RevenuePoint = {
+  /** Data nel formato yyyy-MM-dd (UTC). */
+  date: string;
+  /** Ricavi della giornata in centesimi (solo ACCEPTED). */
+  revenueCents: number;
+};
+
+export type PaymentBreakdownEntry = {
+  /** "PC" | "PE" | "other". */
+  method: string;
+  count: number;
+  revenueCents: number;
+};
+
+export const VALID_RANGES: ReadonlySet<AnalyticsRange> = new Set([
+  "7d",
+  "30d",
+  "90d",
+]);
+
+const RANGE_DAYS: Record<AnalyticsRange, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+/**
+ * Mappa una range string a [from, to) UTC.
+ * `to` e' il giorno SUCCESSIVO al reference (midnight UTC) per includere
+ * tutto il "today".
+ */
+export function rangeToBounds(
+  range: AnalyticsRange,
+  reference: Date = new Date(),
+): { from: Date; to: Date } {
+  const days = RANGE_DAYS[range];
+  const to = new Date(
+    Date.UTC(
+      reference.getUTCFullYear(),
+      reference.getUTCMonth(),
+      reference.getUTCDate() + 1,
+    ),
+  );
+  const from = new Date(to);
+  from.setUTCDate(from.getUTCDate() - days);
+  return { from, to };
+}
+
+/**
+ * Normalizza un valore di paymentMethod proveniente da publicRequest jsonb.
+ * Riconosce "PC" e "PE"; ogni altra cosa diventa "other".
+ */
+export function normalizePaymentMethod(value: unknown): string {
+  if (typeof value !== "string") return "other";
+  if (value === "PC" || value === "PE") return value;
+  return "other";
+}
+
+/**
+ * Espande una Map<date, cents> in un array continuo coprendo tutti i giorni
+ * del range [from, to). I giorni mancanti sono riempiti con `revenueCents: 0`.
+ */
+export function fillMissingDays(
+  byDay: ReadonlyMap<string, number>,
+  from: Date,
+  to: Date,
+): RevenuePoint[] {
+  const out: RevenuePoint[] = [];
+  const cursor = new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()),
+  );
+  const end = new Date(
+    Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()),
+  );
+  while (cursor < end) {
+    const key = cursor.toISOString().slice(0, 10);
+    out.push({ date: key, revenueCents: byDay.get(key) ?? 0 });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return out;
+}
+
+export function toCents(amount: number): number {
+  return Math.round(amount * 100);
+}

--- a/src/server/analytics-helpers.ts
+++ b/src/server/analytics-helpers.ts
@@ -2,6 +2,12 @@
  * Pure helpers per le server actions di analytics. NO "use server" — questo
  * file e' importabile sia da modulo server-action sia direttamente dai test
  * con tutte le funzioni esportate (anche quelle sync).
+ *
+ * **Timezone:** tutta l'aggregazione e' ancorata al fuso fiscale italiano
+ * (Europe/Rome). Un scontrino emesso alle 00:30 ora italiana del 19 maggio
+ * viene memorizzato come 22:30Z del 18 maggio, ma per scopi fiscali e di UX
+ * deve apparire nel giorno "2026-05-19". I bounds di range, i bucket
+ * giornalieri e fillMissingDays usano quindi sempre il calendario Rome.
  */
 
 export type AnalyticsRange = "7d" | "30d" | "90d";
@@ -18,7 +24,7 @@ export type AnalyticsKpis = {
 };
 
 export type RevenuePoint = {
-  /** Data nel formato yyyy-MM-dd (UTC). */
+  /** Data nel formato yyyy-MM-dd (giorno fiscale italiano, Europe/Rome). */
   date: string;
   /** Ricavi della giornata in centesimi (solo ACCEPTED). */
   revenueCents: number;
@@ -43,26 +49,88 @@ const RANGE_DAYS: Record<AnalyticsRange, number> = {
   "90d": 90,
 };
 
+const ROME_TZ = "Europe/Rome";
+const ROME_DAY_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: ROME_TZ,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+const ROME_TIME_FORMATTER = new Intl.DateTimeFormat("en-GB", {
+  timeZone: ROME_TZ,
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
 /**
- * Mappa una range string a [from, to) UTC.
- * `to` e' il giorno SUCCESSIVO al reference (midnight UTC) per includere
- * tutto il "today".
+ * Ritorna il giorno fiscale italiano (yyyy-MM-dd) per l'istante dato.
+ * Internamente usa Intl con timeZone "Europe/Rome" per gestire DST in
+ * modo corretto senza libreria esterna.
+ */
+export function formatRomeDay(d: Date): string {
+  // en-CA produce direttamente "yyyy-MM-dd".
+  return ROME_DAY_FORMATTER.format(d);
+}
+
+/**
+ * Restituisce l'instant UTC che corrisponde alla mezzanotte (00:00:00)
+ * Europe/Rome del giorno fiscale `romeDay`.
+ *
+ * Algoritmo: prendi noon UTC dello stesso giorno calendar (sicuro per DST,
+ * non e' mai 02:00-03:00 di transizione), chiedi a Intl quali sono ore/min/sec
+ * a Rome in quell'instant, sottrai quell'offset da noon → ottieni l'instant
+ * UTC di mezzanotte Rome. Gestisce automaticamente CET e CEST.
+ */
+export function romeMidnightUtc(romeDay: string): Date {
+  const year = Number(romeDay.slice(0, 4));
+  const month = Number(romeDay.slice(5, 7)) - 1;
+  const day = Number(romeDay.slice(8, 10));
+  const noonUtcMs = Date.UTC(year, month, day, 12, 0, 0);
+
+  const parts = ROME_TIME_FORMATTER.formatToParts(new Date(noonUtcMs));
+  const get = (t: string) =>
+    Number(parts.find((p) => p.type === t)?.value ?? "0");
+  // en-GB con hour12:false puo' restituire "24" a mezzanotte: normalizza.
+  const h = get("hour") % 24;
+  const m = get("minute");
+  const s = get("second");
+
+  return new Date(noonUtcMs - (h * 3600 + m * 60 + s) * 1000);
+}
+
+/**
+ * Aggiunge `n` giorni di calendario a una data nel formato yyyy-MM-dd.
+ * Usa aritmetica UTC sulla data nominale (non un instant temporale), quindi
+ * e' insensibile a DST.
+ */
+function addCalendarDays(romeDay: string, n: number): string {
+  const d = new Date(`${romeDay}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Mappa una range string a [from, to) — entrambi instant UTC che
+ * corrispondono alla mezzanotte Europe/Rome del rispettivo giorno fiscale.
+ *
+ * - `to` = mezzanotte Rome del giorno successivo al reference (upper
+ *   bound exclusive che include il giorno corrente per intero).
+ * - `from` = `to` - `days` giorni di calendario fiscale italiano.
  */
 export function rangeToBounds(
   range: AnalyticsRange,
   reference: Date = new Date(),
 ): { from: Date; to: Date } {
   const days = RANGE_DAYS[range];
-  const to = new Date(
-    Date.UTC(
-      reference.getUTCFullYear(),
-      reference.getUTCMonth(),
-      reference.getUTCDate() + 1,
-    ),
-  );
-  const from = new Date(to);
-  from.setUTCDate(from.getUTCDate() - days);
-  return { from, to };
+  const todayRome = formatRomeDay(reference);
+  const toDay = addCalendarDays(todayRome, 1);
+  const fromDay = addCalendarDays(toDay, -days);
+  return {
+    from: romeMidnightUtc(fromDay),
+    to: romeMidnightUtc(toDay),
+  };
 }
 
 /**
@@ -76,8 +144,9 @@ export function normalizePaymentMethod(value: unknown): string {
 }
 
 /**
- * Espande una Map<date, cents> in un array continuo coprendo tutti i giorni
- * del range [from, to). I giorni mancanti sono riempiti con `revenueCents: 0`.
+ * Espande una Map<romeDay, cents> in un array continuo coprendo tutti i
+ * giorni fiscali italiani del range [from, to). I giorni mancanti sono
+ * riempiti con `revenueCents: 0`.
  */
 export function fillMissingDays(
   byDay: ReadonlyMap<string, number>,
@@ -85,16 +154,11 @@ export function fillMissingDays(
   to: Date,
 ): RevenuePoint[] {
   const out: RevenuePoint[] = [];
-  const cursor = new Date(
-    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()),
-  );
-  const end = new Date(
-    Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()),
-  );
+  let cursor = formatRomeDay(from);
+  const end = formatRomeDay(to);
   while (cursor < end) {
-    const key = cursor.toISOString().slice(0, 10);
-    out.push({ date: key, revenueCents: byDay.get(key) ?? 0 });
-    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    out.push({ date: cursor, revenueCents: byDay.get(cursor) ?? 0 });
+    cursor = addCalendarDays(cursor, 1);
   }
   return out;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
         "src/components/cassa/receipt-success.tsx",
         "src/components/storico/storico-client.tsx",
         "src/components/storico/void-receipt-dialog.tsx",
+        "src/components/analytics/analytics-client.tsx", // UI orchestrator — pure render + setState
+        "src/components/analytics/revenue-sparkline.tsx", // Recharts wrapper — UI shell
+        "src/components/analytics/payment-breakdown.tsx", // Recharts wrapper — UI shell
         "src/components/providers.tsx",
         "src/components/marketing/**", // marketing UI components — tested via E2E
         "src/components/billing/checkout-button.tsx", // UI client component — pure fetch + redirect


### PR DESCRIPTION
- v1.3.0 ora descrive le 2 feature Pro concrete del launch gate.
- Rimossa v1.6.0 che duplicava lo stesso scope di v1.3.0.
- Coupon/promo resta consolidato in v1.4.0 insieme a referral.

https://claude.ai/code/session_019qZPEytrT2NkK7F8Z8aSHD