### PR TITLE
fix(validation): UUID-validate server action inputs (review P2.1)

### DIFF
--- a/src/server/receipt-actions.test.ts
+++ b/src/server/receipt-actions.test.ts
@@ -109,8 +109,11 @@ const FAKE_ADE_RESPONSE = {
   errori: [],
 };
 
+// Valid UUID — businessId is a uuid column and the action validates it as such.
+const BIZ_ID = "11111111-1111-4111-8111-111111111111";
+
 const VALID_INPUT: SubmitReceiptInput = {
-  businessId: "biz-789",
+  businessId: BIZ_ID,
   lines: [
     {
       id: "line-1",
@@ -222,6 +225,18 @@ describe("receipt-actions", () => {
 
       expect(result.error).toBeDefined();
       expect(result.error).toContain("Business ID");
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("returns error when businessId is not a valid UUID (no DB query)", async () => {
+      const { emitReceipt } = await import("./receipt-actions");
+      const result = await emitReceipt({
+        ...VALID_INPUT,
+        businessId: "not-a-uuid",
+      });
+
+      expect(result.error).toContain("Business ID");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
       expect(mockInsert).not.toHaveBeenCalled();
     });
 

--- a/src/server/receipt-actions.ts
+++ b/src/server/receipt-actions.ts
@@ -33,7 +33,7 @@ const lineSchema = z.object({
 
 const submitReceiptSchema = z
   .object({
-    businessId: z.string().min(1, "Business ID obbligatorio."),
+    businessId: z.string().uuid("Business ID non valido."),
     lines: z.array(lineSchema).min(1).max(100),
     paymentMethod: z.enum(["PC", "PE"]),
     idempotencyKey: z.string().uuid(),

--- a/src/server/void-actions.test.ts
+++ b/src/server/void-actions.test.ts
@@ -120,6 +120,12 @@ import type { VoidReceiptInput } from "@/types/storico";
 
 const FAKE_USER = { id: "user-123" };
 
+// Valid UUIDs — businessId/documentId/idempotencyKey are uuid columns and the
+// action now validates them as such before any DB query.
+const BIZ_ID = "11111111-1111-4111-8111-111111111111";
+const SALE_DOC_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_DOC_ID = "33333333-3333-4333-8333-333333333333";
+
 const FAKE_SALE_DOC = {
   id: "sale-doc-uuid",
   businessId: "biz-789",
@@ -184,9 +190,9 @@ const FAKE_PREREQUISITES = {
 };
 
 const VALID_VOID_INPUT: VoidReceiptInput = {
-  documentId: "sale-doc-uuid",
+  documentId: SALE_DOC_ID,
   idempotencyKey: "550e8400-e29b-41d4-a716-446655440001",
-  businessId: "biz-789",
+  businessId: BIZ_ID,
 };
 
 // ---------------------------------------------------------------------------
@@ -302,6 +308,30 @@ describe("void-actions", () => {
       expect(mockLogin).not.toHaveBeenCalled();
     });
 
+    it("returns error when documentId is not a valid UUID (no ownership/DB query)", async () => {
+      const { voidReceipt } = await import("./void-actions");
+      const result = await voidReceipt({
+        ...VALID_VOID_INPUT,
+        documentId: "not-a-uuid",
+      });
+
+      expect(result.error).toMatch(/Documento non valido/i);
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    it("returns error when businessId is not a valid UUID", async () => {
+      const { voidReceipt } = await import("./void-actions");
+      const result = await voidReceipt({
+        ...VALID_VOID_INPUT,
+        businessId: "biz-789",
+      });
+
+      expect(result.error).toMatch(/Business ID non valido/i);
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+    });
+
     it("returns error when SALE document is not found (also covers IDOR: wrong businessId)", async () => {
       mockSelect.mockReset();
       mockSelect.mockReturnValueOnce(makeSelectBuilder([])); // saleDoc not found
@@ -321,7 +351,7 @@ describe("void-actions", () => {
       const { voidReceipt } = await import("./void-actions");
       const result = await voidReceipt({
         ...VALID_VOID_INPUT,
-        documentId: "other-business-doc-uuid",
+        documentId: OTHER_DOC_ID,
       });
 
       expect(result.error).toMatch(/non trovato/i);

--- a/src/server/void-actions.ts
+++ b/src/server/void-actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { z } from "zod/v4";
 import { logger } from "@/lib/logger";
 import { getPlan, canEmit } from "@/lib/plans";
 import { RateLimiter } from "@/lib/rate-limit";
@@ -14,6 +15,16 @@ import type { VoidReceiptInput, VoidReceiptResult } from "@/types/storico";
 const voidLimiter = new RateLimiter({
   maxRequests: 10,
   windowMs: 60 * 60 * 1000,
+});
+
+// Runtime validation — businessId/documentId/idempotencyKey are UUID columns
+// in Postgres. Without this guard a tampered client could send a non-UUID and
+// trigger a Postgres "invalid input syntax for type uuid" 500 (log noise + a
+// light DoS surface) instead of a clean application error.
+const voidReceiptSchema = z.object({
+  businessId: z.string().uuid("Business ID non valido."),
+  documentId: z.string().uuid("Documento non valido."),
+  idempotencyKey: z.string().uuid("Chiave di idempotenza non valida."),
 });
 
 export async function voidReceipt(
@@ -34,6 +45,15 @@ export async function voidReceipt(
     return {
       error:
         "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.",
+    };
+  }
+
+  // Validate UUIDs before any DB query so malformed input returns an
+  // application error, not a Postgres uuid-syntax 500.
+  const validation = voidReceiptSchema.safeParse(input);
+  if (!validation.success) {
+    return {
+      error: validation.error.issues[0]?.message ?? "Input non valido.",
     };
   }
 

--- a/tests/_helpers/fixtures.ts
+++ b/tests/_helpers/fixtures.ts
@@ -9,6 +9,8 @@
 
 /** UUID di un Business di test. */
 export const TEST_BUSINESS_ID = "550e8400-e29b-41d4-a716-446655440000";
+/** Secondo UUID di Business di test (quando serve distinguerlo da altri id). */
+export const TEST_BUSINESS_ID_2 = "550e8400-e29b-41d4-a716-446655440002";
 /** UUID per un secondo entity (typically: idempotencyKey, related document). */
 export const TEST_RELATED_ID = "660e8400-e29b-41d4-a716-446655440001";
 /** UUID stabile per usi come idempotencyKey nei test (alias del precedente). */

--- a/tests/unit/server-receipt-actions.test.ts
+++ b/tests/unit/server-receipt-actions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { TEST_BUSINESS_ID } from "../_helpers/fixtures";
+import { TEST_BUSINESS_ID, TEST_BUSINESS_ID_2 } from "../_helpers/fixtures";
 
 // --- Mocks ---
 
@@ -48,7 +48,7 @@ vi.mock("@/lib/services/receipt-service", () => ({
 // --- Helpers ---
 
 const USER_ID = "user-abc";
-const BIZ_ID = "biz-xyz";
+const BIZ_ID = TEST_BUSINESS_ID_2;
 const VALID_UUID = TEST_BUSINESS_ID;
 
 function makeValidInput(overrides: Record<string, unknown> = {}) {

--- a/tests/unit/server-void-actions.test.ts
+++ b/tests/unit/server-void-actions.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { TEST_BUSINESS_ID, TEST_IDEMPOTENCY_KEY } from "../_helpers/fixtures";
+import {
+  TEST_BUSINESS_ID,
+  TEST_BUSINESS_ID_2,
+  TEST_IDEMPOTENCY_KEY,
+} from "../_helpers/fixtures";
 
 // --- Mocks ---
 
@@ -48,7 +52,7 @@ vi.mock("@/lib/services/void-service", () => ({
 // --- Helpers ---
 
 const USER_ID = "user-void";
-const BIZ_ID = "biz-void";
+const BIZ_ID = TEST_BUSINESS_ID_2;
 const VALID_UUID = TEST_BUSINESS_ID;
 
 function makeValidInput(overrides: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Contesto

Finding **P2.1** della code review indipendente: la route API v1 valida gli UUID al boundary, ma le **server action UI** no, in modo non uniforme.

- `emitReceipt` validava `businessId` solo con `z.string().min(1)`, poi lo passava a `checkBusinessOwnership` che lo confronta con una colonna `uuid`.
- `voidReceipt` non aveva **nessuno** schema runtime per `businessId`, `documentId`, `idempotencyKey` prima di interrogare Postgres.

Una chiamata server action manipolata poteva quindi inviare stringhe non-UUID e ottenere un errore Postgres `invalid input syntax for type uuid` → **500/Sentry evitabili**, log noise e una leggera superficie DoS tramite richieste malformate autenticate.

## Modifiche

- `receipt-actions.ts`: `businessId` da `z.string().min(1)` → `z.string().uuid("Business ID non valido.")` nello `submitReceiptSchema` esistente.
- `void-actions.ts`: nuovo `voidReceiptSchema` (`businessId` / `documentId` / `idempotencyKey` tutti `.uuid()`), validato **prima** di `checkBusinessOwnership` e di qualunque query DB.

## Test (TDD)

- `receipt-actions.test.ts`: nuovo test — `businessId` non-UUID → errore applicativo, **nessuna** ownership/DB query. Fixture aggiornate a UUID validi.
- `void-actions.test.ts`: nuovi test — `documentId`/`businessId` non-UUID → errore applicativo prima di ogni query. Fixture aggiornate a UUID validi.

Tutti i test verdi (43/43 sui file toccati), `tsc` / ESLint / Prettier puliti.

## Note

L'API v1 non è impattata: lì `businessId` deriva dalla API key autenticata (`requireBusinessApiAuth`), non da input client, e `idempotencyKey` è già `z.string().uuid()` nel `receiptBodySchema`.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vKN1KjSZ99yVMCRa8Y9Ya)_