### PR TITLE
Refactor CLAUDE.md into modular documentation files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1081 +1,208 @@
 # CLAUDE.md — ScontrinoZero
 
-## General Rules for Claude
-
-1. **Commit/push sempre su branch separato, mai su `main` direttamente.**
-   Dopo aver completato il lavoro: crea un branch, committa, pusha, apri una PR.
-   Non fare mai merge autonomamente — il merge spetta all'utente, a meno che non
-   venga chiesto esplicitamente.
-
-2. We are using a TDD approach
-
-3. If the requirements I give you are ambiguous, ask clarifying questions before writing any code.
-
-4. After you finish writing any code, list the edge cases and add test cases to cover them as well.
-
-5. If a task requires changes to more than 3 files, stop and break it into smaller tasks first.
-
-6. Every time I correct you, reflect on what you did wrong and come up with a plan to never make the same mistake again.
-
-7. Every new file with logic **must** have a corresponding test file. After writing any implementation, always write tests covering the edge cases before committing. No exceptions — even for infrastructure/bootstrap files (e.g. `instrumentation.ts`).
-
-8. **When debugging opaque CI failures (SonarCloud, Gitleaks, etc.) where the
-   report detail is not visible in the PR diff or logs, STOP and ask the user
-   for the specific information needed** (e.g. "which file/lines does SonarCloud
-   flag as duplicated?") rather than attempting blind fixes. Multiple failed
-   guesses waste CI cycles and obscure the root cause. One targeted question
-   yields the answer in seconds; random trial-and-error can take hours and make
-   the problem harder to understand.
-
-9. **SonarCloud quality gates (must not regress):**
-   - Coverage on new code: **≥ 80%**
-   - Duplicated lines on new code: **< 3%**
-   - **0 new issues**: fix every SonarCloud issue before merging, even when the Quality Gate passes. Issues left open accumulate into tech debt and will block future PRs.
-   - Common quick fixes: Cognitive Complexity > 15 → extract helper functions; optional chain suggestions → replace `!x || x.prop` with `x?.prop`.
-   - If a file has no testable logic (pure config, UI shell), add it to `sonar.coverage.exclusions` in `sonar-project.properties` AND to the `exclude` list in `vitest.config.ts` — never leave it untested without explicitly excluding it.
-   - **Service worker files (`src/sw.ts`) must be added to `sonar.exclusions`** (not just `sonar.coverage.exclusions`). They use WebWorker-specific globals (`ServiceWorkerGlobalScope`, `declare const self`) that conflict with the DOM lib and trigger SonarCloud false positives (variable shadowing). Also add to `tsconfig.json` exclude for the same reason.
-   - **Common SonarCloud style rules to anticipate**: `typeof x === "undefined"` → `x === undefined`; `window.*` → `globalThis.window.*` (es2020 portability); `<div role="banner">` → `<header>`; async functions as onClick → `onClick={() => void asyncFn()}`.
-   - **S6861 (React props not readonly)**: ogni `interface` di props di componente React deve avere tutti i campi marcati `readonly`. Applicare sistematicamente a ogni nuovo componente per evitare l'issue. Esempio: `interface MyProps { readonly foo: string; readonly bar: number; }`.
-   - **S6772 (Ambiguous spacing in JSX)**: si attiva in due casi: (1) `{" "}` tra elementi JSX — fix: incorpora lo spazio nel testo adiacente come `{"testo "}` o `{" testo"}`; (2) testo nudo su riga separata adiacente a qualsiasi elemento inline di chiusura o apertura (`</strong>`, `</a>`, `</Link>`, `<strong>`, ecc.) — fix: converti il testo in espressione JSX `{"testo"}`. Il caso (2) si manifesta sia con testo DOPO un tag di chiusura che con testo PRIMA di un tag di apertura su righe separate. Prettier può re-introdurre `{" "}` riformattando: scrivi JSX in modo da non richiederlo.
-   - **S7780 (Escape sequences in template literals)**: usa `String.raw\`...\``invece di template literal con`\\`quando il contenuto mostra backslash letterali (es. curl examples). Con`String.raw`, scrivi `\` singolo invece di `\\` e i newline del sorgente sono preservati.
-   - **Gitleaks e pagine di documentazione**: i placeholder di chiavi API negli esempi curl (es. `szk_live_XXXX`, `Authorization: Bearer ...`) triggerano le regole `curl-auth-header` e `generic-api-key`. Sono falsi positivi — aggiungere i fingerprint al `.gitleaksignore`. **Attenzione**: i fingerprint sono commit-specifici (`COMMIT_SHA:FILE:RULE:LINE`). Ogni commit che modifica le righe coinvolte genera nuovi fingerprint. Aggiungere i fingerprint di tutti i commit in un'unica passata quando possibile, ispezionando le righe esatte con `grep -n`.
-   - **`// NOSONAR` does NOT suppress Security Hotspots** — it only suppresses Issues (Bug/CodeSmell/Vulnerability). Hotspots require either fixing the code so the rule no longer fires, or human review via the SonarCloud UI ("Mark as Safe"). For S5852 (ReDoS): replace regex with Set-based char loop + manual pointer trimming. For S5122 (CORS `*`): `// NOSONAR` is ineffective — the user must acknowledge in SonarCloud UI, or remove the wildcard.
-
-10. **After solving a non-trivial problem, update CLAUDE.md autonomously.**
-    When a task is complete (bug fixed, feature shipped), reflect on what went wrong
-    or could have gone faster. If there's a reusable lesson — a debugging pattern,
-    a setup gotcha, a wrong assumption — add it to CLAUDE.md before committing.
-    Don't wait for the user to ask.
-
-11. **Debugging production HTTP flow errors (e.g. AdE 4xx): diagnose before fixing.**
-    When a production error suggests a wrong HTTP sequence, add diagnostic logging first
-    (phase labels, cookie counts, response status) and reproduce the error locally to
-    confirm the root cause. Only then write the fix. Never merge a hypothesis-based
-    fix without first seeing the diagnostic evidence.
-
-12. **HAR analysis: verify completeness, not just order.**
-    When comparing code against a HAR capture, explicitly check that **every request**
-    in the HAR is present in the implementation — not just that the order matches.
-    A missing call is harder to spot than a wrong order. Go through the HAR
-    request-by-request and cross-reference each one with the corresponding code path.
-
-13. **Git worktree setup checklist.**
-    When working in a worktree under `.claude/worktrees/<name>/`:
-    - Run `npm install` (no `node_modules` symlink from main repo)
-    - Copy `.env.local` from the main repo root
-    - Delete `.next` in both the worktree AND the main repo (`rm -rf .next`) before
-      starting the dev server to avoid Turbopack serving stale cached chunks
-
-14. **DB migrations: TUTTE handwritten dopo lo schema iniziale.**
-
-    ⚠️ **Stato reale del repo (importante):** drizzle-kit è stato usato UNA SOLA volta per generare
-    lo schema iniziale `0000_initial.sql` + `0000_snapshot.json`. Tutte le migrazioni successive
-    sono **scritte a mano**. In `supabase/migrations/meta/` esiste UN solo snapshot
-    (`0000_snapshot.json`), non gli snapshot intermedi.
-
-    🚫 **NON ESEGUIRE MAI `npx drizzle-kit generate` su questo repo nello stato attuale.**
-    Genererebbe una mega-migrazione che riapplica tutto ciò che è successo dopo `0000`
-    confliggendo con le migrazioni handwritten esistenti.
-    Per riattivare drizzle-kit serve prima un task dedicato di **rebuild degli snapshot
-    intermedi** (out of scope finché non diventa pain).
-
-    **Workflow obbligatorio per ogni nuova migrazione (incluse ALTER TABLE ADD/DROP COLUMN):**
-    1. Crea il file `.sql` in `supabase/migrations/` con naming `NNNN_description.sql`
-       (es. `0014_add_signup_source_to_profiles.sql`). Header comment che spiega il "perché".
-    2. Aggiungi la entry in `supabase/migrations/meta/_journal.json`:
-       ```json
-       { "idx": 14, "version": "7", "when": <Date.now() in ms>, "tag": "0014_add_signup_source_to_profiles", "breakpoints": true }
-       ```
-       `idx` incrementale, `when` = `Date.now()` in millisecondi, `tag` = nome file senza `.sql`.
-    3. Aggiorna il file Drizzle in `src/db/schema/<table>.ts` per riflettere il nuovo schema
-       (es. aggiungi `signupSource: text("signup_source")`). Senza questo, TypeScript non vede
-       la colonna e le query falliscono al type check.
-    4. Esegui localmente `node scripts/check-migrations.mjs` per verificare la coerenza
-       SQL ↔ journal (lo stesso check gira in CI).
-    5. Testa su DB locale: `npx tsx scripts/migrate.ts` deve applicare la migrazione
-       senza errori e idempotentemente al re-run.
-
-    **Runtime runner:** `scripts/migrate.ts` legge i `.sql` ordinati per nome, traccia i file
-    applicati nella tabella `__applied_migrations`, wrappa ogni migrazione in transazione.
-    Non legge il journal — quello è solo per il check CI di completezza.
-
-    **Pattern per ALTER TABLE ADD COLUMN (caso comune):**
-    Usa sempre `ADD COLUMN IF NOT EXISTS` (vedi `0002_add_lottery_code.sql`) per idempotenza.
-    Esempio minimo:
-
-    ```sql
-    -- Migration: add <column> to <table>
-    -- Feature/motivo: <link a issue o release>
-    ALTER TABLE <table>
-      ADD COLUMN IF NOT EXISTS <column> <type>;
-    ```
-
-    Niente `NOT NULL` su colonne aggiunte a tabelle popolate senza default — fallisce su
-    righe esistenti. Aggiungi prima la colonna nullable, fai il backfill, poi una migration
-    successiva con `ALTER COLUMN SET NOT NULL`.
-    - **Bootstrap su DB pre-esistente**: se il DB è stato inizializzato senza il
-      migration runner (via drizzle-kit, Supabase dashboard, restore), la tabella
-      `__applied_migrations` è vuota e il runner crasherà con "type already exists".
-      Il runner ha rilevamento automatico: se `__applied_migrations` è vuota ma il
-      tipo `document_kind` esiste già in `pg_type`, segna tutte le migrazioni come
-      applicate senza rieseguirle. Fix manuale di emergenza (se il runner non parte):
-      ```sql
-      INSERT INTO __applied_migrations (filename, checksum)
-      SELECT unnest(ARRAY[
-        -- elencare qui i nomi dei file .sql in supabase/migrations/ già presenti nel DB
-      ]), '' ON CONFLICT (filename) DO NOTHING;
-      ```
-      ⚠️ **L'INSERT manuale va fatto SOLO per le migrazioni già effettivamente presenti
-      nel DB.** Inserire filename di migrazioni non eseguite le marca come applicate
-      senza eseguirle — schema silenziosamente incompleto. Per verificare quali
-      migrazioni sono realmente presenti prima di inserirle, controllare l'esistenza
-      delle tabelle/colonne chiave nel Supabase SQL editor o via MCP.
-
-15. **Client IP trust model: CF-Connecting-IP is the ONLY trusted source.**
-    When the app is behind Cloudflare Tunnel, `CF-Connecting-IP` is the only header
-    that Cloudflare sets and clients cannot spoof. Follow this priority in `getClientIp()`:
-    1. `CF-Connecting-IP` — always trusted (Cloudflare strips incoming copies)
-    2. `X-Forwarded-For` — dev/test fallback only; **explicitly comment** that it is
-       non-trusted outside Cloudflare
-    3. `X-Real-IP` — **drop entirely** (non-standard, no trust model)
-       Never silently fall through a chain of headers without documenting why each one is
-       or isn't trusted. Rate limiting built on a spoofable IP is no rate limiting at all.
-
-16. **Transaction safety for multi-document state changes is correctness, not optimization.**
-    Whenever an operation must update 2+ related DB records that must stay consistent
-    (e.g., void flow: write VOID document + mark original SALE as VOID_ACCEPTED),
-    wrap them in `db.transaction()` immediately. A mid-operation failure without a
-    transaction leaves the system in a silently inconsistent state that is hard to detect
-    and painful to repair. Don't defer this to "a later optimization sprint".
-
-17. **Retry + backoff for critical operations that leave orphan state on failure.**
-    Operations that (a) are irreversible on partial success, (b) can fail transiently
-    (network blip, external service timeout), and (c) leave the system inconsistent on
-    failure (e.g., Supabase auth user deletion leaving an orphan entry that blocks
-    re-registration) must have:
-    - 3 retry attempts with exponential backoff (500 ms → 1 s → 2 s)
-    - `logger.error({ critical: true }, …)` after all retries are exhausted
-    - A comment documenting what **manual cleanup** is required if retries fail
-      Silent failure here is worse than a visible error: the user is permanently blocked
-      with no actionable signal.
-
-18. **UUID validation at external API entry points — before the service layer.**
-    Every external-facing API route that accepts a UUID parameter (e.g., `idempotencyKey`,
-    `receiptId`) must validate the format with `isValidUuid()` and return 400 **before**
-    passing to any service or DB layer. Non-UUID strings passed to PostgreSQL UUID columns
-    produce unhandled 500 errors that bypass all application error handling.
-    UUID validation belongs at the route handler boundary, not inside the service.
-
-19. **Validate hostname of Supabase-generated action links before emailing them.**
-    Before emailing any Supabase-generated link (password reset, magic link, email change),
-    assert that the URL starts with `https://${expectedHostname}`. Supabase misconfiguration
-    (wrong Site URL setting) can produce links pointing to unexpected domains, enabling open
-    redirect attacks. If the check fails: log an error, do NOT send the email, and redirect
-    the user to `/verify-email` with a generic message.
-
-20. **Body size guard before `JSON.parse` on every write endpoint.**
-    Never call `request.json()` directly on an API route that accepts arbitrary input.
-    Use a `readJsonWithLimit(req, maxBytes)` helper that reads the body as `ArrayBuffer`,
-    checks `byteLength` first, and only then calls `JSON.parse`. Return 413 on overflow.
-    Limits: 32 KB for receipt create (up to 100 lines), 8 KB for single-key bodies (void, checkout).
-    This prevents memory/CPU pressure from oversized payloads before any validation runs.
-
-21. **Monetary decimal precision must be enforced in the API layer, not only in the DB.**
-    DB columns `numeric(10,2)` and `numeric(10,3)` silently round/truncate overscale values.
-    The API layer must reject inputs with too many decimals (Zod `.refine`) so the client
-    never receives a confirmed receipt that contains different totals than what it submitted.
-    Refine pattern: `v => parseFloat(v.toFixed(2)) === v` for 2dp; `.toFixed(3)` for 3dp.
-    This roundtrips through the string representation and correctly handles IEEE-754 noise.
-    Do NOT use `Number.isInteger(Math.round(v * 100))` — `Math.round` always returns an integer,
-    so the check is vacuously true and never rejects anything.
-
-22. **Email normalisation must be uniform across ALL auth flows.**
-    `signUp` historically normalised the email (`trim().toLowerCase()`) but `signIn`,
-    `signInWithMagicLink`, and `resetPassword` did not, causing silent failures when users
-    typed `User@EXAMPLE.COM`. Centralise normalisation in a single `normalizeEmail()` helper
-    in `validation.ts` and apply it as the first line of every auth action before validation.
-
-23. **Wrap external SDK calls (Stripe, AdE, etc.) in try-catch — always.**
-    Uncaught errors from `stripe.customers.create()`, `stripe.checkout.sessions.create()`, or
-    any external service propagate as unhandled 500s with no log context, making incidents
-    impossible to diagnose. The correct pattern:
-
-    ```typescript
-    try {
-      result = await stripe.someMethod(…);
-    } catch (err) {
-      logger.error({ err, userId }, "Stripe <operation> failed");
-      return Response.json({ error: "Servizio temporaneamente non disponibile." }, { status: 503 });
-    }
-    ```
-
-    Use 503 (not 500) to signal transient external unavailability. A uniform error
-    envelope (`{code, message, requestId}`) is tracked separately in the backlog.
-
-24. **Key rotation: ENCRYPTION_KEY — procedura obbligatoria prima del deploy.**
-    Le credenziali Fisconline sono cifrate con AES-256-GCM; la chiave sta in `ENCRYPTION_KEY`
-    (env var, 64 hex chars). Se la chiave viene compromessa o va ruotata per policy:
-
-    **PRIMA di cambiare l'env var sul server**, eseguire la migrazione:
-
-    ```bash
-    npx tsx scripts/rotate-encryption-key.ts \
-      --old-key  $ENCRYPTION_KEY \
-      --old-version $ENCRYPTION_KEY_VERSION \
-      --new-key  <NEW_64_HEX_KEY> \
-      --new-version <NEW_VERSION>
-    ```
-
-    Lo script (in `scripts/rotate-encryption-key.ts`):
-    - Legge tutti i record `ade_credentials`
-    - Decifra con la vecchia chiave
-    - Ricicla con la nuova chiave
-    - Aggiorna `key_version` nel DB
-    - Wrappa tutto in `db.transaction()` → atomico
-
-    Dopo la migrazione verificare che tutti i record abbiano `key_version = NEW_VERSION`,
-    poi aggiornare le env var sul server e fare deploy.
-
-    **Rollback:** se il deploy fallisce, riportare le env var alla versione precedente —
-    i record con il vecchio `key_version` sono ancora decifrabili con la vecchia chiave
-    (presente nell'immagine Docker precedente).
-
-    **Generare una nuova chiave:**
-
-    ```bash
-    node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-    ```
-
-25. **Quando si modifica una funzionalità, verificare se le pagine Help associate vanno aggiornate.**
-    Ogni modifica a UI label, percorsi di menu, stati visualizzati, opzioni di filtro,
-    flussi di errore, gating dei piani o nomi di bottoni può rendere obsoleta la documentazione
-    in `src/app/(marketing)/help/**/page.tsx`. Prima di chiudere un task che cambia uno di
-    questi aspetti, fare un grep mirato del termine modificato (es. `grep -rn "<termine>" src/app/\(marketing\)/help`)
-    e aggiornare gli articoli che lo citano. Per le feature ancora non implementate,
-    riformulare al condizionale come roadmap (es. "In arrivo · Piano Pro") anziché
-    descriverle come attive.
-
-26. **Lookup su Record con chiave user-controlled: valida via Set/type guard, mai `record[input]` diretto.**
-    Quando una route dinamica (es. `/per/[slug]`, `/help/[slug]`, `/guide/[slug]`) fa il lookup
-    su un `Record<Slug, T>` con la chiave presa da `params`, `record[slug as Slug]` permette ai
-    nomi del prototype chain (`__proto__`, `constructor`, `toString`, `hasOwnProperty`) di
-    risolvere come truthy, bypassando il guard `notFound()` e generando un 500 server-side
-    nelle property access successive (`category.relatedHelp.map(...)` esplode su un oggetto
-    prototype). Pattern obbligato:
-
-    ```typescript
-    const VALID_SLUGS: ReadonlySet<string> = new Set(slugs);
-
-    export function isValidSlug(slug: string): slug is Slug {
-      return VALID_SLUGS.has(slug);
-    }
-
-    // route handler
-    if (!isValidSlug(slug)) notFound();
-    const item = records[slug]; // type-safe, no prototype risk
-    ```
-
-    `Object.hasOwn(record, slug)` è un'alternativa valida ma meno espressiva del type guard.
-    Aggiungere sempre test mirati per i 4 nomi del prototype chain
-    (`__proto__`, `constructor`, `toString`, `hasOwnProperty`) per documentare l'invariante.
-    Applicare lo stesso pattern a ogni nuova route dinamica.
-
-27. **CSP rollout: Report-Only → Enforce è un cambio di UNA chiave header.**
-    Pattern: introdurre `Content-Security-Policy-Report-Only` con la policy completa
-    - endpoint `/api/csp-report` (rate-limited, allowlist sanitization). Dopo un
-      periodo di osservazione (es. 14 giorni) con zero violation reali in produzione
-      (audit via Sentry — query `message:"CSP violation report received"`),
-      rinominare la chiave in `Content-Security-Policy`. Policy invariata byte-per-byte.
-    * **`'unsafe-inline'` su `script-src`** può essere mantenuto se mitigato da
-      `safeJsonLd()` in `src/components/json-ld.tsx` (escape di `<>&`) e i payload
-      JSON-LD sono tutti statici a build time. Il valore di sicurezza della CSP enforce
-      sta nell'**allowlist di origin** (`default-src 'self'`, `connect-src` restrittivo,
-      `frame-ancestors 'none'`, `object-src 'none'`), non nel divieto di inline.
-    * **Enforce solo in production, Report-Only in dev/test**: `buildSecurityHeaders`
-      sceglie la chiave header in base a `process.env.NODE_ENV`. Motivo: Next.js dev mode
-      (Turbopack/Webpack HMR + React error overlay) usa `eval()`, e l'enforce senza
-      `'unsafe-eval'` riempie la console di `Refused to evaluate a string as JavaScript`
-      e può rompere HMR. Pattern simmetrico a HSTS.
-    * **Anti-pattern**: nonce-based su `script-src`. Incompatibile con SSG largo del sito
-      marketing (il nonce dev'essere per-request, le pagine SSG sono cached statiche).
-    * **Estrarre `securityHeaders` in modulo testabile** (`src/lib/security-headers.ts`):
-      `next.config.ts` non è facilmente unit-testabile, ma una funzione pura
-      `buildSecurityHeaders({nodeEnv, allowedOrigin}): {key, value}[]` sì. Test
-      essenziali: chiave CSP enforce (no Report-Only), HSTS condizionale a
-      `nodeEnv === "production"`, `Reporting-Endpoints` con URL assoluto.
-    * **`Reporting-Endpoints` resta indispensabile in enforce**: utile per detection
-      di XSS attempt e drift della policy. Soglia di allarme: >50 violation/giorno
-      o qualsiasi `blockedUri` riconducibile a un asset legittimo.
-
-28. **Stale recovery di mutazioni esterne idempotenti senza idempotency-key lato remoto.**
-    Il recovery di una row PENDING/ERROR senza `adeTransactionId` ri-invoca
-    `submitSale`/`submitVoid`. AdE non accetta una idempotency-key nel payload:
-    se la prima call era arrivata ad AdE ma la response si è persa in volo
-    (timeout, container kill, network glitch), il retry crea un documento
-    fiscale duplicato o un VOID duplicato, **irreversibile**.
-    Mitigazione: soglia stale di 30 minuti in `getStalePendingThresholdMs()`
-    (sia `receipt-service` che `void-service`). 30 min è sopra la durata sessione
-    AdE tipica, quindi un retry sotto soglia ritorna `PENDING_IN_PROGRESS` e
-    l'utente lo riproverà quando la sessione AdE non sarà più valida. Logging
-    esplicito al rientro in recovery senza `adeTransactionId` per audit.
-    Override env per test E2E o ambienti controllati:
-    `STALE_PENDING_THRESHOLD_MINUTES=5`.
-    **Soluzione corretta**: `searchDocuments`/`getDocument` su AdE pre-retry per
-    scoprire se un documento collegato esiste già — richiede l'endpoint AdE di
-    ricerca, tracciato in roadmap (vedi `ricerca_documento.har`).
-
-29. **Double-gate rate limit prima di chiamate esterne costose (Turnstile, AdE, ecc.).**
-    Quando un endpoint pubblico chiama un servizio esterno (HTTP outbound con timeout
-    non banale, es. 5s su Cloudflare siteverify), il rate limit funzionale per-utente
-    (es. 5/15min per auth) **non è sufficiente** a proteggere il costo della call
-    esterna: prima di raggiungere quella soglia un attaccante può già aver generato
-    n×timeout secondi di socket/promise pendenti e n×call HTTP outbound. Pattern
-    obbligato:
-    1. **Pre-limit** con bucket dedicato (`captchaPre:<action>:<ip>`, threshold
-       più permissivo del limite funzionale — es. 30/15min vs 5/15min) PRIMA
-       della chiamata esterna. Non penalizza l'utente legittimo, blocca i volumi
-       abusivi.
-    2. **Limite funzionale post-call** invariato per bloccare brute-force
-       applicativo (credential stuffing, scraping).
-    3. **Log strutturati separati** (`errorClass: "captcha_prelimit"` vs
-       `"auth_rate_limit"`) per dashboard ops che vogliano distinguere
-       "Turnstile call suppressed" da "auth attempts blocked".
-    4. **Bucket keys namespaced** per evitare collision (`captchaPre:<action>:<ip>`
-       vs `<action>:<ip>`).
-    5. **Test invariant cardinale**: con pre-limit failure, `fetch`/external call
-       NON deve mai essere invocata (`expect(mockFetch).not.toHaveBeenCalled()`).
-
-    Applicato a `signUp`/`signIn`/`resetPassword`. Lo stesso pattern si applica
-    a qualsiasi endpoint che inneschi: invio email (Resend), call AdE, generazione
-    PDF costosa, ecc.
-
-30. **`setInterval` in costruttori long-lived: chiamare sempre `.unref?.()`.**
-    Qualsiasi classe che instanzia un `setInterval` nel costruttore (es.
-    `RateLimiter`, scheduler, cache evictor) deve invocare `.unref?.()` sul
-    timer restituito. Senza unref il timer mantiene il process Node alive
-    anche dopo che tutto il lavoro è completato — irrilevante per il container
-    server (event loop ha sempre altre referenze), ma fragile per script
-    one-shot, test runner e job di setup che si aspettano un exit pulito.
-    Optional chaining (`?.`) per safety in edge runtimes che non espongono
-    l'API. Test: spy su `setInterval` con `mockReturnValueOnce({ unref })`
-    e verifica `expect(unref).toHaveBeenCalledTimes(1)` — richiede
-    `vi.useRealTimers()` quando il file usa `vi.useFakeTimers()`.
-
-31. **Redirect param dal middleware deve preservare il querystring.**
-    Quando il middleware (`proxy.ts`) reindirizza a `/login` per autenticazione,
-    il param `redirect` deve essere valorizzato con `pathname + search`, NON solo
-    `pathname`. Una deep link tipo `/dashboard/storico?from=2024-01-01&to=2024-01-31`
-    altrimenti perde i filtri post-login, costringendo l'utente a re-impostare lo
-    stato. Il consumer (`(auth)/callback/route.ts`) deve sanificare il param
-    ricevuto come path relativa (`startsWith("/")` ma NON `startsWith("//")` per
-    bloccare protocol-relative URLs di open redirect) e poi `new URL(redirect, origin)`
-    parsifica correttamente il querystring senza rischi.
-
-32. **Turnstile hostname check: lista, non single value.**
-    Cloudflare Turnstile ritorna in `data.hostname` l'hostname effettivo dove il
-    widget è stato risolto nel browser. Quando il sito ha sia un dominio app
-    (`app.scontrinozero.it`) sia un dominio marketing (`scontrinozero.it`), e il
-    form `/login` può essere caricato da entrambi — perché la client-side
-    navigation Next.js (`<Link href="/login">` dalla landing) non attraversa
-    sempre il redirect cross-origin del middleware, oppure perché il deploy è
-    single-domain — il check `data.hostname === expectedHostname` causa
-    `captcha_hostname_mismatch` sistemico e fail di ogni captcha.
-
-    Pattern obbligato in `verifyCaptcha` (`src/server/auth-actions.ts`): costruire
-    un `ReadonlySet<string>` con `appHostname`, `marketingHostname`, `www.<marketing>`
-    e usare `acceptedHostnames.has(data.hostname)`. Loggare la lista accettata
-    in caso di mismatch facilita il debug operativo.
-
-    Inoltre: il ramo `data.success: false` di Cloudflare deve **sempre** loggare
-    `data["error-codes"]` (es. `timeout-or-duplicate`, `invalid-input-response`).
-    Senza questo log la causa del rifiuto resta invisibile in produzione.
-
-33. **Drizzle raw ` sql` ``templates: JS`Date` (e qualsiasi valore non primitivo)
-    devono essere pre-serializzati e castati lato SQL.**
-    Dentro `db.update().set({...})` e `eq(col, value)` Drizzle conosce il tipo della
-    colonna e converte il JS value nel formato Postgres corretto (es. `Date` → ISO
-    timestamptz). Dentro un raw `` sql`...${value}...` `` template Drizzle non ha
-    contesto del tipo: il valore viene bindato così com'è a postgres-js, che per
-    valori non primitivi (Date, Buffer custom, oggetti) cade sul path di encoding
-    testuale (`.str(x) → Buffer.byteLength(x)`) e crasha con
-    `TypeError: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date`
-    (vedi Sentry `SCONTRINOZERO-TEST-7`, regressione nascosta per 14 giorni nel
-    flow "Verifica connessione" AdE).
-
-    **Pattern obbligato per ogni `Date` interpolato in ` sql` ``:**
-
-    ```typescript
-    sql`date_trunc('milliseconds', ${col}) = ${date.toISOString()}::timestamptz`;
-    ```
-
-    ISO string + cast esplicito (`::timestamptz`, `::timestamp` o `::date` in base
-    al tipo della colonna). La precisione al millisecondo è preservata.
-
-    **Test di regressione obbligato:** rendere il fragment con `PgDialect.sqlToQuery()`
-    e asserire che nessun `Date` finisca tra i `compiled.params`. I mock di `.where()`
-    in stile `vi.fn().mockReturnValue({ returning })` non catturano il bug perché
-    bypassano l'encoding di postgres-js.
-
-    **Smoke test post-deploy:** per i path DB introdotti ex novo (es. nuovi bottoni
-    di integrazione AdE, recovery flow, batch jobs) cliccare/eseguire almeno una
-    volta su sandbox subito dopo il rilascio del tag. I 2400+ unit test verdi non
-    garantiscono che postgres-js sappia binare i parametri reali.
-
 ## Progetto
 
-ScontrinoZero è un registratore di cassa virtuale (SaaS) mobile-first che consente a
-esercenti e micro-attività di emettere scontrini elettronici e trasmettere i corrispettivi
-all'Agenzia delle Entrate senza registratore telematico fisico, sfruttando la procedura
-"Documento Commerciale Online".
-
-La versione pubblicata è in `package.json`. Roadmap e backlog in `PLAN.md`. Lo storico delle release è ricostruibile dai tag git (`git tag -l "v1.*"`).
-
-## Principi di prodotto
-
-### Performance percepita come priorità #1
-
-L'obiettivo è che ogni interazione si senta **istantanea**. L'emissione di uno scontrino
-deve sembrare immediata anche se il portale AdE risponde in 2-5 secondi.
-
-Tecniche:
-
-- **Optimistic UI** — TanStack Query mutations: lo scontrino appare come "emesso"
-  immediatamente, il backend completa la trasmissione AdE in background.
-  Rollback automatico se l'invio fallisce.
-- **Skeleton loading** — mai schermi bianchi, sempre placeholder animati
-- **Route prefetching** — Next.js prefetch dei link visibili nel viewport
-- **Stale-while-revalidate** — TanStack Query mostra dati cached istantaneamente,
-  aggiorna in background
-- **Transizioni fluide** — no full-page reload, animazioni CSS minimali ma percettibili
-- **SSG per marketing** — pagine statiche pre-renderizzate, TTFB quasi zero
-- **Service worker** — shell PWA in cache, navigazione offline-first
-
-### Hobby project → il più economico del mercato
-
-Questo è un progetto hobby con costi fissi ~€0. Nessun dipendente, nessuna API terze
-parti a pagamento, VPS già pagata. Il costo marginale per utente è praticamente zero.
-Questo permette un pricing aggressivo impossibile per i competitor.
-
-### Leggeri sulle risorse
-
-La VPS ha risorse limitate. Ogni dipendenza, ogni libreria, ogni processo deve
-giustificare la propria esistenza.
-
-- **No headless browser** — niente Playwright, Puppeteer o Chromium in produzione.
-  L'integrazione AdE usa esclusivamente chiamate HTTP dirette (fetch/axios).
-  La generazione PDF usa **pdfkit** (Node.js puro, ~500KB), coerente con questo vincolo.
-  ⚠️ pdfkit richiede `serverExternalPackages: ["pdfkit"]` in `next.config.ts` per evitare
-  che Turbopack riscriva `__dirname` in `/ROOT` e rompa la risoluzione dei font AFM.
-- **Dipendenze minime** — aggiungere librerie solo quando strettamente necessario.
-  Preferire soluzioni native o leggere.
-- **Next.js standalone** — output ottimizzato, solo i file necessari (~100MB vs ~1GB)
-- **Docker slim** — immagine base leggera, no tool di sviluppo nel container
-- **Un solo container** — next-app + cloudflared, niente orchestrazione complessa
-
-### Open source + SaaS (O'Saasy License)
-
-- **Self-hosted gratis** — chiunque può scaricare, installare e usare il software
-  sul proprio server senza pagare nulla
-- **Versione hosted a pagamento** — noi offriamo il servizio gestito (SaaS) con
-  hosting, aggiornamenti, backup, supporto
-- **O'Saasy License** — permissiva come MIT, ma vieta di usare il software per
-  offrire un SaaS concorrente
-- La versione self-hosted è un selling point di fiducia: le credenziali Fisconline
-  restano sul server dell'utente, nessun dato transita da terzi
-
-### Pricing: i meno cari del mercato
-
-| Piano           | Mensile | Annuale | Target                    | Feature principali                               |
-| --------------- | ------- | ------- | ------------------------- | ------------------------------------------------ |
-| **Starter**     | €4.99   | €29.99  | Micro-attività, ambulanti | Scontrini illimitati, catalogo 5 prodotti        |
-| **Pro**         | €8.99   | €49.99  | Negozi, attività regolari | Catalogo illimitato, analytics, export, AdE sync |
-| **Self-hosted** | €0      | €0      | Tecnici, smanettoni       | Tutte le feature, gestione autonoma              |
-| **Unlimited**   | —       | —       | Invite-only (amici/beta)  | Come Pro, gestito direttamente su DB             |
-
-**Strategia pricing:**
-
-- Nessun piano Free hosted — solo self-hosted gratuito
-- **Trial 30 giorni** per Starter e Pro: nessuna carta di credito all'iscrizione,
-  scelta piano + CC solo alla scadenza del trial. Se non aggiunge CC: sola lettura.
-- Starter annuale (€29.99) è il prezzo più basso del mercato (competitor: Scontrinare €30/anno)
-- Starter mensile (€4.99) serve come ancora per far sembrare Pro un affare (decoy effect)
-- Pro annuale (€49.99) salva il 54% vs mensile; Starter annuale (€29.99) salva il 50% — Pro è più conveniente in percentuale
-- **Anti-abuso trial**: P.IVA UNIQUE nel DB — impedisce trial multipli anche con email diverse
-
-**Differenziazione piani (feature gate):**
-
-| Feature                        | Starter | Pro |
-| ------------------------------ | ------- | --- |
-| Scontrini illimitati           | ✅      | ✅  |
-| Metodi pagamento misti         | ✅      | ✅  |
-| Max prodotti catalogo rapido   | 5       | ∞   |
-| Analytics base                 | ✅      | ✅  |
-| Analytics avanzata (dashboard) | ❌      | ✅  |
-| Export CSV scontrini           | ❌      | ✅  |
-| Recupero corrispettivi da AdE  | ❌      | ✅  |
-| Sync catalogo da AdE           | ❌      | ✅  |
-| Supporto prioritario           | ❌      | ✅  |
-
-**Piano Unlimited (invite-only):** inserito direttamente nel DB (`plan = 'unlimited'` su `profiles`),
-nessuna logica Stripe. Bypassa tutti i gate come Pro.
-
-## Tech Stack
-
-### Frontend
-
-| Tecnologia                  | Ruolo                      | Note                                       |
-| --------------------------- | -------------------------- | ------------------------------------------ |
-| **Next.js 16** (App Router) | Framework React full-stack | SSR/SSG, API routes, server actions        |
-| **React 19**                | UI library                 |                                            |
-| **TypeScript**              | Type safety                | Strict mode                                |
-| **Tailwind CSS 4**          | Styling utility-first      |                                            |
-| **shadcn/ui**               | Component library          | Copy-paste, customizzabile, Radix UI sotto |
-| **TanStack Query v5**       | Data fetching client-side  | Cache, mutations, optimistic updates       |
-| **TanStack Table**          | Tabelle dati               | Già integrato in shadcn/ui DataTable       |
-| **PWA** (@serwist/next)     | Mobile-first installabile  | Service worker, offline shell, manifest    |
-
-### Backend
-
-| Tecnologia                              | Ruolo             | Note                                           |
-| --------------------------------------- | ----------------- | ---------------------------------------------- |
-| **Next.js API Routes + Server Actions** | Backend primario  | Integrato nel monolite Next.js                 |
-| **Supabase Cloud**                      | BaaS (PostgreSQL) | DB, auth, storage — free tier (50k MAU, 500MB) |
-
-### Database
-
-- **PostgreSQL** via Supabase Cloud (free tier per iniziare, poi Pro $25/mese)
-- **Drizzle ORM** — type-safe, leggero, ottima DX con TypeScript
-- **Row Level Security (RLS)** — sicurezza a livello di riga per multi-tenancy
-
-### Autenticazione
-
-- **Supabase Auth** — email/password per il login all'app SaaS
-- SPID è usato solo per autenticazione sul portale AdE (non come metodo di login all'app)
-
-### Integrazione Agenzia delle Entrate
-
-L'AdE **non espone API REST pubbliche**. La procedura "Documento Commerciale Online"
-è un'interfaccia web nel portale Fatture e Corrispettivi.
-
-**Strategia: integrazione diretta** (no API terze parti, no headless browser):
-
-- Reverse-engineering delle chiamate HTTP che il portale AdE effettua internamente
-- L'utente fornisce le proprie credenziali Fisconline (cifrate, mai in chiaro)
-- Il backend replica il flusso con chiamate HTTP dirette (fetch/axios)
-- **NO Playwright/headless browser** — troppo pesante per una VPS limitata
-  (~400MB RAM per Chromium). Solo chiamate HTTP leggere.
-- Base legale: Interpello AdE n. 956-1523/2020 — l'AdE non si oppone ai
-  "velocizzatori" purché rispettino le prescrizioni normative
-
-### Pagamenti SaaS (subscription)
-
-- **Stripe** — fee più basse in EU (1.5% + €0.25 per carte europee)
-- SDK: `stripe` npm v20.4.1, API version `2026-02-25.clover`
-
-**⚠️ Attenzione API version 2026-02-25.clover (breaking changes rispetto alle versioni precedenti):**
-
-- `Invoice.subscription` **rimosso** → usare `invoice.parent?.subscription_details?.subscription`
-- `Subscription.current_period_end` **spostato** a livello item → `subscription.items.data[0]?.current_period_end`
-- Non usare `!` (non-null assertion) su `process.env.STRIPE_WEBHOOK_SECRET` — aggiungere
-  un guard esplicito (`if (!secret) return 500`) per evitare SonarCloud code smell
-
-### Email transazionali
-
-- **Resend** — email transazionali (welcome, password reset, account deletion)
-- Free tier: 3.000 email/mese; Pro $20/mese per 50k quando si scala
-- React Email per template type-safe nello stesso stack
-- **Welcome email**: inviata al completamento dell'onboarding (step finale), **non** al signUp —
-  evita email a utenti che abbandonano il wizard prima di completarlo
-
-### Deployment
-
-- **Docker self-hosted su VPS** — Next.js `standalone`, Cloudflare Tunnel come ingress
-  - HTTPS automatico, CDN, DDoS protection, IP nascosto — zero porte pubbliche
-  - Docker Compose: next-app + cloudflared
-  - Health check endpoint: `/api/health/live` (liveness), `/api/health/ready` (readiness, DB ping)
-  - `start-period` healthcheck: **60s** (tempo per completare le migrazioni DB al primo avvio)
-- **Supabase Cloud** per il database (no DB da gestire sulla VPS)
-- **Deploy manuale via tag** `v*.*.*` → GitHub Actions: build Docker → push GHCR → VPS:
-  ```bash
-  cd /opt/scontrinozero
-  docker compose pull && docker compose up -d
-  ```
-  (VPS accessibile solo via Cloudflare Access SSH)
-
-**⚠️ Variabili `NEXT_PUBLIC_*` nel Docker build:**
-Next.js bake le variabili `NEXT_PUBLIC_*` **durante la build**, non a runtime.
-Devono essere passate come `--build-arg` al `docker build` (configurato in GitHub Actions via `ARG` nel Dockerfile).
-In particolare: `NEXT_PUBLIC_TURNSTILE_SITE_KEY` — se manca al build, Turnstile non funziona in produzione.
-
-### Monitoring, Analytics, Code quality
-
-| Tool                  | Ruolo                               | Note                                                |
-| --------------------- | ----------------------------------- | --------------------------------------------------- |
-| **Sentry**            | Error tracking + performance        | Free tier: 5k errori/mese; `@sentry/nextjs`         |
-| **pino**              | Structured logging                  |                                                     |
-| **Umami**             | Web analytics privacy-first         | Self-hosted, GDPR compliant, script ~2KB, no cookie |
-| **SonarQube Cloud**   | Analisi statica, SAST, coverage     | Free ≤50k LOC; PR decoration; Quality Gate          |
-| **ESLint + Prettier** | Linting e formattazione             | lint-staged + husky sui file staged                 |
-| **Dependabot**        | Aggiornamenti dipendenze automatici | Settimanale, patch/minor raggruppati                |
-
-### CI/CD
-
-- **GitHub Actions** — pipeline su push/PR verso main:
-  1. Secret scan (Gitleaks, sempre attivo)
-  2. Security audit (`audit-ci` `--moderate` con allowlist `audit-ci.json`)
-  3. Parallel: lint + type-check, test+coverage (Vitest→lcov), SonarQube scan, build
-- **Pipeline Deploy** (tag `v*.*.*`): build Docker → smoke test container → Trivy scan CVE → push GHCR
-- **Code review on-demand** (`claude-code-review.yml`): commenta `/claude review` su PR
-- **Branch protection**: abilitare "Require status checks" su GitHub Settings → Branches
-
-### Testing
-
-- **Approccio TDD** — test-first: scrivere i test prima dell'implementazione
-- **Vitest** — unit e integration test; coverage `@vitest/coverage-v8` (report lcov)
-- I componenti shadcn/ui (`src/components/ui/`) sono esclusi dalla coverage
-- I componenti marketing (`src/components/marketing/**`) sono esclusi dalla coverage
-  (pura UI presentazionale, zero logica di business)
-
-## Ambienti: sandbox e produzione
-
-### Due ambienti sulla stessa VPS
-
-|                   | **Sandbox**                                  | **Produzione**               |
-| ----------------- | -------------------------------------------- | ---------------------------- |
-| URL               | `sandbox.scontrinozero.it`                   | `scontrinozero.it`           |
-| API URL           | `api.sandbox.scontrinozero.it`               | `api.scontrinozero.it`       |
-| Cloudflare Tunnel | Route separata verso container sandbox       | Route verso container prod   |
-| Docker Compose    | `/opt/scontrinozero-sandbox/`                | `/opt/scontrinozero/`        |
-| DB Supabase       | Progetto Supabase separato (free tier)       | Progetto Supabase principale |
-| Variabile         | `ADE_MODE=mock`                              | `ADE_MODE=real`              |
-| Stripe            | Stripe test mode (chiavi `sk_test_*`)        | Stripe live mode             |
-| Scopo             | Test integrazione API per sviluppatori terzi | Utenti finali                |
-
-**Nota runtime hostname:** `APP_HOSTNAME` (senza prefisso `NEXT_PUBLIC_`) è una
-variabile runtime che sovrascrive il valore baked nell'immagine Docker. Va impostata
-a `sandbox.scontrinozero.it` nel `.env` del container sandbox per la validazione
-Turnstile e dei link email. Utile anche per installazioni self-hosted su dominio custom.
-
-### Strategia mock AdE per ambiente sandbox
-
-L'integrazione AdE usa un **pattern adapter/strategy**:
-
-- Interfaccia `AdeClient` con metodi: `submitSale()`, `submitVoid()`, etc.
-- `RealAdeClient` — invia davvero all'AdE (produzione)
-- `MockAdeClient` — esegue **tutta la logica** (validazione, formattazione,
-  preparazione payload) ma si ferma prima dell'invio HTTP all'AdE, restituendo
-  una risposta simulata
-- Controllato da `ADE_MODE=real|mock` (variabile d'ambiente)
-- Il codice in sandbox è **identico** a quello in produzione, cambia solo l'ultimo step
-
-### Flusso di rilascio (tag-based)
-
-```
-sviluppo su branch → PR → merge su main → CI (test + lint + sonar)
-                                              ↓
-                              git tag vX.Y.Z → GitHub Actions: build + push su GHCR
-                                              ↓
-                              VPS (browser SSH Cloudflare Access):
-                              cd /opt/scontrinozero
-                              docker compose pull && docker compose up -d
-```
-
-## Linee guida test e qualità
-
-### Regole obbligatorie (evitano failure CI / SonarCloud Blocker)
-
-#### Ogni test deve avere almeno un `expect()`
-
-SonarCloud classifica come **Blocker** qualsiasi `it()`/`test()` senza assertion.
-Anche i test che verificano "non lancia eccezione" o "chiama redirect" devono
-contenere almeno un `expect()` esplicito.
-
-```typescript
-// ❌ SBAGLIATO — SonarCloud Blocker
-it("chiama signIn senza errori", async () => {
-  try {
-    await signIn(formData);
-  } catch {
-    // redirect expected
-  }
-});
-
-// ✅ CORRETTO — assertion su effetto osservabile
-it("chiama signIn senza errori", async () => {
-  try {
-    await signIn(formData);
-  } catch {
-    // redirect expected
-  }
-  expect(mockSomeFn).toHaveBeenCalled();
-});
-```
-
-#### `vi.mock` di classi: usare `function` o `class`, mai arrow function
-
-Quando un modulo esporta una **classe** che viene istanziata con `new`,
-il mock deve usare la keyword `function` o `class` nel `mockImplementation`.
-Le arrow function non possono essere costruttori e causano:
-`TypeError: () => ({...}) is not a constructor`.
-
-Le variabili usate nella factory `vi.mock` **devono iniziare con `mock`**
-(Vitest le includa nell'hoisting automatico).
-
-```typescript
-// ❌ SBAGLIATO — arrow function non è un costruttore
-const mockCheck = vi.fn();
-vi.mock("@/lib/rate-limit", () => ({
-  RateLimiter: vi.fn().mockImplementation(() => ({ check: mockCheck })),
-}));
-
-// ✅ CORRETTO — regular function restituisce l'oggetto mock
-const mockCheck = vi.fn();
-vi.mock("@/lib/rate-limit", () => ({
-  RateLimiter: vi.fn().mockImplementation(function () {
-    return { check: mockCheck };
-  }),
-}));
-```
-
-> Nota: variabili nel factory `vi.mock` devono iniziare con `mock` —
-> Vitest le issa automaticamente, le altre risultano `undefined`.
-
-### Pattern: rate limiting su server actions autenticate
-
-Le server actions che operano per conto di un utente autenticato usano chiavi **per-user**
-(non per-IP). Le azioni pubbliche (PDF pubblici, ecc.) usano chiavi per-IP.
-
-```typescript
-// Istanziare a livello di modulo (singleton per processo)
-const myLimiter = new RateLimiter({
-  maxRequests: 30, // soglia appropriata all'operazione
-  windowMs: 60 * 60 * 1000, // finestra di 1 ora
-});
-
-export async function myAction(input: MyInput): Promise<MyResult> {
-  const user = await getAuthenticatedUser(); // prima cosa sempre
-
-  const rateLimitResult = myLimiter.check(`prefix:${user.id}`);
-  if (!rateLimitResult.success) {
-    logger.warn({ userId: user.id }, "Rate limit exceeded");
-    return { error: "Troppe richieste. Riprova tra qualche minuto." };
-  }
-  // ... resto della logica
-}
-```
-
-**Soglie consolidate:**
-
-- `emit:<userId>` — `emitReceipt` → 30/ora (operazione frequente)
-- `void:<userId>` — `voidReceipt` → 10/ora (operazione rara e irreversibile)
-- `pdf:<ip>` — PDF pubblico → 60/ora (per-IP, non autenticato)
-- `checkout:<userId>` — `POST /api/stripe/checkout` → 10/ora
-- `portal:<userId>` — `GET|POST /api/stripe/portal` → 10/ora
-- Auth actions — 5/15min per-IP (in `src/server/auth-actions.ts`)
-
-### Aggiornare i mock quando si ottimizzano query DB con JOIN
-
-Quando si refactora una funzione che esegue N query separate in un JOIN singolo,
-**tutti** i file di test che chiamano quella funzione (anche indirettamente) devono
-aggiornare i propri mock. Il pattern da cercare:
-
-- Test che mockano `@/db` con chain `select().from().where().limit()` senza `innerJoin`
-- Funzioni nel codice sotto test che chiamano `checkBusinessOwnership` o simili
-  **senza mockare `@/lib/server-auth`** → usano la funzione reale, che ora usa JOIN
-
-Fix: aggiungere `innerJoin` al mock chain E ridurre le `mockLimit.mockResolvedValueOnce`
-da 2 (profile + business separati) a 1 (risultato JOIN). In alternativa: mockare sempre
-`@/lib/server-auth` nei test delle server actions che usano ownership check.
-
-Cerca file affetti con: `grep -rn "FAKE_PROFILE\|Ownership check" tests/ src/ --include="*.test.ts"`
-
-### Testare NODE_ENV in unit test con `vi.stubEnv`
-
-`process.env.NODE_ENV` **non è direttamente scrivibile** in Vitest (TypeError se si usa
-`Object.defineProperty`). Usare sempre `vi.stubEnv` + `vi.unstubAllEnvs()` in `afterEach`:
-
-```typescript
-import { afterEach, it, vi } from "vitest";
-
-afterEach(() => vi.unstubAllEnvs());
-
-it("si comporta diversamente in produzione", () => {
-  vi.stubEnv("NODE_ENV", "production");
-  // ... assertions ...
-});
-```
-
-### URL parsing vs startsWith per controlli hostname
-
-Usare **sempre** `new URL(link)` + `url.hostname === expected` per verificare che un link
-punti al proprio dominio. `link.startsWith("https://mio.dominio.it")` è bypassabile con
-`https://mio.dominio.it.attacker.tld/`. Il check corretto:
-
-```typescript
-let parsed: URL | null = null;
-try {
-  parsed = new URL(link);
-} catch {
-  /* malformed */
-}
-if (
-  !parsed ||
-  parsed.protocol !== "https:" ||
-  parsed.hostname !== expectedHostname
-) {
-  // blocca
-}
-```
-
-### Race condition su operazioni multi-riga: preferire constraint DB all'application lock
-
-Per prevenire operazioni duplicate concorrenti (es. doppio VOID dello stesso SALE), la
-soluzione più robusta è un **constraint DB** (UNIQUE, partial index) piuttosto che un
-lock applicativo. Il DB garantisce atomicità; il codice applicativo può solo essere
-TOCTOU-vulnerabile. Pattern:
-
-1. Aggiungere `UNIQUE INDEX ... WHERE col IS NOT NULL` in una migrazione
-2. Inserire con `onConflictDoNothing()`
-3. Se `returning` è vuoto, discriminare il caso "stessa key" (idempotency) da "key diversa, stessa riga target" (race condition) via query separata
-
-### Scope idempotency key: sempre per-tenant, mai globale
-
-I vincoli UNIQUE su `idempotency_key` vanno sempre scoped al tenant (`business_id`):
-`UNIQUE(business_id, idempotency_key)`. Un constraint globale blocca business diversi
-che usano accidentalmente la stessa UUID e può esporre metadati cross-tenant. I fallback
-di lookup devono filtrare per `businessId` in aggiunta alla key.
-
-### Checklist pre-PR
-
-Prima di aprire una PR verificare che la pipeline CI passi localmente:
+ScontrinoZero è un registratore di cassa virtuale SaaS mobile-first per esercenti
+e micro-attività: emette scontrini elettronici e trasmette i corrispettivi all'AdE
+via "Documento Commerciale Online", senza registratore telematico fisico.
+
+**Stack:** Next.js 16 (App Router) · React 19 · TypeScript strict · Tailwind 4 ·
+shadcn/ui · TanStack Query/Table · PWA (Serwist) · Supabase Cloud (Postgres) ·
+Drizzle ORM · Supabase Auth · Stripe (`2026-02-25.clover`) · Resend · Sentry ·
+pino · Umami · SonarCloud · Vitest. Deploy Docker self-hosted su VPS dietro
+Cloudflare Tunnel.
+
+**Due ambienti** sulla stessa VPS:
+
+- **Produzione** — `scontrinozero.it` · `ADE_MODE=real` · Stripe live
+- **Sandbox** — `sandbox.scontrinozero.it` · `ADE_MODE=mock` · Stripe test
+
+Versione corrente in `package.json`. Roadmap in `PLAN.md`. Storico release dai
+tag git (`git tag -l "v1.*"`).
+
+## Principi guida
+
+- **Performance percepita = priorità #1.** Optimistic UI, skeleton loading,
+  route prefetching, SSG marketing. L'emissione scontrino sembra istantanea
+  anche se AdE risponde in 2-5 secondi.
+- **Hobby project, costi fissi ~€0.** Pricing aggressivo possibile perché il
+  costo marginale per utente è ~zero.
+- **Leggeri sulle risorse.** No headless browser (Playwright/Puppeteer/Chromium):
+  integrazione AdE solo via HTTP diretto. PDF via `pdfkit` (Node puro, ~500KB) —
+  richiede `serverExternalPackages: ["pdfkit"]` in `next.config.ts`. Dipendenze
+  minime, Next standalone, Docker slim, un solo container (next-app + cloudflared).
+
+## Regole sempre-attive (applicano a ogni task)
+
+1. **Branch separato sempre.** Mai commit/push diretti su `main`. PR sempre,
+   merge spetta all'utente (a meno che non chiesto esplicito).
+2. **TDD.** Test prima dell'implementazione. Ogni file con logica ha il suo
+   test file (anche `instrumentation.ts` e simili bootstrap).
+3. **Chiedi se ambiguo** prima di scrivere codice.
+4. **Edge case dopo ogni implementazione:** elencare gli edge case e aggiungere
+   test che li coprono prima di committare.
+5. **Task > 3 file → break in sub-task.** Stop e suddividere.
+6. **Riflessione dopo correzione:** quando l'utente corregge, capire perché ho
+   sbagliato e come non rifarlo.
+7. **Aggiornare `CLAUDE.md` (o `docs/claude-*.md` pertinente) autonomamente**
+   dopo aver risolto un problema non triviale con lezione riusabile (debugging
+   pattern, setup gotcha, wrong assumption). Non aspettare che lo chiedano.
+8. **Aggiornare pagine `/help`** se si modifica una funzionalità (label, menu,
+   stati, filtri, error flow, gating piani, nomi bottoni). `grep -rn "<termine>"
+   src/app/\(marketing\)/help` prima di chiudere il task. Feature non ancora
+   implementate → riformulare al condizionale come roadmap.
+9. **Boundary delle API:** UUID validation con `isValidUuid()` + 400 prima del
+   service; body size guard con `readJsonWithLimit(req, maxBytes)` + 413 prima
+   di `JSON.parse`; email normalizzata con `normalizeEmail()` in `validation.ts`
+   come prima riga di ogni auth action.
+10. **Wrap SDK esterni (Stripe, AdE, Resend) in try-catch** con log strutturato
+    e response 503 — mai lasciare propagare 500 senza context.
+11. **DB migrations: TUTTE handwritten dopo `0000`.** 🚫 **MAI eseguire
+    `npx drizzle-kit generate`** nello stato attuale del repo (conflitto con
+    handwritten migrations). Dettaglio workflow in `docs/claude-db.md`.
+12. **Debug CI failure opachi:** se SonarCloud/Gitleaks flagga qualcosa non
+    visibile nel diff/log, **chiedere all'utente** quale file/riga invece di
+    tentare blind fix.
+13. **Debug produzione HTTP (AdE 4xx, ecc.):** aggiungere diagnostic logging
+    prima del fix, riprodurre locale, confermare la root cause. Mai mergiare
+    un'ipotesi senza evidenza.
+14. **HAR analysis:** verificare che **ogni request** in HAR sia presente
+    nell'implementazione, non solo l'ordine. Cross-reference one-by-one.
+
+## SonarCloud quality gate
+
+- Coverage on new code ≥ **80%**
+- Duplicated lines on new code < **3%**
+- **0 new issues** (fix sempre, anche con Quality Gate verde — accumulano debt)
+
+Regole specifiche ricorrenti (S6861 readonly props, S6772 JSX spacing, S7780
+template literals, S5852/S5122 hotspots, Gitleaks placeholder) → `docs/claude-sonar.md`.
+
+## Stripe API version `2026-02-25.clover` — breaking changes
+
+- `Invoice.subscription` rimosso → `invoice.parent?.subscription_details?.subscription`
+- `Subscription.current_period_end` → `subscription.items.data[0]?.current_period_end`
+- Mai `!` su `process.env.STRIPE_WEBHOOK_SECRET` — guard esplicito
+
+Webhook events list (8 da registrare, niente di meno) e recovery patterns in
+`docs/claude-stripe.md`.
+
+## Workflow operativi
+
+### Nuova migrazione DB
+
+1. File `.sql` in `supabase/migrations/NNNN_description.sql` con header comment
+2. Entry in `supabase/migrations/meta/_journal.json`
+   (`idx` incrementale, `when` = `Date.now()`, `tag` = nome file senza `.sql`)
+3. Aggiorna schema Drizzle in `src/db/schema/<table>.ts`
+4. `node scripts/check-migrations.mjs` (anche in CI)
+5. `npx tsx scripts/migrate.ts` su DB locale, verificare idempotenza al re-run
+
+Pattern ADD COLUMN: `ADD COLUMN IF NOT EXISTS`, mai `NOT NULL` su tabelle già
+popolate senza default. Dettaglio + bootstrap su DB pre-esistente in
+`docs/claude-db.md`.
+
+### Worktree setup (`.claude/worktrees/<name>/`)
+
+- `npm install` (no `node_modules` symlink)
+- Copy `.env.local` dalla root del main repo
+- `rm -rf .next` in worktree E main repo prima del dev server (evita stale
+  Turbopack chunks)
+
+### Pre-PR
 
 ```bash
-npm run lint          # nessun errore ESLint / TypeScript
-npx prettier --check src/  # nessun errore di formattazione
-npm run test:coverage # tutti i test verdi, coverage non in calo
+npm run lint                # ESLint / TypeScript
+npx prettier --check src/   # ⚠️ dopo modifiche a classi Tailwind: prettier --write
+npm run test:coverage       # tutti i test verdi, coverage non in calo
 ```
-
-**⚠️ `prettier-plugin-tailwindcss` ordina automaticamente le classi Tailwind.**
-Dopo aver aggiunto o modificato classi Tailwind in file `.tsx`/`.ts`, eseguire sempre:
-
-```bash
-npx prettier --write <file modificati>
-```
-
-altrimenti il check `prettier --check` in CI fallisce. Il plugin è configurato in
-`.prettierrc` e riordina le classi secondo la sequenza canonica di Tailwind CSS.
 
 Controlli manuali:
 
-- [ ] Ogni `it()`/`test()` ha almeno un `expect()`
-- [ ] I mock di classi usano `function`/`class` (non arrow function)
-- [ ] I nomi delle variabili nel factory `vi.mock` iniziano con `mock`
-- [ ] Nessuna nuova issue SonarCloud Blocker/Critical introdotta
+- [ ] Ogni `it()`/`test()` ha almeno un `expect()` (S6661 Blocker)
+- [ ] Mock di classi usano `function`/`class` (non arrow)
+- [ ] Variabili in `vi.mock` factory iniziano con `mock` (hoisting Vitest)
+- [ ] Nessuna nuova issue SonarCloud Blocker/Critical
 
-### `react/cache` non deduplicaza tra Route Handler e RSC page
-
-`cache()` da `react` è scoped al singolo render tree RSC. **Non** deduplicata
-tra la page RSC `/r/[id]` e la Route Handler `/r/[id]/pdf` — sono HTTP request
-separate. Usare `cache()` in una funzione di data-access condivisa crea una
-falsa aspettativa. Preferire plain async function + chiamata diretta al DB in
-ogni entry point.
-
-### Pattern `INSERT ... ON CONFLICT DO NOTHING` per race condition sul creazione riga
-
-Quando un endpoint può essere invocato concorrentemente per lo stesso utente
-(es. doppio click su "Checkout"), il pattern "SELECT then INSERT" causa un
-unique-constraint violation → 500 sulla richiesta persa. Fix pattern Drizzle:
-
-```typescript
-const [inserted] = await db
-  .insert(table)
-  .values({...})
-  .onConflictDoNothing()
-  .returning({ col: table.col });
-
-if (!inserted) {
-  // Conflict: re-SELECT per recuperare il valore del "winner"
-  const [existing] = await db.select(...).where(...);
-}
-```
-
-### Mock Drizzle con `transaction`: il callback riceve `tx`, non `db`
-
-Quando il codice usa `db.transaction(async (tx) => { tx.update(...) })`, i
-test devono aggiungere `transaction` al mock di `getDb()` come passthrough:
-
-```typescript
-const mockTransaction = vi.fn();
-// In beforeEach (dopo vi.clearAllMocks()):
-mockTransaction.mockImplementation(async (fn) =>
-  fn({ select: mockSelect, insert: mockInsert, update: mockUpdate }),
-);
-```
-
-Se si dimentica, il codice chiama `db.transaction(undefined)` → TypeError silenzioso.
-
-### Sentry: pino logMethod hook fires BEFORE redaction — sanitize before captureException
-
-`pino`'s `redact` config runs during **serialisation** (when the log is written to output), but the `logMethod` hook fires before serialisation with the **raw** object. Any field forwarded to `Sentry.captureException/captureMessage` from inside `logMethod` is therefore un-redacted.
-
-Fix: always pass context through `sanitizeForTelemetry()` before any Sentry call. Use an explicit **allowlist** of safe keys (requestId, userId, path, documentId, adeErrorCodes, …) rather than a denylist — easier to reason about and impossible to accidentally miss new sensitive fields.
-
-Pattern in `src/lib/logger.ts`:
-
-```typescript
-function captureToSentry(obj: unknown, msg?: string): void {
-  const sanitized = sanitizeForTelemetry(obj); // allowlist, strips PII
-  if (... instanceof Error) {
-    Sentry.captureException(err, { extra: sanitized });
-  }
-}
-```
-
-Error objects in `extra` must be extracted as `{ name, message }` only — the stack trace and cause chain can embed request context (query params, headers) from the call site.
-
-### deleteAccount: delete auth user FIRST to prevent orphan auth entries
-
-The safe ordering for account deletion is **auth-first**:
-
-1. Delete Supabase Auth user (admin API, 3 retries × backoff)
-2. If auth deletion fails → return `{ error }` immediately; profile is untouched and user can still log in and retry
-3. If auth deletion succeeds → delete profile (FK cascade)
-4. If profile deletion fails → log `critical: true`, manual cleanup needed (but auth entry is gone, so no login is possible)
-
-Previous ordering (profile-first) left an orphan auth entry that blocked re-registration when auth deletion exhausted all retries. Inverting the order contains the failure: either nothing is deleted (safe), or only the profile orphan remains (less harmful).
-
-### Aggiornamento `last_used_at` con WHERE condizionale anti-write-amplification
-
-Per evitare un DB write su ogni API request, usare:
-
-```typescript
-.where(and(eq(table.id, id), or(isNull(table.lastUsedAt), lt(table.lastUsedAt, threshold))))
-```
-
-Il DB aggiorna solo se `lastUsedAt IS NULL OR lastUsedAt < NOW - N_min`.
-Sempre fire-and-forget (`.catch(logger.warn)`). Throttle consigliato: 10 minuti.
-
-### Stripe webhook: lista completa degli eventi da registrare
-
-Il webhook handler gestisce **8 eventi**. Ogni endpoint (prod, sandbox, dev locale) deve
-avere il proprio `whsec_*` separato generato da Stripe (Settings → Webhooks → Add endpoint).
-Non condividere mai lo stesso `STRIPE_WEBHOOK_SECRET` tra ambienti diversi.
-
-**Evento più critico da non dimenticare:** `customer.subscription.updated` — è l'unico che
-chiama `syncSubscriptionData` sui rinnovi, aggiornando `profiles.planExpiresAt`. Senza di
-esso la data di rinnovo in UI è sempre stale e la recovery da `past_due` non funziona mai.
-
-| Evento                            | Perché                                                       |
-| --------------------------------- | ------------------------------------------------------------ |
-| `checkout.session.completed`      | Attiva l'abbonamento dopo il pagamento                       |
-| `checkout.session.expired`        | Cleanup righe `pending` abbandonate (24h di default)         |
-| `customer.subscription.updated`   | Rinnovi, upgrade/downgrade, recovery da `past_due`           |
-| `customer.subscription.deleted`   | Cancellazione → reset a `trial` in transaction               |
-| `invoice.paid`                    | Aggiorna `currentPeriodEnd` su ogni rinnovo (safety net)     |
-| `invoice.payment_failed`          | Imposta status `past_due`                                    |
-| `invoice.payment_action_required` | 3D Secure / SCA obbligatorio in EU (PSD2)                    |
-| `charge.dispute.created`          | Alert chargeback con `critical: true` — nessuna scrittura DB |
-
-**Non serve registrare:** `customer.subscription.created` (coperto da `checkout.session.completed`),
-`payment_intent.*` (coperti dagli eventi `invoice.*`), `customer.subscription.paused/resumed`
-(feature non usata).
-
-**Stato "misto" subscription card (pending + trial):** se dopo un checkout la card mostra
-"Prova gratuita" + "Abbonamento annuale" + portale, la riga `subscriptions` è `pending`
-(webhook non arrivato o fallito). Verificare: (1) endpoint registrato su Stripe per
-quell'ambiente, (2) `STRIPE_WEBHOOK_SECRET` corretto, (3) log server per errori di firma.
-
-## Sito vetrina (landing/marketing)
-
-Stesso progetto Next.js, non un sito separato:
-
-- La pagina marketing principale (`/`) è una route SSG nel Next.js App Router —
-  generata staticamente al build, veloce. Le sezioni funzionalità e prezzi sono
-  anchor link sulla homepage (`#funzionalita`, `#prezzi`), non route separate.
-- L'app SaaS vive sotto /dashboard — route dinamiche protette da auth
-- Meta tag e Open Graph automatici via Next.js `metadata` API
-- Sitemap via `next-sitemap`; structured data JSON-LD per rich snippets
-- **Dati di contatto centralizzati** — P.IVA, email e altri riferimenti aziendali
-  sono in un file costanti condiviso (non duplicati nelle singole pagine marketing).
-  Aggiornare lì e si propagano ovunque automaticamente.
-
-## Conformità legale
-
-- **Privacy Policy** — obbligatoria (GDPR). Versione attuale: `/privacy/v01`
-- **Cookie Policy** — solo cookie tecnici (Supabase auth) + analytics cookieless (Umami) → no banner
-- **Termini di Servizio** — versione attuale: `/termini/v01`
-- **GDPR art. 20 — Portabilità dati** — `exportUserData()` in `src/server/export-actions.ts`; UI in `/dashboard/settings`
-- **Accettazione T&C tracciata** — `signUp` salva `terms_accepted_at` + `terms_version` su `profiles`.
-  La versione corrente è `CURRENT_TERMS_VERSION` in `src/server/auth-actions.ts`.
-
-**Procedura aggiornamento T&C:**
-
-1. Creare `src/app/(marketing)/termini/vXX/page.tsx` con il nuovo testo
-2. Aggiornare il redirect in `src/app/(marketing)/termini/page.tsx` → `/termini/vXX`
-3. Aggiornare `CURRENT_TERMS_VERSION = "vXX"` in `src/server/auth-actions.ts`
-4. Aggiornare il testo del **secondo flag** (clausole vessatorie art. 1341 c.c.) in
-   `src/app/(auth)/register/page.tsx` — i numeri di paragrafo devono rispecchiare
-   la struttura della nuova versione
-
-**Procedura aggiornamento Privacy Policy:**
-
-1. Creare `src/app/(marketing)/privacy/vXX/page.tsx`
-2. Aggiornare redirect in `src/app/(marketing)/privacy/page.tsx` → `/privacy/vXX`
-3. Aggiungere `/privacy/vXX` in `src/app/sitemap.ts` e aggiornare `sitemap.test.ts`
-4. Aggiungere `privacy/vXX/page.tsx` a `sonar.coverage.exclusions`
-5. Notificare gli utenti almeno 15 giorni prima dell'entrata in vigore
-
-## Decisioni architetturali
-
-| Scelta                       | Motivo chiave                                                                      |
-| ---------------------------- | ---------------------------------------------------------------------------------- |
-| **Next.js** vs SPA           | SSR per SEO + Server Actions eliminano backend separato                            |
-| **Supabase** vs Firebase     | PostgreSQL standard, RLS nativo, no vendor lock-in                                 |
-| **PWA** vs app nativa        | Un codebase, no App Store, aggiornamenti istantanei                                |
-| **shadcn/ui**                | Componenti accessibili, copia nel progetto (non dipendenza), Radix UI              |
-| **Integrazione diretta AdE** | Zero costo per scontrino, no dipendenza da terze parti                             |
-| **Cloudflare Tunnel**        | Già attivo sulla VPS, HTTPS/CDN/DDoS gratis, IP nascosto                           |
-| **Stripe**                   | Fee EU più basse (1.5% + €0.25), API eccellente; MoR rimandato a espansione estera |
-| **Resend**                   | Free tier 3k/mese, React Email type-safe, deliverability ottima                    |
-| **SonarQube Cloud**          | SAST gratuito ≤50k LOC, PR decoration, Quality Gate                                |
-| **TDD**                      | Fondamentale per l'integrazione AdE (fragile) e refactoring sicuro                 |
-| **Due ambienti**             | AdE irreversibile: un scontrino emesso non si cancella                             |
-| **Umami self-hosted**        | Analytics GDPR-compliant senza cookie, gratis sulla stessa VPS                     |
-
-## Struttura progetto
+### Deploy (tag-based)
 
 ```
-scontrinozero/
-├── src/
-│   ├── app/                # Next.js App Router
-│   │   ├── (marketing)/    # Route group: landing, prezzi, blog (SSG)
-│   │   ├── (auth)/         # Route group: login, register, reset-password
-│   │   └── dashboard/      # App SaaS protetta da auth
-│   ├── components/         # Componenti React (shadcn/ui + custom)
-│   │   └── ui/             # shadcn/ui components
-│   ├── lib/                # Utility, client Supabase, helpers
-│   │   └── ade/            # Modulo integrazione Agenzia delle Entrate
-│   ├── server/             # Server actions, business logic
-│   ├── emails/             # Template email (React Email)
-│   └── types/              # TypeScript types/interfaces
-├── public/                 # Static assets, PWA manifest, icons
-├── supabase/               # Migrazioni DB, seed, config
-├── tests/                  # Vitest unit tests
-├── .github/workflows/      # GitHub Actions CI/CD
-├── CLAUDE.md
-└── PLAN.md
+sviluppo → PR → merge main → CI
+git tag vX.Y.Z → GitHub Actions: build Docker + push GHCR
+VPS (Cloudflare Access SSH):
+  cd /opt/scontrinozero && docker compose pull && docker compose up -d
 ```
 
-## File HAR da analizzare
+⚠️ Variabili `NEXT_PUBLIC_*` sono **baked al build** (non runtime): vanno
+passate come `--build-arg` al `docker build`. `APP_HOSTNAME` (senza
+`NEXT_PUBLIC_`) è runtime e sovrascrive l'hostname baked — usato per sandbox
+e self-hosting su dominio custom.
 
-Presenti nella root del repo, da analizzare prima delle relative release:
+### Procedura aggiornamento T&C
 
-| File                             | Feature                                            | Target                               |
-| -------------------------------- | -------------------------------------------------- | ------------------------------------ |
-| `dati_doc_commerciale.har`       | Aggiornamento dati business su AdE post-onboarding | rinviato (possibile feature premium) |
-| `aggiungi_prodotto_catalogo.har` | Aggiunta prodotto su rubrica AdE                   | v1.7.0                               |
-| `modifica_prodotto_catalogo.har` | Modifica prodotto su rubrica AdE                   | v1.7.0                               |
-| `elimina_prodotto_catalogo.har`  | Eliminazione prodotto su rubrica AdE               | v1.7.0                               |
-| `ricerca_prodotto_catalogo.har`  | Ricerca prodotto su rubrica AdE                    | v1.7.0                               |
-| `ricerca_documento.har`          | Ricerca documento su AdE                           | v2.0.0+                              |
-| `login_cie.har`                  | CIE login flow                                     | v1.8.0+                              |
+1. Crea `src/app/(marketing)/termini/vXX/page.tsx`
+2. Aggiorna redirect in `src/app/(marketing)/termini/page.tsx` → `/termini/vXX`
+3. Aggiorna `CURRENT_TERMS_VERSION = "vXX"` in `src/server/auth-actions.ts`
+4. Aggiorna il **secondo flag** (clausole vessatorie art. 1341 c.c.) in
+   `src/app/(auth)/register/page.tsx` con i nuovi numeri di paragrafo
+
+Privacy Policy: stessa procedura, aggiungere anche a `sitemap.ts`,
+`sitemap.test.ts` e `sonar.coverage.exclusions`. Notifica utenti ≥15 giorni
+prima dell'entrata in vigore.
+
+## Pricing (per plan-gate nel codice)
+
+| Piano       | Mensile | Annuale | Note                                            |
+| ----------- | ------- | ------- | ----------------------------------------------- |
+| Starter     | €4.99   | €29.99  | Catalogo rapido max 5 prodotti                  |
+| Pro         | €8.99   | €49.99  | Catalogo ∞, analytics avanzata, export, AdE sync |
+| Self-hosted | €0      | €0      | Tutte le feature, gestione autonoma             |
+| Unlimited   | —       | —       | Invite-only, `plan='unlimited'` su `profiles`   |
+
+Feature gate canonico in `src/lib/plans.ts`. Trial 30 giorni Starter/Pro, no
+carta all'iscrizione. P.IVA UNIQUE nel DB (anti-abuso trial).
+
+## Indice docs di approfondimento
+
+Pattern e lezioni dettagliate consultabili al bisogno via `Read`/`grep`:
+
+- **`docs/claude-testing.md`** — Vitest: `expect()` obbligatori, mock di
+  classi, rate limit pattern, JOIN refactor, NODE_ENV, mock Drizzle
+  transaction, `react/cache`, INSERT ON CONFLICT, Sentry+pino, `deleteAccount`
+  ordering, `last_used_at` throttle
+- **`docs/claude-db.md`** — Migrazioni handwritten, bootstrap su DB
+  pre-esistente, transazioni multi-doc, Drizzle raw `sql\`\`` con `Date`,
+  race condition / constraint DB, idempotency key per-tenant
+- **`docs/claude-security.md`** — `CF-Connecting-IP` trust, retry+backoff,
+  UUID/body size/email guards, hostname validation, double-gate rate limit
+  con Turnstile, `setInterval.unref()`, redirect param query string, CSP
+  rollout
+- **`docs/claude-stripe.md`** — API version breaking changes, 8 webhook
+  events da registrare, stale recovery AdE
+- **`docs/claude-ade.md`** — Integrazione diretta (no headless),
+  adapter/strategy mock, debug HTTP, HAR analysis, key rotation `ENCRYPTION_KEY`
+- **`docs/claude-sonar.md`** — Regole specifiche S6861/S6772/S7780/S5852/S5122,
+  Gitleaks placeholder fingerprint, coverage exclusions
+
+Altri riferimenti già nel repo:
+
+- **`PLAN.md`** — roadmap e backlog
+- **`DEVELOPER.md`** — Developer API (Tier 1/2)
+- **`docs/api-spec.md`** — surface REST
+- **`README.md`** — overview pubblico
+
+## Scelte architetturali rapide
+
+Tutte motivate dalle priorità sopra (performance, hobby project, leggero):
+
+- **Next.js** monolite (SSR + Server Actions, no backend separato)
+- **Supabase** vs Firebase (Postgres standard, RLS nativo, no lock-in)
+- **PWA** vs nativa (un codebase, no store, update istantanei)
+- **shadcn/ui** (copy-paste in repo, Radix sotto)
+- **Integrazione diretta AdE** (zero costo per scontrino, no terzi)
+- **Cloudflare Tunnel** (HTTPS/CDN/DDoS gratis, IP nascosto)
+- **Stripe** (fee EU 1.5% + €0.25, API ottima; MoR rimandato)
+- **Resend** (free 3k/mese, React Email type-safe)
+- **TDD** (integrazione AdE fragile, refactoring sicuro)
+- **Due ambienti** (AdE irreversibile: uno scontrino emesso non si cancella)
+- **Umami self-hosted** (GDPR, no cookie, gratis sulla stessa VPS)

--- a/docs/claude-ade.md
+++ b/docs/claude-ade.md
@@ -1,0 +1,108 @@
+# claude-ade.md — Integrazione Agenzia delle Entrate, mock, debug
+
+Riferimento dal `CLAUDE.md` core.
+
+---
+
+## Strategia: integrazione diretta (no API REST, no headless browser)
+
+L'AdE **non espone API REST pubbliche**. La procedura "Documento Commerciale
+Online" è un'interfaccia web nel portale Fatture e Corrispettivi.
+
+Approccio:
+
+- Reverse-engineering delle chiamate HTTP che il portale AdE effettua internamente
+- L'utente fornisce le proprie credenziali Fisconline (cifrate, mai in chiaro)
+- Il backend replica il flusso con chiamate HTTP dirette (fetch/axios)
+- **NO Playwright/headless browser** — troppo pesante per VPS limitata
+  (~400MB RAM per Chromium). Solo HTTP leggero.
+- **Base legale:** Interpello AdE n. 956-1523/2020 — l'AdE non si oppone ai
+  "velocizzatori" purché rispettino le prescrizioni normative
+
+---
+
+## Pattern adapter/strategy per ambiente sandbox
+
+L'integrazione AdE usa `AdeClient` con due implementazioni:
+
+- **`RealAdeClient`** — invia davvero all'AdE (produzione)
+- **`MockAdeClient`** — esegue **tutta la logica** (validazione, formattazione,
+  preparazione payload) ma si ferma prima dell'invio HTTP, restituendo una
+  risposta simulata
+
+Controllato da `ADE_MODE=real|mock` (env var). Il codice in sandbox è
+**identico** a quello in produzione, cambia solo l'ultimo step.
+
+---
+
+## Debugging production HTTP flow errors
+
+Quando un errore produzione suggerisce sequenza HTTP sbagliata:
+
+1. Aggiungere diagnostic logging **prima** del fix (phase labels, cookie counts,
+   response status)
+2. Riprodurre l'errore locale per confermare la root cause
+3. Solo allora scrivere il fix
+
+Mai mergiare un fix hypothesis-based senza prima vedere l'evidenza diagnostica.
+
+---
+
+## HAR analysis: completezza, non solo ordine
+
+Confrontando il codice contro una HAR capture, controllare esplicitamente che
+**ogni request** in HAR sia presente nell'implementazione — non solo che
+l'ordine matcha. Una call mancante è più difficile da spottare di una sbagliata.
+Cross-reference request-by-request.
+
+### File HAR nel repo
+
+| File                             | Feature                                            | Target                               |
+| -------------------------------- | -------------------------------------------------- | ------------------------------------ |
+| `dati_doc_commerciale.har`       | Aggiornamento dati business su AdE post-onboarding | rinviato (possibile feature premium) |
+| `aggiungi_prodotto_catalogo.har` | Aggiunta prodotto su rubrica AdE                   | v1.7.0                               |
+| `modifica_prodotto_catalogo.har` | Modifica prodotto su rubrica AdE                   | v1.7.0                               |
+| `elimina_prodotto_catalogo.har`  | Eliminazione prodotto su rubrica AdE               | v1.7.0                               |
+| `ricerca_prodotto_catalogo.har`  | Ricerca prodotto su rubrica AdE                    | v1.7.0                               |
+| `ricerca_documento.har`          | Ricerca documento su AdE                           | v2.0.0+                              |
+| `login_cie.har`                  | CIE login flow                                     | v1.8.0+                              |
+
+---
+
+## Key rotation: `ENCRYPTION_KEY`
+
+Le credenziali Fisconline sono cifrate con AES-256-GCM; la chiave sta in
+`ENCRYPTION_KEY` (env var, 64 hex chars). Se compromessa o da ruotare:
+
+### Procedura obbligatoria prima del deploy
+
+**PRIMA di cambiare l'env var sul server**, eseguire la migrazione:
+
+```bash
+npx tsx scripts/rotate-encryption-key.ts \
+  --old-key  $ENCRYPTION_KEY \
+  --old-version $ENCRYPTION_KEY_VERSION \
+  --new-key  <NEW_64_HEX_KEY> \
+  --new-version <NEW_VERSION>
+```
+
+`scripts/rotate-encryption-key.ts`:
+
+- Legge tutti i record `ade_credentials`
+- Decifra con la vecchia chiave
+- Ricicla con la nuova chiave
+- Aggiorna `key_version` nel DB
+- Wrappa tutto in `db.transaction()` → atomico
+
+Dopo la migrazione verificare che tutti i record abbiano `key_version = NEW_VERSION`,
+poi aggiornare le env var sul server e fare deploy.
+
+**Rollback:** se il deploy fallisce, riportare le env var alla versione precedente —
+i record con il vecchio `key_version` sono ancora decifrabili con la vecchia chiave
+(presente nell'immagine Docker precedente).
+
+### Generare una nuova chiave
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```

--- a/docs/claude-db.md
+++ b/docs/claude-db.md
@@ -1,0 +1,149 @@
+# claude-db.md — Migrazioni handwritten, transazioni, gotchas Drizzle
+
+Riferimento dal `CLAUDE.md` core. La regola "tutte handwritten dopo `0000`" è
+ribadita anche nel core perché va sempre presente.
+
+---
+
+## DB migrations: TUTTE handwritten dopo lo schema iniziale
+
+⚠️ **Stato reale del repo:** drizzle-kit è stato usato UNA SOLA volta per generare
+`0000_initial.sql` + `0000_snapshot.json`. Tutte le migrazioni successive sono
+**scritte a mano**. In `supabase/migrations/meta/` esiste UN solo snapshot
+(`0000_snapshot.json`), non gli snapshot intermedi.
+
+🚫 **NON ESEGUIRE MAI `npx drizzle-kit generate`** nello stato attuale.
+Genererebbe una mega-migrazione che riapplica tutto ciò che è successo dopo `0000`,
+confliggendo con le migrazioni handwritten esistenti. Per riattivare drizzle-kit
+serve prima un task dedicato di rebuild degli snapshot intermedi (out of scope
+finché non diventa pain).
+
+### Workflow obbligatorio per ogni nuova migrazione
+
+1. Crea il file `.sql` in `supabase/migrations/` con naming `NNNN_description.sql`
+   (es. `0014_add_signup_source_to_profiles.sql`). Header comment che spiega il "perché".
+2. Aggiungi la entry in `supabase/migrations/meta/_journal.json`:
+   ```json
+   {
+     "idx": 14,
+     "version": "7",
+     "when": <Date.now() in ms>,
+     "tag": "0014_add_signup_source_to_profiles",
+     "breakpoints": true
+   }
+   ```
+3. Aggiorna il file Drizzle in `src/db/schema/<table>.ts` per riflettere il nuovo
+   schema (es. `signupSource: text("signup_source")`). Senza questo, TypeScript
+   non vede la colonna e le query falliscono al type check.
+4. Esegui `node scripts/check-migrations.mjs` (stesso check gira in CI).
+5. Test su DB locale: `npx tsx scripts/migrate.ts` deve applicare la migrazione
+   senza errori e idempotentemente al re-run.
+
+**Runtime runner:** `scripts/migrate.ts` legge i `.sql` ordinati per nome, traccia
+i file applicati in `__applied_migrations`, wrappa ogni migrazione in transazione.
+Non legge il journal — quello è solo per il check CI di completezza.
+
+### Pattern `ALTER TABLE ADD COLUMN`
+
+Usa sempre `ADD COLUMN IF NOT EXISTS` (vedi `0002_add_lottery_code.sql`):
+
+```sql
+-- Migration: add <column> to <table>
+-- Feature/motivo: <link a issue o release>
+ALTER TABLE <table>
+  ADD COLUMN IF NOT EXISTS <column> <type>;
+```
+
+**Niente `NOT NULL`** su colonne aggiunte a tabelle popolate senza default —
+fallisce su righe esistenti. Aggiungi prima nullable, backfill, poi migration
+successiva con `ALTER COLUMN SET NOT NULL`.
+
+### Bootstrap su DB pre-esistente
+
+Se il DB è stato inizializzato senza il migration runner (drizzle-kit, Supabase
+dashboard, restore), la tabella `__applied_migrations` è vuota e il runner crasha
+con "type already exists". Il runner ha rilevamento automatico: se vuota ma
+`document_kind` esiste già in `pg_type`, marca tutte le migrazioni come applicate.
+
+Fix manuale di emergenza:
+
+```sql
+INSERT INTO __applied_migrations (filename, checksum)
+SELECT unnest(ARRAY[
+  -- elencare qui i nomi dei file .sql in supabase/migrations/ già presenti nel DB
+]), '' ON CONFLICT (filename) DO NOTHING;
+```
+
+⚠️ **Inserire SOLO le migrazioni effettivamente presenti nel DB.** Marcare come
+applicate migrazioni non eseguite = schema silenziosamente incompleto. Verificare
+con SQL editor Supabase o via MCP prima di inserirle.
+
+---
+
+## Transazioni multi-document = correttezza, non ottimizzazione
+
+Operazioni che aggiornano 2+ record DB che devono restare consistenti
+(es. void flow: VOID + mark SALE come VOID_ACCEPTED) **devono** essere
+wrappate in `db.transaction()` da subito. Mid-operation failure senza transazione
+= stato inconsistente silenzioso, difficile da rilevare e doloroso da riparare.
+
+Esempi nel codice: `void-service.ts`, `receipt-service.ts`.
+
+---
+
+## Drizzle raw `sql\`\`` templates: `Date` va pre-serializzato
+
+Dentro `db.update().set({...})` e `eq(col, value)` Drizzle conosce il tipo della
+colonna e converte JS value nel formato Postgres corretto. Dentro `` sql`...${value}...` ``
+**non ha contesto del tipo**: il valore va a postgres-js, che per non-primitive
+(`Date`, `Buffer` custom, oggetti) cade sul path di encoding testuale
+(`.str(x) → Buffer.byteLength(x)`) e crasha con:
+
+```
+TypeError: The "string" argument must be of type string or an instance of
+Buffer or ArrayBuffer. Received an instance of Date
+```
+
+(Regressione `SCONTRINOZERO-TEST-7`, 14 giorni nascosta nel flow "Verifica
+connessione" AdE.)
+
+**Pattern obbligato per `Date` in `` sql`` ``:**
+
+```typescript
+sql`date_trunc('milliseconds', ${col}) = ${date.toISOString()}::timestamptz`;
+```
+
+ISO string + cast esplicito (`::timestamptz`, `::timestamp`, `::date` in base
+al tipo). La precisione al millisecondo è preservata.
+
+**Test di regressione obbligato:** rendere il fragment con `PgDialect.sqlToQuery()`
+e asserire che nessun `Date` finisca tra i `compiled.params`. I mock di `.where()`
+in stile `vi.fn().mockReturnValue({ returning })` non catturano il bug perché
+bypassano l'encoding di postgres-js.
+
+**Smoke test post-deploy:** per path DB introdotti ex novo (nuovi bottoni AdE,
+recovery flow, batch jobs) cliccare almeno una volta su sandbox subito dopo il
+tag. I 2400+ unit test verdi non garantiscono che postgres-js sappia binare i
+parametri reali.
+
+---
+
+## Race condition multi-riga: constraint DB > application lock
+
+Per operazioni duplicate concorrenti (es. doppio VOID dello stesso SALE), la
+soluzione robusta è un **constraint DB** (UNIQUE, partial index), non un lock
+applicativo. Il DB garantisce atomicità; il codice è TOCTOU-vulnerabile.
+
+Pattern:
+
+1. `UNIQUE INDEX ... WHERE col IS NOT NULL` in migrazione
+2. Insert con `onConflictDoNothing()`
+3. Se `returning` è vuoto, discriminare il caso "stessa key" (idempotency) da
+   "key diversa, stessa riga target" (race) via query separata
+
+## Idempotency key: SEMPRE per-tenant
+
+I vincoli UNIQUE su `idempotency_key` vanno scoped al tenant
+(`UNIQUE(business_id, idempotency_key)`). Un constraint globale blocca business
+diversi che usano accidentalmente la stessa UUID ed espone metadati cross-tenant.
+I fallback di lookup devono filtrare per `businessId` in aggiunta alla key.

--- a/docs/claude-security.md
+++ b/docs/claude-security.md
@@ -1,0 +1,271 @@
+# claude-security.md — IP trust, rate limit, hostname, CSP, input validation
+
+Pattern di sicurezza per route handler, server actions e middleware.
+Riferimento dal `CLAUDE.md` core.
+
+---
+
+## Client IP: `CF-Connecting-IP` è l'UNICA sorgente fidata
+
+Con Cloudflare Tunnel davanti all'app, solo `CF-Connecting-IP` è impostato da
+Cloudflare e non spoofabile. Ordine in `getClientIp()`:
+
+1. **`CF-Connecting-IP`** — sempre fidato (Cloudflare strippa copie in entrata)
+2. **`X-Forwarded-For`** — solo fallback dev/test; **commentare esplicitamente**
+   che fuori da Cloudflare non è fidato
+3. **`X-Real-IP`** — **droppare completamente** (non-standard, no trust model)
+
+Mai cadere silenziosamente attraverso una chain di header senza documentare
+perché ognuno è (o non è) fidato. Rate limit su IP spoofabile = nessun rate limit.
+
+---
+
+## Retry + backoff per operazioni che lasciano orphan state
+
+Operazioni che (a) sono irreversibili su partial success, (b) possono fallire
+transient (network blip, external timeout), (c) lasciano lo stato inconsistente
+in failure (es. Supabase auth user delete con orphan che blocca re-register)
+devono avere:
+
+- 3 retry con exponential backoff (500 ms → 1 s → 2 s)
+- `logger.error({ critical: true }, ...)` dopo esaurimento retries
+- Comment che documenta il **manual cleanup** richiesto se i retries falliscono
+
+Silent failure qui è peggio di un errore visibile: l'utente resta bloccato
+senza signal actionable.
+
+---
+
+## UUID validation: ai boundary delle API, PRIMA del service layer
+
+Ogni route API esterna che accetta un UUID (es. `idempotencyKey`, `receiptId`)
+deve validare con `isValidUuid()` e ritornare 400 **prima** di passare a
+service/DB. Stringhe non-UUID passate a colonne PostgreSQL UUID producono 500
+non gestiti che bypassano tutto l'error handling applicativo.
+
+La validation UUID sta al route handler boundary, non dentro il service.
+
+---
+
+## Hostname validation di link Supabase prima di emailing
+
+Prima di mandare via email qualsiasi link generato da Supabase (password reset,
+magic link, email change), assertare che l'URL inizi con `https://${expectedHostname}`.
+Una misconfig Supabase (Site URL sbagliato) può produrre link a domini inattesi,
+abilitando open redirect.
+
+Se il check fallisce: log error, NON inviare email, redirect utente a
+`/verify-email` con messaggio generico.
+
+### URL parsing vs `startsWith`
+
+`link.startsWith("https://mio.dominio.it")` è bypassabile con
+`https://mio.dominio.it.attacker.tld/`. Pattern corretto:
+
+```typescript
+let parsed: URL | null = null;
+try {
+  parsed = new URL(link);
+} catch {
+  /* malformed */
+}
+if (
+  !parsed ||
+  parsed.protocol !== "https:" ||
+  parsed.hostname !== expectedHostname
+) {
+  // blocca
+}
+```
+
+---
+
+## Body size guard PRIMA di `JSON.parse`
+
+Mai chiamare `request.json()` direttamente su una route API che accetta input
+arbitrario. Usare un helper `readJsonWithLimit(req, maxBytes)` che legge il body
+come `ArrayBuffer`, controlla `byteLength` per primo, poi `JSON.parse`. Return
+413 on overflow.
+
+**Limiti consolidati:**
+
+- 32 KB per receipt create (fino a 100 lines)
+- 8 KB per single-key bodies (void, checkout)
+
+Previene memory/CPU pressure da payload oversized prima di qualsiasi validation.
+
+---
+
+## Decimal precision: API layer, non solo DB
+
+Le colonne `numeric(10,2)` e `numeric(10,3)` silenziosamente arrotondano/troncano
+valori overscale. L'API layer deve rigettare input con troppe decimali (Zod
+`.refine`):
+
+```typescript
+v => parseFloat(v.toFixed(2)) === v   // 2 dp
+v => parseFloat(v.toFixed(3)) === v   // 3 dp
+```
+
+Il roundtrip via stringa gestisce correttamente IEEE-754 noise.
+
+❌ NON usare `Number.isInteger(Math.round(v * 100))` — `Math.round` torna sempre
+intero, quindi il check è vacuously true e non rigetta nulla.
+
+---
+
+## Email normalisation: uniforme su TUTTI gli auth flows
+
+`signUp` storicamente normalizzava (`trim().toLowerCase()`) ma `signIn`,
+`signInWithMagicLink` e `resetPassword` no, causando fail silenti su
+`User@EXAMPLE.COM`. Centralizzare in `normalizeEmail()` in `validation.ts` e
+applicare come prima riga di ogni auth action prima della validation.
+
+---
+
+## Wrap external SDK calls (Stripe, AdE, ...) in try-catch — sempre
+
+Errori non catchati da `stripe.customers.create()`, ecc. si propagano come 500
+non gestiti senza log context. Pattern corretto:
+
+```typescript
+try {
+  result = await stripe.someMethod(...);
+} catch (err) {
+  logger.error({ err, userId }, "Stripe <operation> failed");
+  return Response.json(
+    { error: "Servizio temporaneamente non disponibile." },
+    { status: 503 }
+  );
+}
+```
+
+Usare 503 (non 500) per unavailability transient di servizi esterni.
+
+---
+
+## Lookup `Record` con key user-controlled: Set/type guard, mai `record[input]`
+
+Route dinamiche (`/per/[slug]`, `/help/[slug]`, ...) che fanno lookup su
+`Record<Slug, T>` con key da `params`: `record[slug as Slug]` permette ai nomi
+del prototype chain (`__proto__`, `constructor`, `toString`, `hasOwnProperty`)
+di risolvere come truthy, bypassando `notFound()` e generando 500 server-side
+(`category.relatedHelp.map(...)` esplode su un oggetto prototype).
+
+Pattern obbligato:
+
+```typescript
+const VALID_SLUGS: ReadonlySet<string> = new Set(slugs);
+
+export function isValidSlug(slug: string): slug is Slug {
+  return VALID_SLUGS.has(slug);
+}
+
+// route handler
+if (!isValidSlug(slug)) notFound();
+const item = records[slug]; // type-safe, no prototype risk
+```
+
+`Object.hasOwn(record, slug)` è alternativa valida ma meno espressiva.
+Aggiungere sempre test mirati per i 4 nomi del prototype chain.
+
+---
+
+## CSP: lezioni dal rollout (completato)
+
+Il rollout è già attivo in `src/lib/security-headers.ts`. Le lezioni residue
+da preservare:
+
+- **`Content-Security-Policy` enforce solo in production**, Report-Only in
+  dev/test (Next.js dev usa `eval()`, l'enforce senza `'unsafe-eval'` rompe HMR).
+  Scelta header in `buildSecurityHeaders` in base a `process.env.NODE_ENV`.
+- **`'unsafe-inline'` su `script-src`** OK se mitigato da `safeJsonLd()` in
+  `src/components/json-ld.tsx` (escape `<>&`) e payload statici a build time.
+  Il valore di sicurezza è nell'**allowlist di origin**, non nel divieto di inline.
+- **Anti-pattern:** nonce-based su `script-src` — incompatibile con SSG largo
+  marketing (il nonce dev'essere per-request, le pagine SSG sono cached).
+- **Security headers in modulo testabile separato** (`src/lib/security-headers.ts`):
+  `next.config.ts` non è facilmente unit-testabile, una funzione pura lo è.
+- **`Reporting-Endpoints`** indispensabile anche in enforce per detection di
+  XSS attempt. Soglia di allarme: >50 violation/giorno o `blockedUri` riconducibile
+  a un asset legittimo.
+
+---
+
+## Double-gate rate limit prima di call esterne costose
+
+Endpoint pubblici che chiamano servizi esterni (Turnstile siteverify ~5s
+timeout, Resend, AdE) non sono protetti a sufficienza dal solo rate limit
+funzionale per-utente: prima di raggiungerlo, un attaccante può aver generato
+n×timeout secondi di socket pendenti e n×call HTTP outbound.
+
+Pattern obbligato:
+
+1. **Pre-limit** con bucket dedicato (`captchaPre:<action>:<ip>`, più permissivo
+   del limite funzionale — es. 30/15min vs 5/15min) PRIMA della call esterna
+2. **Limite funzionale post-call** invariato per brute-force applicativo
+3. **Log strutturati separati** (`errorClass: "captcha_prelimit"` vs
+   `"auth_rate_limit"`)
+4. **Bucket keys namespaced** (`captchaPre:<action>:<ip>` vs `<action>:<ip>`)
+5. **Test invariant cardinale**: con pre-limit failure, `fetch`/external call
+   NON deve essere invocata (`expect(mockFetch).not.toHaveBeenCalled()`).
+
+Applicato a `signUp`/`signIn`/`resetPassword`. Stesso pattern per qualsiasi
+endpoint che inneschi invio email, call AdE, generazione PDF, ecc.
+
+---
+
+## `setInterval` in costruttori long-lived: chiamare `.unref?.()`
+
+Classi che istanziano `setInterval` nel costruttore (`RateLimiter`, scheduler,
+cache evictor) devono invocare `.unref?.()` sul timer. Senza unref il timer
+mantiene il process Node alive — irrilevante per container server (event loop
+ha sempre altre referenze), fragile per script one-shot, test runner, setup
+jobs che si aspettano exit pulito.
+
+Optional chaining (`?.`) per safety in edge runtime che non espongono l'API.
+Test: spy su `setInterval` con `mockReturnValueOnce({ unref })` + verifica
+`expect(unref).toHaveBeenCalledTimes(1)` (richiede `vi.useRealTimers()` se il
+file usa `vi.useFakeTimers()`).
+
+---
+
+## Redirect param: preservare il querystring
+
+Quando middleware (`proxy.ts`) reindirizza a `/login`, il param `redirect`
+deve essere `pathname + search`, NON solo `pathname`. Deep link tipo
+`/dashboard/storico?from=2024-01-01&to=2024-01-31` altrimenti perde i filtri
+post-login.
+
+Consumer (`(auth)/callback/route.ts`): sanificare come path relativa
+(`startsWith("/")` ma NON `startsWith("//")` per bloccare protocol-relative
+URLs di open redirect), poi `new URL(redirect, origin)` parsifica il
+querystring senza rischi.
+
+---
+
+## Turnstile hostname check: usare una lista, non singolo valore
+
+Cloudflare Turnstile ritorna in `data.hostname` l'hostname dove il widget è
+stato risolto. Quando il sito ha sia dominio app (`app.scontrinozero.it`) sia
+marketing (`scontrinozero.it`), e il form `/login` può essere caricato da
+entrambi (Next.js client-side `<Link>` dalla landing non sempre attraversa il
+redirect cross-origin del middleware), il check `===` causa
+`captcha_hostname_mismatch` sistemico.
+
+Pattern obbligato in `verifyCaptcha` (`src/server/auth-actions.ts`):
+
+```typescript
+const acceptedHostnames: ReadonlySet<string> = new Set([
+  appHostname,
+  marketingHostname,
+  `www.${marketingHostname}`,
+]);
+if (!acceptedHostnames.has(data.hostname)) { ... }
+```
+
+Loggare la lista accettata in caso di mismatch facilita il debug operativo.
+
+Inoltre: il ramo `data.success: false` di Cloudflare deve **sempre** loggare
+`data["error-codes"]` (`timeout-or-duplicate`, `invalid-input-response`).
+Senza questo log la causa del rifiuto resta invisibile in produzione.

--- a/docs/claude-sonar.md
+++ b/docs/claude-sonar.md
@@ -1,0 +1,114 @@
+# claude-sonar.md — Regole SonarCloud specifiche
+
+Quality gate ricorrente e regole che si attivano spesso. Riferimento dal
+`CLAUDE.md` core.
+
+---
+
+## Quality gate (must not regress)
+
+- **Coverage on new code:** ≥ 80%
+- **Duplicated lines on new code:** < 3%
+- **0 new issues:** fix every SonarCloud issue before merging, anche quando il
+  Quality Gate passa. Issues lasciati aperti accumulano debt e bloccheranno
+  future PR.
+
+---
+
+## Quick fixes ricorrenti
+
+- **Cognitive Complexity > 15** → estrarre helper functions
+- **Optional chain suggestions** → `!x || x.prop` → `x?.prop`
+- **`typeof x === "undefined"`** → `x === undefined`
+- **`window.*`** → `globalThis.window.*` (es2020 portability)
+- **`<div role="banner">`** → `<header>` (semantic element)
+- **Async functions as `onClick`** → `onClick={() => void asyncFn()}`
+
+---
+
+## Coverage exclusions
+
+Se un file ha **no testable logic** (pure config, UI shell):
+
+- Aggiungere a `sonar.coverage.exclusions` in `sonar-project.properties`
+- E al `exclude` in `vitest.config.ts`
+- Mai lasciare untested senza esclusione esplicita
+
+**Service worker files (`src/sw.ts`)** devono essere in `sonar.exclusions`
+(non solo coverage exclusions). Usano WebWorker-specific globals
+(`ServiceWorkerGlobalScope`, `declare const self`) che confliggono con la DOM
+lib e triggerano falsi positivi (variable shadowing). Aggiungere anche a
+`tsconfig.json` exclude per lo stesso motivo.
+
+---
+
+## Regole specifiche da anticipare
+
+### S6861 — React props not readonly
+
+Ogni `interface` di props di componente React deve avere tutti i campi marcati
+`readonly`. Applicare sistematicamente a ogni nuovo componente.
+
+```typescript
+interface MyProps {
+  readonly foo: string;
+  readonly bar: number;
+}
+```
+
+### S6772 — Ambiguous spacing in JSX
+
+Si attiva in due casi:
+
+1. `{" "}` tra elementi JSX — fix: incorpora lo spazio nel testo adiacente
+   come `{"testo "}` o `{" testo"}`.
+2. Testo nudo su riga separata adiacente a qualsiasi elemento inline di
+   chiusura o apertura (`</strong>`, `</a>`, `</Link>`, `<strong>`, ecc.) —
+   fix: converti il testo in espressione JSX `{"testo"}`.
+
+Si manifesta sia con testo DOPO un tag di chiusura che con testo PRIMA di un
+tag di apertura su righe separate. Prettier può re-introdurre `{" "}`
+riformattando: scrivi JSX in modo da non richiederlo.
+
+### S7780 — Escape sequences in template literals
+
+Usa `` String.raw`...` `` invece di template literal con `\\` quando il contenuto
+mostra backslash letterali (es. curl examples). Con `String.raw`, scrivi `\`
+singolo invece di `\\` e i newline del sorgente sono preservati.
+
+### S5852 (ReDoS) — Security Hotspot
+
+`// NOSONAR` **NON** sopprime Security Hotspots — solo Issues (Bug/CodeSmell/
+Vulnerability). Hotspots richiedono fix del codice (rule non fires più) o
+review umana via SonarCloud UI ("Mark as Safe").
+
+Per S5852: sostituire regex con Set-based char loop + manual pointer trimming.
+
+### S5122 (CORS `*`) — Security Hotspot
+
+`// NOSONAR` inefficace. L'utente deve acknowledge nella SonarCloud UI o
+rimuovere il wildcard.
+
+---
+
+## Gitleaks e pagine di documentazione
+
+Placeholder di chiavi API negli esempi curl (es. `szk_live_XXXX`,
+`Authorization: Bearer ...`) triggerano le rules `curl-auth-header` e
+`generic-api-key`. Sono falsi positivi — aggiungere i fingerprint al
+`.gitleaksignore`.
+
+⚠️ **I fingerprint sono commit-specifici** (`COMMIT_SHA:FILE:RULE:LINE`). Ogni
+commit che modifica le righe coinvolte genera nuovi fingerprint. Aggiungere i
+fingerprint di tutti i commit in un'unica passata quando possibile, ispezionando
+le righe esatte con `grep -n`.
+
+---
+
+## Debug di CI failure opachi
+
+Quando un CI fail (SonarCloud, Gitleaks, ecc.) **non è visibile** nel diff PR o
+nei log, **STOP e chiedere all'utente** l'info specifica (es. "quale file/righe
+SonarCloud flagga come duplicate?") invece di tentare blind fix. Tentativi a
+casaccio sprecano CI cycles e oscurano la root cause. Una domanda mirata =
+risposta in secondi; trial-and-error random = ore.

--- a/docs/claude-stripe.md
+++ b/docs/claude-stripe.md
@@ -1,0 +1,83 @@
+# claude-stripe.md — Stripe API version, webhook events, recovery patterns
+
+Riferimento dal `CLAUDE.md` core. La nota sull'API version 2026-02-25.clover è
+ripetuta nel core (è una breaking-change zone), il resto è qui.
+
+---
+
+## API version `2026-02-25.clover` — breaking changes
+
+SDK: `stripe` npm v20.4.1.
+
+- `Invoice.subscription` **rimosso** →
+  `invoice.parent?.subscription_details?.subscription`
+- `Subscription.current_period_end` **spostato** a livello item →
+  `subscription.items.data[0]?.current_period_end`
+- Non usare `!` (non-null assertion) su `process.env.STRIPE_WEBHOOK_SECRET` —
+  aggiungere guard esplicito (`if (!secret) return 500`) per evitare SonarCloud
+  code smell
+
+---
+
+## Webhook events: lista completa (8 eventi)
+
+Il webhook handler gestisce **8 eventi**. Ogni endpoint (prod, sandbox, dev
+locale) deve avere il proprio `whsec_*` separato generato da Stripe (Settings →
+Webhooks → Add endpoint). **Mai condividere** lo stesso `STRIPE_WEBHOOK_SECRET`
+tra ambienti diversi.
+
+**Evento più critico da non dimenticare:** `customer.subscription.updated` — è
+l'unico che chiama `syncSubscriptionData` sui rinnovi, aggiornando
+`profiles.planExpiresAt`. Senza di esso la data di rinnovo in UI è sempre stale
+e la recovery da `past_due` non funziona mai.
+
+| Evento                            | Perché                                                       |
+| --------------------------------- | ------------------------------------------------------------ |
+| `checkout.session.completed`      | Attiva l'abbonamento dopo il pagamento                       |
+| `checkout.session.expired`        | Cleanup righe `pending` abbandonate (24h di default)         |
+| `customer.subscription.updated`   | Rinnovi, upgrade/downgrade, recovery da `past_due`           |
+| `customer.subscription.deleted`   | Cancellazione → reset a `trial` in transaction               |
+| `invoice.paid`                    | Aggiorna `currentPeriodEnd` su ogni rinnovo (safety net)     |
+| `invoice.payment_failed`          | Imposta status `past_due`                                    |
+| `invoice.payment_action_required` | 3D Secure / SCA obbligatorio in EU (PSD2)                    |
+| `charge.dispute.created`          | Alert chargeback con `critical: true` — nessuna scrittura DB |
+
+**NON serve registrare:**
+
+- `customer.subscription.created` — coperto da `checkout.session.completed`
+- `payment_intent.*` — coperti dagli eventi `invoice.*`
+- `customer.subscription.paused/resumed` — feature non usata
+
+### Stato "misto" subscription card (pending + trial)
+
+Se dopo un checkout la card mostra "Prova gratuita" + "Abbonamento annuale" +
+portale, la riga `subscriptions` è `pending` (webhook non arrivato o fallito).
+
+Verificare:
+
+1. Endpoint registrato su Stripe per quell'ambiente
+2. `STRIPE_WEBHOOK_SECRET` corretto
+3. Log server per errori di firma
+
+---
+
+## Stale recovery di mutazioni esterne idempotenti (AdE)
+
+Il recovery di una row PENDING/ERROR senza `adeTransactionId` ri-invoca
+`submitSale`/`submitVoid`. AdE non accetta idempotency-key nel payload: se la
+prima call era arrivata ad AdE ma la response si è persa in volo (timeout,
+container kill, network glitch), il retry crea un documento fiscale duplicato
+o un VOID duplicato — **irreversibile**.
+
+**Mitigazione:** soglia stale di 30 minuti in `getStalePendingThresholdMs()`
+(sia `receipt-service` che `void-service`). 30 min è sopra la durata sessione
+AdE tipica, quindi un retry sotto soglia ritorna `PENDING_IN_PROGRESS` e
+l'utente lo riproverà quando la sessione AdE non sarà più valida.
+
+Logging esplicito al rientro in recovery senza `adeTransactionId` per audit.
+Override env per test E2E o ambienti controllati:
+`STALE_PENDING_THRESHOLD_MINUTES=5`.
+
+**Soluzione corretta (roadmap):** `searchDocuments`/`getDocument` su AdE
+pre-retry per scoprire se un documento collegato esiste già — richiede
+l'endpoint AdE di ricerca (vedi `ricerca_documento.har`).

--- a/docs/claude-testing.md
+++ b/docs/claude-testing.md
@@ -1,0 +1,235 @@
+# claude-testing.md — Vitest patterns e regole CI
+
+Lezioni operative per evitare i failure più comuni di SonarCloud e i bug silenziosi
+nei mock. Riferimento dal `CLAUDE.md` core.
+
+---
+
+## Ogni test deve avere almeno un `expect()`
+
+SonarCloud classifica come **Blocker** qualsiasi `it()`/`test()` senza assertion.
+Anche i test che verificano "non lancia eccezione" o "chiama redirect" devono
+contenere almeno un `expect()` esplicito.
+
+```typescript
+// ❌ SBAGLIATO — SonarCloud Blocker
+it("chiama signIn senza errori", async () => {
+  try {
+    await signIn(formData);
+  } catch {
+    // redirect expected
+  }
+});
+
+// ✅ CORRETTO — assertion su effetto osservabile
+it("chiama signIn senza errori", async () => {
+  try {
+    await signIn(formData);
+  } catch {
+    // redirect expected
+  }
+  expect(mockSomeFn).toHaveBeenCalled();
+});
+```
+
+---
+
+## `vi.mock` di classi: usare `function` o `class`, mai arrow function
+
+Quando un modulo esporta una **classe** che viene istanziata con `new`,
+il mock deve usare la keyword `function` o `class` nel `mockImplementation`.
+Le arrow function non possono essere costruttori e causano:
+`TypeError: () => ({...}) is not a constructor`.
+
+Le variabili usate nella factory `vi.mock` **devono iniziare con `mock`**
+(Vitest le includa nell'hoisting automatico).
+
+```typescript
+// ❌ SBAGLIATO — arrow function non è un costruttore
+const mockCheck = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(() => ({ check: mockCheck })),
+}));
+
+// ✅ CORRETTO — regular function restituisce l'oggetto mock
+const mockCheck = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockCheck };
+  }),
+}));
+```
+
+---
+
+## Rate limiting su server actions autenticate
+
+Le server actions per utenti autenticati usano chiavi **per-user**.
+Le azioni pubbliche (PDF, ecc.) usano chiavi per-IP.
+
+```typescript
+const myLimiter = new RateLimiter({
+  maxRequests: 30,
+  windowMs: 60 * 60 * 1000,
+});
+
+export async function myAction(input: MyInput): Promise<MyResult> {
+  const user = await getAuthenticatedUser();
+
+  const rateLimitResult = myLimiter.check(`prefix:${user.id}`);
+  if (!rateLimitResult.success) {
+    logger.warn({ userId: user.id }, "Rate limit exceeded");
+    return { error: "Troppe richieste. Riprova tra qualche minuto." };
+  }
+  // ...
+}
+```
+
+**Soglie consolidate:**
+
+- `emit:<userId>` — `emitReceipt` → 30/ora
+- `void:<userId>` — `voidReceipt` → 10/ora (irreversibile)
+- `pdf:<ip>` — PDF pubblico → 60/ora
+- `checkout:<userId>` — `POST /api/stripe/checkout` → 10/ora
+- `portal:<userId>` — `GET|POST /api/stripe/portal` → 10/ora
+- Auth actions — 5/15min per-IP
+
+---
+
+## Aggiornare mock quando si introducono JOIN
+
+Quando si refactora N query separate in un JOIN, **tutti** i file di test che
+chiamano (anche indirettamente) la funzione devono aggiornare i mock. Pattern
+da cercare:
+
+- Mock di `@/db` con chain `select().from().where().limit()` senza `innerJoin`
+- Funzioni nel codice sotto test che chiamano `checkBusinessOwnership` o simili
+  **senza mockare `@/lib/server-auth`** → usano la funzione reale, che ora usa JOIN
+
+Fix: aggiungere `innerJoin` al mock chain E ridurre le `mockLimit.mockResolvedValueOnce`
+da 2 (profile + business separati) a 1 (risultato JOIN). In alternativa: mockare
+sempre `@/lib/server-auth` nei test delle server actions che usano ownership check.
+
+Cerca file affetti con:
+`grep -rn "FAKE_PROFILE\|Ownership check" tests/ src/ --include="*.test.ts"`
+
+---
+
+## Testare `NODE_ENV` con `vi.stubEnv`
+
+`process.env.NODE_ENV` **non è direttamente scrivibile** in Vitest. Usare:
+
+```typescript
+import { afterEach, it, vi } from "vitest";
+
+afterEach(() => vi.unstubAllEnvs());
+
+it("si comporta diversamente in produzione", () => {
+  vi.stubEnv("NODE_ENV", "production");
+  // ...
+});
+```
+
+---
+
+## Mock Drizzle con `transaction`: il callback riceve `tx`, non `db`
+
+Quando il codice usa `db.transaction(async (tx) => { tx.update(...) })`, i test
+devono aggiungere `transaction` al mock di `getDb()` come passthrough:
+
+```typescript
+const mockTransaction = vi.fn();
+mockTransaction.mockImplementation(async (fn) =>
+  fn({ select: mockSelect, insert: mockInsert, update: mockUpdate }),
+);
+```
+
+Senza, il codice chiama `db.transaction(undefined)` → TypeError silenzioso.
+
+---
+
+## `react/cache` non deduplica tra Route Handler e RSC
+
+`cache()` da `react` è scoped al singolo render tree RSC. Non deduplica
+tra page RSC `/r/[id]` e Route Handler `/r/[id]/pdf` — sono HTTP request
+separate. Preferire plain async function + chiamata diretta al DB in ogni
+entry point.
+
+---
+
+## `INSERT ... ON CONFLICT DO NOTHING` per race su creazione riga
+
+Per endpoint concorrenti sullo stesso utente (doppio click su "Checkout"),
+"SELECT then INSERT" causa unique-constraint violation → 500. Pattern Drizzle:
+
+```typescript
+const [inserted] = await db
+  .insert(table)
+  .values({ ... })
+  .onConflictDoNothing()
+  .returning({ col: table.col });
+
+if (!inserted) {
+  // Conflict: re-SELECT per il "winner"
+  const [existing] = await db.select(...).where(...);
+}
+```
+
+---
+
+## Sentry + pino: sanitize PRIMA di `captureException`
+
+`pino.redact` gira durante la **serialisation**, ma il hook `logMethod` riceve
+l'oggetto **raw** prima della serializzazione. Tutto ciò che viene forwardato a
+`Sentry.captureException/captureMessage` da dentro `logMethod` è quindi
+**un-redacted**.
+
+Fix: passare il context attraverso `sanitizeForTelemetry()` prima di ogni call
+Sentry. Usare un'**allowlist** esplicita (`requestId`, `userId`, `path`,
+`documentId`, `adeErrorCodes`, …) piuttosto che denylist.
+
+Pattern in `src/lib/logger.ts`:
+
+```typescript
+function captureToSentry(obj: unknown, msg?: string): void {
+  const sanitized = sanitizeForTelemetry(obj);
+  if (... instanceof Error) {
+    Sentry.captureException(err, { extra: sanitized });
+  }
+}
+```
+
+Error objects in `extra` vanno estratti come `{ name, message }` only — lo stack
+trace e il cause chain possono incorporare request context (query params, headers)
+dal call site.
+
+---
+
+## `deleteAccount`: auth user FIRST
+
+Safe ordering per account deletion: **auth-first**.
+
+1. Delete Supabase Auth user (admin API, 3 retries × backoff)
+2. Auth deletion fails → return `{ error }` immediatamente; profile intatto,
+   user può fare login e ritentare
+3. Auth deletion succeeds → delete profile (FK cascade)
+4. Profile deletion fails → log `critical: true`, manual cleanup needed
+   (ma auth entry già rimosso, quindi nessun login possibile)
+
+Inverting fix: o nulla è eliminato (safe), o solo orphan profile (less harmful).
+
+---
+
+## `last_used_at` con WHERE condizionale (anti write-amplification)
+
+Per evitare DB write su ogni request:
+
+```typescript
+.where(and(
+  eq(table.id, id),
+  or(isNull(table.lastUsedAt), lt(table.lastUsedAt, threshold))
+))
+```
+
+Il DB aggiorna solo se `lastUsedAt IS NULL OR lastUsedAt < NOW - N_min`.
+Sempre fire-and-forget (`.catch(logger.warn)`). Throttle consigliato: 10 min.


### PR DESCRIPTION
## Summary

Refactored the monolithic `CLAUDE.md` (1081 lines) into a modular documentation structure with focused topic files. The core `CLAUDE.md` now contains only essential project rules (31 items), while domain-specific guidance has been extracted into dedicated reference documents.

## Changes

- **`CLAUDE.md`** — Reduced from 1081 to 208 lines. Retained only the 31 core rules that apply broadly across the project (TDD, PR workflow, file structure, edge cases, CI/CD fundamentals).

- **`docs/claude-security.md`** (new, 271 lines) — Security patterns for route handlers, server actions, and middleware:
  - Client IP trust model (`CF-Connecting-IP` priority)
  - Retry + backoff for orphan-state operations
  - UUID validation at API boundaries
  - Hostname validation for Supabase links
  - Body size guards before `JSON.parse`
  - Decimal precision enforcement
  - Email normalization
  - External SDK error handling
  - Record lookup with prototype-chain safety
  - CSP rollout patterns

- **`docs/claude-testing.md`** (new, 235 lines) — Vitest and CI patterns:
  - Assertion requirements (SonarCloud Blocker prevention)
  - Class mocking with `function`/`class` (not arrow functions)
  - Rate limiting on server actions
  - Mock updates for JOIN refactors
  - `NODE_ENV` stubbing with `vi.stubEnv`
  - Drizzle transaction mocking
  - `react/cache` deduplication scope
  - Race condition handling with `ON CONFLICT DO NOTHING`

- **`docs/claude-db.md`** (new, 149 lines) — Database operations:
  - Handwritten migrations workflow (post-`0000_initial`)
  - Migration file naming and journal entry format
  - Schema file updates in `src/db/schema/`
  - `ALTER TABLE ADD COLUMN IF NOT EXISTS` pattern
  - Bootstrap recovery for pre-existing databases
  - Encryption key rotation procedure

- **`docs/claude-sonar.md`** (new, 114 lines) — SonarCloud quality gates:
  - Coverage (≥80%), duplication (<3%), zero new issues
  - Quick fixes (Cognitive Complexity, optional chaining, `typeof`, `window.*`, semantic HTML, async onClick)
  - Coverage exclusions for config/UI-only files
  - Service worker exclusion from `sonar.exclusions`
  - Specific rules: S6861 (readonly props), S6772 (JSX spacing), S7780 (escape sequences), S5852 (ReDoS), S5122 (CORS)
  - Gitleaks fingerprint management

- **`docs/claude-ade.md`** (new, 108 lines) — Agenzia delle Entrate integration:
  - Direct HTTP integration strategy (no REST API, no headless browser)
  - Adapter/strategy pattern for sandbox (`RealAdeClient` vs `MockAdeClient`)
  - Production HTTP flow debugging (diagnostic logging before fixes)
  - HAR analysis completeness checks
  - HAR file reference table

- **`docs/claude-stripe.md`** (new, 83 lines) — Stripe API and webhooks:
  - API version `2026-02-25.clover` breaking changes
  - 8 webhook events with critical note on `customer.subscription.updated`
  - Webhook secret per-environment isolation

## Implementation Details

- All domain-specific guidance is now cross-referenced from the core `CLAUDE.md` with explicit "Riferimento dal `CLAUDE.md` core" headers.
- Each new file is self-contained and can be consulted independently without reading the entire core document.
- The modular structure improves discoverability: developers can quickly find security patterns, testing rules, database procedures, or integration details without scrolling through 1000+ lines.
- No functional changes to the rules themselves — this is purely a documentation reorganization for maintainability and clarity.

https://claude.ai/code/session_017a3EZktwtbtF5Eqz8oug8L