### PR TITLE
Code review PR-High: analytics bundle aggregation + hook hardening

### DIFF
--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -11,7 +11,16 @@ cmd=$(jq -r '.tool_input.command // ""')
 # Strip leading "cd <dir> && " noise so the regex sees the actual git command.
 normalized=$(printf '%s' "$cmd" | tr -s ' ')
 
-if printf '%s' "$normalized" | grep -qE 'git[[:space:]]+push([[:space:]]+[^&|;]*)?[[:space:]](main|HEAD:main)(\b|$)'; then
+# Catch any refspec whose destination is `main`. The previous regex only
+# matched `main` after a literal space, leaving the following bypasses:
+#   - `develop:main` (push develop commits to main)
+#   - `:main` (delete remote main)
+#   - `+main` / `--force-with-lease … main` (force-update main)
+#   - `refs/heads/main` (explicit refspec)
+# Boundary `([[:space:]:+]|^)` admits space, `:`, `+`, or line start before
+# the destination. `refs/heads/main` is included explicitly because `/`
+# is not in the boundary class.
+if printf '%s' "$normalized" | grep -qE 'git[[:space:]]+push.*([[:space:]:+]|^)(main|HEAD:main|refs/heads/main)([[:space:]]|$)'; then
   echo "Blocked by .claude/hooks/block-push-to-main.sh:" >&2
   echo "  Direct push to main is forbidden (CLAUDE.md regola 1). Always go through a PR." >&2
   echo "  If this is intentional (release tag, hotfix authorized by the user), bypass via" >&2

--- a/.claude/hooks/test-block-push-to-main.sh
+++ b/.claude/hooks/test-block-push-to-main.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tests for .claude/hooks/block-push-to-main.sh
+#
+# Runs the hook with synthetic Bash tool invocations and asserts the
+# expected exit code (2 = block, 0 = pass). Run from repo root:
+#   ./.claude/hooks/test-block-push-to-main.sh
+#
+# This is a defense-in-depth net for CLAUDE.md regola 1: a regex that
+# fails to block `develop:main`, `:main`, `+main`, force-push refspec
+# or `refs/heads/main` would defeat the whole purpose of the hook.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+HOOK="$SCRIPT_DIR/block-push-to-main.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+failures=0
+
+# Run the hook in a subshell with the given fake Bash command on stdin.
+# Returns the hook's exit code via the global $rc. We can't use `local`
+# at the top level so we use a global.
+run_hook() {
+  local cmd="$1"
+  local payload
+  payload=$(printf '%s' "$cmd" | python3 -c '
+import json, sys
+print(json.dumps({"tool_input": {"command": sys.stdin.read()}}))')
+  printf '%s' "$payload" | bash "$HOOK" >/dev/null 2>&1
+  rc=$?
+}
+
+assert_block() {
+  local cmd="$1"
+  run_hook "$cmd"
+  if [ "$rc" -ne 2 ]; then
+    echo "FAIL: expected BLOCK (exit 2) but got exit $rc for: $cmd" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_pass() {
+  local cmd="$1"
+  run_hook "$cmd"
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: expected PASS (exit 0) but got exit $rc for: $cmd" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# --- PASS cases: legitimate operations that must not be blocked ---
+assert_pass "git push origin feature"
+assert_pass "git push origin develop"
+assert_pass "git push origin HEAD:feature"
+assert_pass "git push -u origin claude/code-review-findings-zrLLU"
+assert_pass "git tag v1.3.3"
+assert_pass "git push origin maintenance"
+assert_pass "git push origin domain"
+assert_pass "git push origin feature/main-fix"
+assert_pass "git status"
+assert_pass "git fetch origin main"
+
+# --- BLOCK cases: any refspec whose destination is main ---
+assert_block "git push origin main"
+assert_block "git push origin HEAD:main"
+assert_block "git push origin develop:main"
+assert_block "git push origin :main"
+assert_block "git push -f origin develop:main"
+assert_block "git push --force origin develop:main"
+assert_block "git push --force-with-lease origin main"
+assert_block "git push origin +main"
+assert_block "git push origin refs/heads/main"
+assert_block "git push origin main:main"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures test(s) failed." >&2
+  exit 1
+fi
+
+echo "All block-push-to-main hook tests passed."

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -2,13 +2,7 @@ import { redirect } from "next/navigation";
 import { getOnboardingStatus } from "@/server/onboarding-actions";
 import {
   type AnalyticsKpis,
-  type PaymentBreakdownEntry,
-  type ProductBreakdownEntry,
-  type RevenuePoint,
-  getAnalyticsKpis,
-  getPaymentBreakdown,
-  getProductBreakdown,
-  getRevenueTimeseries,
+  getAnalyticsBundle,
 } from "@/server/analytics-actions";
 import { AnalyticsClient } from "@/components/analytics/analytics-client";
 import { ProFeatureGate } from "@/components/billing/pro-feature-gate";
@@ -22,24 +16,6 @@ const ZERO_KPIS: AnalyticsKpis = {
   aovCents: 0,
   voidCount: 0,
 };
-
-type ActionResult<T> = T | { error: string };
-
-/**
- * Normalizza il risultato di una server action in `{ ok, data, error }`.
- * Una action puo' fallire come `{ error: string }` (kpis) o come non-array
- * (timeseries/breakdown ritornano `T[] | { error }`): la firma generica
- * copre entrambi tramite il discriminante `"error" in result`.
- */
-function unwrap<T>(
-  result: ActionResult<T>,
-  fallback: T,
-): { ok: boolean; data: T; error?: string } {
-  if (result && typeof result === "object" && "error" in result) {
-    return { ok: false, data: fallback, error: result.error };
-  }
-  return { ok: true, data: result };
-}
 
 export default async function AnalyticsPage() {
   const status = await getOnboardingStatus();
@@ -69,28 +45,13 @@ export default async function AnalyticsPage() {
   }
 
   const businessId = status.businessId;
-  const [kpisRes, timeseriesRes, breakdownRes, productBreakdownRes] =
-    await Promise.all([
-      getAnalyticsKpis(businessId, "30d"),
-      getRevenueTimeseries(businessId, "30d"),
-      getPaymentBreakdown(businessId, "30d"),
-      getProductBreakdown(businessId, "30d"),
-    ]);
-
-  const kpis = unwrap<AnalyticsKpis>(kpisRes, ZERO_KPIS);
-  const timeseries = unwrap<RevenuePoint[]>(timeseriesRes, []);
-  const breakdown = unwrap<PaymentBreakdownEntry[]>(breakdownRes, []);
-  const productBreakdown = unwrap<ProductBreakdownEntry[]>(
-    productBreakdownRes,
-    [],
-  );
+  const bundle = await getAnalyticsBundle(businessId, "30d");
 
   // Non collassare silenziosamente {error} in zero: un utente con DB
   // timeout o ownership glitch vedrebbe "0 €, 0 scontrini" indistinguibile
   // da un negozio senza scontrini. Logghiamo lato server (Sentry) e
   // passiamo un flag al client per mostrare un banner inline.
-  const loadFailed =
-    !kpis.ok || !timeseries.ok || !breakdown.ok || !productBreakdown.ok;
+  const loadFailed = "error" in bundle;
 
   if (loadFailed) {
     logger.warn(
@@ -98,10 +59,7 @@ export default async function AnalyticsPage() {
         userId: user.id,
         businessId,
         errorClass: "analytics_dashboard_load",
-        kpisError: kpis.error,
-        timeseriesError: timeseries.error,
-        breakdownError: breakdown.error,
-        productBreakdownError: productBreakdown.error,
+        bundleError: bundle.error,
       },
       "analytics: server action failed",
     );
@@ -111,10 +69,10 @@ export default async function AnalyticsPage() {
     <AnalyticsClient
       businessId={businessId}
       initialRange="30d"
-      initialKpis={kpis.data}
-      initialTimeseries={timeseries.data}
-      initialBreakdown={breakdown.data}
-      initialProductBreakdown={productBreakdown.data}
+      initialKpis={loadFailed ? ZERO_KPIS : bundle.kpis}
+      initialTimeseries={loadFailed ? [] : bundle.timeseries}
+      initialBreakdown={loadFailed ? [] : bundle.breakdown}
+      initialProductBreakdown={loadFailed ? [] : bundle.productBreakdown}
       initialLoadFailed={loadFailed}
     />
   );

--- a/src/components/analytics/analytics-client.test.tsx
+++ b/src/components/analytics/analytics-client.test.tsx
@@ -2,23 +2,17 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AnalyticsClient } from "./analytics-client";
 import type {
+  AnalyticsBundle,
   AnalyticsKpis,
   PaymentBreakdownEntry,
   ProductBreakdownEntry,
   RevenuePoint,
 } from "@/server/analytics-actions";
 
-const mockGetAnalyticsKpis = vi.fn();
-const mockGetRevenueTimeseries = vi.fn();
-const mockGetPaymentBreakdown = vi.fn();
-const mockGetProductBreakdown = vi.fn();
+const mockGetAnalyticsBundle = vi.fn();
 
 vi.mock("@/server/analytics-actions", () => ({
-  getAnalyticsKpis: (...args: unknown[]) => mockGetAnalyticsKpis(...args),
-  getRevenueTimeseries: (...args: unknown[]) =>
-    mockGetRevenueTimeseries(...args),
-  getPaymentBreakdown: (...args: unknown[]) => mockGetPaymentBreakdown(...args),
-  getProductBreakdown: (...args: unknown[]) => mockGetProductBreakdown(...args),
+  getAnalyticsBundle: (...args: unknown[]) => mockGetAnalyticsBundle(...args),
 }));
 
 // Stub Radix UI Select per evitare di gestire portals/scrollIntoView nei test.
@@ -94,36 +88,39 @@ const INITIAL_KPIS: AnalyticsKpis = {
   voidCount: 0,
 };
 
+function makeBundle(kpis: AnalyticsKpis): AnalyticsBundle {
+  return {
+    kpis,
+    timeseries: [],
+    breakdown: [],
+    productBreakdown: [],
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe("AnalyticsClient handleRangeChange", () => {
   it("scarta il risultato del range precedente se l'utente cambia range velocemente (race condition)", async () => {
-    // Prima chiamata (7d): risolve LENTAMENTE con 7777 cents
-    // Seconda chiamata (30d): risolve VELOCEMENTE con 3030 cents
+    // Prima chiamata (7d): risolve LENTAMENTE con bundle.kpis.revenueCents=7777
+    // Seconda chiamata (30d): risolve VELOCEMENTE con bundle.kpis.revenueCents=3030
     // Senza guard, il setKpis del 7d sovrascriverebbe quello del 30d.
-    let resolveSlow!: (v: AnalyticsKpis) => void;
-    const slowKpis = new Promise<AnalyticsKpis>((r) => {
+    let resolveSlow!: (v: AnalyticsBundle) => void;
+    const slowBundle = new Promise<AnalyticsBundle>((r) => {
       resolveSlow = r;
     });
-    mockGetAnalyticsKpis.mockImplementationOnce(() => slowKpis);
-    mockGetRevenueTimeseries.mockImplementationOnce(() => Promise.resolve([]));
-    mockGetPaymentBreakdown.mockImplementationOnce(() => Promise.resolve([]));
-    mockGetProductBreakdown.mockImplementationOnce(() => Promise.resolve([]));
+    mockGetAnalyticsBundle.mockImplementationOnce(() => slowBundle);
 
-    const fastKpis: AnalyticsKpis = {
+    const fastBundle: AnalyticsBundle = makeBundle({
       revenueCents: 3030,
       count: 5,
       aovCents: 606,
       voidCount: 0,
-    };
-    mockGetAnalyticsKpis.mockImplementationOnce(() =>
-      Promise.resolve(fastKpis),
+    });
+    mockGetAnalyticsBundle.mockImplementationOnce(() =>
+      Promise.resolve(fastBundle),
     );
-    mockGetRevenueTimeseries.mockImplementationOnce(() => Promise.resolve([]));
-    mockGetPaymentBreakdown.mockImplementationOnce(() => Promise.resolve([]));
-    mockGetProductBreakdown.mockImplementationOnce(() => Promise.resolve([]));
 
     render(
       <AnalyticsClient
@@ -141,7 +138,7 @@ describe("AnalyticsClient handleRangeChange", () => {
     fireEvent.click(screen.getByTestId("range-30d"));
 
     await waitFor(() => {
-      expect(mockGetAnalyticsKpis).toHaveBeenCalledTimes(2);
+      expect(mockGetAnalyticsBundle).toHaveBeenCalledTimes(2);
     });
 
     // La fast (30d) risolve → setKpis(3030)
@@ -152,12 +149,14 @@ describe("AnalyticsClient handleRangeChange", () => {
     });
 
     // Ora la slow (7d) risolve in ritardo: NON deve sovrascrivere lo state.
-    resolveSlow({
-      revenueCents: 7777,
-      count: 10,
-      aovCents: 778,
-      voidCount: 0,
-    });
+    resolveSlow(
+      makeBundle({
+        revenueCents: 7777,
+        count: 10,
+        aovCents: 778,
+        voidCount: 0,
+      }),
+    );
 
     // Lascia che il microtask della slow completi.
     await new Promise((r) => setTimeout(r, 10));
@@ -169,17 +168,14 @@ describe("AnalyticsClient handleRangeChange", () => {
     expect(screen.getByTestId("kpis").textContent).not.toContain("7777");
   });
 
-  it("invoca le server actions con range 'ytd' quando l'utente seleziona Da inizio anno", async () => {
-    const ytdKpis: AnalyticsKpis = {
+  it("invoca la server action con range 'ytd' quando l'utente seleziona Da inizio anno", async () => {
+    const ytdBundle: AnalyticsBundle = makeBundle({
       revenueCents: 12345,
       count: 7,
       aovCents: 1763,
       voidCount: 0,
-    };
-    mockGetAnalyticsKpis.mockResolvedValueOnce(ytdKpis);
-    mockGetRevenueTimeseries.mockResolvedValueOnce([]);
-    mockGetPaymentBreakdown.mockResolvedValueOnce([]);
-    mockGetProductBreakdown.mockResolvedValueOnce([]);
+    });
+    mockGetAnalyticsBundle.mockResolvedValueOnce(ytdBundle);
 
     render(
       <AnalyticsClient
@@ -195,11 +191,10 @@ describe("AnalyticsClient handleRangeChange", () => {
     fireEvent.click(screen.getByTestId("range-ytd"));
 
     await waitFor(() => {
-      expect(mockGetAnalyticsKpis).toHaveBeenCalledWith("biz-1", "ytd");
+      expect(mockGetAnalyticsBundle).toHaveBeenCalledWith("biz-1", "ytd");
     });
-    expect(mockGetRevenueTimeseries).toHaveBeenCalledWith("biz-1", "ytd");
-    expect(mockGetPaymentBreakdown).toHaveBeenCalledWith("biz-1", "ytd");
-    expect(mockGetProductBreakdown).toHaveBeenCalledWith("biz-1", "ytd");
+    // H1: una sola call al server, non quattro.
+    expect(mockGetAnalyticsBundle).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(screen.getByTestId("kpis").textContent).toContain(
@@ -208,7 +203,7 @@ describe("AnalyticsClient handleRangeChange", () => {
     });
   });
 
-  it("ignora valori non validi senza invocare le server actions", () => {
+  it("ignora valori non validi senza invocare la server action", () => {
     render(
       <AnalyticsClient
         businessId="biz-1"
@@ -222,9 +217,29 @@ describe("AnalyticsClient handleRangeChange", () => {
 
     fireEvent.click(screen.getByTestId("range-invalid"));
 
-    expect(mockGetAnalyticsKpis).not.toHaveBeenCalled();
-    expect(mockGetRevenueTimeseries).not.toHaveBeenCalled();
-    expect(mockGetPaymentBreakdown).not.toHaveBeenCalled();
-    expect(mockGetProductBreakdown).not.toHaveBeenCalled();
+    expect(mockGetAnalyticsBundle).not.toHaveBeenCalled();
+  });
+
+  it("mostra il banner di errore quando il bundle ritorna { error }", async () => {
+    mockGetAnalyticsBundle.mockResolvedValueOnce({ error: "Boom" });
+
+    render(
+      <AnalyticsClient
+        businessId="biz-1"
+        initialRange="30d"
+        initialKpis={INITIAL_KPIS}
+        initialTimeseries={[]}
+        initialBreakdown={[]}
+        initialProductBreakdown={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("range-7d"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    // KPI azzerati sul fail (no carry-over del range precedente).
+    expect(screen.getByTestId("kpis").textContent).toContain("revenueCents=0");
   });
 });

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -8,10 +8,7 @@ import {
   type PaymentBreakdownEntry,
   type ProductBreakdownEntry,
   type RevenuePoint,
-  getAnalyticsKpis,
-  getPaymentBreakdown,
-  getProductBreakdown,
-  getRevenueTimeseries,
+  getAnalyticsBundle,
 } from "@/server/analytics-actions";
 import { KpiCards } from "./kpi-cards";
 import { PaymentBreakdown } from "./payment-breakdown";
@@ -64,7 +61,7 @@ export function AnalyticsClient({
   const [loadFailed, setLoadFailed] = useState<boolean>(initialLoadFailed);
   const [isPending, startTransition] = useTransition();
   // `latestRangeRef` traccia l'ultimo range richiesto. Se l'utente cambia
-  // range due volte velocemente e la prima Promise.all risolve dopo la
+  // range due volte velocemente e la prima Promise risolve dopo la
   // seconda, la prima viene scartata: senza questo guard la UI mostrerebbe
   // i KPI del range precedente sopra il selettore aggiornato.
   const latestRangeRef = useRef<AnalyticsRange>(initialRange);
@@ -76,23 +73,21 @@ export function AnalyticsClient({
     latestRangeRef.current = nextRange;
     setRange(nextRange);
     startTransition(async () => {
-      const [k, t, b, p] = await Promise.all([
-        getAnalyticsKpis(businessId, nextRange),
-        getRevenueTimeseries(businessId, nextRange),
-        getPaymentBreakdown(businessId, nextRange),
-        getProductBreakdown(businessId, nextRange),
-      ]);
+      const result = await getAnalyticsBundle(businessId, nextRange);
       if (latestRangeRef.current !== nextRange) return;
-      const failed =
-        "error" in k ||
-        !Array.isArray(t) ||
-        !Array.isArray(b) ||
-        !Array.isArray(p);
-      setKpis("error" in k ? ZERO_KPIS : k);
-      setTimeseries(Array.isArray(t) ? t : []);
-      setBreakdown(Array.isArray(b) ? b : []);
-      setProductBreakdown(Array.isArray(p) ? p : []);
-      setLoadFailed(failed);
+      if ("error" in result) {
+        setKpis(ZERO_KPIS);
+        setTimeseries([]);
+        setBreakdown([]);
+        setProductBreakdown([]);
+        setLoadFailed(true);
+        return;
+      }
+      setKpis(result.kpis);
+      setTimeseries(result.timeseries);
+      setBreakdown(result.breakdown);
+      setProductBreakdown(result.productBreakdown);
+      setLoadFailed(false);
     });
   }
 

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -101,18 +101,38 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import {
+  type AnalyticsRange,
   fillMissingDays,
   formatRomeDay,
   normalizePaymentMethod,
   rangeToBounds,
   romeMidnightUtc,
 } from "./analytics-helpers";
-import {
-  getAnalyticsKpis,
-  getPaymentBreakdown,
-  getProductBreakdown,
-  getRevenueTimeseries,
-} from "./analytics-actions";
+import { getAnalyticsBundle } from "./analytics-actions";
+
+// Test helpers: unwrap the aggregated bundle for the specific dataset each
+// test cares about. Mirrors the old per-dataset Server Action surface so
+// existing test bodies keep their shape after the H1 consolidation.
+async function getAnalyticsKpis(businessId: string, range: AnalyticsRange) {
+  const res = await getAnalyticsBundle(businessId, range);
+  return "error" in res ? res : res.kpis;
+}
+async function getRevenueTimeseries(
+  businessId: string,
+  range: AnalyticsRange,
+  reference?: Date,
+) {
+  const res = await getAnalyticsBundle(businessId, range, reference);
+  return "error" in res ? res : res.timeseries;
+}
+async function getPaymentBreakdown(businessId: string, range: AnalyticsRange) {
+  const res = await getAnalyticsBundle(businessId, range);
+  return "error" in res ? res : res.breakdown;
+}
+async function getProductBreakdown(businessId: string, range: AnalyticsRange) {
+  const res = await getAnalyticsBundle(businessId, range);
+  return "error" in res ? res : res.productBreakdown;
+}
 
 // --- Helpers ---
 
@@ -349,9 +369,24 @@ describe("getAnalyticsKpis", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
-      { documentId: "d2", grossUnitPrice: "5.00", quantity: "2" },
-      { documentId: "d3", grossUnitPrice: "99.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
+      {
+        documentId: "d2",
+        description: "Cornetto",
+        grossUnitPrice: "5.00",
+        quantity: "2",
+      },
+      {
+        documentId: "d3",
+        description: "Brioche",
+        grossUnitPrice: "99.00",
+        quantity: "1",
+      },
     ]);
     const res = await getAnalyticsKpis("biz-1", "30d");
     expect(res).toEqual({
@@ -385,7 +420,12 @@ describe("getAnalyticsKpis", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
     ]);
     const res = await getAnalyticsKpis("biz-1", "30d");
     expect(res).toEqual({
@@ -403,7 +443,12 @@ describe("getAnalyticsKpis", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
     ]);
     const res = await getAnalyticsKpis("biz-1", "30d");
     expect(res).toEqual({
@@ -429,7 +474,12 @@ describe("getRevenueTimeseries", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
     ]);
 
     const res = await getRevenueTimeseries(
@@ -465,9 +515,24 @@ describe("getRevenueTimeseries", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
-      { documentId: "d2", grossUnitPrice: "5.00", quantity: "1" },
-      { documentId: "d3", grossUnitPrice: "5.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
+      {
+        documentId: "d2",
+        description: "Caffè",
+        grossUnitPrice: "5.00",
+        quantity: "1",
+      },
+      {
+        documentId: "d3",
+        description: "Cornetto",
+        grossUnitPrice: "5.00",
+        quantity: "1",
+      },
     ]);
 
     const res = await getRevenueTimeseries(
@@ -507,7 +572,12 @@ describe("getRevenueTimeseries", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "100.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "100.00",
+        quantity: "1",
+      },
     ]);
     const res = await getRevenueTimeseries(
       "biz-1",
@@ -546,10 +616,30 @@ describe("getPaymentBreakdown", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([
-      { documentId: "d1", grossUnitPrice: "10.00", quantity: "1" },
-      { documentId: "d2", grossUnitPrice: "20.00", quantity: "1" },
-      { documentId: "d3", grossUnitPrice: "5.00", quantity: "2" },
-      { documentId: "d4", grossUnitPrice: "1.00", quantity: "1" },
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
+      {
+        documentId: "d2",
+        description: "Cornetto",
+        grossUnitPrice: "20.00",
+        quantity: "1",
+      },
+      {
+        documentId: "d3",
+        description: "Caffè",
+        grossUnitPrice: "5.00",
+        quantity: "2",
+      },
+      {
+        documentId: "d4",
+        description: "Brioche",
+        grossUnitPrice: "1.00",
+        quantity: "1",
+      },
     ]);
     const res = await getPaymentBreakdown("biz-1", "30d");
     if (!Array.isArray(res)) throw new Error("Expected array");
@@ -679,5 +769,73 @@ describe("getProductBreakdown", () => {
     mockFetchLinesByDocIds.mockResolvedValue([]);
     const res = await getProductBreakdown("biz-1", "30d");
     expect(res).toEqual([]);
+  });
+});
+
+describe("getAnalyticsBundle", () => {
+  it("returns kpis/timeseries/breakdown/productBreakdown from a single dataset fetch", async () => {
+    const at = new Date("2026-05-19T10:00:00Z");
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        {
+          id: "d1",
+          status: "ACCEPTED",
+          createdAt: at,
+          publicRequest: { paymentMethod: "PC" },
+        },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      {
+        documentId: "d1",
+        description: "Caffè",
+        quantity: "2",
+        grossUnitPrice: "1.50",
+      },
+    ]);
+
+    const res = await getAnalyticsBundle(
+      "biz-1",
+      "7d",
+      new Date("2026-05-19T12:00:00Z"),
+    );
+
+    if ("error" in res) throw new Error(`Expected bundle, got: ${res.error}`);
+    expect(res.kpis).toEqual({
+      revenueCents: 300,
+      count: 1,
+      aovCents: 300,
+      voidCount: 0,
+    });
+    expect(res.breakdown).toEqual([
+      { method: "PC", count: 1, revenueCents: 300 },
+    ]);
+    expect(res.productBreakdown).toEqual([
+      // count == lines (1), revenue == qty*price (2 * 1.50 = 3.00 → 300 cents)
+      { description: "Caffè", revenueCents: 300, count: 1 },
+    ]);
+    expect(
+      res.timeseries.find((p) => p.date === "2026-05-19")?.revenueCents,
+    ).toBe(300);
+  });
+
+  it("fetches the dataset only once per call (H1: collapses 4 round-trips into 1)", async () => {
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockFetchLinesByDocIds.mockResolvedValue([]);
+
+    await getAnalyticsBundle("biz-1", "30d");
+
+    // mockSelect è chiamato 1× per fetchSaleDocsInRange.
+    // Senza l'aggregazione (4 server action separate) verrebbe chiamato 4×.
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    // fetchLinesByDocIds invocato 0× perché non ci sono documenti, ma anche
+    // con dati sarebbe 1× soltanto (mock helper sopra lo conferma).
+    expect(mockFetchLinesByDocIds).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns { error } when auth fails (single error path for the whole bundle)", async () => {
+    mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
+    const res = await getAnalyticsBundle("biz-1", "30d");
+    expect(res).toEqual({ error: "Non autorizzato." });
   });
 });

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -294,44 +294,40 @@ async function getAnalyticsDataset(
 // Server actions
 // ---------------------------------------------------------------------------
 
-export async function getAnalyticsKpis(
-  businessId: string,
-  range: AnalyticsRange,
-): Promise<AnalyticsKpis | { error: string }> {
-  const result = await getAnalyticsDataset(businessId, range);
-  if (!result.ok) return { error: result.error };
-  return computeKpis(result.docs, result.totalsByDoc);
-}
+export type AnalyticsBundle = {
+  kpis: AnalyticsKpis;
+  timeseries: RevenuePoint[];
+  breakdown: PaymentBreakdownEntry[];
+  productBreakdown: ProductBreakdownEntry[];
+};
 
-export async function getRevenueTimeseries(
+/**
+ * Aggregated server action returning all four analytics datasets in one
+ * round-trip. Server-side runs a single `getAnalyticsDataset` (cached by
+ * `react/cache()` during the RSC render) and computes all aggregates from
+ * the shared dataset. Client-side range changes used to invoke four
+ * separate Server Actions (kpis/timeseries/breakdown/productBreakdown):
+ * each instantiated its own `cache()` scope, so `getAnalyticsDataset` ran
+ * four times — quadrupling auth checks, DB fetches, and rate-limit tokens.
+ * Funneling through this single entry point preserves the cache benefit
+ * across both RSC initial render and client range-change paths.
+ */
+export async function getAnalyticsBundle(
   businessId: string,
   range: AnalyticsRange,
   reference?: Date,
-): Promise<RevenuePoint[] | { error: string }> {
+): Promise<AnalyticsBundle | { error: string }> {
   const result = await getAnalyticsDataset(businessId, range, reference);
   if (!result.ok) return { error: result.error };
-  return computeTimeseries(
-    result.docs,
-    result.totalsByDoc,
-    result.from,
-    result.to,
-  );
-}
-
-export async function getPaymentBreakdown(
-  businessId: string,
-  range: AnalyticsRange,
-): Promise<PaymentBreakdownEntry[] | { error: string }> {
-  const result = await getAnalyticsDataset(businessId, range);
-  if (!result.ok) return { error: result.error };
-  return computeBreakdown(result.docs, result.totalsByDoc);
-}
-
-export async function getProductBreakdown(
-  businessId: string,
-  range: AnalyticsRange,
-): Promise<ProductBreakdownEntry[] | { error: string }> {
-  const result = await getAnalyticsDataset(businessId, range);
-  if (!result.ok) return { error: result.error };
-  return computeProductBreakdown(result.docs, result.linesByDoc);
+  return {
+    kpis: computeKpis(result.docs, result.totalsByDoc),
+    timeseries: computeTimeseries(
+      result.docs,
+      result.totalsByDoc,
+      result.from,
+      result.to,
+    ),
+    breakdown: computeBreakdown(result.docs, result.totalsByDoc),
+    productBreakdown: computeProductBreakdown(result.docs, result.linesByDoc),
+  };
 }


### PR DESCRIPTION
Primo dei 3 PR derivati da `REVIEW.md` (review indipendente del range `v1.3.2..HEAD`).

## Summary

- **H1 — Analytics: 4× server action → 1× `getAnalyticsBundle`**.
  `handleRangeChange` faceva 4 chiamate parallele a `getAnalyticsKpis`, `getRevenueTimeseries`, `getPaymentBreakdown`, `getProductBreakdown`. `react/cache()` deduplica solo entro un singolo render RSC, quindi sul client ogni action partiva con il proprio scope: 4× `getAnalyticsDataset` per cambio range = 4× `authorizePro`, 4× fetch jsonb `publicRequest`, 4× rate-limit token (su budget 60/h → utente esauriva dopo 15 cambi range/ora). Nuova action `getAnalyticsBundle` ritorna `{ kpis, timeseries, breakdown, productBreakdown }` da una sola fetch del dataset condiviso; le 4 action originali sono rimosse perché non più chiamate altrove. Anche la pagina RSC iniziale è semplificata: 1 sola call → semantica più chiara e nessuna pseudo-dedupe da spiegare.
- **H2 — Hook `block-push-to-main.sh` chiuso ai bypass**. La regex precedente richiedeva uno spazio prima della destinazione, lasciando 4 vie di bypass per il refspec di Git: `develop:main`, `:main`, `+main`, `refs/heads/main`. La nuova regex ammette spazio/`:`/`+`/inizio-stringa come boundary e aggiunge `refs/heads/main` esplicito. Aggiunto `test-block-push-to-main.sh` come safety-net del hook stesso (10 PASS + 10 BLOCK case).

## Test plan

- [x] `npm run lint` — verde
- [x] `npx prettier --check src/` — verde
- [x] `npx vitest run` — 2489/2489 verdi
- [x] `./.claude/hooks/test-block-push-to-main.sh` — "All block-push-to-main hook tests passed."
- [ ] Manuale post-merge: `/dashboard/analytics`, cambio range → DevTools Network mostra **1 sola** server-action invocation (vs 4 prima).

## Note

Parte 1/3. PR-Medium (M1+M2+M3+M4+M6) e PR-Low (L1+L2+L3+L4) seguiranno dopo il merge di questo PR. M5 viene rinviato in `PLAN.md` (entry v1.4.x, sarà aggiunta nel PR-Low insieme alla pulizia di `REVIEW.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2ckFMCntmAU6xSw1HvGZq)_