### PR TITLE
Format receipt timestamps in Rome timezone with ISO 8601

### DIFF
--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -3,6 +3,7 @@ import {
   getFiscalDate,
   parseStrictIsoDateUtc,
   formatFiscalDateTime,
+  formatIsoInRome,
 } from "./date-utils";
 
 describe("getFiscalDate", () => {
@@ -96,6 +97,44 @@ describe("formatFiscalDateTime", () => {
     expect(result).toContain("2026");
     // The Rome hour (13) must appear, not the UTC hour (12)
     expect(result).toContain("13");
+  });
+});
+
+describe("formatIsoInRome", () => {
+  it("returns ISO 8601 with +02:00 offset in summer (CEST)", () => {
+    // 2026-05-19T12:34:56.789Z → Rome CEST (UTC+2) → 14:34:56+02:00
+    expect(formatIsoInRome(new Date("2026-05-19T12:34:56.789Z"))).toBe(
+      "2026-05-19T14:34:56+02:00",
+    );
+  });
+
+  it("returns ISO 8601 with +01:00 offset in winter (CET)", () => {
+    // 2026-01-15T12:34:56Z → Rome CET (UTC+1) → 13:34:56+01:00
+    expect(formatIsoInRome(new Date("2026-01-15T12:34:56Z"))).toBe(
+      "2026-01-15T13:34:56+01:00",
+    );
+  });
+
+  it("uses Rome day, not UTC day, for a timestamp just past midnight UTC in summer", () => {
+    // 2026-07-15T22:30:00Z = 2026-07-16T00:30:00 CEST → July 16 in Rome
+    expect(formatIsoInRome(new Date("2026-07-15T22:30:00Z"))).toBe(
+      "2026-07-16T00:30:00+02:00",
+    );
+  });
+
+  it("uses Rome day, not UTC day, for a timestamp just past midnight UTC in winter", () => {
+    // 2026-12-31T23:30:00Z = 2027-01-01T00:30:00 CET → Jan 1 2027 in Rome
+    expect(formatIsoInRome(new Date("2026-12-31T23:30:00Z"))).toBe(
+      "2027-01-01T00:30:00+01:00",
+    );
+  });
+
+  it("drops milliseconds from the output", () => {
+    const result = formatIsoInRome(new Date("2026-05-01T10:00:00.999Z"));
+    expect(result).not.toContain(".");
+    expect(result).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/,
+    );
   });
 });
 

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -42,6 +42,33 @@ export function formatFiscalDateTime(date: Date): string {
 }
 
 /**
+ * Formats a Date as ISO 8601 with explicit Europe/Rome UTC offset,
+ * e.g. "2026-05-19T14:34:56+02:00". Milliseconds are intentionally dropped
+ * (fiscal CSV precision is seconds). Handles CET (+01:00) and CEST (+02:00)
+ * transitions correctly via Intl.
+ */
+export function formatIsoInRome(date: Date): string {
+  // sv-SE locale produces ISO-style "YYYY-MM-DD HH:mm:ss" without AM/PM noise.
+  const wall = new Intl.DateTimeFormat("sv-SE", {
+    timeZone: "Europe/Rome",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date); // → "2026-05-19 14:34:56"
+  const isoWall = wall.replace(" ", "T"); // → "2026-05-19T14:34:56"
+  // Treat Rome wall-clock as fake UTC, then diff with real UTC to get the offset.
+  const offsetMs = new Date(isoWall + "Z").getTime() - date.getTime();
+  const sign = offsetMs >= 0 ? "+" : "-";
+  const absMin = Math.round(Math.abs(offsetMs) / 60000);
+  const hh = String(Math.floor(absMin / 60)).padStart(2, "0");
+  const mm = String(absMin % 60).padStart(2, "0");
+  return `${isoWall}${sign}${hh}:${mm}`; // → "2026-05-19T14:34:56+02:00"
+}
+
+/**
  * Parses an ISO YYYY-MM-DD string to a UTC-midnight Date.
  * Returns null for invalid format or impossible dates (e.g. 2026-02-31).
  * Round-trip check: parsed year/month/day must equal input to catch JS Date

--- a/src/lib/receipts/csv-export.test.ts
+++ b/src/lib/receipts/csv-export.test.ts
@@ -99,7 +99,7 @@ describe("formatReceiptRow", () => {
     expect(row).toEqual([
       "doc-1",
       "00042",
-      "2026-05-19T12:34:56.789Z",
+      "2026-05-19T14:34:56+02:00",
       "SALE",
       "ACCEPTED",
       "12,34",

--- a/src/lib/receipts/csv-export.ts
+++ b/src/lib/receipts/csv-export.ts
@@ -14,6 +14,7 @@ import {
   groupLinesByDocId,
 } from "@/lib/receipts/document-lines";
 import { CSV_BOM, rowToCsv } from "@/lib/csv";
+import { formatIsoInRome } from "@/lib/date-utils";
 
 /**
  * Batch size per la cursor query. 500 e' un compromesso fra memoria
@@ -84,7 +85,7 @@ export function formatReceiptRow(doc: ReceiptDocRow, total: number): string[] {
   return [
     doc.id,
     doc.adeProgressive ?? "",
-    doc.createdAt.toISOString(),
+    formatIsoInRome(doc.createdAt),
     doc.kind,
     doc.status,
     formatItalianAmount(total),


### PR DESCRIPTION
## Summary
Adds a new `formatIsoInRome()` utility function to format dates as ISO 8601 strings with explicit Europe/Rome UTC offset, and updates the receipt CSV export to use Rome timezone instead of UTC.

## Changes
- **New function `formatIsoInRome()`** in `src/lib/date-utils.ts`:
  - Formats dates as ISO 8601 with explicit `+HH:MM` offset (e.g., `"2026-05-19T14:34:56+02:00"`)
  - Correctly handles CET (+01:00) and CEST (+02:00) transitions via `Intl.DateTimeFormat`
  - Drops milliseconds (fiscal CSV precision is seconds)
  - Uses `sv-SE` locale to produce ISO-style wall-clock time without AM/PM noise

- **Updated `formatReceiptRow()`** in `src/lib/receipts/csv-export.ts`:
  - Changed from `doc.createdAt.toISOString()` (UTC) to `formatIsoInRome(doc.createdAt)` (Rome timezone)
  - Ensures receipt timestamps reflect the actual local time in Rome

- **Comprehensive test coverage** in `src/lib/date-utils.test.ts`:
  - Summer (CEST) offset verification
  - Winter (CET) offset verification
  - Day boundary handling (UTC midnight → Rome next day)
  - Year boundary handling (UTC Dec 31 → Rome Jan 1)
  - Millisecond truncation validation

## Implementation Details
The offset calculation works by treating the Rome wall-clock time as fake UTC, then computing the difference with the actual UTC timestamp to derive the correct offset. This approach elegantly handles DST transitions without manual logic.

https://claude.ai/code/session_015V2NToycXdCNGggRGVEghQ