### PR TITLE
Extract service error response mapping to shared helper

### DIFF
--- a/src/app/api/v1/receipts/[id]/void/route.ts
+++ b/src/app/api/v1/receipts/[id]/void/route.ts
@@ -7,6 +7,7 @@ import {
   corsOptionsResponse,
   checkRateLimitApi,
   parseAndValidateBody,
+  serviceErrorResponse,
   withCors,
 } from "@/lib/api-v1-helpers";
 
@@ -67,44 +68,7 @@ export async function POST(
   );
 
   if (result.error) {
-    // DB timeout → 503 + Retry-After
-    if (result.code === "DB_TIMEOUT") {
-      return withCors(
-        Response.json(
-          { code: "DB_TIMEOUT", error: result.error },
-          { status: 503, headers: { "Retry-After": "5" } },
-        ),
-      );
-    }
-    // VOID_PENDING_IN_PROGRESS → 409
-    if (result.code === "VOID_PENDING_IN_PROGRESS") {
-      return withCors(
-        Response.json(
-          { code: "VOID_PENDING_IN_PROGRESS", error: result.error },
-          { status: 409, headers: { "Retry-After": "2" } },
-        ),
-      );
-    }
-    // VOID_ALREADY_TARGETED: 409 (race condition)
-    if (result.code === "VOID_ALREADY_TARGETED") {
-      return withCors(
-        Response.json(
-          { code: "VOID_ALREADY_TARGETED", error: result.error },
-          { status: 409 },
-        ),
-      );
-    }
-    // VOID_SYNC_FAILED: 500 + machine-readable code (DB out of sync con AdE,
-    // richiede cleanup manuale, non un retry automatico utile)
-    if (result.code === "VOID_SYNC_FAILED") {
-      return withCors(
-        Response.json(
-          { code: "VOID_SYNC_FAILED", error: result.error },
-          { status: 500 },
-        ),
-      );
-    }
-    return withCors(Response.json({ error: result.error }, { status: 422 }));
+    return serviceErrorResponse({ error: result.error, code: result.code });
   }
 
   return withCors(

--- a/src/app/api/v1/receipts/route.ts
+++ b/src/app/api/v1/receipts/route.ts
@@ -18,6 +18,7 @@ import {
   corsOptionsResponse,
   checkRateLimitApi,
   parseAndValidateBody,
+  serviceErrorResponse,
   withCors,
 } from "@/lib/api-v1-helpers";
 import type { SubmitReceiptInput } from "@/types/cassa";
@@ -137,34 +138,7 @@ export async function POST(request: Request): Promise<Response> {
   const result = await emitReceiptForBusiness(input, auth.apiKey.id);
 
   if (result.error) {
-    // DB timeout → 503 + Retry-After (transient, retryable)
-    if (result.code === "DB_TIMEOUT") {
-      return withCors(
-        Response.json(
-          { code: "DB_TIMEOUT", error: result.error },
-          { status: 503, headers: { "Retry-After": "5" } },
-        ),
-      );
-    }
-    // PENDING_IN_PROGRESS → 409 (conflict, retryable a breve termine)
-    if (result.code === "PENDING_IN_PROGRESS") {
-      return withCors(
-        Response.json(
-          { code: "PENDING_IN_PROGRESS", error: result.error },
-          { status: 409, headers: { "Retry-After": "2" } },
-        ),
-      );
-    }
-    // ALREADY_REJECTED: 409 con istruzione di usare nuova key
-    if (result.code === "ALREADY_REJECTED") {
-      return withCors(
-        Response.json(
-          { code: "ALREADY_REJECTED", error: result.error },
-          { status: 409 },
-        ),
-      );
-    }
-    return withCors(Response.json({ error: result.error }, { status: 422 }));
+    return serviceErrorResponse({ error: result.error, code: result.code });
   }
 
   return withCors(

--- a/src/lib/api-v1-helpers.ts
+++ b/src/lib/api-v1-helpers.ts
@@ -151,6 +151,44 @@ export function checkRateLimitApi(
 }
 
 /**
+ * Maps service error codes (`emitReceiptForBusiness`, `voidReceiptForBusiness`)
+ * to HTTP responses. Centralised so route handlers don't repeat the same
+ * status/Retry-After mapping (SonarCloud duplicated-lines guard).
+ *
+ * Fallback (unknown / undefined code): 422 with `{ error }` envelope.
+ */
+const SERVICE_ERROR_STATUS_MAP: Record<
+  string,
+  { status: number; retryAfter?: number }
+> = {
+  DB_TIMEOUT: { status: 503, retryAfter: 5 },
+  PENDING_IN_PROGRESS: { status: 409, retryAfter: 2 },
+  ALREADY_REJECTED: { status: 409 },
+  VOID_PENDING_IN_PROGRESS: { status: 409, retryAfter: 2 },
+  VOID_ALREADY_TARGETED: { status: 409 },
+  VOID_SYNC_FAILED: { status: 500 },
+};
+
+export function serviceErrorResponse(result: {
+  error: string;
+  code?: string;
+}): Response {
+  const mapping = result.code
+    ? SERVICE_ERROR_STATUS_MAP[result.code]
+    : undefined;
+  if (!mapping) {
+    return withCors(Response.json({ error: result.error }, { status: 422 }));
+  }
+  const init: ResponseInit = { status: mapping.status };
+  if (mapping.retryAfter !== undefined) {
+    init.headers = { "Retry-After": String(mapping.retryAfter) };
+  }
+  return withCors(
+    Response.json({ code: result.code, error: result.error }, init),
+  );
+}
+
+/**
  * Reads and validates the request body against a Zod schema.
  *
  * Returns `{ error: Response }` on size/parse/validation failure,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -105,9 +105,9 @@ function captureToSentry(obj: unknown, msg?: string): void {
     typeof obj === "object" &&
     obj !== null &&
     "err" in obj &&
-    (obj as { err: unknown }).err instanceof Error
+    obj.err instanceof Error
   ) {
-    Sentry.captureException((obj as { err: Error }).err, {
+    Sentry.captureException(obj.err, {
       extra: sanitized,
     });
   } else if (obj instanceof Error) {

--- a/tests/unit/api-v1-helpers.test.ts
+++ b/tests/unit/api-v1-helpers.test.ts
@@ -44,6 +44,7 @@ import {
   corsOptionsResponse,
   checkRateLimitApi,
   parseAndValidateBody,
+  serviceErrorResponse,
   withCors,
 } from "@/lib/api-v1-helpers";
 
@@ -317,5 +318,84 @@ describe("parseAndValidateBody", () => {
     if ("data" in result) {
       expect(result.data).toEqual({ name: "Caffè" });
     }
+  });
+});
+
+describe("serviceErrorResponse", () => {
+  it("returns 503 + Retry-After 5 for DB_TIMEOUT", async () => {
+    const res = serviceErrorResponse({ error: "timeout", code: "DB_TIMEOUT" });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = await res.json();
+    expect(body).toEqual({ code: "DB_TIMEOUT", error: "timeout" });
+  });
+
+  it("returns 409 + Retry-After 2 for PENDING_IN_PROGRESS", async () => {
+    const res = serviceErrorResponse({
+      error: "pending",
+      code: "PENDING_IN_PROGRESS",
+    });
+    expect(res.status).toBe(409);
+    expect(res.headers.get("Retry-After")).toBe("2");
+    const body = await res.json();
+    expect(body.code).toBe("PENDING_IN_PROGRESS");
+  });
+
+  it("returns 409 (no Retry-After) for ALREADY_REJECTED", async () => {
+    const res = serviceErrorResponse({
+      error: "rejected",
+      code: "ALREADY_REJECTED",
+    });
+    expect(res.status).toBe(409);
+    expect(res.headers.get("Retry-After")).toBeNull();
+    const body = await res.json();
+    expect(body.code).toBe("ALREADY_REJECTED");
+  });
+
+  it("returns 409 + Retry-After 2 for VOID_PENDING_IN_PROGRESS", async () => {
+    const res = serviceErrorResponse({
+      error: "void pending",
+      code: "VOID_PENDING_IN_PROGRESS",
+    });
+    expect(res.status).toBe(409);
+    expect(res.headers.get("Retry-After")).toBe("2");
+  });
+
+  it("returns 409 (no Retry-After) for VOID_ALREADY_TARGETED", async () => {
+    const res = serviceErrorResponse({
+      error: "race",
+      code: "VOID_ALREADY_TARGETED",
+    });
+    expect(res.status).toBe(409);
+    expect(res.headers.get("Retry-After")).toBeNull();
+  });
+
+  it("returns 500 for VOID_SYNC_FAILED", async () => {
+    const res = serviceErrorResponse({
+      error: "sync failed",
+      code: "VOID_SYNC_FAILED",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("VOID_SYNC_FAILED");
+  });
+
+  it("falls back to 422 with bare error envelope when code is unknown", async () => {
+    const res = serviceErrorResponse({
+      error: "boom",
+      code: "SOMETHING_ELSE",
+    });
+    expect(res.status).toBe(422);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = await res.json();
+    expect(body).toEqual({ error: "boom" });
+  });
+
+  it("falls back to 422 when code is undefined", async () => {
+    const res = serviceErrorResponse({ error: "boom" });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body).toEqual({ error: "boom" });
   });
 });


### PR DESCRIPTION
## Summary
Centralizes HTTP error response mapping for service errors (`emitReceiptForBusiness`, `voidReceiptForBusiness`) into a reusable `serviceErrorResponse()` helper function. This eliminates duplicated error-handling logic across multiple route handlers and ensures consistent status codes and `Retry-After` headers.

## Changes
- **New helper function** `serviceErrorResponse()` in `src/lib/api-v1-helpers.ts`:
  - Maps error codes to HTTP status and `Retry-After` headers via `SERVICE_ERROR_STATUS_MAP`
  - Handles 6 known error codes (DB_TIMEOUT, PENDING_IN_PROGRESS, ALREADY_REJECTED, VOID_PENDING_IN_PROGRESS, VOID_ALREADY_TARGETED, VOID_SYNC_FAILED)
  - Falls back to 422 with bare `{ error }` envelope for unknown/undefined codes
  - Automatically applies CORS headers via `withCors()`

- **Route handlers simplified**:
  - `src/app/api/v1/receipts/route.ts`: Replaced 30 lines of conditional error handling with single `serviceErrorResponse()` call
  - `src/app/api/v1/receipts/[id]/void/route.ts`: Replaced 37 lines of conditional error handling with single `serviceErrorResponse()` call

- **Comprehensive test coverage** in `tests/unit/api-v1-helpers.test.ts`:
  - 8 test cases covering all mapped error codes and fallback behavior
  - Validates status codes, `Retry-After` headers, CORS headers, and response bodies

- **Minor refactor** in `src/lib/logger.ts`:
  - Removed unnecessary type assertions (`as { err: unknown }`, `as { err: Error }`) for cleaner code

## Implementation Details
- Error codes are mapped in a single `SERVICE_ERROR_STATUS_MAP` record for easy maintenance
- `Retry-After` header is only set when `retryAfter` is defined in the mapping
- Response body includes `code` field only for known error codes (fallback omits it)
- All responses are wrapped with `withCors()` to ensure consistent CORS headers

https://claude.ai/code/session_01JNPAkdDtLdSCNXZEupXurs