### PR TITLE
Remove Integrazioni help category

### DIFF
--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -160,15 +160,6 @@ const helpCategories: HelpCategory[] = [
     ],
   },
   {
-    name: "Integrazioni",
-    description: "Connessioni con canali di vendita esterni.",
-    articles: [
-      { title: "Integrazione con Shopify: panoramica e casi d'uso" },
-      { title: "Integrazione con WooCommerce: setup base" },
-      { title: "Collegare un registratore telematico esistente" },
-    ],
-  },
-  {
     name: "API per sviluppatori",
     description: "Integra l'emissione scontrini nel tuo gestionale o POS.",
     articles: [


### PR DESCRIPTION
## Summary
Removes the "Integrazioni" (Integrations) help category from the help page, consolidating integration-related documentation under the existing "API per sviluppatori" section.

## Changes
- Deleted the "Integrazioni" help category block containing three articles:
  - "Integrazione con Shopify: panoramica e casi d'uso"
  - "Integrazione con WooCommerce: setup base"
  - "Collegare un registratore telematico esistente"

The "API per sviluppatori" category remains as the primary integration documentation resource.

https://claude.ai/code/session_016WzAxcRAHcTrALdPDBJW3o