### PR TITLE
Fix Tailwind v4 oklch color wrapping in chart components

### DIFF
--- a/src/components/analytics/payment-breakdown.tsx
+++ b/src/components/analytics/payment-breakdown.tsx
@@ -71,11 +71,7 @@ export function PaymentBreakdown({ data }: PaymentBreakdownProps) {
               fontSize: 12,
             }}
           />
-          <Bar
-            dataKey="revenue"
-            fill="hsl(var(--primary, 220 90% 56%))"
-            radius={[4, 4, 0, 0]}
-          />
+          <Bar dataKey="revenue" fill="var(--primary)" radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/analytics/revenue-sparkline.tsx
+++ b/src/components/analytics/revenue-sparkline.tsx
@@ -74,7 +74,7 @@ export function RevenueSparkline({ data }: RevenueSparklineProps) {
           <Line
             type="monotone"
             dataKey="revenue"
-            stroke="hsl(var(--primary, 220 90% 56%))"
+            stroke="var(--primary)"
             strokeWidth={2}
             dot={false}
             activeDot={{ r: 4 }}

--- a/tests/unit/payment-breakdown.test.tsx
+++ b/tests/unit/payment-breakdown.test.tsx
@@ -19,7 +19,9 @@ vi.mock("recharts", () => ({
       {children}
     </div>
   ),
-  Bar: () => null,
+  Bar: ({ fill }: { fill?: string }) => (
+    <div data-testid="bar" data-fill={fill} />
+  ),
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
@@ -88,6 +90,20 @@ describe("PaymentBreakdown", () => {
     expect(chartData).toHaveLength(1);
     expect(chartData[0].method).toBe("Altro");
     expect(chartData[0].revenue).toBeCloseTo(9.99, 2);
+  });
+
+  it("passes a valid CSS color to the Bar fill (no hsl()-wrapped oklch token)", () => {
+    // Regressione: `hsl(var(--primary))` produceva `hsl(oklch(...))` invalido
+    // con Tailwind v4 (--primary è un oklch), rendendo le barre trasparenti.
+    render(
+      <PaymentBreakdown
+        data={[{ method: "PC", count: 1, revenueCents: 100 }]}
+      />,
+    );
+
+    const fill = screen.getByTestId("bar").getAttribute("data-fill") ?? "";
+    expect(fill).not.toMatch(/^hsl\(\s*var\(/);
+    expect(fill).toBe("var(--primary)");
   });
 
   it("falls back to the raw method code when not in the known label map", () => {

--- a/tests/unit/revenue-sparkline.test.tsx
+++ b/tests/unit/revenue-sparkline.test.tsx
@@ -11,7 +11,9 @@ vi.mock("recharts", () => ({
   LineChart: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="line-chart">{children}</div>
   ),
-  Line: () => null,
+  Line: ({ stroke }: { stroke?: string }) => (
+    <div data-testid="line" data-stroke={stroke} />
+  ),
   XAxis: () => null,
   YAxis: () => null,
   Tooltip: () => null,
@@ -41,5 +43,19 @@ describe("RevenueSparkline", () => {
     expect(
       screen.queryByText("Nessuno scontrino nel periodo selezionato."),
     ).toBeNull();
+  });
+
+  it("passes a valid CSS color to the Line stroke (no hsl()-wrapped oklch token)", () => {
+    // Regressione: `hsl(var(--primary))` produceva `hsl(oklch(...))` invalido
+    // con Tailwind v4 (--primary è un oklch), rendendo la linea trasparente.
+    render(
+      <RevenueSparkline
+        data={[{ date: "2026-05-19", revenueCents: 12_345 }]}
+      />,
+    );
+
+    const stroke = screen.getByTestId("line").getAttribute("data-stroke") ?? "";
+    expect(stroke).not.toMatch(/^hsl\(\s*var\(/);
+    expect(stroke).toBe("var(--primary)");
   });
 });


### PR DESCRIPTION
## Summary
Fixes a regression where chart components (`PaymentBreakdown` and `RevenueSparkline`) were wrapping Tailwind v4 oklch color tokens in invalid `hsl()` functions, causing bars and lines to render as transparent.

## Changes
- **PaymentBreakdown**: Changed `Bar` fill from `"hsl(var(--primary, 220 90% 56%))"` to `"var(--primary)"` to pass the raw CSS variable without wrapping
- **RevenueSparkline**: Changed `Line` stroke from `"hsl(var(--primary, 220 90% 56%))"` to `"var(--primary)"` for the same reason
- **Tests**: Updated mocks for `Bar` and `Line` components to capture and expose the `fill`/`stroke` attributes, then added regression tests to verify the color values are passed correctly without `hsl()` wrapping

## Details
With Tailwind v4, the `--primary` CSS variable is defined as an oklch color space value. Wrapping it in `hsl(var(--primary))` produces invalid CSS like `hsl(oklch(...))`, which browsers ignore, rendering the chart elements transparent. The fix passes the variable directly, allowing the browser to resolve it to the correct oklch color value.

Both test files now verify that the color attributes are valid CSS and do not contain the problematic `hsl(var(...))` pattern.

https://claude.ai/code/session_011HRJ2ihJnxCNtFjNP7fVxn