### PR TITLE
Migrate docs to skill-based architecture with PreToolUse hooks

### DIFF
--- a/.claude/hooks/block-drizzle-generate.sh
+++ b/.claude/hooks/block-drizzle-generate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Bash — blocks `drizzle-kit generate`.
+# Rationale: CLAUDE.md regola 11. The repo uses handwritten migrations after
+# 0000_initial.sql; regenerating would conflict with the existing journal.
+# See skill: db-migrations.
+
+set -euo pipefail
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+if printf '%s' "$cmd" | grep -qE 'drizzle-kit[[:space:]]+generate'; then
+  echo "Blocked by .claude/hooks/block-drizzle-generate.sh:" >&2
+  echo "  \`drizzle-kit generate\` is forbidden in this repo (CLAUDE.md regola 11)." >&2
+  echo "  Migrations after 0000 are handwritten. See skill 'db-migrations' for the workflow." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Bash — blocks `git push` targeting main.
+# Rationale: CLAUDE.md regola 1. All changes go through a PR; merging is the
+# user's prerogative. Tag pushes (vX.Y.Z) are allowed because they don't
+# reference main.
+
+set -euo pipefail
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+# Strip leading "cd <dir> && " noise so the regex sees the actual git command.
+normalized=$(printf '%s' "$cmd" | tr -s ' ')
+
+if printf '%s' "$normalized" | grep -qE 'git[[:space:]]+push([[:space:]]+[^&|;]*)?[[:space:]](main|HEAD:main)(\b|$)'; then
+  echo "Blocked by .claude/hooks/block-push-to-main.sh:" >&2
+  echo "  Direct push to main is forbidden (CLAUDE.md regola 1). Always go through a PR." >&2
+  echo "  If this is intentional (release tag, hotfix authorized by the user), bypass via" >&2
+  echo "  a manual shell outside Claude, or temporarily disable this hook." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-drizzle-generate.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-push-to-main.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ade-integration/SKILL.md
+++ b/.claude/skills/ade-integration/SKILL.md
@@ -1,8 +1,9 @@
-# claude-ade.md — Integrazione Agenzia delle Entrate, mock, debug
-
-Riferimento dal `CLAUDE.md` core.
-
 ---
+name: ade-integration
+description: Use when working with the Agenzia delle Entrate (AdE) "Documento Commerciale Online" integration — editing files under src/server/ade/, handling Fisconline credential encryption/decryption, rotating ENCRYPTION_KEY via scripts/rotate-encryption-key.ts, reverse-engineering AdE HTTP flows from HAR captures (login_cie.har, ricerca_documento.har, etc.), wiring the RealAdeClient/MockAdeClient adapter for ADE_MODE=real|mock, or debugging production AdE 4xx/5xx errors. Covers why no headless browser is allowed and the diagnostic-logging-first debug pattern.
+---
+
+# ade-integration — Integrazione Agenzia delle Entrate, mock, debug
 
 ## Strategia: integrazione diretta (no API REST, no headless browser)
 

--- a/.claude/skills/db-migrations/SKILL.md
+++ b/.claude/skills/db-migrations/SKILL.md
@@ -1,9 +1,9 @@
-# claude-db.md — Migrazioni handwritten, transazioni, gotchas Drizzle
-
-Riferimento dal `CLAUDE.md` core. La regola "tutte handwritten dopo `0000`" è
-ribadita anche nel core perché va sempre presente.
-
 ---
+name: db-migrations
+description: Use when creating or modifying SQL files under supabase/migrations/, updating Drizzle schema in src/db/schema/, editing supabase/migrations/meta/_journal.json, writing raw sql`` templates that bind Date values, debugging race conditions on UNIQUE constraints, designing per-tenant idempotency keys, or wrapping multi-row updates in db.transaction(). Covers the handwritten migrations workflow (NEVER run `npx drizzle-kit generate` in this repo), ADD COLUMN IF NOT EXISTS pattern, bootstrap on a pre-existing DB via __applied_migrations, and the Date-in-sql`` regression that crashed AdE "Verifica connessione".
+---
+
+# db-migrations — Migrazioni handwritten, transazioni, gotchas Drizzle
 
 ## DB migrations: TUTTE handwritten dopo lo schema iniziale
 

--- a/.claude/skills/security-patterns/SKILL.md
+++ b/.claude/skills/security-patterns/SKILL.md
@@ -1,7 +1,11 @@
-# claude-security.md — IP trust, rate limit, hostname, CSP, input validation
+---
+name: security-patterns
+description: Use when implementing or reviewing security-sensitive boundaries — reading client IP (CF-Connecting-IP), rate limiting (single or double-gate with Turnstile), validating UUIDs/emails/decimals/hostnames/redirect params at API boundaries, enforcing body size limits before JSON.parse, wrapping external SDK calls (Stripe, AdE, Resend) in try-catch returning 503, configuring CSP/security headers in src/lib/security-headers.ts, normalizing emails in auth flows, building lookups from user-controlled keys (prototype pollution), or calling setInterval in long-lived constructors. Also covers the Turnstile hostname allowlist for app vs marketing domains.
+---
+
+# security-patterns — IP trust, rate limit, hostname, CSP, input validation
 
 Pattern di sicurezza per route handler, server actions e middleware.
-Riferimento dal `CLAUDE.md` core.
 
 ---
 

--- a/.claude/skills/sonar-quality-gate/SKILL.md
+++ b/.claude/skills/sonar-quality-gate/SKILL.md
@@ -1,7 +1,11 @@
-# claude-sonar.md — Regole SonarCloud specifiche
+---
+name: sonar-quality-gate
+description: Use when fixing SonarCloud or Gitleaks findings — Cognitive Complexity > 15, S6861 readonly React props, S6772 ambiguous JSX spacing, S7780 escape sequences in template literals (use String.raw), S5852 ReDoS or S5122 CORS wildcard Security Hotspots (NOSONAR does not suppress hotspots), or curl-auth-header / generic-api-key false positives in docs requiring .gitleaksignore fingerprints. Also covers coverage exclusions in sonar-project.properties + vitest.config.ts, service worker exclusions, and the rule "ask the user when CI failure is opaque" instead of blind-fixing.
+---
 
-Quality gate ricorrente e regole che si attivano spesso. Riferimento dal
-`CLAUDE.md` core.
+# sonar-quality-gate — Regole SonarCloud specifiche
+
+Quality gate ricorrente e regole che si attivano spesso.
 
 ---
 

--- a/.claude/skills/stripe-webhooks/SKILL.md
+++ b/.claude/skills/stripe-webhooks/SKILL.md
@@ -1,9 +1,9 @@
-# claude-stripe.md — Stripe API version, webhook events, recovery patterns
-
-Riferimento dal `CLAUDE.md` core. La nota sull'API version 2026-02-25.clover è
-ripetuta nel core (è una breaking-change zone), il resto è qui.
-
 ---
+name: stripe-webhooks
+description: Use when working with Stripe billing — handling API version `2026-02-25.clover` breaking changes (Invoice.subscription moved to invoice.parent?.subscription_details?.subscription, Subscription.current_period_end moved to items[0]), registering the 8 required webhook events (checkout.session.completed/expired, customer.subscription.updated/deleted, invoice.paid/payment_failed/payment_action_required, charge.dispute.created), debugging "pending" subscription rows after checkout, or implementing stale-pending recovery thresholds for idempotent AdE mutations (getStalePendingThresholdMs in receipt-service/void-service). Files: src/server/stripe/, src/app/api/stripe/, webhook handler.
+---
+
+# stripe-webhooks — Stripe API version, webhook events, recovery patterns
 
 ## API version `2026-02-25.clover` — breaking changes
 

--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -1,7 +1,12 @@
-# claude-testing.md — Vitest patterns e regole CI
+---
+name: testing-patterns
+description: Use when writing or fixing Vitest tests — avoiding SonarCloud S6661 Blocker (every it()/test() must have at least one expect()), mocking classes correctly with function/class keyword (never arrow), prefixing vi.mock factory variables with "mock" for hoisting, mocking Drizzle's db.transaction() callback with a passthrough, stubbing NODE_ENV with vi.stubEnv, updating mocks after refactoring N queries into a JOIN, INSERT ON CONFLICT DO NOTHING for race conditions, sanitizing context before Sentry.captureException via sanitizeForTelemetry(), auth-first ordering in deleteAccount, conditional last_used_at writes to prevent write-amplification, or react/cache deduplication across RSC and Route Handlers. Also lists the consolidated rate-limit thresholds for server actions (emit/void/pdf/checkout/portal/auth).
+---
+
+# testing-patterns — Vitest patterns e regole CI
 
 Lezioni operative per evitare i failure più comuni di SonarCloud e i bug silenziosi
-nei mock. Riferimento dal `CLAUDE.md` core.
+nei mock.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,10 @@ tag git (`git tag -l "v1.*"`).
 5. **Task > 3 file → break in sub-task.** Stop e suddividere.
 6. **Riflessione dopo correzione:** quando l'utente corregge, capire perché ho
    sbagliato e come non rifarlo.
-7. **Aggiornare `CLAUDE.md` (o `docs/claude-*.md` pertinente) autonomamente**
-   dopo aver risolto un problema non triviale con lezione riusabile (debugging
-   pattern, setup gotcha, wrong assumption). Non aspettare che lo chiedano.
+7. **Aggiornare `CLAUDE.md` (o la skill pertinente in `.claude/skills/`)
+   autonomamente** dopo aver risolto un problema non triviale con lezione
+   riusabile (debugging pattern, setup gotcha, wrong assumption). Non
+   aspettare che lo chiedano.
 8. **Aggiornare pagine `/help`** se si modifica una funzionalità (label, menu,
    stati, filtri, error flow, gating piani, nomi bottoni). `grep -rn "<termine>"
    src/app/\(marketing\)/help` prima di chiudere il task. Feature non ancora
@@ -59,7 +60,8 @@ tag git (`git tag -l "v1.*"`).
     e response 503 — mai lasciare propagare 500 senza context.
 11. **DB migrations: TUTTE handwritten dopo `0000`.** 🚫 **MAI eseguire
     `npx drizzle-kit generate`** nello stato attuale del repo (conflitto con
-    handwritten migrations). Dettaglio workflow in `docs/claude-db.md`.
+    handwritten migrations). Workflow nella skill `db-migrations`. Un hook
+    PreToolUse blocca automaticamente questo comando.
 12. **Debug CI failure opachi:** se SonarCloud/Gitleaks flagga qualcosa non
     visibile nel diff/log, **chiedere all'utente** quale file/riga invece di
     tentare blind fix.
@@ -76,7 +78,7 @@ tag git (`git tag -l "v1.*"`).
 - **0 new issues** (fix sempre, anche con Quality Gate verde — accumulano debt)
 
 Regole specifiche ricorrenti (S6861 readonly props, S6772 JSX spacing, S7780
-template literals, S5852/S5122 hotspots, Gitleaks placeholder) → `docs/claude-sonar.md`.
+template literals, S5852/S5122 hotspots, Gitleaks placeholder) → skill `sonar-quality-gate`.
 
 ## Stripe API version `2026-02-25.clover` — breaking changes
 
@@ -84,8 +86,8 @@ template literals, S5852/S5122 hotspots, Gitleaks placeholder) → `docs/claude-
 - `Subscription.current_period_end` → `subscription.items.data[0]?.current_period_end`
 - Mai `!` su `process.env.STRIPE_WEBHOOK_SECRET` — guard esplicito
 
-Webhook events list (8 da registrare, niente di meno) e recovery patterns in
-`docs/claude-stripe.md`.
+Webhook events list (8 da registrare, niente di meno) e recovery patterns
+nella skill `stripe-webhooks`.
 
 ## Workflow operativi
 
@@ -99,8 +101,8 @@ Webhook events list (8 da registrare, niente di meno) e recovery patterns in
 5. `npx tsx scripts/migrate.ts` su DB locale, verificare idempotenza al re-run
 
 Pattern ADD COLUMN: `ADD COLUMN IF NOT EXISTS`, mai `NOT NULL` su tabelle già
-popolate senza default. Dettaglio + bootstrap su DB pre-esistente in
-`docs/claude-db.md`.
+popolate senza default. Dettaglio + bootstrap su DB pre-esistente nella skill
+`db-migrations`.
 
 ### Worktree setup (`.claude/worktrees/<name>/`)
 
@@ -162,27 +164,29 @@ prima dell'entrata in vigore.
 Feature gate canonico in `src/lib/plans.ts`. Trial 30 giorni Starter/Pro, no
 carta all'iscrizione. P.IVA UNIQUE nel DB (anti-abuso trial).
 
-## Indice docs di approfondimento
+## Skill dominio-specifiche
 
-Pattern e lezioni dettagliate consultabili al bisogno via `Read`/`grep`:
+Le lezioni dettagliate vivono in `.claude/skills/<name>/SKILL.md` e si
+auto-attivano quando il task matcha il `description`:
 
-- **`docs/claude-testing.md`** — Vitest: `expect()` obbligatori, mock di
-  classi, rate limit pattern, JOIN refactor, NODE_ENV, mock Drizzle
-  transaction, `react/cache`, INSERT ON CONFLICT, Sentry+pino, `deleteAccount`
-  ordering, `last_used_at` throttle
-- **`docs/claude-db.md`** — Migrazioni handwritten, bootstrap su DB
-  pre-esistente, transazioni multi-doc, Drizzle raw `sql\`\`` con `Date`,
-  race condition / constraint DB, idempotency key per-tenant
-- **`docs/claude-security.md`** — `CF-Connecting-IP` trust, retry+backoff,
-  UUID/body size/email guards, hostname validation, double-gate rate limit
-  con Turnstile, `setInterval.unref()`, redirect param query string, CSP
-  rollout
-- **`docs/claude-stripe.md`** — API version breaking changes, 8 webhook
-  events da registrare, stale recovery AdE
-- **`docs/claude-ade.md`** — Integrazione diretta (no headless),
-  adapter/strategy mock, debug HTTP, HAR analysis, key rotation `ENCRYPTION_KEY`
-- **`docs/claude-sonar.md`** — Regole specifiche S6861/S6772/S7780/S5852/S5122,
-  Gitleaks placeholder fingerprint, coverage exclusions
+- **`testing-patterns`** — Vitest, `expect()` obbligatori, mock di classi,
+  rate limit, JOIN refactor, NODE_ENV, mock Drizzle transaction, Sentry+pino
+- **`db-migrations`** — handwritten migrations, bootstrap DB pre-esistente,
+  Drizzle raw `sql\`\`` con `Date`, race / idempotency per-tenant
+- **`security-patterns`** — `CF-Connecting-IP`, UUID/body/email guards,
+  hostname validation, double-gate rate limit, CSP, prototype-safe lookup
+- **`stripe-webhooks`** — API `2026-02-25.clover`, 8 webhook events,
+  stale-pending recovery AdE
+- **`ade-integration`** — integrazione HTTP diretta, mock strategy, HAR
+  analysis, rotazione `ENCRYPTION_KEY`
+- **`sonar-quality-gate`** — regole S6861/S6772/S7780/S5852/S5122, Gitleaks,
+  coverage exclusions
+
+## Hook automatici (`.claude/hooks/`)
+
+- `block-drizzle-generate.sh` — blocca `drizzle-kit generate` (regola 11)
+- `block-push-to-main.sh` — blocca `git push` verso `main` / `HEAD:main`
+  (regola 1)
 
 Altri riferimenti già nel repo:
 


### PR DESCRIPTION
## Summary

Refactor the documentation structure from flat `docs/claude-*.md` files to a skill-based architecture under `.claude/skills/` with auto-activating descriptions. Add two PreToolUse hooks to enforce critical rules (block `drizzle-kit generate` and direct pushes to `main`).

## Key Changes

- **Skill migration:** Converted 6 domain-specific docs (`claude-testing.md`, `claude-db.md`, `claude-security.md`, `claude-stripe.md`, `claude-ade.md`, `claude-sonar.md`) into structured skill files under `.claude/skills/<name>/SKILL.md` with:
  - YAML frontmatter (`name`, `description`)
  - Auto-activation triggers based on task description matching
  - Preserved all technical content and patterns

- **PreToolUse hooks:** Added `.claude/hooks/` with two bash scripts:
  - `block-drizzle-generate.sh` — prevents `npx drizzle-kit generate` (CLAUDE.md regola 11)
  - `block-push-to-main.sh` — prevents direct `git push` to `main` (CLAUDE.md regola 1)
  - Registered both in `.claude/settings.json` for automatic enforcement

- **CLAUDE.md updates:**
  - Updated all references from `docs/claude-*.md` to skill names (e.g., `docs/claude-db.md` → skill `db-migrations`)
  - Added new "Skill dominio-specifiche" section explaining the skill architecture
  - Added new "Hook automatici" section documenting the two PreToolUse hooks
  - Clarified that `drizzle-kit generate` is now blocked by an automatic hook

## Implementation Details

- Skills use descriptive `description` fields that match common task patterns (e.g., "Use when creating or modifying SQL files under supabase/migrations/") to enable Claude's auto-activation
- Hooks parse `jq` JSON input from tool invocation and use `grep -E` regex to detect forbidden commands
- Exit code `2` signals hook failure; exit code `0` allows the command
- All technical content preserved; only structure and reference paths changed

https://claude.ai/code/session_01PBtEmk16XmS6i9SkU5Tfuf