### PR TITLE
Add AdE rejection help article and improve error messaging

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -8,17 +8,18 @@ La versione pubblicata corrente è in `package.json`. Lo storico delle release �
 
 ## Roadmap
 
-| Versione     | Descrizione                                                                                                                  |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| **v1.4.0**   | Coupon/promo codes, referral program, Stripe Customer Portal polish                                                          |
-| **v1.5.0**   | Email scontrino al cliente (PDF allegato via Resend)                                                                         |
-| **v1.7.0**   | Catalogo: modifica prodotto + sync AdE (HAR: aggiungi/modifica/elimina)                                                      |
-| **v1.8.0**   | AdE auth multi-metodo: SPID e CIE selezionabili in onboarding + settings; cookie jar cifrato, re-auth on 401                 |
-| **v1.9.0**   | CSV import prodotti, barcode scanner (BarcodeDetector API), Umami analytics                                                  |
-| **v1.10.0+** | Bluetooth printing (58/80mm), Passkey                                                                                        |
-| **v1.11.0**  | Storno avanzato: memorizzare progressivo documento AdE di annullamento e stampare ricevuta di annullamento                   |
-| **v1.x**     | Developer API Fase A: API key per-merchant, Pro gate, endpoints emissione/annullamento — vedi [DEVELOPER.md](./DEVELOPER.md) |
-| **v2.0.0+**  | Developer API Fase B: partner account, management API, piani developer, webhook, multi-operatore                             |
+| Versione     | Descrizione                                                                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **v1.4.0**   | Coupon/promo codes, referral program, Stripe Customer Portal polish                                                                                                                                 |
+| **v1.4.x**   | Supporto in-app: voce "Supporto" nelle impostazioni del dashboard (link a `/help/contatto-assistenza`, eventuale mailto pre-compilato). Da approfondire in conversazione ad-hoc prima della v1.5.0. |
+| **v1.5.0**   | Email scontrino al cliente (PDF allegato via Resend)                                                                                                                                                |
+| **v1.7.0**   | Catalogo: modifica prodotto + sync AdE (HAR: aggiungi/modifica/elimina)                                                                                                                             |
+| **v1.8.0**   | AdE auth multi-metodo: SPID e CIE selezionabili in onboarding + settings; cookie jar cifrato, re-auth on 401                                                                                        |
+| **v1.9.0**   | CSV import prodotti, barcode scanner (BarcodeDetector API), Umami analytics                                                                                                                         |
+| **v1.10.0+** | Bluetooth printing (58/80mm), Passkey                                                                                                                                                               |
+| **v1.11.0**  | Storno avanzato: memorizzare progressivo documento AdE di annullamento e stampare ricevuta di annullamento                                                                                          |
+| **v1.x**     | Developer API Fase A: API key per-merchant, Pro gate, endpoints emissione/annullamento — vedi [DEVELOPER.md](./DEVELOPER.md)                                                                        |
+| **v2.0.0+**  | Developer API Fase B: partner account, management API, piani developer, webhook, multi-operatore                                                                                                    |
 
 ---
 

--- a/src/app/(marketing)/help/errori-ade/page.tsx
+++ b/src/app/(marketing)/help/errori-ade/page.tsx
@@ -8,7 +8,7 @@ import { RelatedHelpArticles } from "@/components/help/related-articles";
 export const metadata: Metadata = {
   title: "Errori comuni di accesso AdE e come risolverli | ScontrinoZero Help",
   description:
-    "Guida alla risoluzione degli errori più frequenti nel collegamento con l'Agenzia delle Entrate: password scaduta, credenziali errate, password bloccata e portale non disponibile.",
+    "Guida alla risoluzione degli errori più frequenti nel collegamento con l'Agenzia delle Entrate: password scaduta, credenziali errate, password bloccata, portale non disponibile e scontrino rifiutato in fase di emissione.",
 };
 
 export default function ErroriAdePage() {
@@ -261,6 +261,54 @@ export default function ErroriAdePage() {
               info@scontrinozero.it
             </a>
             {"."}
+          </li>
+        </ul>
+
+        {/* ─── Scontrino rifiutato dall'AdE in fase di emissione ─── */}
+        <h2
+          id="scontrino-rifiutato"
+          className="mt-10 scroll-mt-20 text-xl font-semibold"
+        >
+          Scontrino rifiutato dall&apos;AdE in fase di emissione
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Sintomo:</strong> in cassa, dopo aver premuto{" "}
+          <strong>Emetti</strong>, appare il messaggio{" "}
+          <em>
+            &quot;Il portale Agenzia delle Entrate Fatture e Corrispettivi ha
+            rifiutato l&apos;emissione dello scontrino. Non dipende da te né da
+            ScontrinoZero. Riprova tra qualche minuto.&quot;
+          </em>{" "}
+          Lo scontrino non viene emesso e nessuna trasmissione fiscale è andata
+          a buon fine.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          <strong>Causa:</strong> AdE ha risposto al tentativo di trasmissione
+          con un rifiuto applicativo (esito negativo). È diverso dai casi
+          precedenti: le credenziali sono corrette, l&apos;attività è abilitata
+          e il portale risponde, ma un controllo interno del portale ha respinto
+          quella specifica trasmissione. Capita raramente, di solito in modo
+          intermittente.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm font-medium">
+          Cosa fare:
+        </p>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Aspetta qualche secondo e riprova l&apos;emissione: nella maggior
+            parte dei casi il secondo tentativo va a buon fine.
+          </li>
+          <li>
+            Se l&apos;errore si ripete in modo continuativo sullo stesso
+            scontrino, scrivici a{" "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              info@scontrinozero.it
+            </a>{" "}
+            indicando data e ora del tentativo: dai nostri log possiamo risalire
+            al messaggio specifico restituito dall&apos;AdE e capire la causa.
           </li>
         </ul>
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -71,6 +71,7 @@ export function sanitizeForTelemetry(obj: unknown): Record<string, unknown> {
     "adeTransactionId",
     "adeProgressivo",
     "adeErrorCodes",
+    "adeErrorDescriptions",
     "action",
     "ipHash",
     "errorClass",

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -414,6 +414,30 @@ describe("emitReceiptForBusiness", () => {
     );
   });
 
+  it("logga array vuoti se AdE ritorna esito:false senza errori array", async () => {
+    const { logger } = await import("@/lib/logger");
+    mockSubmitSale.mockResolvedValue({
+      esito: false,
+      idtrx: null,
+      progressivo: null,
+      // errori intentionally omitted: AdE può non includere il campo.
+    });
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    const result = await emitReceiptForBusiness(VALID_INPUT);
+
+    expect(result.error).toContain(
+      "portale Agenzia delle Entrate Fatture e Corrispettivi",
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adeErrorCodes: [],
+        adeErrorDescriptions: [],
+      }),
+      "AdE rejected sale",
+    );
+  });
+
   it("aggiorna documento a ERROR e ritorna errore se AdE login fallisce", async () => {
     mockLogin.mockRejectedValue(new Error("AdE login failed"));
 

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -382,19 +382,36 @@ describe("emitReceiptForBusiness", () => {
   });
 
   it("aggiorna documento a REJECTED se AdE ritorna esito:false", async () => {
+    const { logger } = await import("@/lib/logger");
     mockSubmitSale.mockResolvedValue({
       esito: false,
       idtrx: null,
       progressivo: null,
-      errori: [{ codice: "ERR002", descrizione: "Dati non validi" }],
+      errori: [{ codice: "EF0", descrizione: "Dati non validi" }],
     });
 
     const { emitReceiptForBusiness } = await import("./receipt-service");
     const result = await emitReceiptForBusiness(VALID_INPUT);
 
-    expect(result.error).toMatch(/rifiutato/i);
+    expect(result.error).toContain(
+      "portale Agenzia delle Entrate Fatture e Corrispettivi",
+    );
+    expect(result.error).toContain("Non dipende da te né da ScontrinoZero");
+    expect(result.error).not.toContain("EF0");
+    expect(result.error).not.toMatch(/codice/i);
     const setArg = mockUpdateSet.mock.calls[0][0];
     expect(setArg.status).toBe("REJECTED");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adeErrorCodes: ["EF0"],
+        adeErrorDescriptions: ["Dati non validi"],
+      }),
+      "AdE rejected sale",
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "AdE rejected sale",
+    );
   });
 
   it("aggiorna documento a ERROR e ritorna errore se AdE login fallisce", async () => {

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -503,12 +503,18 @@ async function submitSaleToAde(
 
     if (!adeResponse.esito) {
       const errorCodes = adeResponse.errori?.map((e) => e.codice) ?? [];
-      logger.error(
+      const errorDescriptions =
+        adeResponse.errori?.map((e) => e.descrizione) ?? [];
+      // warn (level 40) — sotto la soglia Sentry: un rifiuto business AdE
+      // (esito:false) non è un errore applicativo, quindi non apre issue
+      // Sentry. Resta nei log Docker per indagine.
+      logger.warn(
         {
           documentId,
           adeIdtrx: adeResponse.idtrx,
           adeProgressivo: adeResponse.progressivo,
           adeErrorCodes: errorCodes,
+          adeErrorDescriptions: errorDescriptions,
           recovery: options.recovery,
         },
         "AdE rejected sale",
@@ -526,10 +532,9 @@ async function submitSaleToAde(
           })
           .where(eq(commercialDocuments.id, documentId)),
       );
-      const codeList =
-        errorCodes.length > 0 ? ` (${errorCodes.join(", ")})` : "";
       return {
-        error: `Scontrino rifiutato dall'AdE${codeList}. Verifica i dati e riprova.`,
+        error:
+          "Il portale Agenzia delle Entrate Fatture e Corrispettivi ha rifiutato l'emissione dello scontrino. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
       };
     }
 

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -318,21 +318,38 @@ describe("voidReceiptForBusiness", () => {
   });
 
   it("aggiorna documento a REJECTED se AdE ritorna esito:false", async () => {
+    const { logger } = await import("@/lib/logger");
     mockSubmitVoid.mockResolvedValue({
       esito: false,
       idtrx: null,
       progressivo: null,
-      errori: [{ codice: "ERR001", descrizione: "Documento già annullato" }],
+      errori: [{ codice: "EF0", descrizione: "Documento già annullato" }],
     });
 
     const { voidReceiptForBusiness } = await import("./void-service");
     const result = await voidReceiptForBusiness(VALID_INPUT);
 
-    expect(result.error).toMatch(/rifiutato/i);
+    expect(result.error).toContain(
+      "portale Agenzia delle Entrate Fatture e Corrispettivi",
+    );
+    expect(result.error).toContain("Non dipende da te né da ScontrinoZero");
+    expect(result.error).not.toContain("EF0");
+    expect(result.error).not.toMatch(/codice/i);
     const setArg = mockUpdateSet.mock.calls[0][0];
     expect(setArg.status).toBe("REJECTED");
     expect(setArg.adeResponse).toBeDefined();
     expect(mockUpdateSet.mock.calls).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adeErrorCodes: ["EF0"],
+        adeErrorDescriptions: ["Documento già annullato"],
+      }),
+      "AdE rejected void",
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "AdE rejected void",
+    );
   });
 
   it("aggiorna documento a ERROR e ritorna errore se AdE login fallisce", async () => {

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -352,6 +352,30 @@ describe("voidReceiptForBusiness", () => {
     );
   });
 
+  it("logga array vuoti se AdE ritorna esito:false senza errori array", async () => {
+    const { logger } = await import("@/lib/logger");
+    mockSubmitVoid.mockResolvedValue({
+      esito: false,
+      idtrx: null,
+      progressivo: null,
+      // errori intentionally omitted: AdE può non includere il campo.
+    });
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    const result = await voidReceiptForBusiness(VALID_INPUT);
+
+    expect(result.error).toContain(
+      "portale Agenzia delle Entrate Fatture e Corrispettivi",
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adeErrorCodes: [],
+        adeErrorDescriptions: [],
+      }),
+      "AdE rejected void",
+    );
+  });
+
   it("aggiorna documento a ERROR e ritorna errore se AdE login fallisce", async () => {
     mockLogin.mockRejectedValue(new Error("AdE login failed"));
 

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -250,13 +250,19 @@ async function processVoidAdeResponse(args: {
   // AdE can return HTTP 200 with esito:false when it rejects the void.
   if (!adeResponse.esito) {
     const errorCodes = adeResponse.errori?.map((e) => e.codice) ?? [];
-    logger.error(
+    const errorDescriptions =
+      adeResponse.errori?.map((e) => e.descrizione) ?? [];
+    // warn (level 40) — sotto la soglia Sentry: un rifiuto business AdE
+    // (esito:false) non è un errore applicativo, quindi non apre issue
+    // Sentry. Resta nei log Docker per indagine.
+    logger.warn(
       {
         voidDocumentId,
         saleDocumentId,
         adeIdtrx: adeResponse.idtrx,
         adeProgressivo: adeResponse.progressivo,
         adeErrorCodes: errorCodes,
+        adeErrorDescriptions: errorDescriptions,
       },
       "AdE rejected void",
     );
@@ -272,9 +278,9 @@ async function processVoidAdeResponse(args: {
         })
         .where(eq(commercialDocuments.id, voidDocumentId)),
     );
-    const codeList = errorCodes.length > 0 ? ` (${errorCodes.join(", ")})` : "";
     return {
-      error: `Annullo rifiutato dall'AdE${codeList}. Verifica i dati e riprova.`,
+      error:
+        "Il portale Agenzia delle Entrate Fatture e Corrispettivi ha rifiutato l'annullamento dello scontrino. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
     };
   }
 

--- a/tests/unit/lib-logger.test.ts
+++ b/tests/unit/lib-logger.test.ts
@@ -133,12 +133,16 @@ describe("sanitizeForTelemetry", () => {
       token: "should-not-appear",
       codiceFiscale: "RSSMRA80A01H501U",
       adeErrorCodes: ["GEN001"],
+      adeErrorDescriptions: ["Documento non valido"],
       err: new Error("AdE rejected"),
     });
 
     expect(result).toHaveProperty("userId", "u1");
     expect(result).toHaveProperty("businessId", "b1");
     expect(result).toHaveProperty("adeErrorCodes");
+    expect(result).toHaveProperty("adeErrorDescriptions", [
+      "Documento non valido",
+    ]);
     expect(result["err"]).toMatchObject({
       name: "Error",
       message: "AdE rejected",


### PR DESCRIPTION
## Summary

Adds a new help article documenting the "Scontrino rifiutato dall'AdE in fase di emissione" error case, and improves error messaging and logging for AdE application-level rejections (esito:false responses).

## Key Changes

- **Help documentation** (`page.tsx`): Added new section explaining AdE receipt rejection during emission, with symptoms, causes, and troubleshooting steps (retry + contact support with timestamp)
- **Error messaging**: Changed user-facing error messages from technical code-based format (`"Scontrino rifiutato dall'AdE (EF0). Verifica i dati e riprova."`) to user-friendly, non-technical message (`"Il portale Agenzia delle Entrate Fatture e Corrispettivi ha rifiutato l'emissione dello scontrino. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto."`)
- **Logging level**: Changed from `logger.error()` to `logger.warn()` for AdE rejections in both `receipt-service.ts` and `void-service.ts`, since application-level rejections (esito:false) are business logic outcomes, not application errors — prevents spurious Sentry issues
- **Error context**: Added `adeErrorDescriptions` to structured logs alongside `adeErrorCodes` for better diagnostics
- **Test updates**: Updated test expectations in `receipt-service.test.ts` and `void-service.test.ts` to verify new error message format and logger.warn calls with error descriptions
- **Telemetry**: Added `adeErrorDescriptions` to the sanitization allowlist in `logger.ts` for safe transmission to Sentry
- **Roadmap**: Added v1.4.x entry for in-app support feature (dashboard settings link to help contact page)

## Implementation Details

- Error messages now match the help article's symptom description for consistency
- Logging includes both error codes and descriptions for complete diagnostics without exposing technical details to users
- The warn-level logging preserves data in Docker logs for investigation while avoiding Sentry noise
- Help article follows existing structure with symptom → cause → action pattern

https://claude.ai/code/session_011n8cdT63csWmsgbcEVDQm9