### PR TITLE
Add SPID login and document retrieval tests to MockAdeClient

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,6 +19,9 @@ sonar.coverage.exclusions=\
   src/app/(marketing)/funzionalita/page.tsx,\
   src/app/(marketing)/privacy/page.tsx,\
   src/app/(marketing)/privacy/v01/page.tsx,\
+  src/app/(marketing)/termini/v01/page.tsx,\
+  src/lib/ade/types.ts,\
+  src/components/catalogo/catalogo-client.tsx,\
   src/app/(marketing)/help/page.tsx,\
   src/app/(marketing)/help/api/page.tsx,\
   src/app/(marketing)/help/come-collegare-ade/page.tsx,\

--- a/src/lib/ade/mock-client.test.ts
+++ b/src/lib/ade/mock-client.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, beforeEach } from "vitest";
 
 import { MockAdeClient } from "./mock-client";
 import { createAdeClient } from "./index";
-import type { AdePayload, AdeCedentePrestatore } from "./types";
+import type {
+  AdePayload,
+  AdeCedentePrestatore,
+  SpidCredentials,
+} from "./types";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -210,6 +214,104 @@ describe("MockAdeClient", () => {
 
     it("does not throw if already logged out", async () => {
       await expect(client.logout()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("loginSpid", () => {
+    const spidCreds: SpidCredentials = {
+      codiceFiscale: "RSSMRA80A01H501A",
+      password: "spidpassword",
+      spidProvider: "poste",
+    };
+
+    it("returns a mock session marked as spid", async () => {
+      const session = await client.loginSpid(spidCreds);
+
+      expect(session.pAuth).toMatch(/^mock_p_auth_spid_/);
+      expect(session.partitaIva.length).toBe(11);
+      expect(session.createdAt).toBeGreaterThan(0);
+    });
+
+    it("enables subsequent operations like a regular login", async () => {
+      await client.loginSpid(spidCreds);
+      const response = await client.submitSale(makeSalePayload());
+
+      expect(response.esito).toBe(true);
+    });
+  });
+
+  describe("getProducts", () => {
+    it("returns an empty array when logged in", async () => {
+      await client.login(mockCredentials);
+      const products = await client.getProducts();
+
+      expect(products).toEqual([]);
+    });
+
+    it("throws if not logged in", async () => {
+      await expect(client.getProducts()).rejects.toThrow();
+    });
+  });
+
+  describe("getStampa", () => {
+    it("returns an empty string when logged in", async () => {
+      await client.login(mockCredentials);
+      const stampa = await client.getStampa("151000000");
+
+      expect(stampa).toBe("");
+    });
+
+    it("accepts the isGift parameter without error", async () => {
+      await client.login(mockCredentials);
+      const stampa = await client.getStampa("151000000", true);
+
+      expect(stampa).toBe("");
+    });
+
+    it("throws if not logged in", async () => {
+      await expect(client.getStampa("151000000")).rejects.toThrow();
+    });
+  });
+
+  describe("getDocument", () => {
+    it("returns a minimal document with the requested idtrx", async () => {
+      await client.login(mockCredentials);
+      const doc = await client.getDocument("151000123");
+
+      expect(doc.idtrx).toBe("151000123");
+      expect(doc.documentoCommerciale).toBeDefined();
+      expect(doc.documentoCommerciale.elementiContabili).toEqual([]);
+    });
+
+    it("throws if not logged in", async () => {
+      await expect(client.getDocument("151000000")).rejects.toThrow();
+    });
+  });
+
+  describe("searchDocuments", () => {
+    it("returns an empty list when logged in", async () => {
+      await client.login(mockCredentials);
+      const result = await client.searchDocuments({ tipoOperazione: "V" });
+
+      expect(result.totalCount).toBe(0);
+      expect(result.elencoRisultati).toEqual([]);
+    });
+
+    it("throws if not logged in", async () => {
+      await expect(client.searchDocuments({})).rejects.toThrow();
+    });
+  });
+
+  describe("changePasswordFisconline", () => {
+    it("resolves without throwing (mock no-op)", async () => {
+      await expect(
+        client.changePasswordFisconline({
+          codiceFiscale: "RSSMRA80A01H501A",
+          oldPassword: "oldpw",
+          newPassword: "newpw",
+          confirmNewPassword: "newpw",
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
         // UI orchestration components — pure UI shells, no testable logic
         "src/app/onboarding/onboarding-form.tsx",
         "src/components/cassa/cassa-client.tsx",
+        "src/components/catalogo/catalogo-client.tsx", // UI orchestrator — pure render + setState, same pattern as cassa-client
+        "src/lib/ade/types.ts", // pure type declarations + 1 regex constant (covered indirectly via validation)
+        "src/app/(marketing)/termini/v01/page.tsx", // static legal text — pure UI, no logic (same as privacy/v01)
         "src/components/cassa/receipt-success.tsx",
         "src/components/storico/storico-client.tsx",
         "src/components/storico/void-receipt-dialog.tsx",


### PR DESCRIPTION
## Summary
Expanded test coverage for the MockAdeClient by adding comprehensive test suites for SPID authentication and document retrieval operations. Also updated SonarCloud and Vitest configuration to exclude files with no testable logic.

## Key Changes

### Test Coverage (`src/lib/ade/mock-client.test.ts`)
- **Added `loginSpid` test suite**: Validates SPID login returns a properly formatted session with `mock_p_auth_spid_` prefix and enables subsequent operations
- **Added `getProducts` test suite**: Verifies empty array return when logged in and proper error handling when not authenticated
- **Added `getStampa` test suite**: Tests document printing with and without the `isGift` parameter, validates authentication requirement
- **Added `getDocument` test suite**: Confirms document retrieval returns correct structure with requested `idtrx` and empty accounting elements
- **Added `searchDocuments` test suite**: Validates empty result list when logged in and authentication enforcement
- **Added `changePasswordFisconline` test suite**: Confirms password change operation resolves without error (mock no-op)
- Updated imports to include `SpidCredentials` type

### Configuration Updates
- **`sonar-project.properties`**: Added three files to `sonar.coverage.exclusions`:
  - `src/app/(marketing)/termini/v01/page.tsx` (static legal text)
  - `src/lib/ade/types.ts` (pure type declarations)
  - `src/components/catalogo/catalogo-client.tsx` (UI orchestrator)

- **`vitest.config.ts`**: Added same three files to the `exclude` list with explanatory comments matching SonarCloud exclusion rationale

## Implementation Details
- All new tests follow the existing pattern: login setup → operation → assertion
- Tests verify both happy path and error conditions (authentication required)
- Mock responses are minimal but structurally valid (e.g., `getDocument` returns proper document shape with empty accounting elements)
- Configuration changes align with project convention: files with no testable logic must be excluded from both SonarCloud coverage and Vitest to avoid false negatives

https://claude.ai/code/session_01PnxfV75vXxQr2og8hvUSLx