### PR TITLE
fix(auth): accetta marketing hostname nel check Turnstile + log error-codes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,10 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Production values for hostname routing (proxy.ts):
 # NEXT_PUBLIC_APP_URL=https://app.scontrinozero.it
 NEXT_PUBLIC_APP_HOSTNAME=app.scontrinozero.it
+# Marketing/landing hostname. Anche usato da `verifyCaptcha` come hostname
+# accettato per il widget Turnstile (oltre all'app hostname e a `www.<marketing>`),
+# perché la client-side navigation di Next.js verso /login può lasciare il
+# browser sul dominio marketing.
 NEXT_PUBLIC_MARKETING_HOSTNAME=scontrinozero.it
 # Runtime override of the hostname baked at build time. Used by self-hosted
 # installs on a custom domain or by the sandbox container.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,25 @@
     bloccare protocol-relative URLs di open redirect) e poi `new URL(redirect, origin)`
     parsifica correttamente il querystring senza rischi.
 
+32. **Turnstile hostname check: lista, non single value.**
+    Cloudflare Turnstile ritorna in `data.hostname` l'hostname effettivo dove il
+    widget è stato risolto nel browser. Quando il sito ha sia un dominio app
+    (`app.scontrinozero.it`) sia un dominio marketing (`scontrinozero.it`), e il
+    form `/login` può essere caricato da entrambi — perché la client-side
+    navigation Next.js (`<Link href="/login">` dalla landing) non attraversa
+    sempre il redirect cross-origin del middleware, oppure perché il deploy è
+    single-domain — il check `data.hostname === expectedHostname` causa
+    `captcha_hostname_mismatch` sistemico e fail di ogni captcha.
+
+    Pattern obbligato in `verifyCaptcha` (`src/server/auth-actions.ts`): costruire
+    un `ReadonlySet<string>` con `appHostname`, `marketingHostname`, `www.<marketing>`
+    e usare `acceptedHostnames.has(data.hostname)`. Loggare la lista accettata
+    in caso di mismatch facilita il debug operativo.
+
+    Inoltre: il ramo `data.success: false` di Cloudflare deve **sempre** loggare
+    `data["error-codes"]` (es. `timeout-or-duplicate`, `invalid-input-response`).
+    Senza questo log la causa del rifiuto resta invisibile in produzione.
+
 ## Progetto
 
 ScontrinoZero è un registratore di cassa virtuale (SaaS) mobile-first che consente a

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -933,6 +933,154 @@ describe("auth-actions", () => {
 
       expect(mockSignUp).toHaveBeenCalled();
     });
+
+    it("accepts a captcha token whose hostname is the marketing domain (single-domain / client-side nav)", async () => {
+      // Reproduces the production bug: the widget is loaded from the marketing
+      // domain (e.g. via Next.js <Link> client-side navigation to /login) and
+      // Cloudflare therefore returns hostname=<marketing>, not <app>. Pre-fix
+      // verifyCaptcha rejected this as `captcha_hostname_mismatch`.
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+      mockFetch.mockResolvedValueOnce(
+        captchaResponse("signup", "scontrinozero.it"),
+      );
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        if (!isRedirectError(err)) throw err;
+      }
+
+      expect(mockSignUp).toHaveBeenCalled();
+    });
+
+    it("accepts a captcha token whose hostname is the www variant of the marketing domain", async () => {
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+      mockFetch.mockResolvedValueOnce(
+        captchaResponse("signup", "www.scontrinozero.it"),
+      );
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        if (!isRedirectError(err)) throw err;
+      }
+
+      expect(mockSignUp).toHaveBeenCalled();
+    });
+
+    it("still rejects hostnames outside the app/marketing/www allowlist (e.g. attacker domain)", async () => {
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+      mockFetch.mockResolvedValueOnce(
+        captchaResponse("signup", "evil.example.com"),
+      );
+
+      const { signUp } = await import("./auth-actions");
+      const result = await signUp(
+        formData({
+          email: "test@example.com",
+          password: "Secure#99x",
+          confirmPassword: "Secure#99x",
+          termsAccepted: "true",
+          specificClausesAccepted: "true",
+          captchaToken: "stolen-token",
+        }),
+      );
+
+      expect(result).toEqual({ error: "Verifica CAPTCHA fallita. Riprova." });
+      expect(mockSignUp).not.toHaveBeenCalled();
+    });
+
+    it("logs captcha_verification_failed with error-codes when Turnstile returns success:false", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: false,
+          "error-codes": ["timeout-or-duplicate"],
+        }),
+      });
+      const { logger } = await import("@/lib/logger");
+
+      const { signUp } = await import("./auth-actions");
+      const result = await signUp(
+        formData({
+          email: "test@example.com",
+          password: "Secure#99x",
+          confirmPassword: "Secure#99x",
+          termsAccepted: "true",
+          specificClausesAccepted: "true",
+          captchaToken: "duplicate-token",
+        }),
+      );
+
+      expect(result).toEqual({ error: "Verifica CAPTCHA fallita. Riprova." });
+      expect(mockSignUp).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorClass: "captcha_verification_failed",
+          errorCodes: ["timeout-or-duplicate"],
+        }),
+        "Turnstile siteverify rejected token",
+      );
+    });
+
+    it("logs captcha_verification_failed with empty array when error-codes is absent", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: false }),
+      });
+      const { logger } = await import("@/lib/logger");
+
+      const { signUp } = await import("./auth-actions");
+      await signUp(
+        formData({
+          email: "test@example.com",
+          password: "Secure#99x",
+          confirmPassword: "Secure#99x",
+          termsAccepted: "true",
+          specificClausesAccepted: "true",
+          captchaToken: "bad-token",
+        }),
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorClass: "captcha_verification_failed",
+          errorCodes: [],
+        }),
+        "Turnstile siteverify rejected token",
+      );
+    });
   });
 
   describe("signIn", () => {

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -99,6 +99,26 @@ function checkCaptchaPreLimit(
 
 type CaptchaAction = "signup" | "signin" | "reset-password";
 
+/**
+ * Hostname accettati nella response Turnstile siteverify.
+ *
+ * Il widget può essere caricato sia dal dominio app sia dal dominio marketing:
+ * la client-side navigation di Next.js (`<Link href="/login">` dalla landing)
+ * non sempre attraversa il redirect del middleware cross-origin, quindi il
+ * browser può restare sull'hostname marketing quando renderizza /login. Anche
+ * i deploy single-domain (app servita dal dominio marketing) sono coperti da
+ * questa lista.
+ */
+function getAcceptedTurnstileHostnames(): ReadonlySet<string> {
+  const appHostname =
+    process.env.APP_HOSTNAME ?? // runtime override (sandbox, self-hosted)
+    process.env.NEXT_PUBLIC_APP_HOSTNAME ?? // baked at build time
+    "app.scontrinozero.it";
+  const marketingHostname =
+    process.env.NEXT_PUBLIC_MARKETING_HOSTNAME ?? "scontrinozero.it";
+  return new Set([appHostname, marketingHostname, `www.${marketingHostname}`]);
+}
+
 async function verifyCaptcha(
   token: string | null,
   remoteIp: string | undefined,
@@ -134,16 +154,26 @@ async function verifyCaptcha(
       success: boolean;
       hostname: string;
       action?: string;
+      "error-codes"?: string[];
     };
-    if (!data.success) return false;
-    const expectedHostname =
-      process.env.APP_HOSTNAME ?? // runtime override (sandbox, self-hosted)
-      process.env.NEXT_PUBLIC_APP_HOSTNAME ?? // baked at build time
-      "app.scontrinozero.it";
-    if (data.hostname !== expectedHostname) {
+    if (!data.success) {
+      // `error-codes` distingue `invalid-input-response`, `timeout-or-duplicate`,
+      // `internal-error`, ecc. — segnale necessario per diagnosi captcha in prod.
+      logger.warn(
+        {
+          errorCodes: data["error-codes"] ?? [],
+          errorClass: "captcha_verification_failed",
+        },
+        "Turnstile siteverify rejected token",
+      );
+      return false;
+    }
+    const acceptedHostnames = getAcceptedTurnstileHostnames();
+    if (!acceptedHostnames.has(data.hostname)) {
       logger.warn(
         {
           captchaHostname: data.hostname,
+          acceptedHostnames: [...acceptedHostnames],
           errorClass: "captcha_hostname_mismatch",
         },
         "Turnstile hostname mismatch",


### PR DESCRIPTION
Root cause: dopo aver esteso Turnstile a signIn/resetPassword (8d14b1d),
verifyCaptcha accettava un solo expectedHostname. In produzione il widget
viene caricato anche dal dominio marketing (Next.js client-side navigation
verso /login senza full reload, oppure single-domain deploy), causando
captcha_hostname_mismatch sistemico e fallimento di ogni login.

Log Docker prod (2026-05-18T10:14:06Z / 10:19:27Z):
  {"errorClass":"captcha_hostname_mismatch","captchaHostname":"scontrinozero.it"}

Cambiamenti:
- verifyCaptcha ora costruisce una ReadonlySet con app + marketing + www
  hostname (env già esistenti: APP_HOSTNAME, NEXT_PUBLIC_APP_HOSTNAME,
  NEXT_PUBLIC_MARKETING_HOSTNAME) e usa Set.has(data.hostname).
- Aggiunto log mancante per il ramo data.success: false con
  errorCodes da Cloudflare (timeout-or-duplicate, invalid-input-response,
  ecc.) — gap esistente che rendeva invisibili in prod le cause di rigetto.
- 5 nuovi test: marketing hostname accepted, www variant accepted,
  outside-allowlist rejected, error-codes logged con e senza codici.
- CLAUDE.md regola #32 documenta il pattern multi-hostname.