### PR TITLE
Correct PWA caching guidance in react-patterns skill

### DIFF
--- a/.claude/skills/react-patterns/SKILL.md
+++ b/.claude/skills/react-patterns/SKILL.md
@@ -285,11 +285,17 @@ le richieste `/api/*`. Conseguenze:
 
 - **Server Action (POST)** → non cachate, sempre rete.
 - **Route Handler GET sotto `/api/*`** → potenzialmente serviti dalla cache
-  su timeout/offline. Per dati tenant-specifici, sensibili o che cambiano
-  spesso, il handler **deve** dichiarare `Cache-Control: no-store` (e/o
-  `Vary: Cookie/Authorization`) nella response per evitare stale cross-user.
-  In alternativa, override del `runtimeCaching` in `src/sw.ts` con una regola
-  `NetworkOnly` per il pattern specifico, prima di `defaultCache`.
+  su timeout/offline. ⚠️ `Cache-Control: no-store` sulla response **non
+  basta**: in Serwist 9.x la `NetworkFirst` scrive in cache via
+  `fetchAndCachePut`, e il `cacheOkAndOpaquePlugin` aggiunto di default
+  decide solo in base allo status (200/opaque) ignorando l'header
+  `Cache-Control`. Per dati tenant-specifici / sensibili / che cambiano
+  spesso bisogna **override esplicito** in `src/sw.ts`: una regola
+  `NetworkOnly` (o un matcher che esclude il pattern) registrata **prima**
+  di `defaultCache`, oppure una `NetworkFirst` con plugin custom che rifiuta
+  via `cacheWillUpdate` le response non cacheable. `Vary: Cookie/Authorization`
+  da solo non previene la scrittura in cache, al massimo isola la voce per
+  variante.
 - **Pagine / RSC payload** → cachate con strategia network-first analoga;
   per route autenticate fare affidamento su `cookies()`/redirect server-side,
   non su "il SW non interferisce".

--- a/.claude/skills/react-patterns/SKILL.md
+++ b/.claude/skills/react-patterns/SKILL.md
@@ -276,12 +276,23 @@ l'ultima classe. Utile per override:
 
 ---
 
-## PWA / Serwist — niente trucchi React
+## PWA / Serwist — attenzione al `defaultCache`
 
-Il service worker (`src/app/sw.ts` + Serwist) intercetta le richieste, ma
-**non** le risposte di Server Action / Route Handler dinamici (rete sempre).
-Non assumere che `fetch` lato client sia cache-first: caching strategy è
-asset-only.
+Il service worker (`src/sw.ts`) usa `runtimeCaching: defaultCache` di
+`@serwist/next/worker`. **Non è asset-only:** `defaultCache` include strategie
+di runtime caching anche per same-origin GET, tra cui una `NetworkFirst` per
+le richieste `/api/*`. Conseguenze:
+
+- **Server Action (POST)** → non cachate, sempre rete.
+- **Route Handler GET sotto `/api/*`** → potenzialmente serviti dalla cache
+  su timeout/offline. Per dati tenant-specifici, sensibili o che cambiano
+  spesso, il handler **deve** dichiarare `Cache-Control: no-store` (e/o
+  `Vary: Cookie/Authorization`) nella response per evitare stale cross-user.
+  In alternativa, override del `runtimeCaching` in `src/sw.ts` con una regola
+  `NetworkOnly` per il pattern specifico, prima di `defaultCache`.
+- **Pagine / RSC payload** → cachate con strategia network-first analoga;
+  per route autenticate fare affidamento su `cookies()`/redirect server-side,
+  non su "il SW non interferisce".
 
 `src/components/pwa/` contiene gli hook lato client per install prompt e
 update detection — sono Client Components che usano `window.matchMedia` e


### PR DESCRIPTION
The previous text claimed the service worker is "asset-only" and Route Handlers / Server Actions are "rete sempre". That is wrong: src/sw.ts uses defaultCache from @serwist/next/worker, which includes a NetworkFirst runtime cache for same-origin /api/ GETs (and analogous strategies for page/RSC payloads).

Rewrite the section to:
- distinguish Server Actions (POST, never cached) from Route Handler GETs (potentially served stale from cache on timeout/offline)
- require Cache-Control: no-store (+ Vary) for tenant/user-specific GET handlers, or a NetworkOnly override in src/sw.ts before defaultCache
- note that authenticated pages must rely on server-side cookies()/redirect, not on the SW staying out of the way