### PR TITLE
Clear cart on auth pages to prevent session leakage

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import { ClearCassaCart } from "@/components/clear-cassa-cart";
 
 export default function AuthLayout({
   children,
@@ -8,6 +9,7 @@ export default function AuthLayout({
 }>) {
   return (
     <div className="bg-muted/30 flex min-h-screen flex-col items-center justify-center px-4 py-8">
+      <ClearCassaCart />
       <Link
         href="/"
         className="text-primary mb-8 flex items-center gap-2 text-2xl font-bold"

--- a/src/components/clear-cassa-cart.test.tsx
+++ b/src/components/clear-cassa-cart.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ClearCassaCart } from "./clear-cassa-cart";
+import { CASSA_SESSION_KEY } from "@/hooks/use-cassa";
+
+describe("ClearCassaCart", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("rimuove cassa_cart da sessionStorage al mount", () => {
+    sessionStorage.setItem(
+      CASSA_SESSION_KEY,
+      JSON.stringify({ lines: [{ id: "1" }], paymentMethod: "PC" }),
+    );
+
+    render(<ClearCassaCart />);
+
+    expect(sessionStorage.getItem(CASSA_SESSION_KEY)).toBeNull();
+  });
+
+  it("non solleva eccezioni se cassa_cart non esiste", () => {
+    expect(() => render(<ClearCassaCart />)).not.toThrow();
+    expect(sessionStorage.getItem(CASSA_SESSION_KEY)).toBeNull();
+  });
+
+  it("non tocca altre chiavi di sessionStorage", () => {
+    sessionStorage.setItem(CASSA_SESSION_KEY, "x");
+    sessionStorage.setItem("other_key", "preserve-me");
+
+    render(<ClearCassaCart />);
+
+    expect(sessionStorage.getItem(CASSA_SESSION_KEY)).toBeNull();
+    expect(sessionStorage.getItem("other_key")).toBe("preserve-me");
+  });
+
+  it("non renderizza nulla nel DOM", () => {
+    const { container } = render(<ClearCassaCart />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/clear-cassa-cart.tsx
+++ b/src/components/clear-cassa-cart.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { CASSA_SESSION_KEY } from "@/hooks/use-cassa";
+
+// Pulisce il carrello in sessionStorage. Da montare sulle pagine raggiungibili
+// solo da utenti non autenticati (login/register/reset-password/verify-email):
+// evita che il carrello di un utente sopravviva al logout e venga ereditato
+// da chi accede dopo nella stessa tab.
+export function ClearCassaCart(): null {
+  useEffect(() => {
+    sessionStorage.removeItem(CASSA_SESSION_KEY);
+  }, []);
+
+  return null;
+}

--- a/src/hooks/use-cassa.ts
+++ b/src/hooks/use-cassa.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { CartLine, PaymentMethod, VatCode } from "@/types/cassa";
 
-const SESSION_KEY = "cassa_cart";
+export const CASSA_SESSION_KEY = "cassa_cart";
 
 interface SessionData {
   lines: CartLine[];
@@ -16,7 +16,7 @@ interface CartState extends SessionData {
 
 function readFromSession(): SessionData {
   try {
-    const raw = sessionStorage.getItem(SESSION_KEY);
+    const raw = sessionStorage.getItem(CASSA_SESSION_KEY);
     if (!raw) return { lines: [], paymentMethod: "PC" };
     return JSON.parse(raw) as SessionData;
   } catch {
@@ -62,7 +62,7 @@ export function useCassa(): UseCassaReturn {
   useEffect(() => {
     if (!isHydrated) return;
     sessionStorage.setItem(
-      SESSION_KEY,
+      CASSA_SESSION_KEY,
       JSON.stringify({ lines, paymentMethod }),
     );
   }, [lines, paymentMethod, isHydrated]);


### PR DESCRIPTION
## Summary

Adds a `ClearCassaCart` component that removes the shopping cart from `sessionStorage` when mounted on authentication pages (login, register, reset password, verify email). This prevents a user's cart from persisting in `sessionStorage` after logout and being inherited by the next person who logs in on the same browser tab.

## Changes

- **New component `src/components/clear-cassa-cart.tsx`**: A client component that clears `CASSA_SESSION_KEY` from `sessionStorage` on mount and renders nothing to the DOM.
- **New test file `src/components/clear-cassa-cart.test.tsx`**: Comprehensive test coverage including:
  - Removes cart data on mount
  - Handles missing cart gracefully
  - Preserves other `sessionStorage` keys
  - Renders nothing to DOM
- **Export `CASSA_SESSION_KEY` from `src/hooks/use-cassa.ts`**: Changed `SESSION_KEY` constant to `export const CASSA_SESSION_KEY` to allow the new component to reference it.
- **Mount component in `src/app/(auth)/layout.tsx`**: Added `<ClearCassaCart />` to the auth layout so it runs on all authentication pages.

## Implementation Details

- Uses `useEffect` with empty dependency array to run once on mount
- Returns `null` to avoid rendering any DOM elements
- Exported constant allows reuse across the codebase without duplication
- All tests pass; no edge cases left uncovered (missing key, other keys, no DOM output)

https://claude.ai/code/session_01GzzkvaxcEAwrXgJRhPe4H7