### PR TITLE
Add year-to-date (YTD) analytics range support

### DIFF
--- a/src/components/analytics/analytics-client.test.tsx
+++ b/src/components/analytics/analytics-client.test.tsx
@@ -39,6 +39,16 @@ vi.mock("@/components/ui/select", () => ({
         onClick={() => onValueChange("30d")}
         type="button"
       />
+      <button
+        data-testid="range-ytd"
+        onClick={() => onValueChange("ytd")}
+        type="button"
+      />
+      <button
+        data-testid="range-invalid"
+        onClick={() => onValueChange("bogus")}
+        type="button"
+      />
     </div>
   ),
   SelectContent: ({ children }: { children: React.ReactNode }) => (
@@ -146,5 +156,59 @@ describe("AnalyticsClient handleRangeChange", () => {
       "revenueCents=3030",
     );
     expect(screen.getByTestId("kpis").textContent).not.toContain("7777");
+  });
+
+  it("invoca le server actions con range 'ytd' quando l'utente seleziona Da inizio anno", async () => {
+    const ytdKpis: AnalyticsKpis = {
+      revenueCents: 12345,
+      count: 7,
+      aovCents: 1763,
+      voidCount: 0,
+    };
+    mockGetAnalyticsKpis.mockResolvedValueOnce(ytdKpis);
+    mockGetRevenueTimeseries.mockResolvedValueOnce([]);
+    mockGetPaymentBreakdown.mockResolvedValueOnce([]);
+
+    render(
+      <AnalyticsClient
+        businessId="biz-1"
+        initialRange="30d"
+        initialKpis={INITIAL_KPIS}
+        initialTimeseries={[]}
+        initialBreakdown={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("range-ytd"));
+
+    await waitFor(() => {
+      expect(mockGetAnalyticsKpis).toHaveBeenCalledWith("biz-1", "ytd");
+    });
+    expect(mockGetRevenueTimeseries).toHaveBeenCalledWith("biz-1", "ytd");
+    expect(mockGetPaymentBreakdown).toHaveBeenCalledWith("biz-1", "ytd");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("kpis").textContent).toContain(
+        "revenueCents=12345",
+      );
+    });
+  });
+
+  it("ignora valori non validi senza invocare le server actions", () => {
+    render(
+      <AnalyticsClient
+        businessId="biz-1"
+        initialRange="30d"
+        initialKpis={INITIAL_KPIS}
+        initialTimeseries={[]}
+        initialBreakdown={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("range-invalid"));
+
+    expect(mockGetAnalyticsKpis).not.toHaveBeenCalled();
+    expect(mockGetRevenueTimeseries).not.toHaveBeenCalled();
+    expect(mockGetPaymentBreakdown).not.toHaveBeenCalled();
   });
 });

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -62,7 +62,8 @@ export function AnalyticsClient({
   const latestRangeRef = useRef<AnalyticsRange>(initialRange);
 
   function handleRangeChange(next: string) {
-    if (next !== "7d" && next !== "30d" && next !== "90d") return;
+    if (next !== "7d" && next !== "30d" && next !== "90d" && next !== "ytd")
+      return;
     const nextRange = next;
     latestRangeRef.current = nextRange;
     setRange(nextRange);
@@ -102,6 +103,7 @@ export function AnalyticsClient({
               <SelectItem value="7d">Ultimi 7 giorni</SelectItem>
               <SelectItem value="30d">Ultimi 30 giorni</SelectItem>
               <SelectItem value="90d">Ultimi 90 giorni</SelectItem>
+              <SelectItem value="ytd">Da inizio anno</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -196,6 +196,39 @@ describe("rangeToBounds", () => {
       "2026-02-18T23:00:00.000Z",
     );
   });
+
+  it("supports ytd: from = mezzanotte Rome del 1° gennaio dell'anno della reference", () => {
+    // Reference a maggio 2026 (CEST), 1° gennaio cade in CET (UTC+1).
+    const refMay = new Date("2026-05-19T12:00:00Z"); // Rome day "2026-05-19"
+    const ytdMay = rangeToBounds("ytd", refMay);
+    expect(ytdMay.from.toISOString()).toBe("2025-12-31T23:00:00.000Z");
+    expect(ytdMay.to.toISOString()).toBe("2026-05-19T22:00:00.000Z");
+  });
+
+  it("ytd il 1° gennaio produce un range di esattamente 1 giorno fiscale", () => {
+    // Rome day "2026-01-01" → from = 2026-01-01 00:00 Rome, to = 2026-01-02 00:00 Rome.
+    const refJan1 = new Date("2026-01-01T12:00:00Z");
+    const { from, to } = rangeToBounds("ytd", refJan1);
+    expect(formatRomeDay(from)).toBe("2026-01-01");
+    expect(formatRomeDay(to)).toBe("2026-01-02");
+    expect(to.getTime() - from.getTime()).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("ytd a fine anno bisestile copre 366 giorni fiscali", () => {
+    // 2028 e' bisestile. Reference 31 dicembre 2028.
+    const refDec31 = new Date("2028-12-31T12:00:00Z");
+    const { from, to } = rangeToBounds("ytd", refDec31);
+    expect(formatRomeDay(from)).toBe("2028-01-01");
+    expect(formatRomeDay(to)).toBe("2029-01-01");
+  });
+
+  it("ytd a cavallo del cambio anno usa l'anno fiscale italiano della reference", () => {
+    // Mezzanotte UTC del 1° gennaio 2026 = 01:00 Rome di "2026-01-01" (CET),
+    // quindi l'anno fiscale italiano e' 2026, non 2025.
+    const refMidnightUtc = new Date("2026-01-01T00:00:00Z");
+    const { from } = rangeToBounds("ytd", refMidnightUtc);
+    expect(formatRomeDay(from)).toBe("2026-01-01");
+  });
 });
 
 describe("normalizePaymentMethod", () => {

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -40,9 +40,10 @@ export type {
 // Authorization
 // ---------------------------------------------------------------------------
 
-// Range fino a 90d scansiona migliaia di documenti + lines per call: senza
-// rate limit per-utente, una pagina aperta che retry'a o un client mal scritto
-// può martellare il DB. Soglia 60/h coerente con CLAUDE.md (pdf:<ip> 60/h).
+// Range fino a YTD scansiona migliaia di documenti + lines per call (a fine
+// anno YTD ≈ 365 giorni, ben oltre il vecchio max 90d): senza rate limit
+// per-utente, una pagina aperta che retry'a o un client mal scritto può
+// martellare il DB. Soglia 60/h coerente con CLAUDE.md (pdf:<ip> 60/h).
 const analyticsLimiter = new RateLimiter({
   maxRequests: 60,
   windowMs: RATE_LIMIT_WINDOWS.HOURLY,
@@ -141,15 +142,16 @@ function isDocRow(value: unknown): value is DocRow {
   );
 }
 
-// 5s budget allineato con altri endpoint Pro: il range max e' 90d, su
-// dataset normali la query risponde in <200ms. Oltre i 5s significa
-// dataset degenere o contention DB — preferiamo errore 503 friendly
-// piuttosto che pinning della connessione.
+// 5s budget allineato con altri endpoint Pro: il range max e' YTD (~365d
+// a fine anno), su dataset normali la query risponde in <500ms. Oltre i 5s
+// significa dataset degenere o contention DB — preferiamo errore 503
+// friendly piuttosto che pinning della connessione.
 const ANALYTICS_QUERY_TIMEOUT_MS = 5_000;
 
 // Safety net contro tenant con volumi anomali: nessun business Pro reale
-// emette >50k scontrini in 90d (≈555/giorno). Oltre, la pagina analytics
-// produrrebbe un payload da MB e degraderebbe l'istanza.
+// emette >50k scontrini su un range YTD (≈137/giorno sull'intero anno).
+// Oltre, la pagina analytics produrrebbe un payload da MB e degraderebbe
+// l'istanza.
 const ANALYTICS_MAX_DOCS = 50_000;
 
 async function fetchSaleDocsInRange(

--- a/src/server/analytics-helpers.ts
+++ b/src/server/analytics-helpers.ts
@@ -10,7 +10,7 @@
  * giornalieri e fillMissingDays usano quindi sempre il calendario Rome.
  */
 
-export type AnalyticsRange = "7d" | "30d" | "90d";
+export type AnalyticsRange = "7d" | "30d" | "90d" | "ytd";
 
 export type AnalyticsKpis = {
   /** Totale ricavi (solo SALE ACCEPTED) espresso in centesimi. */
@@ -41,9 +41,12 @@ export const VALID_RANGES: ReadonlySet<AnalyticsRange> = new Set([
   "7d",
   "30d",
   "90d",
+  "ytd",
 ]);
 
-const RANGE_DAYS: Record<AnalyticsRange, number> = {
+// I range fixed-window hanno un numero costante di giorni. YTD e' variabile
+// (1..366), quindi gestito separatamente in rangeToBounds.
+const RANGE_DAYS: Record<Exclude<AnalyticsRange, "ytd">, number> = {
   "7d": 7,
   "30d": 30,
   "90d": 90,
@@ -117,16 +120,23 @@ function addCalendarDays(romeDay: string, n: number): string {
  *
  * - `to` = mezzanotte Rome del giorno successivo al reference (upper
  *   bound exclusive che include il giorno corrente per intero).
- * - `from` = `to` - `days` giorni di calendario fiscale italiano.
+ * - `from`:
+ *   - per i range fixed-window (`7d`/`30d`/`90d`) = `to` - `days` giorni di
+ *     calendario fiscale italiano.
+ *   - per `ytd` = mezzanotte Rome del 1° gennaio dell'anno fiscale italiano
+ *     della reference. La lunghezza varia tra 1 giorno (1° gennaio) e
+ *     366 giorni (31 dicembre di anno bisestile).
  */
 export function rangeToBounds(
   range: AnalyticsRange,
   reference: Date = new Date(),
 ): { from: Date; to: Date } {
-  const days = RANGE_DAYS[range];
   const todayRome = formatRomeDay(reference);
   const toDay = addCalendarDays(todayRome, 1);
-  const fromDay = addCalendarDays(toDay, -days);
+  const fromDay =
+    range === "ytd"
+      ? `${todayRome.slice(0, 4)}-01-01`
+      : addCalendarDays(toDay, -RANGE_DAYS[range]);
   return {
     from: romeMidnightUtc(fromDay),
     to: romeMidnightUtc(toDay),


### PR DESCRIPTION
## Summary
Adds support for a new "year-to-date" (YTD) analytics range option, allowing users to view analytics data from January 1st of the current year through the current date. This complements the existing fixed-window ranges (7d, 30d, 90d).

## Key Changes

- **Analytics range type**: Extended `AnalyticsRange` type to include `"ytd"` and added it to `VALID_RANGES` set
- **Range bounds calculation**: Implemented YTD logic in `rangeToBounds()` that:
  - Sets `from` to midnight Rome time on January 1st of the reference year
  - Sets `to` to midnight Rome time on the day after the reference date (consistent with other ranges)
  - Handles edge cases: leap years (366 days), January 1st (1-day range), and year boundary transitions
- **UI**: Added "Da inizio anno" (From start of year) select option in the analytics client
- **Input validation**: Updated `handleRangeChange()` to accept and validate the `"ytd"` range value
- **Documentation**: Updated comments to reflect that max range is now YTD (~365 days) instead of 90 days, affecting rate limiting and query timeout context

## Test Coverage

Added comprehensive test cases covering:
- YTD range selection and server action invocation with correct parameters
- Invalid range values are silently ignored without triggering server actions
- YTD boundary conditions: January 1st (1-day range), leap year end (366 days), year boundary transitions with timezone considerations
- Rome timezone handling for fiscal year determination

All tests follow Italian naming conventions consistent with the codebase.

https://claude.ai/code/session_01LjrJCPm9hGzdnikzeg3p5m