### PR TITLE
Honor APP_HOSTNAME runtime override for sandbox/self-host

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -43,13 +43,14 @@ const nextConfig: NextConfig = {
     // Priorità host: APP_HOSTNAME (runtime override, sandbox/self-host) →
     // NEXT_PUBLIC_APP_HOSTNAME (baked al build) → default. Coerente con
     // auth-actions.ts, trusted-app-url.ts, marketing-to-app-href.ts.
-    const appHostname =
-      process.env.APP_HOSTNAME !== undefined
-        ? parseTrustedHostnameEnv("APP_HOSTNAME", "app.scontrinozero.it")
-        : parseTrustedHostnameEnv(
-            "NEXT_PUBLIC_APP_HOSTNAME",
-            "app.scontrinozero.it",
-          );
+    const appHostnameEnv =
+      process.env.APP_HOSTNAME === undefined
+        ? "NEXT_PUBLIC_APP_HOSTNAME"
+        : "APP_HOSTNAME";
+    const appHostname = parseTrustedHostnameEnv(
+      appHostnameEnv,
+      "app.scontrinozero.it",
+    );
     return [
       {
         source: "/",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import withSerwistInit from "@serwist/next";
+import { parseTrustedHostnameEnv } from "./src/lib/hostname-env";
 import { buildSecurityHeaders } from "./src/lib/security-headers";
 
 const withSerwist = withSerwistInit({
@@ -27,6 +28,34 @@ const nextConfig: NextConfig = {
       {
         source: "/v1/:path*",
         destination: "/api/v1/:path*",
+      },
+    ];
+  },
+  async redirects() {
+    // `/` su dominio app → `/dashboard`. Lo stesso branch esiste in
+    // src/proxy.ts:hostnameRedirect ma in Next.js 16 la landing marketing
+    // (src/app/(marketing)/page.tsx) è prerenderizzata in build e servita
+    // dal Full Route Cache PRIMA che il proxy venga invocato (verificato in
+    // prod v1.3.2: GET https://app.scontrinozero.it/ → 200 con header
+    // `x-nextjs-prerender: 1` + `x-nextjs-cache: HIT`, niente 307).
+    // `redirects()` è valutato a livello routing, prima della FRC → scatta.
+    //
+    // Priorità host: APP_HOSTNAME (runtime override, sandbox/self-host) →
+    // NEXT_PUBLIC_APP_HOSTNAME (baked al build) → default. Coerente con
+    // auth-actions.ts, trusted-app-url.ts, marketing-to-app-href.ts.
+    const appHostname =
+      process.env.APP_HOSTNAME !== undefined
+        ? parseTrustedHostnameEnv("APP_HOSTNAME", "app.scontrinozero.it")
+        : parseTrustedHostnameEnv(
+            "NEXT_PUBLIC_APP_HOSTNAME",
+            "app.scontrinozero.it",
+          );
+    return [
+      {
+        source: "/",
+        has: [{ type: "host", value: appHostname }],
+        destination: "/dashboard",
+        permanent: false,
       },
     ];
   },

--- a/src/lib/hostname-env.ts
+++ b/src/lib/hostname-env.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/lib/logger";
+import { logger } from "./logger";
 
 /**
  * Parses and validates a hostname read from an environment variable.

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -468,6 +468,56 @@ describe("proxy", () => {
       expect(location.hostname).not.toBe("evil.com");
     });
 
+    it("APP_HOSTNAME runtime override is honoured (sandbox/self-host)", async () => {
+      // Su sandbox/self-host l'immagine è buildata con NEXT_PUBLIC_APP_HOSTNAME=
+      // app.scontrinozero.it (baked) ma a runtime APP_HOSTNAME=sandbox.scontrinozero.it
+      // sovrascrive. Senza questa precedenza il proxy cadrebbe in safe-deny
+      // sull'host sandbox e non triggererebbe il redirect / → /dashboard.
+      process.env.APP_HOSTNAME = "sandbox.scontrinozero.it";
+      vi.resetModules();
+      try {
+        const { proxy } = await import("./proxy");
+
+        const response = await proxy(
+          createRequestForHost("/", "sandbox.scontrinozero.it"),
+        );
+        expect(response.status).toBe(307);
+        const location = new URL(response.headers.get("location")!);
+        expect(location.pathname).toBe("/dashboard");
+      } finally {
+        delete process.env.APP_HOSTNAME;
+      }
+    });
+
+    it("APP_HOSTNAME takes precedence over NEXT_PUBLIC_APP_HOSTNAME", async () => {
+      // Both set, runtime override wins. The baked hostname must NOT trigger
+      // the /  → /dashboard branch on its own host.
+      process.env.APP_HOSTNAME = "sandbox.scontrinozero.it";
+      // NEXT_PUBLIC_APP_HOSTNAME stays "app.scontrinozero.it" from beforeEach.
+      vi.resetModules();
+      try {
+        const { proxy } = await import("./proxy");
+
+        // Request on the baked hostname (app.scontrinozero.it): with the
+        // runtime override pointing to sandbox, app.scontrinozero.it is now
+        // OUTSIDE the allowlist → safe-deny, no app-domain redirect to /dashboard.
+        const response = await proxy(
+          createRequestForHost("/", "app.scontrinozero.it"),
+        );
+        // Either passes through (200) or routes through Supabase auth — the
+        // invariant is that no implicit cross-domain redirect was issued.
+        const location = response.headers.get("location");
+        if (location) {
+          const url = new URL(location);
+          expect(url.pathname).not.toBe("/dashboard");
+        } else {
+          expect(response.status).toBe(200);
+        }
+      } finally {
+        delete process.env.APP_HOSTNAME;
+      }
+    });
+
     it("ignores a spoofed Host header when nextUrl.hostname differs", async () => {
       const { proxy } = await import("./proxy");
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -42,10 +42,17 @@ function hostnameRedirect(request: NextRequest): NextResponse | null {
   // (scheme leak, trailing slash, spaces, …) would otherwise alter routing
   // decisions silently. `parseTrustedHostnameEnv` fails closed to the fallback
   // and logs `critical:true` in production.
-  const appHostname = parseTrustedHostnameEnv(
-    "NEXT_PUBLIC_APP_HOSTNAME",
-    "app.scontrinozero.it",
-  );
+  // APP_HOSTNAME (runtime override per sandbox/self-host) > NEXT_PUBLIC_APP_HOSTNAME
+  // (baked al build) > default. Coerente con auth-actions.ts, trusted-app-url.ts,
+  // marketing-to-app-href.ts: senza questa precedenza il middleware su sandbox
+  // confronterebbe contro l'hostname baked di produzione e cadrebbe in safe-deny.
+  const appHostname =
+    process.env.APP_HOSTNAME !== undefined
+      ? parseTrustedHostnameEnv("APP_HOSTNAME", "app.scontrinozero.it")
+      : parseTrustedHostnameEnv(
+          "NEXT_PUBLIC_APP_HOSTNAME",
+          "app.scontrinozero.it",
+        );
   const marketingHostname = parseTrustedHostnameEnv(
     "NEXT_PUBLIC_MARKETING_HOSTNAME",
     "scontrinozero.it",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,13 +46,14 @@ function hostnameRedirect(request: NextRequest): NextResponse | null {
   // (baked al build) > default. Coerente con auth-actions.ts, trusted-app-url.ts,
   // marketing-to-app-href.ts: senza questa precedenza il middleware su sandbox
   // confronterebbe contro l'hostname baked di produzione e cadrebbe in safe-deny.
-  const appHostname =
-    process.env.APP_HOSTNAME !== undefined
-      ? parseTrustedHostnameEnv("APP_HOSTNAME", "app.scontrinozero.it")
-      : parseTrustedHostnameEnv(
-          "NEXT_PUBLIC_APP_HOSTNAME",
-          "app.scontrinozero.it",
-        );
+  const appHostnameEnv =
+    process.env.APP_HOSTNAME === undefined
+      ? "NEXT_PUBLIC_APP_HOSTNAME"
+      : "APP_HOSTNAME";
+  const appHostname = parseTrustedHostnameEnv(
+    appHostnameEnv,
+    "app.scontrinozero.it",
+  );
   const marketingHostname = parseTrustedHostnameEnv(
     "NEXT_PUBLIC_MARKETING_HOSTNAME",
     "scontrinozero.it",


### PR DESCRIPTION
## Summary

Fixes hostname resolution priority in proxy and Next.js config to respect `APP_HOSTNAME` (runtime override) over `NEXT_PUBLIC_APP_HOSTNAME` (baked at build). This ensures sandbox and self-hosted deployments on custom domains work correctly without falling into safe-deny blocks.

## Key Changes

- **`src/proxy.ts`** — Updated `hostnameRedirect()` to check `APP_HOSTNAME` first, then fall back to `NEXT_PUBLIC_APP_HOSTNAME`. Aligns with existing patterns in `auth-actions.ts`, `trusted-app-url.ts`, and `marketing-to-app-href.ts`.
- **`next.config.ts`** — Added `redirects()` handler to redirect `/` → `/dashboard` on the app domain. Necessary because the marketing landing page is prerendered in build and served from Full Route Cache before the proxy runs (verified in prod v1.3.2 with `x-nextjs-prerender: 1` header). Uses same hostname priority as proxy.
- **`src/proxy.test.ts`** — Added two test cases:
  - `APP_HOSTNAME runtime override is honoured (sandbox/self-host)` — verifies that setting `APP_HOSTNAME` at runtime triggers the redirect on that hostname
  - `APP_HOSTNAME takes precedence over NEXT_PUBLIC_APP_HOSTNAME` — verifies that the baked hostname is excluded from the allowlist when runtime override is active, preventing implicit cross-domain redirects

## Implementation Details

- Hostname priority is now consistent across all entry points: `APP_HOSTNAME` (runtime) → `NEXT_PUBLIC_APP_HOSTNAME` (build-time) → default fallback
- Both proxy and Next.js config use `parseTrustedHostnameEnv()` to safely parse and validate hostnames
- Tests use `vi.resetModules()` to reload the proxy module with different environment state
- Follows existing patterns for environment variable handling and safe-deny security model

https://claude.ai/code/session_01869k5voqQkTZxHWaaG6FbJ