### PR TITLE
fix(ade): fail-closed ADE_MODE resolution (review P3.2)

### DIFF
--- a/src/lib/ade/index.test.ts
+++ b/src/lib/ade/index.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getAdeMode, createAdeClient } from "./index";
+import { MockAdeClient } from "./mock-client";
+import { RealAdeClient } from "./real-client";
+
+describe("getAdeMode", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns "real" when ADE_MODE=real (production)', () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("ADE_MODE", "real");
+    expect(getAdeMode()).toBe("real");
+  });
+
+  it('returns "mock" when ADE_MODE=mock (production sandbox)', () => {
+    // Sandbox runs a production build with ADE_MODE=mock — must NOT throw.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("ADE_MODE", "mock");
+    expect(getAdeMode()).toBe("mock");
+  });
+
+  it("throws in production when ADE_MODE is absent (fail-closed)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("ADE_MODE", "");
+    expect(() => getAdeMode()).toThrow(/ADE_MODE non valido o assente/);
+  });
+
+  it("throws in production when ADE_MODE has an unrecognized value", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("ADE_MODE", "REAL"); // wrong case → not recognized
+    expect(() => getAdeMode()).toThrow(/ADE_MODE non valido o assente/);
+  });
+
+  it('falls back to "mock" in test env when ADE_MODE is absent', () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("ADE_MODE", "");
+    expect(getAdeMode()).toBe("mock");
+  });
+
+  it('falls back to "mock" in development when ADE_MODE has a garbage value', () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("ADE_MODE", "nonsense");
+    expect(getAdeMode()).toBe("mock");
+  });
+
+  it('honours an explicit "real" even outside production', () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("ADE_MODE", "real");
+    expect(getAdeMode()).toBe("real");
+  });
+});
+
+describe("createAdeClient", () => {
+  it("returns a MockAdeClient for mode=mock", () => {
+    expect(createAdeClient("mock")).toBeInstanceOf(MockAdeClient);
+  });
+
+  it("returns a RealAdeClient for mode=real", () => {
+    expect(createAdeClient("real")).toBeInstanceOf(RealAdeClient);
+  });
+});

--- a/src/lib/ade/index.ts
+++ b/src/lib/ade/index.ts
@@ -11,6 +11,40 @@ import { RealAdeClient } from "./real-client";
 export type AdeMode = "mock" | "real";
 
 /**
+ * Risolve `ADE_MODE` in modo strict, fail-closed.
+ *
+ * Sostituisce il pattern sparso `(process.env.ADE_MODE as ...) || "mock"`, che
+ * in caso di variabile mancante o con valore inatteso cadeva silenziosamente su
+ * `mock`: in produzione significherebbe far sembrare riuscite emissioni/annulli
+ * fiscali senza interagire davvero con l'AdE.
+ *
+ * Politica:
+ *  - `"real"` o `"mock"` espliciti → usati così come sono.
+ *  - In `NODE_ENV === "production"` un valore assente o non riconosciuto
+ *    fa **throw** (fail-closed): la misconfigurazione esplode subito invece di
+ *    degradare in silenzio.
+ *  - In dev/test si torna a `"mock"` per non richiedere setup esplicito.
+ *
+ * NB: NON si forza `ADE_MODE=real` in produzione. Sia produzione
+ * (`scontrinozero.it`, `ADE_MODE=real`) sia sandbox (`sandbox.scontrinozero.it`,
+ * `ADE_MODE=mock`) girano con `NODE_ENV=production`: imporre `real` romperebbe
+ * la sandbox. Si richiede solo che il valore sia esplicito e valido.
+ */
+export function getAdeMode(): AdeMode {
+  const raw = process.env.ADE_MODE;
+  if (raw === "real" || raw === "mock") return raw;
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      `ADE_MODE non valido o assente in produzione: "${raw ?? ""}". ` +
+        `Imposta esplicitamente ADE_MODE=real (produzione) o ADE_MODE=mock (sandbox).`,
+    );
+  }
+
+  return "mock";
+}
+
+/**
  * Creates an AdeClient instance based on the specified mode.
  *
  * @param mode - "mock" for testing, "real" for production

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -54,6 +54,7 @@ const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockSubmitSale = vi.fn();
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
     login: mockLogin,
     logout: mockLogout,

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -11,7 +11,7 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
-import { createAdeClient } from "@/lib/ade";
+import { createAdeClient, getAdeMode } from "@/lib/ade";
 import { AdePasswordExpiredError } from "@/lib/ade/errors";
 import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
 import { mapSaleToAdePayload } from "@/lib/ade/mapper";
@@ -491,8 +491,7 @@ async function submitSaleToAde(
     deductibleAmount: 0,
   };
 
-  const adeMode = (process.env.ADE_MODE as "mock" | "real") || "mock";
-  const adeClient = createAdeClient(adeMode);
+  const adeClient = createAdeClient(getAdeMode());
   let loggedIn = false;
 
   try {

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -54,6 +54,7 @@ const mockLogout = vi.fn();
 const mockGetDocument = vi.fn();
 const mockSubmitVoid = vi.fn();
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
     login: mockLogin,
     logout: mockLogout,

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -11,7 +11,7 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
-import { createAdeClient } from "@/lib/ade";
+import { createAdeClient, getAdeMode } from "@/lib/ade";
 import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
 import { mapVoidToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
@@ -560,8 +560,7 @@ export async function voidReceiptForBusiness(
   const { codiceFiscale, password, pin, cedentePrestatore } =
     prep.prerequisites;
 
-  const adeMode = (process.env.ADE_MODE as "mock" | "real") || "mock";
-  const adeClient = createAdeClient(adeMode);
+  const adeClient = createAdeClient(getAdeMode());
   let loggedIn = false;
 
   try {

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -78,6 +78,7 @@ const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockGetFiscalData = vi.fn();
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
     login: mockLogin,
     logout: mockLogout,

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -11,7 +11,7 @@ import {
   getEncryptionKey,
   getKeyVersion,
 } from "@/lib/crypto";
-import { createAdeClient } from "@/lib/ade";
+import { createAdeClient, getAdeMode } from "@/lib/ade";
 import {
   AdeAuthError,
   AdeError,
@@ -328,8 +328,7 @@ export async function verifyAdeCredentials(
   const password = decrypt(cred.encryptedPassword, keys);
   const pin = decrypt(cred.encryptedPin, keys);
 
-  const adeMode = (process.env.ADE_MODE as "mock" | "real") || "mock";
-  const adeClient = createAdeClient(adeMode);
+  const adeClient = createAdeClient(getAdeMode());
 
   try {
     await adeClient.login({ codiceFiscale, password, pin });
@@ -543,8 +542,7 @@ export async function changeAdePassword(
   const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);
   const codiceFiscale = decrypt(cred.encryptedCodiceFiscale, keys);
 
-  const adeMode = (process.env.ADE_MODE as "mock" | "real") || "mock";
-  const adeClient = createAdeClient(adeMode);
+  const adeClient = createAdeClient(getAdeMode());
 
   try {
     await adeClient.changePasswordFisconline({

--- a/src/server/receipt-actions.test.ts
+++ b/src/server/receipt-actions.test.ts
@@ -74,6 +74,7 @@ const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockSubmitSale = vi.fn();
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
     login: mockLogin,
     logout: mockLogout,

--- a/src/server/void-actions.test.ts
+++ b/src/server/void-actions.test.ts
@@ -54,6 +54,7 @@ const mockLogout = vi.fn();
 const mockGetDocument = vi.fn();
 const mockSubmitVoid = vi.fn();
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
     login: mockLogin,
     logout: mockLogout,

--- a/tests/unit/receipt-service-password-expired.test.ts
+++ b/tests/unit/receipt-service-password-expired.test.ts
@@ -53,6 +53,7 @@ vi.mock("@/lib/server-auth", () => ({
   fetchAdePrerequisites: mockFetchAdePrerequisites,
 }));
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: mockCreateAdeClient,
 }));
 vi.mock("@/lib/ade/mapper", () => ({

--- a/tests/unit/server-onboarding-actions.test.ts
+++ b/tests/unit/server-onboarding-actions.test.ts
@@ -74,6 +74,7 @@ vi.mock("@/lib/crypto", () => ({
 }));
 
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: mockCreateAdeClient,
 }));
 

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -70,6 +70,7 @@ vi.mock("@/lib/crypto", () => ({
 }));
 
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: mockCreateAdeClient,
 }));
 

--- a/tests/unit/void-service.test.ts
+++ b/tests/unit/void-service.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/server-auth", () => ({
   fetchAdePrerequisites: mockFetchAdePrerequisites,
 }));
 vi.mock("@/lib/ade", () => ({
+  getAdeMode: () => "mock",
   createAdeClient: mockCreateAdeClient,
 }));
 vi.mock("@/lib/ade/mapper", () => ({


### PR DESCRIPTION
## Contesto

Finding **P3.2** della code review: i flussi di verifica/cambio password/emissione/annullo usavano `(process.env.ADE_MODE as "mock" | "real") || "mock"`. Se in produzione la variabile manca o ha un valore inatteso, l'app cadeva **silenziosamente** su `mock` → verifiche/emissioni/annulli sembrerebbero riuscire senza interagire davvero con l'AdE. In ambito fiscale è preferibile **fallire chiuso**.

## Modifiche

Nuovo helper `getAdeMode()` in `src/lib/ade/index.ts`:
- `"real"` / `"mock"` espliciti → passano invariati;
- in `NODE_ENV === "production"` un valore **assente o non riconosciuto** fa `throw` (fail-closed);
- in dev/test fallback a `"mock"` (nessun setup richiesto).

Sostituiti i 4 cast inline: `verifyAdeCredentials`, `changeAdePassword` (`onboarding-actions.ts`), `submitSaleToAde` (`receipt-service.ts`), `voidReceiptForBusiness` (`void-service.ts`).

## ⚠️ Deviazione consapevole dal testo del finding

Il finding suggeriva di *"richiedere esplicitamente `ADE_MODE=real` in produzione"*. **Non l'ho fatto**, perché romperebbe la **sandbox**: per `CLAUDE.md` sia produzione (`scontrinozero.it`, `ADE_MODE=real`) sia sandbox (`sandbox.scontrinozero.it`, `ADE_MODE=mock`) girano con `NODE_ENV=production`. Forzare `real` farebbe crashare la sandbox al primo flusso AdE.

La soluzione adottata cattura comunque la misconfigurazione che il finding teme (valore mancante/garbage → niente fallback silenzioso a mock), richiedendo solo che il valore sia **esplicito e valido**. Se preferisci una distinzione più forte (es. un flag `ADE_SANDBOX=1` dedicato), posso aggiungerla — fammi sapere.

## Test (TDD)

`src/lib/ade/index.test.ts`: 7 nuovi test (real/mock in prod, missing/garbage in prod → throw, fallback dev/test, real esplicito fuori prod). Tutti verdi; `tsc`/ESLint/Prettier puliti.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vKN1KjSZ99yVMCRa8Y9Ya)_