### PR TITLE
Make appHref() server-only with APP_HOSTNAME runtime override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,12 @@ src/app/\(marketing\)/help` prima di chiudere il task. Feature non ancora
     `<Link>` di Next.js. Serve a forzare la cross-origin navigation verso
     `app.scontrinozero.it`: il soft routing di Next farebbe restare l'utente
     sull'origin marketing, riportando il bug `captcha_hostname_mismatch` su
-    Turnstile (commit ac59efc).
+    Turnstile (commit ac59efc). **`appHref()` è server-only in pratica**:
+    da un client component (es. `pricing-section.tsx`) `NEXT_PUBLIC_APP_URL`
+    non è nel bundle (non baked dal Dockerfile) e `APP_HOSTNAME` non è
+    `NEXT_PUBLIC_*`, quindi cadrebbe sul default hardcoded di produzione
+    rompendo sandbox/self-hosted. Calcolare l'href nel parent server
+    component e passarlo come prop al client.
 
 ## SonarCloud quality gate
 

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -381,7 +381,7 @@ export default function Home() {
       </section>
 
       {/* Piani */}
-      <PricingSection />
+      <PricingSection registerHref={appHref("/register")} />
 
       {/* FAQ */}
       <section id="faq" className="bg-muted/50 px-4 py-20">

--- a/src/app/(marketing)/prezzi/page.tsx
+++ b/src/app/(marketing)/prezzi/page.tsx
@@ -117,7 +117,7 @@ export default function PrezziPage() {
       />
 
       {/* Pricing toggle + cards */}
-      <PricingSection />
+      <PricingSection registerHref={appHref("/register")} />
 
       {/* Comparison table */}
       <section className="px-4 py-16">

--- a/src/components/marketing/pricing-section.tsx
+++ b/src/components/marketing/pricing-section.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Check, ArrowRight } from "lucide-react";
-import { appHref } from "@/lib/marketing-to-app-href";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,7 +32,14 @@ const proFeatures: Feature[] = [
   { label: "Supporto prioritario" },
 ];
 
-export function PricingSection() {
+interface PricingSectionProps {
+  // Precomputed in un server parent via `appHref("/register")`. Non chiamare
+  // `appHref` qui: in client bundle `NEXT_PUBLIC_APP_URL` non è baked, quindi
+  // ricadrebbe sul default hardcoded di produzione anche in sandbox.
+  readonly registerHref: string;
+}
+
+export function PricingSection({ registerHref }: PricingSectionProps) {
   const [billing, setBilling] = useState<Billing>("annual");
 
   const isAnnual = billing === "annual";
@@ -176,7 +182,7 @@ export function PricingSection() {
 
         <div className="mt-8 text-center">
           <Button asChild size="lg">
-            <a href={appHref("/register")}>
+            <a href={registerHref}>
               Inizia i 30 giorni gratis
               <ArrowRight className="h-4 w-4" />
             </a>

--- a/src/lib/marketing-to-app-href.test.ts
+++ b/src/lib/marketing-to-app-href.test.ts
@@ -35,6 +35,31 @@ describe("appHref", () => {
     expect(appHref("/login")).toBe("https://sandbox.scontrinozero.it/login");
   });
 
+  it("derives base URL from APP_HOSTNAME runtime override even if NEXT_PUBLIC_APP_URL is baked to production", async () => {
+    // Scenario: single Docker image built with prod NEXT_PUBLIC_APP_URL and
+    // deployed in sandbox with APP_HOSTNAME override. Without this priority,
+    // /login and /register links would point to production.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it");
+    vi.stubEnv("APP_HOSTNAME", "sandbox.scontrinozero.it");
+    const { appHref } = await import("./marketing-to-app-href");
+    expect(appHref("/login")).toBe("https://sandbox.scontrinozero.it/login");
+    expect(appHref("/register")).toBe(
+      "https://sandbox.scontrinozero.it/register",
+    );
+  });
+
+  it("derives base URL from APP_HOSTNAME runtime override when NEXT_PUBLIC_APP_URL is unset (client bundle case)", async () => {
+    // In client bundles process.env.NEXT_PUBLIC_APP_URL is whatever was baked
+    // at build time. If not baked, it's undefined; APP_HOSTNAME (server-only)
+    // is also undefined client-side, so this test simulates the server side
+    // of a deployment where only APP_HOSTNAME is set.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_HOSTNAME", "custom.example.com");
+    const { appHref } = await import("./marketing-to-app-href");
+    expect(appHref("/login")).toBe("https://custom.example.com/login");
+  });
+
   it("falls back to hardcoded default if NEXT_PUBLIC_APP_URL is malformed (never throws)", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "not-a-url");

--- a/src/lib/marketing-to-app-href.ts
+++ b/src/lib/marketing-to-app-href.ts
@@ -23,6 +23,17 @@ function allowedHostnames(): Set<string> {
 }
 
 function resolveBaseUrl(): string {
+  // Priority 1: APP_HOSTNAME runtime override (server-only). Honours the
+  // documented "single image, per-env runtime override" pattern: a Docker
+  // image built with the production NEXT_PUBLIC_APP_URL but deployed in
+  // sandbox/self-hosted must emit links to the runtime hostname, not the
+  // baked one.
+  const runtimeHost = process.env.APP_HOSTNAME;
+  if (runtimeHost) {
+    const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
+    return `${protocol}://${runtimeHost}`;
+  }
+
   const raw = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
   let parsed: URL;
   try {
@@ -53,8 +64,12 @@ function resolveBaseUrl(): string {
  * ricade su `https://app.scontrinozero.it` per non rompere il render delle
  * pagine marketing pubbliche.
  *
- * Safe sia dai server component sia dai client component (no dipendenze
- * server-only come pino/Sentry).
+ * **Server-only in pratica**: deve essere chiamata da server component / SSR.
+ * Dai client component (post-hydration) `APP_HOSTNAME` e
+ * `NEXT_PUBLIC_APP_URL` non sono nel bundle (non sono baked dal Dockerfile
+ * corrente) e la funzione cadrebbe sul default hardcoded di produzione,
+ * causando un mismatch in sandbox/self-hosted. Da un client component,
+ * calcolare l'href in un parent server component e passarlo come prop.
  */
 export function appHref(path: `/${string}`): string {
   return `${resolveBaseUrl()}${path}`;


### PR DESCRIPTION
## Summary

Fixes a critical bug where `appHref()` called from client components would fall back to the hardcoded production URL even in sandbox/self-hosted deployments, breaking cross-origin navigation to the app domain.

The solution implements a two-tier resolution strategy:
1. **Priority 1 (new):** `APP_HOSTNAME` runtime override (server-only) — honors the "single Docker image, per-env runtime override" pattern
2. **Priority 2 (existing):** `NEXT_PUBLIC_APP_URL` baked at build time

## Key Changes

- **`src/lib/marketing-to-app-href.ts`**
  - Added `APP_HOSTNAME` runtime override check in `resolveBaseUrl()` with correct protocol selection (https in production, http otherwise)
  - Updated JSDoc to clarify that `appHref()` is **server-only in practice** — client components must compute the href in a parent server component and pass it as a prop
  - Documented the bundle limitation: `NEXT_PUBLIC_APP_URL` and `APP_HOSTNAME` are not available client-side

- **`src/components/marketing/pricing-section.tsx`**
  - Converted from client component calling `appHref()` to accepting `registerHref` as a prop
  - Removed direct import of `appHref()`
  - Added `PricingSectionProps` interface with documentation explaining the pattern

- **`src/app/(marketing)/page.tsx` & `src/app/(marketing)/prezzi/page.tsx`**
  - Updated `<PricingSection />` calls to pass `registerHref={appHref("/register")}` from the server component parent

- **`src/lib/marketing-to-app-href.test.ts`**
  - Added test: `APP_HOSTNAME` override takes priority over baked `NEXT_PUBLIC_APP_URL` in production
  - Added test: `APP_HOSTNAME` works when `NEXT_PUBLIC_APP_URL` is unset (client bundle case)

- **`CLAUDE.md`**
  - Updated rule #15 with guidance on the server-only pattern and prop-passing requirement for client components

## Implementation Details

The `APP_HOSTNAME` check happens **before** attempting to parse `NEXT_PUBLIC_APP_URL`, ensuring that runtime overrides always win. This is critical for deployments where a single Docker image (built with production credentials) is deployed in sandbox or self-hosted environments with a different hostname.

The pattern enforces that client components cannot call `appHref()` directly — they must receive the computed href from a server parent, preventing silent failures where the client bundle lacks the necessary environment variables.

https://claude.ai/code/session_01W5J263tbSK7oVCrDa5Y2Z5