### PR TITLE
Code review PR-Medium: services hardening + APP_HOSTNAME validation + recharts dynamic

### DIFF
--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useRef, useState, useTransition } from "react";
 import {
   type AnalyticsKpis,
@@ -11,9 +12,6 @@ import {
   getAnalyticsBundle,
 } from "@/server/analytics-actions";
 import { KpiCards } from "./kpi-cards";
-import { PaymentBreakdown } from "./payment-breakdown";
-import { ProductBreakdown } from "./product-breakdown";
-import { RevenueSparkline } from "./revenue-sparkline";
 import {
   Select,
   SelectContent,
@@ -22,6 +20,39 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+// Recharts pesa ~100KB gzipped. I 3 widget (sparkline/payment/product) lo
+// importano top-level: senza dynamic, recharts entra nel bundle iniziale
+// di /dashboard/analytics anche prima che KpiCards si renderizzi. Caricarli
+// dinamicamente sposta i 100KB in un chunk separato che viene fetchato
+// solo dopo l'hydration del client component, allineato al principio
+// CLAUDE.md "Leggeri sulle risorse" (target mobile 3G/4G).
+//
+// ssr: false perché recharts usa ResizeObserver (no-op in Node SSR) e i
+// dati arrivano via setState dal range change. Le altezze del loading
+// placeholder devono matchare quelle reali (220/220/260) per evitare
+// layout shift al mount.
+const PaymentBreakdown = dynamic(
+  () =>
+    import("./payment-breakdown").then((m) => ({
+      default: m.PaymentBreakdown,
+    })),
+  { ssr: false, loading: () => <div className="h-[220px]" /> },
+);
+const RevenueSparkline = dynamic(
+  () =>
+    import("./revenue-sparkline").then((m) => ({
+      default: m.RevenueSparkline,
+    })),
+  { ssr: false, loading: () => <div className="h-[220px]" /> },
+);
+const ProductBreakdown = dynamic(
+  () =>
+    import("./product-breakdown").then((m) => ({
+      default: m.ProductBreakdown,
+    })),
+  { ssr: false, loading: () => <div className="h-[260px]" /> },
+);
 
 interface AnalyticsClientProps {
   readonly businessId: string;

--- a/src/lib/ade/error-messages.test.ts
+++ b/src/lib/ade/error-messages.test.ts
@@ -9,7 +9,10 @@ import {
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
 } from "./errors";
-import { getUserFacingAdeErrorMessage } from "./error-messages";
+import {
+  getUserFacingAdeErrorMessage,
+  isTransientAdeError,
+} from "./error-messages";
 
 const FALLBACK = "Operazione fallita. Riprova.";
 
@@ -105,5 +108,66 @@ describe("getUserFacingAdeErrorMessage", () => {
   it("returns the fallback for a non-Error value", () => {
     const result = getUserFacingAdeErrorMessage("oops", FALLBACK);
     expect(result.message).toBe(FALLBACK);
+  });
+});
+
+describe("isTransientAdeError", () => {
+  it("returns true for AdeNetworkError", () => {
+    expect(
+      isTransientAdeError(new AdeNetworkError(new Error("ECONNRESET"))),
+    ).toBe(true);
+  });
+
+  it("returns true for AdeSpidTimeoutError", () => {
+    expect(isTransientAdeError(new AdeSpidTimeoutError(30))).toBe(true);
+  });
+
+  it("returns true for AdePortalError with 5xx status", () => {
+    expect(isTransientAdeError(new AdePortalError(500, "boom"))).toBe(true);
+    expect(isTransientAdeError(new AdePortalError(503, "boom"))).toBe(true);
+    expect(isTransientAdeError(new AdePortalError(599, "boom"))).toBe(true);
+  });
+
+  it("returns false for AdePortalError with 4xx status (permanent: bad input)", () => {
+    expect(isTransientAdeError(new AdePortalError(400, "bad request"))).toBe(
+      false,
+    );
+    expect(isTransientAdeError(new AdePortalError(404, "not found"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for AdePortalError with 3xx status (redirect malformed)", () => {
+    expect(isTransientAdeError(new AdePortalError(302, "redirect"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for AdeAuthError (permanent: wrong credentials)", () => {
+    expect(isTransientAdeError(new AdeAuthError())).toBe(false);
+  });
+
+  it("returns false for AdePasswordExpiredError (permanent: user action required)", () => {
+    expect(isTransientAdeError(new AdePasswordExpiredError())).toBe(false);
+  });
+
+  it("returns false for AdeSessionExpiredError", () => {
+    expect(isTransientAdeError(new AdeSessionExpiredError())).toBe(false);
+  });
+
+  it("returns false for a generic AdeError", () => {
+    expect(isTransientAdeError(new AdeError("ADE_UNKNOWN", "boom"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for a non-Ade Error", () => {
+    expect(isTransientAdeError(new Error("unrelated"))).toBe(false);
+  });
+
+  it("returns false for a non-Error value", () => {
+    expect(isTransientAdeError("oops")).toBe(false);
+    expect(isTransientAdeError(null)).toBe(false);
+    expect(isTransientAdeError(undefined)).toBe(false);
   });
 });

--- a/src/lib/ade/error-messages.ts
+++ b/src/lib/ade/error-messages.ts
@@ -56,3 +56,21 @@ export function getUserFacingAdeErrorMessage(
   }
   return { message: fallback };
 }
+
+/**
+ * Ritorna true se l'errore è una condizione transient su cui ScontrinoZero
+ * non può fare nulla (downtime AdE, rete, SPID timeout).
+ *
+ * Usato dai catch site dei servizi AdE per decidere il log level: i
+ * transient vanno loggati a `warn` (non `error`) per non aprire issue
+ * Sentry spurie. Durante un downtime AdE da 100 utenti riceveremmo ~100
+ * issue identiche e non actionable per noi — il logger.ts hook a livello
+ * 50 (error) le farebbe scattare. Coerente con il downgrade di
+ * `esito:false` (rifiuto business AdE) a `warn` fatto in 8c654b5.
+ */
+export function isTransientAdeError(err: unknown): boolean {
+  if (err instanceof AdeNetworkError) return true;
+  if (err instanceof AdeSpidTimeoutError) return true;
+  if (err instanceof AdePortalError && err.statusCode >= 500) return true;
+  return false;
+}

--- a/src/lib/ade/log-failure.test.ts
+++ b/src/lib/ade/log-failure.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import {
+  AdeAuthError,
+  AdeNetworkError,
+  AdePortalError,
+  AdeSpidTimeoutError,
+} from "./errors";
+import { logger } from "@/lib/logger";
+import { logAdeFailure } from "./log-failure";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("logAdeFailure", () => {
+  it("routes AdeNetworkError to logger.warn with errorClass ade_transient", () => {
+    logAdeFailure(
+      new AdeNetworkError(new Error("ECONNRESET")),
+      { businessId: "biz-1" },
+      { transient: "op transient", failure: "op failed" },
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        businessId: "biz-1",
+        errorClass: "ade_transient",
+      }),
+      "op transient",
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("routes AdePortalError 5xx to logger.warn (transient)", () => {
+    logAdeFailure(
+      new AdePortalError(503, "down"),
+      { documentId: "doc-1" },
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_transient" }),
+      "transient",
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("routes AdeSpidTimeoutError to logger.warn (transient)", () => {
+    logAdeFailure(
+      new AdeSpidTimeoutError(30),
+      {},
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_transient" }),
+      "transient",
+    );
+  });
+
+  it("routes AdePortalError 4xx to logger.error (permanent: caller error)", () => {
+    logAdeFailure(
+      new AdePortalError(400, "bad request"),
+      {},
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_failure" }),
+      "failed",
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("routes AdeAuthError to logger.error (permanent: wrong credentials)", () => {
+    logAdeFailure(
+      new AdeAuthError(),
+      {},
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_failure" }),
+      "failed",
+    );
+  });
+
+  it("routes a generic Error to logger.error", () => {
+    logAdeFailure(
+      new Error("boom"),
+      {},
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_failure" }),
+      "failed",
+    );
+  });
+
+  it("forwards arbitrary context fields into the log payload", () => {
+    logAdeFailure(
+      new Error("boom"),
+      {
+        documentId: "doc-1",
+        businessId: "biz-1",
+        recovery: true,
+      },
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: "doc-1",
+        businessId: "biz-1",
+        recovery: true,
+        err: expect.any(Error),
+      }),
+      "failed",
+    );
+  });
+});

--- a/src/lib/ade/log-failure.ts
+++ b/src/lib/ade/log-failure.ts
@@ -1,0 +1,36 @@
+import { logger } from "@/lib/logger";
+import { isTransientAdeError } from "./error-messages";
+
+/**
+ * Logga un errore AdE-side con il livello corretto.
+ *
+ * - Transient (network, SPID timeout, AdE 5xx via `isTransientAdeError`)
+ *   → `logger.warn` con `errorClass: "ade_transient"`. NON triggera
+ *   Sentry capture (logger.ts hook a riga 136 cattura solo `level >= 50`),
+ *   evitando ~100 issue Sentry identiche durante un downtime AdE.
+ * - Non transient → `logger.error` con `errorClass: "ade_failure"`.
+ *
+ * Mai estrarre i metodi pino in una variabile (`const fn = logger.warn`):
+ * pino li dispatcha tramite `this`-binding (accesso a `this.level`,
+ * `this.bindings`, ...) e una chiamata unbound crasha dentro il catch,
+ * mascherando l'errore AdE originale e impedendo l'update DB di
+ * conseguenza. Qui usiamo sempre `logger.warn(...)` / `logger.error(...)`
+ * direttamente.
+ */
+export function logAdeFailure(
+  err: unknown,
+  context: Record<string, unknown>,
+  messages: { transient: string; failure: string },
+): void {
+  const transient = isTransientAdeError(err);
+  const payload = {
+    err,
+    ...context,
+    errorClass: transient ? "ade_transient" : "ade_failure",
+  };
+  if (transient) {
+    logger.warn(payload, messages.transient);
+  } else {
+    logger.error(payload, messages.failure);
+  }
+}

--- a/src/lib/marketing-to-app-href.test.ts
+++ b/src/lib/marketing-to-app-href.test.ts
@@ -89,4 +89,20 @@ describe("appHref", () => {
     const { appHref } = await import("./marketing-to-app-href");
     expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
   });
+
+  it("falls back to hardcoded default if APP_HOSTNAME contains a scheme (typo guard)", async () => {
+    // `.env` typo: APP_HOSTNAME=https://app.scontrinozero.it
+    // → senza guard produrrebbe `https://https://app.scontrinozero.it/login`.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_HOSTNAME", "https://app.scontrinozero.it");
+    const { appHref } = await import("./marketing-to-app-href");
+    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
+  });
+
+  it("falls back to hardcoded default if APP_HOSTNAME contains a path/slash", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_HOSTNAME", "app.scontrinozero.it/redirect");
+    const { appHref } = await import("./marketing-to-app-href");
+    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
+  });
 });

--- a/src/lib/marketing-to-app-href.ts
+++ b/src/lib/marketing-to-app-href.ts
@@ -30,6 +30,19 @@ function resolveBaseUrl(): string {
   // baked one.
   const runtimeHost = process.env.APP_HOSTNAME;
   if (runtimeHost) {
+    // Validate hostname-only: a typo nel `.env` come
+    // `APP_HOSTNAME=https://app.scontrinozero.it` produrrebbe l'URL
+    // malformato `https://https://app.scontrinozero.it/login`; un
+    // `APP_HOSTNAME=app.scontrinozero.it/redirect` produrrebbe link
+    // verso un path arbitrario. Ricadiamo sul default invece di emettere
+    // un href rotto. Niente check contro `allowedHostnames()`: la
+    // allowlist auto-include `APP_HOSTNAME` (riga 14-16) quindi sarebbe
+    // tautologica — la vera difesa contro la compromessione dell'env è
+    // fuori dal nostro perimetro (chi controlla l'env controlla anche la
+    // sua allowlist).
+    if (runtimeHost.includes("://") || runtimeHost.includes("/")) {
+      return HARDCODED_DEFAULT;
+    }
     const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
     return `${protocol}://${runtimeHost}`;
   }

--- a/src/lib/services/ade-recovery.test.ts
+++ b/src/lib/services/ade-recovery.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getStalePendingThresholdMs } from "./ade-recovery";
+
+describe("getStalePendingThresholdMs", () => {
+  beforeEach(() => {
+    delete process.env.STALE_PENDING_THRESHOLD_MINUTES;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 30 minutes (1_800_000 ms) when the env var is unset", () => {
+    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("honours a positive override in minutes", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "60");
+    expect(getStalePendingThresholdMs()).toBe(60 * 60 * 1000);
+  });
+
+  it("honours a fractional minute override", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "0.5");
+    expect(getStalePendingThresholdMs()).toBe(0.5 * 60 * 1000);
+  });
+
+  it("falls back to default on zero (avoids immediate recovery)", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "0");
+    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("falls back to default on negative values", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "-5");
+    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("falls back to default on non-numeric strings", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "abc");
+    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("falls back to default on NaN string", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "NaN");
+    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("falls back to default when the env var is an empty string", () => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "");
+    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
+  });
+});

--- a/src/lib/services/ade-recovery.ts
+++ b/src/lib/services/ade-recovery.ts
@@ -1,0 +1,23 @@
+/**
+ * Soglia oltre la quale un documento commerciale PENDING/ERROR è
+ * considerato "stale" e può entrare nel recovery path (re-submit ad AdE).
+ *
+ * Default: 30 min. Override via env `STALE_PENDING_THRESHOLD_MINUTES`
+ * (utile per i test di integrazione che non vogliono aspettare 30 min).
+ *
+ * Condiviso fra receipt-service e void-service per evitare drift: la
+ * soglia governa lo stesso trade-off (collision window vs UX di retry) in
+ * entrambi i flussi. Un drift potrebbe lasciare la sale recovery più
+ * aggressiva del void recovery (o viceversa) per errore di copia.
+ *
+ * NB: la soluzione corretta al collision-window problem è il lookup AdE
+ * pre-retry via `searchDocuments` (vedi `ricerca_documento.har`); la
+ * soglia temporale è una mitigation finché quel lookup non viene
+ * implementato — tracciato nel backlog.
+ */
+export function getStalePendingThresholdMs(): number {
+  const raw = process.env.STALE_PENDING_THRESHOLD_MINUTES;
+  const minutes = raw ? Number.parseFloat(raw) : Number.NaN;
+  const effective = Number.isFinite(minutes) && minutes > 0 ? minutes : 30;
+  return effective * 60 * 1000;
+}

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -465,6 +465,57 @@ describe("emitReceiptForBusiness", () => {
     expect(result.error).not.toContain("Riprova più tardi");
   });
 
+  it("M3: AdE transient (AdePortalError 5xx) logga a warn invece di error (no Sentry noise)", async () => {
+    const { AdePortalError } = await import("@/lib/ade/errors");
+    mockSubmitSale.mockRejectedValue(
+      new AdePortalError(503, "service unavailable"),
+    );
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_transient" }),
+      expect.stringContaining("transient failure"),
+    );
+    // logger.error PUÒ essere chiamato per altri eventi (es. "Failed to mark
+    // document as ERROR"), ma NON per emitReceiptForBusiness failed.
+    const errorCalls = (logger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const failedCalls = errorCalls.filter((c) =>
+      String(c[1] ?? "").includes("emitReceiptForBusiness failed"),
+    );
+    expect(failedCalls).toHaveLength(0);
+  });
+
+  it("M3: AdeNetworkError logga a warn (transient)", async () => {
+    const { AdeNetworkError } = await import("@/lib/ade/errors");
+    mockSubmitSale.mockRejectedValue(new AdeNetworkError(new Error("ECONN")));
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_transient" }),
+      expect.stringContaining("transient failure"),
+    );
+  });
+
+  it("M3: errore non transient (AdeAuthError) resta a logger.error", async () => {
+    const { AdeAuthError } = await import("@/lib/ade/errors");
+    mockSubmitSale.mockRejectedValue(new AdeAuthError());
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_failure" }),
+      expect.stringContaining("emitReceiptForBusiness failed"),
+    );
+  });
+
   it("non chiama logout se AdE login fallisce (nessuna sessione aperta)", async () => {
     mockLogin.mockRejectedValue(new Error("AdE login failed"));
 

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -13,7 +13,10 @@ import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
 import { createAdeClient } from "@/lib/ade";
 import { AdePasswordExpiredError } from "@/lib/ade/errors";
-import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import {
+  getUserFacingAdeErrorMessage,
+  isTransientAdeError,
+} from "@/lib/ade/error-messages";
 import { mapSaleToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
 import {
@@ -31,34 +34,12 @@ import type {
 } from "@/types/cassa";
 import type { PaymentType, SaleDocumentRequest } from "@/lib/ade/public-types";
 import type { AdeCedentePrestatore } from "@/lib/ade/types";
+import { getStalePendingThresholdMs } from "./ade-recovery";
 
 const PAYMENT_METHOD_TO_ADE: Record<PaymentMethod, PaymentType> = {
   PC: "CASH",
   PE: "ELECTRONIC",
 };
-
-/**
- * Soglia oltre la quale un documento PENDING/ERROR è considerato "stale".
- * Sopra questa soglia, un retry con la stessa idempotencyKey entra nel
- * recovery path invece di ricevere "stato inconsistente".
- *
- * Default: 30 minuti. Override via env STALE_PENDING_THRESHOLD_MINUTES.
- *
- * Rischio residuo: AdE non supporta una chiave d'idempotenza nel payload
- * submitSale. Se il primo submit è arrivato ad AdE ma la risposta è andata
- * persa (timeout / connessione interrotta), un retry sotto la soglia ritorna
- * PENDING_IN_PROGRESS e l'utente lo riproverà più tardi. Sopra la soglia si
- * rientra in recovery e potenzialmente si fa un SECONDO submit ad AdE —
- * scontrino duplicato. 30 min sopra la durata sessione AdE tipica riduce
- * drasticamente la collision window. Soluzione corretta: lookup AdE pre-retry
- * via searchDocuments — tracciata nel backlog (vedi ricerca_documento.har).
- */
-function getStalePendingThresholdMs(): number {
-  const raw = process.env.STALE_PENDING_THRESHOLD_MINUTES;
-  const minutes = raw ? Number.parseFloat(raw) : Number.NaN;
-  const effective = Number.isFinite(minutes) && minutes > 0 ? minutes : 30;
-  return effective * 60 * 1000;
-}
 
 /** Validates and resolves the effective lottery code from the input. */
 function resolveLotteryCode(input: SubmitReceiptInput): {
@@ -377,17 +358,22 @@ async function finalizeSaleOnly(
   adeTransactionId: string,
   adeProgressive: string,
 ): Promise<SubmitReceiptResult> {
-  const db = getDb();
   try {
+    // Retry on statement timeout + SET LOCAL statement_timeout (3s).
+    // submitSale è già andato a buon fine, dobbiamo riuscire a finalizzare
+    // prima di rinunciare (3 tentativi: 200ms → 500ms → 1s). Simmetrico a
+    // finalizeVoidOnly in void-service.ts.
     await retryOnStatementTimeout("emit-finalize-only", () =>
-      db
-        .update(commercialDocuments)
-        .set({
-          status: "ACCEPTED",
-          adeTransactionId,
-          adeProgressive,
-        })
-        .where(eq(commercialDocuments.id, documentId)),
+      withStatementTimeout(3000, async (tx) =>
+        tx
+          .update(commercialDocuments)
+          .set({
+            status: "ACCEPTED",
+            adeTransactionId,
+            adeProgressive,
+          })
+          .where(eq(commercialDocuments.id, documentId)),
+      ),
     );
     logger.info(
       { documentId, adeTransactionId, recovery: true },
@@ -571,14 +557,19 @@ async function submitSaleToAde(
       adeProgressive: adeResponse.progressivo ?? undefined,
     };
   } catch (err) {
-    logger.error(
+    const transient = isTransientAdeError(err);
+    const logFn = transient ? logger.warn : logger.error;
+    logFn(
       {
         err,
         documentId,
         businessId: input.businessId,
         recovery: options.recovery,
+        errorClass: transient ? "ade_transient" : "ade_failure",
       },
-      "emitReceiptForBusiness failed",
+      transient
+        ? "emitReceiptForBusiness AdE transient failure"
+        : "emitReceiptForBusiness failed",
     );
 
     // Don't mark ERROR if the failure is a statement timeout — the row

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -13,10 +13,8 @@ import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
 import { createAdeClient } from "@/lib/ade";
 import { AdePasswordExpiredError } from "@/lib/ade/errors";
-import {
-  getUserFacingAdeErrorMessage,
-  isTransientAdeError,
-} from "@/lib/ade/error-messages";
+import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import { logAdeFailure } from "@/lib/ade/log-failure";
 import { mapSaleToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
 import {
@@ -557,19 +555,17 @@ async function submitSaleToAde(
       adeProgressive: adeResponse.progressivo ?? undefined,
     };
   } catch (err) {
-    const transient = isTransientAdeError(err);
-    const logFn = transient ? logger.warn : logger.error;
-    logFn(
+    logAdeFailure(
+      err,
       {
-        err,
         documentId,
         businessId: input.businessId,
         recovery: options.recovery,
-        errorClass: transient ? "ade_transient" : "ade_failure",
       },
-      transient
-        ? "emitReceiptForBusiness AdE transient failure"
-        : "emitReceiptForBusiness failed",
+      {
+        transient: "emitReceiptForBusiness AdE transient failure",
+        failure: "emitReceiptForBusiness failed",
+      },
     );
 
     // Don't mark ERROR if the failure is a statement timeout — the row

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -403,6 +403,40 @@ describe("voidReceiptForBusiness", () => {
     expect(result.error).not.toContain("Riprova più tardi");
   });
 
+  it("M3: AdE transient (AdePortalError 5xx) logga a warn invece di error (no Sentry noise)", async () => {
+    const { AdePortalError } = await import("@/lib/ade/errors");
+    mockSubmitVoid.mockRejectedValue(
+      new AdePortalError(503, "service unavailable"),
+    );
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_transient" }),
+      expect.stringContaining("transient failure"),
+    );
+    const errorCalls = (logger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const failedCalls = errorCalls.filter((c) =>
+      String(c[1] ?? "").includes("voidReceiptForBusiness failed"),
+    );
+    expect(failedCalls).toHaveLength(0);
+  });
+
+  it("M3: errore non transient (generic Error) resta a logger.error", async () => {
+    mockSubmitVoid.mockRejectedValue(new Error("unexpected boom"));
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_failure" }),
+      expect.stringContaining("voidReceiptForBusiness failed"),
+    );
+  });
+
   it("non chiama logout se AdE login fallisce (nessuna sessione aperta)", async () => {
     mockLogin.mockRejectedValue(new Error("AdE login failed"));
 

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -12,7 +12,10 @@ import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
 import { createAdeClient } from "@/lib/ade";
-import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import {
+  getUserFacingAdeErrorMessage,
+  isTransientAdeError,
+} from "@/lib/ade/error-messages";
 import { mapVoidToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
 import {
@@ -25,24 +28,7 @@ import { fetchAdePrerequisites } from "@/lib/server-auth";
 import type { VoidReceiptInput, VoidReceiptResult } from "@/types/storico";
 import type { VoidRequest } from "@/lib/ade/public-types";
 import type { AdeResponse } from "@/lib/ade/types";
-
-/**
- * Soglia oltre la quale un VOID PENDING/ERROR è considerato "stale".
- * Sopra questa soglia, un retry con la stessa idempotencyKey entra nel
- * recovery path. Default: 30 min. Override via STALE_PENDING_THRESHOLD_MINUTES.
- *
- * Rischio residuo: vedi receipt-service.ts per il commento esteso. AdE non
- * accetta una idempotency-key nel payload submitVoid: se la risposta del primo
- * submit si è persa in volo, un retry crea un VOID duplicato IRREVERSIBILE.
- * La soglia di 30 min riduce la finestra ma non la elimina. La soluzione
- * corretta (lookup AdE pre-retry) è tracciata nel backlog.
- */
-function getStalePendingThresholdMs(): number {
-  const raw = process.env.STALE_PENDING_THRESHOLD_MINUTES;
-  const minutes = raw ? Number.parseFloat(raw) : Number.NaN;
-  const effective = Number.isFinite(minutes) && minutes > 0 ? minutes : 30;
-  return effective * 60 * 1000;
-}
+import { getStalePendingThresholdMs } from "./ade-recovery";
 
 type ConflictOutcome =
   | { kind: "done"; result: VoidReceiptResult }
@@ -600,9 +586,18 @@ export async function voidReceiptForBusiness(
       apiKeyId,
     });
   } catch (err) {
-    logger.error(
-      { err, voidDocumentId, saleDocumentId: input.documentId },
-      "voidReceiptForBusiness failed",
+    const transient = isTransientAdeError(err);
+    const logFn = transient ? logger.warn : logger.error;
+    logFn(
+      {
+        err,
+        voidDocumentId,
+        saleDocumentId: input.documentId,
+        errorClass: transient ? "ade_transient" : "ade_failure",
+      },
+      transient
+        ? "voidReceiptForBusiness AdE transient failure"
+        : "voidReceiptForBusiness failed",
     );
 
     // Don't mark ERROR on timeout. Leave the row PENDING so:

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -12,10 +12,8 @@ import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
 import { createAdeClient } from "@/lib/ade";
-import {
-  getUserFacingAdeErrorMessage,
-  isTransientAdeError,
-} from "@/lib/ade/error-messages";
+import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import { logAdeFailure } from "@/lib/ade/log-failure";
 import { mapVoidToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
 import {
@@ -586,18 +584,13 @@ export async function voidReceiptForBusiness(
       apiKeyId,
     });
   } catch (err) {
-    const transient = isTransientAdeError(err);
-    const logFn = transient ? logger.warn : logger.error;
-    logFn(
+    logAdeFailure(
+      err,
+      { voidDocumentId, saleDocumentId: input.documentId },
       {
-        err,
-        voidDocumentId,
-        saleDocumentId: input.documentId,
-        errorClass: transient ? "ade_transient" : "ade_failure",
+        transient: "voidReceiptForBusiness AdE transient failure",
+        failure: "voidReceiptForBusiness failed",
       },
-      transient
-        ? "voidReceiptForBusiness AdE transient failure"
-        : "voidReceiptForBusiness failed",
     );
 
     // Don't mark ERROR on timeout. Leave the row PENDING so:

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -744,6 +744,67 @@ describe("onboarding-actions", () => {
       expect(mockLogin).not.toHaveBeenCalled();
     });
 
+    it("M3: AdE transient (AdePortalError 5xx) logga a warn invece di error", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+      const { AdePortalError } = await import("@/lib/ade/errors");
+      mockLogin.mockRejectedValue(new AdePortalError(503, "down"));
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      const { logger } = await import("@/lib/logger");
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessId: "biz-789",
+          errorClass: "ade_transient",
+        }),
+        expect.stringContaining("transient failure"),
+      );
+      const errorCalls = (logger.error as ReturnType<typeof vi.fn>).mock.calls;
+      const failedCalls = errorCalls.filter((c) =>
+        String(c[1] ?? "").includes("AdE credential verification failed"),
+      );
+      expect(failedCalls).toHaveLength(0);
+    });
+
+    it("M3: errore non transient (AdeAuthError) resta a logger.error", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+      const { AdeAuthError } = await import("@/lib/ade/errors");
+      mockLogin.mockRejectedValue(new AdeAuthError());
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      const { logger } = await import("@/lib/logger");
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessId: "biz-789",
+          errorClass: "ade_failure",
+        }),
+        expect.stringContaining("AdE credential verification failed"),
+      );
+    });
+
     it("sends welcome email on first successful verification", async () => {
       // Ownership check: JOIN profile+business
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -17,10 +17,8 @@ import {
   AdeError,
   AdePasswordExpiredError,
 } from "@/lib/ade/errors";
-import {
-  getUserFacingAdeErrorMessage,
-  isTransientAdeError,
-} from "@/lib/ade/error-messages";
+import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import { logAdeFailure } from "@/lib/ade/log-failure";
 import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { sendEmail } from "@/lib/email";
@@ -359,17 +357,13 @@ export async function verifyAdeCredentials(
         passwordExpired: true,
       };
     }
-    const transient = isTransientAdeError(err);
-    const logFn = transient ? logger.warn : logger.error;
-    logFn(
+    logAdeFailure(
+      err,
+      { businessId },
       {
-        err,
-        businessId,
-        errorClass: transient ? "ade_transient" : "ade_failure",
+        transient: "AdE credential verification: transient failure",
+        failure: "AdE credential verification failed",
       },
-      transient
-        ? "AdE credential verification: transient failure"
-        : "AdE credential verification failed",
     );
     const userFacing = getUserFacingAdeErrorMessage(
       err,
@@ -599,17 +593,13 @@ export async function changeAdePassword(
         error: "La nuova password deve essere diversa da quella attuale.",
       };
     }
-    const transient = isTransientAdeError(err);
-    const logFn = transient ? logger.warn : logger.error;
-    logFn(
+    logAdeFailure(
+      err,
+      { businessId },
       {
-        err,
-        businessId,
-        errorClass: transient ? "ade_transient" : "ade_failure",
+        transient: "changeAdePassword: AdE transient failure",
+        failure: "Cambio password AdE fallito",
       },
-      transient
-        ? "changeAdePassword: AdE transient failure"
-        : "Cambio password AdE fallito",
     );
     const userFacing = getUserFacingAdeErrorMessage(
       err,

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -17,7 +17,10 @@ import {
   AdeError,
   AdePasswordExpiredError,
 } from "@/lib/ade/errors";
-import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import {
+  getUserFacingAdeErrorMessage,
+  isTransientAdeError,
+} from "@/lib/ade/error-messages";
 import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { sendEmail } from "@/lib/email";
@@ -356,7 +359,18 @@ export async function verifyAdeCredentials(
         passwordExpired: true,
       };
     }
-    logger.error({ err, businessId }, "AdE credential verification failed");
+    const transient = isTransientAdeError(err);
+    const logFn = transient ? logger.warn : logger.error;
+    logFn(
+      {
+        err,
+        businessId,
+        errorClass: transient ? "ade_transient" : "ade_failure",
+      },
+      transient
+        ? "AdE credential verification: transient failure"
+        : "AdE credential verification failed",
+    );
     const userFacing = getUserFacingAdeErrorMessage(
       err,
       "Verifica fallita. Controlla le credenziali Fisconline.",
@@ -585,7 +599,18 @@ export async function changeAdePassword(
         error: "La nuova password deve essere diversa da quella attuale.",
       };
     }
-    logger.error({ err, businessId }, "Cambio password AdE fallito");
+    const transient = isTransientAdeError(err);
+    const logFn = transient ? logger.warn : logger.error;
+    logFn(
+      {
+        err,
+        businessId,
+        errorClass: transient ? "ade_transient" : "ade_failure",
+      },
+      transient
+        ? "changeAdePassword: AdE transient failure"
+        : "Cambio password AdE fallito",
+    );
     const userFacing = getUserFacingAdeErrorMessage(
       err,
       "Errore durante il cambio password. Riprova più tardi.",


### PR DESCRIPTION
Secondo dei 3 PR derivati da `REVIEW.md`. Consolida tutti i finding di severity Medium (M1+M2+M3+M4+M6) per "massima consolidazione" come richiesto.

## Summary

- **M2 — `finalizeSaleOnly` wrappa `withStatementTimeout(3000, …)`**. Asimmetria con `finalizeVoidOnly` (che già lo usa): senza `SET LOCAL statement_timeout` ogni tentativo della UPDATE post-submitSale poteva attendere indefinitamente, lasciando il documento PENDING in DB mentre ACCEPTED su AdE.
- **M3 — `isTransientAdeError` + classificazione transient/permanent**. Nuovo helper in `src/lib/ade/error-messages.ts` che riconosce `AdeNetworkError`, `AdeSpidTimeoutError`, `AdePortalError` con statusCode ≥ 500. I 4 catch site (receipt-service, void-service, `verifyAdeCredentials`, `changeAdePassword`) ora routano i transient a `logger.warn` con `errorClass: "ade_transient"` invece di `logger.error`. Durante un downtime AdE di 2 ore con 100 utenti niente più ~100 issue Sentry identiche non-actionable. Coerente con il downgrade di `esito:false` a warn fatto in 8c654b5.
- **M4 — `APP_HOSTNAME` valida scheme/slash**. Typo nel `.env` come `APP_HOSTNAME=https://…` o `APP_HOSTNAME=host/path` ricadono ora su `HARDCODED_DEFAULT` invece di emettere href rotti. Niente allowlist check (sarebbe tautologica: `allowedHostnames()` auto-include `APP_HOSTNAME`).
- **M6 — `getStalePendingThresholdMs` deduplicato**. Nuovo modulo `src/lib/services/ade-recovery.ts` con la funzione (logica byte-identica, default 30 min, env override). receipt-service e void-service importano da lì. Evita drift se in futuro si differenzia la soglia per sale vs void.
- **M1 — `recharts` dynamic import**. I 3 widget (sparkline/payment/product) sono caricati con `next/dynamic` (ssr: false, loading placeholder alle stesse altezze 220/220/260 per zero layout shift). ~100KB gzipped fuori dal bundle iniziale di `/dashboard/analytics`. Chiude entry P3 PLAN.md "`recharts` dynamic import".

## Test plan

- [x] `npm run lint` — verde
- [x] `npx prettier --check src/` — verde
- [x] `npx vitest run` — 2517/2517 verdi (+28 nuovi test)
- [x] Test specifici M3: `AdePortalError(503)` → `logger.warn` chiamato, niente `logger.error "failed"`. `AdeAuthError` → `logger.error` rimane.
- [x] Test specifici M4: `APP_HOSTNAME=https://...` e `APP_HOSTNAME=host/path` → fallback default.
- [x] Test M6: default 30 min, override, 0/-/abc/NaN/empty → tutti fallback.
- [ ] Manuale post-merge: bundle analyzer su `/dashboard/analytics` → chunk recharts separato (~100KB) caricato dopo l'hydration.

## Note

Parte 2/3. PR-Low (L1+L2+L3+L4) e PLAN.md update (M5 → v1.4.x) + pulizia `REVIEW.md` seguiranno dopo il merge di questo PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2ckFMCntmAU6xSw1HvGZq)_