### PR TITLE
Add operator notification on user onboarding completion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ RESEND_API_KEY=re_...
 # Use a dedicated subdomain to isolate email reputation from the root domain
 # Example: YourApp <noreply@mail.yourdomain.com>
 FROM_EMAIL=YourApp <noreply@mail.yourdomain.com>
+# Internal notification address — receives an email each time a user
+# completes onboarding (first successful AdE credential verification).
+# Leave empty/unset to disable (recommended in test/sandbox).
+NEW_SIGNUP_NOTIFICATION_EMAIL=
 
 # =============================================================================
 # Sentry

--- a/src/emails/operator-signup-notification.test.tsx
+++ b/src/emails/operator-signup-notification.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OperatorSignupNotificationEmail } from "./operator-signup-notification";
+
+describe("OperatorSignupNotificationEmail", () => {
+  it("renders first name, last name and email", () => {
+    const html = renderToStaticMarkup(
+      createElement(OperatorSignupNotificationEmail, {
+        firstName: "Mario",
+        lastName: "Rossi",
+        email: "mario@example.it",
+      }),
+    );
+    expect(html).toContain("Mario Rossi");
+    expect(html).toContain("mario@example.it");
+  });
+
+  it("falls back to placeholder when name is empty", () => {
+    const html = renderToStaticMarkup(
+      createElement(OperatorSignupNotificationEmail, {
+        firstName: "",
+        lastName: "",
+        email: "test@example.it",
+      }),
+    );
+    expect(html).toContain("(non fornito)");
+    expect(html).toContain("test@example.it");
+  });
+});

--- a/src/emails/operator-signup-notification.tsx
+++ b/src/emails/operator-signup-notification.tsx
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { emailStyles } from "./styles";
+
+type OperatorSignupNotificationEmailProps = Readonly<{
+  firstName: string;
+  lastName: string;
+  email: string;
+}>;
+
+export function OperatorSignupNotificationEmail({
+  firstName,
+  lastName,
+  email,
+}: OperatorSignupNotificationEmailProps) {
+  const fullName = `${firstName} ${lastName}`.trim();
+  return (
+    <Html lang="it">
+      <Head />
+      <Preview>Nuovo utente ha completato l&apos;onboarding</Preview>
+      <Body style={emailStyles.body}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.header}>
+            <Text style={emailStyles.headerTitle}>ScontrinoZero</Text>
+            <Text style={emailStyles.headerSubtitle}>Notifica interna</Text>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Heading as="h2" style={emailStyles.subheading}>
+              Nuovo onboarding completato
+            </Heading>
+            <Text style={emailStyles.text}>
+              <strong>Nome:</strong> {fullName || "(non fornito)"}
+            </Text>
+            <Text style={emailStyles.text}>
+              <strong>Email:</strong> {email}
+            </Text>
+          </Section>
+          <Hr style={emailStyles.hr} />
+          <Text style={emailStyles.footer}>
+            ScontrinoZero · notifica automatica
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/lib/operator-notification.test.ts
+++ b/src/lib/operator-notification.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSendEmail = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/email", () => ({
+  sendEmail: mockSendEmail,
+}));
+
+const mockLimit = vi.fn();
+const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({ select: mockSelect }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  profiles: {
+    authUserId: "auth-user-id-col",
+    firstName: "first-name-col",
+    lastName: "last-name-col",
+    email: "email-col",
+  },
+}));
+
+vi.mock("@/emails/operator-signup-notification", () => ({
+  OperatorSignupNotificationEmail: vi.fn().mockReturnValue(null),
+}));
+
+describe("notifyOperatorOfNewSignup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLimit.mockReset();
+    delete process.env.NEW_SIGNUP_NOTIFICATION_EMAIL;
+  });
+
+  it("does nothing when NEW_SIGNUP_NOTIFICATION_EMAIL is not set", async () => {
+    const { notifyOperatorOfNewSignup } =
+      await import("./operator-notification");
+    await notifyOperatorOfNewSignup("user-123");
+
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends an email with name, surname and email when env is set", async () => {
+    process.env.NEW_SIGNUP_NOTIFICATION_EMAIL = "marco@scontrinozero.it";
+    mockLimit.mockResolvedValueOnce([
+      {
+        firstName: "Mario",
+        lastName: "Rossi",
+        email: "mario@example.it",
+      },
+    ]);
+
+    const { notifyOperatorOfNewSignup } =
+      await import("./operator-notification");
+    await notifyOperatorOfNewSignup("user-123");
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "marco@scontrinozero.it",
+        subject: expect.stringContaining("Nuovo onboarding"),
+      }),
+    );
+  });
+
+  it("does not send when the profile is not found", async () => {
+    process.env.NEW_SIGNUP_NOTIFICATION_EMAIL = "marco@scontrinozero.it";
+    mockLimit.mockResolvedValueOnce([]);
+
+    const { notifyOperatorOfNewSignup } =
+      await import("./operator-notification");
+    await notifyOperatorOfNewSignup("user-123");
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("propagates sendEmail errors so the caller can log them", async () => {
+    process.env.NEW_SIGNUP_NOTIFICATION_EMAIL = "marco@scontrinozero.it";
+    mockLimit.mockResolvedValueOnce([
+      { firstName: "Mario", lastName: "Rossi", email: "mario@example.it" },
+    ]);
+    mockSendEmail.mockRejectedValueOnce(new Error("Resend boom"));
+
+    const { notifyOperatorOfNewSignup } =
+      await import("./operator-notification");
+
+    await expect(notifyOperatorOfNewSignup("user-123")).rejects.toThrow(
+      "Resend boom",
+    );
+  });
+
+  it("tolerates null firstName/lastName from the DB", async () => {
+    process.env.NEW_SIGNUP_NOTIFICATION_EMAIL = "marco@scontrinozero.it";
+    mockLimit.mockResolvedValueOnce([
+      { firstName: null, lastName: null, email: "mario@example.it" },
+    ]);
+
+    const { notifyOperatorOfNewSignup } =
+      await import("./operator-notification");
+    await notifyOperatorOfNewSignup("user-123");
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/operator-notification.ts
+++ b/src/lib/operator-notification.ts
@@ -1,0 +1,46 @@
+import { createElement } from "react";
+import { eq } from "drizzle-orm";
+import { getDb } from "@/db";
+import { profiles } from "@/db/schema";
+import { sendEmail } from "@/lib/email";
+import { OperatorSignupNotificationEmail } from "@/emails/operator-signup-notification";
+
+/**
+ * Sends an internal notification to the operator (configured via
+ * `NEW_SIGNUP_NOTIFICATION_EMAIL`) when a user completes onboarding.
+ *
+ * Designed to be called fire-and-forget from the onboarding flow:
+ * any failure is non-critical and must NOT block the user. Caller is
+ * expected to `.catch()` the returned promise and log a warning.
+ *
+ * No-op when the env var is unset — keeps test/sandbox environments quiet.
+ */
+export async function notifyOperatorOfNewSignup(
+  authUserId: string,
+): Promise<void> {
+  const to = process.env.NEW_SIGNUP_NOTIFICATION_EMAIL;
+  if (!to) return;
+
+  const db = getDb();
+  const [profile] = await db
+    .select({
+      firstName: profiles.firstName,
+      lastName: profiles.lastName,
+      email: profiles.email,
+    })
+    .from(profiles)
+    .where(eq(profiles.authUserId, authUserId))
+    .limit(1);
+
+  if (!profile) return;
+
+  await sendEmail({
+    to,
+    subject: "ScontrinoZero — Nuovo onboarding completato",
+    react: createElement(OperatorSignupNotificationEmail, {
+      firstName: profile.firstName ?? "",
+      lastName: profile.lastName ?? "",
+      email: profile.email,
+    }),
+  });
+}

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -570,6 +570,15 @@ describe("onboarding-actions", () => {
   });
 
   describe("verifyAdeCredentials", () => {
+    beforeEach(() => {
+      // Default snapshot for the businesses.fiscalCode read added in
+      // verifyAdeCredentials (gates the welcome/operator emails on first
+      // onboarding). Tests that need "already onboarded" semantics override
+      // with mockResolvedValueOnce({ fiscalCode: "..." }) AFTER queuing the
+      // ownership + credentials mocks.
+      mockLimit.mockResolvedValue([{ fiscalCode: null }]);
+    });
+
     it("verifies credentials successfully and fetches fiscal data", async () => {
       // Ownership check: JOIN profile+business
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
@@ -806,7 +815,7 @@ describe("onboarding-actions", () => {
       expect(result.error).toBeUndefined();
     });
 
-    it("does not send welcome email on re-verification", async () => {
+    it("does not send welcome email when business is already onboarded", async () => {
       // Ownership check: JOIN profile+business
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       // Credentials found — verifiedAt already set (re-verification)
@@ -821,6 +830,47 @@ describe("onboarding-actions", () => {
           verifiedAt: new Date("2026-01-01"),
         },
       ]);
+      // Business snapshot: fiscalCode already set → already onboarded.
+      mockLimit.mockResolvedValueOnce([{ fiscalCode: "RSSMRA80A01H501U" }]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      await Promise.resolve();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockNotifyOperator).not.toHaveBeenCalled();
+    });
+
+    // Regression: gating on cred.verifiedAt would re-send welcome + operator
+    // emails when the user replaces AdE credentials (saveAdeCredentials
+    // resets verifiedAt to null) and re-verifies. Gating on
+    // businesses.fiscalCode — set once on first successful verification and
+    // never reset — closes this hole.
+    it("does not re-send welcome email after credential reset", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      // verifiedAt is null (credentials were just replaced) BUT fiscalCode
+      // was already set on a previous successful verification.
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+          verifiedAt: null,
+        },
+      ]);
+      mockLimit.mockResolvedValueOnce([{ fiscalCode: "RSSMRA80A01H501U" }]);
       mockLogin.mockResolvedValue({});
       mockLogout.mockResolvedValue(undefined);
       mockGetFiscalData.mockResolvedValue({

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -98,6 +98,11 @@ vi.mock("@/emails/welcome", () => ({
   WelcomeEmail: vi.fn().mockReturnValue(null),
 }));
 
+const mockNotifyOperator = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/operator-notification", () => ({
+  notifyOperatorOfNewSignup: mockNotifyOperator,
+}));
+
 // --- Helpers ---
 
 function formData(entries: Record<string, string>): FormData {
@@ -763,6 +768,42 @@ describe("onboarding-actions", () => {
       expect(mockSendEmail).toHaveBeenCalledWith(
         expect.objectContaining({ to: "test@example.com" }),
       );
+      expect(mockNotifyOperator).toHaveBeenCalledWith("user-123");
+    });
+
+    it("does not fail when operator notification rejects", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+          verifiedAt: null,
+        },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+      mockNotifyOperator.mockRejectedValueOnce(new Error("resend down"));
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      // Caller swallows the rejection via .catch — flush microtasks so the
+      // unhandled-rejection guard doesn't trip in the test runner.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(result.businessId).toBe("biz-789");
+      expect(result.error).toBeUndefined();
     });
 
     it("does not send welcome email on re-verification", async () => {
@@ -795,6 +836,7 @@ describe("onboarding-actions", () => {
 
       await Promise.resolve();
       expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockNotifyOperator).not.toHaveBeenCalled();
     });
 
     it("blocca la verifica se la P.IVA è già in uso su un altro account (anti-abuso trial)", async () => {

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -22,6 +22,7 @@ import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { sendEmail } from "@/lib/email";
 import { WelcomeEmail } from "@/emails/welcome";
+import { notifyOperatorOfNewSignup } from "@/lib/operator-notification";
 import {
   getAuthenticatedUser,
   checkBusinessOwnership,
@@ -429,6 +430,11 @@ export async function verifyAdeCredentials(
       subject: "Sei pronto! Inizia a emettere scontrini con ScontrinoZero",
       react: createElement(WelcomeEmail, { email: user.email }),
     }).catch((err) => logger.error({ err }, "Welcome email failed"));
+
+    // Internal notification (fire-and-forget, non-critical, env-gated).
+    void notifyOperatorOfNewSignup(user.id).catch((err) =>
+      logger.warn({ err }, "Operator signup notification failed"),
+    );
   }
 
   revalidatePath("/dashboard", "layout");

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -317,6 +317,20 @@ export async function verifyAdeCredentials(
     return { error: "Credenziali non trovate." };
   }
 
+  // Snapshot fiscalCode BEFORE the transaction that sets it. fiscalCode is
+  // assigned once on the first successful AdE verification and never reset
+  // (saveBusiness/saveAdeCredentials preserve it), so its absence is the
+  // canonical "user has never completed onboarding" signal. Using
+  // cred.verifiedAt would re-fire welcome/operator emails when the user
+  // replaces credentials (saveAdeCredentials resets verifiedAt to null) and
+  // re-verifies — fiscalCode survives that path.
+  const [businessSnapshot] = await db
+    .select({ fiscalCode: businesses.fiscalCode })
+    .from(businesses)
+    .where(eq(businesses.id, businessId))
+    .limit(1);
+  const wasAlreadyOnboarded = Boolean(businessSnapshot?.fiscalCode);
+
   // Snapshot updatedAt to detect concurrent credential updates (optimistic locking).
   // If the user saves new credentials while AdE login is in progress, the WHERE
   // below will match 0 rows, preventing verifiedAt from being set on stale data.
@@ -423,8 +437,10 @@ export async function verifyAdeCredentials(
     return { businessId };
   }
 
-  // Send welcome email on first successful verification (fire-and-forget)
-  if (!cred.verifiedAt && user.email) {
+  // Send welcome email on first successful verification (fire-and-forget).
+  // Gated on fiscalCode (not verifiedAt) to avoid duplicate emails when the
+  // user replaces AdE credentials and re-verifies — see snapshot above.
+  if (!wasAlreadyOnboarded && user.email) {
     void sendEmail({
       to: user.email,
       subject: "Sei pronto! Inizia a emettere scontrini con ScontrinoZero",


### PR DESCRIPTION
## Summary

Adds an internal notification system that alerts the operator (via `NEW_SIGNUP_NOTIFICATION_EMAIL` env var) when a user completes onboarding by successfully verifying AdE credentials for the first time.

## Key Changes

- **New module `src/lib/operator-notification.ts`**: Exports `notifyOperatorOfNewSignup(authUserId)` that queries the user's profile and sends an email to the configured operator address. Fire-and-forget design with no-op when env var is unset (keeps test/sandbox quiet).

- **New email template `src/emails/operator-signup-notification.tsx`**: React email component displaying the new user's name and email address in Italian. Gracefully handles null/empty name fields with a "(non fornito)" placeholder.

- **Updated `src/server/onboarding-actions.ts`**: 
  - Snapshots `businesses.fiscalCode` **before** the verification transaction to detect first-time onboarding (canonical signal, survives credential resets).
  - Calls `notifyOperatorOfNewSignup()` fire-and-forget alongside the welcome email, gated on `!wasAlreadyOnboarded` instead of `!cred.verifiedAt`.
  - Prevents duplicate emails when user replaces AdE credentials and re-verifies (verifiedAt resets but fiscalCode persists).

- **Updated `.env.example`**: Documents `NEW_SIGNUP_NOTIFICATION_EMAIL` configuration.

- **Comprehensive test coverage**:
  - `src/lib/operator-notification.test.ts`: 5 tests covering env var gating, email dispatch, missing profile, error propagation, and null name tolerance.
  - `src/emails/operator-signup-notification.test.tsx`: 2 tests for rendering and placeholder fallback.
  - `src/server/onboarding-actions.test.ts`: Updated to mock the new function; added 3 new tests for operator notification behavior and regression coverage (credential reset scenario).

## Implementation Details

- **Gating logic**: Uses `businesses.fiscalCode` (set once on first successful verification, never reset) as the "already onboarded" signal instead of `cred.verifiedAt` (which resets when credentials are replaced). This closes a hole where re-verification after credential replacement would re-fire welcome and operator emails.

- **Error handling**: Operator notification failures are caught and logged as warnings (non-critical, fire-and-forget). Welcome email failures remain error-level logs.

- **Database query**: Snapshots fiscalCode before the transaction that sets it, ensuring the check reflects pre-verification state.

https://claude.ai/code/session_01WvtZtDkm2KTQUcNJABW6J2