### PR TITLE
feat(settings): aggiungi card "Informazioni" con versione e contatto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,7 @@ jobs:
             NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+            BUILD_SHA=${{ github.sha }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# SHA del commit buildato — letto a runtime dal Server Component /dashboard/settings
+ARG BUILD_SHA
+ENV BUILD_SHA=$BUILD_SHA
+
 RUN apk upgrade --no-cache && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -21,6 +21,8 @@ import { ApiKeySection } from "@/components/settings/api-key-section";
 import { PlanBadge } from "@/components/billing/plan-badge";
 import { PlanSelection } from "@/components/billing/plan-selection";
 import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
+import { CONTACT_EMAIL } from "@/lib/contact";
+import { APP_VERSION, getBuildSha } from "@/lib/version";
 
 export default async function SettingsPage({
   searchParams,
@@ -360,6 +362,26 @@ export default async function SettingsPage({
       <ExportDataSection />
 
       <AccountDeleteSection />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Informazioni</CardTitle>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2 text-sm">
+          <p>
+            ScontrinoZero {APP_VERSION} &mdash; build {getBuildSha()}
+          </p>
+          <p>
+            Per dubbi, domande o feedback contattaci:{" "}
+            <a
+              className="text-primary underline"
+              href={`mailto:${CONTACT_EMAIL}`}
+            >
+              {CONTACT_EMAIL}
+            </a>
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import pkg from "../../package.json";
+import { APP_VERSION, getBuildSha } from "./version";
+
+describe("APP_VERSION", () => {
+  it("matches the version in package.json", () => {
+    expect(APP_VERSION).toBe(pkg.version);
+  });
+});
+
+describe("getBuildSha", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 'dev' when BUILD_SHA is not set", () => {
+    vi.stubEnv("BUILD_SHA", "");
+    expect(getBuildSha()).toBe("dev");
+  });
+
+  it("truncates a 40-char SHA to its first 7 characters", () => {
+    vi.stubEnv("BUILD_SHA", "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678");
+    expect(getBuildSha()).toBe("a1b2c3d");
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,10 @@
+import pkg from "../../package.json";
+
+/** Versione semantica dell'app (= tag git), fonte unica in package.json. */
+export const APP_VERSION = pkg.version;
+
+/** SHA breve del commit buildato; "dev" se non iniettato (locale/self-host). */
+export function getBuildSha(): string {
+  const sha = process.env.BUILD_SHA;
+  return sha ? sha.slice(0, 7) : "dev";
+}


### PR DESCRIPTION
Nuova card in fondo a /dashboard/settings che mostra
"ScontrinoZero <versione> — build <sha>" e l'email di supporto.

- src/lib/version.ts: APP_VERSION da package.json, getBuildSha() legge
  process.env.BUILD_SHA (fallback "dev" per locale/self-host)
- la SHA del commit viene iniettata come ENV runtime nello stage runner
  del Dockerfile e passata da deploy.yml come build-arg (github.sha)
- email supporto riusata da CONTACT_EMAIL (src/lib/contact.ts)

https://claude.ai/code/session_01B8nmnKgd5kmD5BsbxCEKgY