### PR TITLE
fix(ade): cast updatedAt snapshot to timestamptz in verifyAdeCredentials

### DIFF
--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -576,6 +576,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
         },
       ]);
       mockLogin.mockResolvedValue({});
@@ -611,6 +612,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
         },
       ]);
       mockLogin.mockResolvedValue({});
@@ -653,6 +655,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
         },
       ]);
       mockLogin.mockRejectedValue(new Error("Invalid credentials"));
@@ -685,6 +688,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
           verifiedAt: null,
         },
       ]);
@@ -719,6 +723,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
           verifiedAt: new Date("2026-01-01"),
         },
       ]);
@@ -750,6 +755,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
           verifiedAt: null,
         },
       ]);
@@ -796,6 +802,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
           verifiedAt: null,
         },
       ]);
@@ -820,6 +827,7 @@ describe("onboarding-actions", () => {
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
           keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
           verifiedAt: null,
         },
       ]);
@@ -837,6 +845,52 @@ describe("onboarding-actions", () => {
       await verifyAdeCredentials("biz-789");
 
       expect(mockLogout).toHaveBeenCalled();
+    });
+
+    // Regression: postgres-js cannot encode a JS Date as a parameter inside a
+    // raw `sql` template (no column-type context), and crashes in
+    // `Buffer.byteLength(<Date>)`. The snapshot must be serialized to a string
+    // before being bound. See https://dstmrk.sentry.io/issues/SCONTRINOZERO-TEST-7
+    it("binds the updatedAt snapshot as ISO string, not as a raw Date", async () => {
+      const { PgDialect } = await import("drizzle-orm/pg-core");
+
+      const credentialUpdatedAt = new Date("2026-03-26T14:36:07.000Z");
+
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          verifiedAt: null,
+          updatedAt: credentialUpdatedAt,
+        },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      // The last db.update(...).where(...) call targets adeCredentials.verifiedAt.
+      // Render the SQL fragment via the real PgDialect so we observe exactly
+      // what would be sent to postgres-js as bound parameters.
+      const whereArg = mockUpdateWhere.mock.calls.at(-1)?.[0];
+      const dialect = new PgDialect();
+      const compiled = dialect.sqlToQuery(whereArg);
+
+      expect(compiled.params.some((p) => p instanceof Date)).toBe(false);
+      expect(compiled.params).toContain(credentialUpdatedAt.toISOString());
+      expect(compiled.sql).toContain("::timestamptz");
     });
   });
 

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -386,13 +386,19 @@ export async function verifyAdeCredentials(
   // date_trunc to milliseconds: defaultNow() lets PostgreSQL set updatedAt via
   // NOW() (microsecond precision), but JS Date is only millisecond-precise.
   // Truncating before comparison prevents false mismatches on the first SELECT.
+  //
+  // The snapshot is serialized as ISO string + `::timestamptz` cast: inside a
+  // raw `sql` template Drizzle has no column-type context to tell postgres-js
+  // how to bind a JS Date, so passing one directly crashes
+  // `Buffer.byteLength(<Date>)` in postgres-js. ISO string + explicit cast is
+  // safe and lossless (millisecond precision is preserved).
   const updated = await db
     .update(adeCredentials)
     .set({ verifiedAt: new Date() })
     .where(
       and(
         eq(adeCredentials.businessId, businessId),
-        sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion}`,
+        sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion.toISOString()}::timestamptz`,
       ),
     )
     .returning({ id: adeCredentials.id });


### PR DESCRIPTION
postgres-js has no column-type context for params bound inside a raw
`sql` template tag, so passing the JS Date `credentialVersion` directly
crashed in `Buffer.byteLength(<Date>)` and turned the AdE "Verifica
connessione" click into a Server Component 500.

Serialize the snapshot to ISO string and add an explicit `::timestamptz`
cast on the SQL side; millisecond precision is preserved.

Closes SCONTRINOZERO-TEST-7.