### PR TITLE
fix(onboarding): guard fiscal-identity write against stale AdE creds (review P1.1)

### DIFF
--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -996,11 +996,19 @@ describe("onboarding-actions", () => {
         },
       });
 
-      // businesses update OK, profiles update → unique constraint violation
+      // P1.1: la finalizzazione è una sola transazione che parte dall'UPDATE
+      // guardato di verifiedAt, poi businesses, poi profiles. Ordine dei
+      // .set(): [0] adeCredentials.verifiedAt (returning 1 riga → lock OK),
+      // [1] businesses OK, [2] profiles → unique constraint violation.
       const pgConflictError = Object.assign(new Error("unique constraint"), {
         code: "23505",
       });
       mockUpdateSet
+        .mockReturnValueOnce({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: "mock-cred-id" }]),
+          }),
+        }) // adeCredentials verifiedAt (guard)
         .mockReturnValueOnce({ where: vi.fn().mockResolvedValue(undefined) }) // businesses
         .mockReturnValueOnce({
           where: vi.fn().mockRejectedValue(pgConflictError),
@@ -1011,10 +1019,71 @@ describe("onboarding-actions", () => {
 
       expect(result.error).toContain("P.IVA");
       expect(result.businessId).toBeUndefined();
-      // Logout must still be called (finally block)
+      // Logout must still be called (getFiscalData finally block)
       expect(mockLogout).toHaveBeenCalled();
-      // adeCredentials.verifiedAt must NOT be updated (returned early)
-      expect(mockUpdate).toHaveBeenCalledTimes(2); // businesses + profiles only
+      // Tutti e 3 gli UPDATE sono tentati nella stessa transazione (verifiedAt
+      // + businesses + profiles); il vincolo unique su profiles fa il rollback
+      // dell'intera transazione, verifiedAt incluso.
+      expect(mockUpdate).toHaveBeenCalledTimes(3);
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    // P1.1 (code review): se le credenziali vengono sostituite mentre AdE
+    // login/getFiscalData è in corso, l'UPDATE guardato di verifiedAt matcha 0
+    // righe e l'intera transazione viene abbandonata: i dati fiscali della
+    // sessione STALE non devono MAI finire su businesses/profiles. Prima del
+    // fix solo verifiedAt era guardato, mentre vatNumber/fiscalCode/partitaIva
+    // venivano scritti incondizionatamente.
+    it("non scrive i dati fiscali su businesses/profiles se le credenziali cambiano durante la verifica (P1.1)", async () => {
+      // Ownership check
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      // Credentials found
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+          verifiedAt: null,
+        },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+      // Optimistic-lock miss: l'UPDATE guardato di verifiedAt matcha 0 righe.
+      mockUpdateReturning.mockReset();
+      mockUpdateReturning.mockResolvedValue([]);
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      // Ritorno non fatale con businessId (le nuove credenziali verranno
+      // verificate al prossimo tentativo) + warning sulla race.
+      expect(result.businessId).toBe("biz-789");
+      expect(result.error).toBeUndefined();
+      const { logger } = await import("@/lib/logger");
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ businessId: "biz-789" }),
+        expect.stringContaining("credenziali modificate"),
+      );
+
+      // Nessuna scrittura fiscale: l'unico UPDATE è il verifiedAt guardato
+      // (poi rollback). businesses/profiles non vengono toccati.
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      const setPayloads = mockUpdateSet.mock.calls.map((c) => c[0]);
+      const wroteFiscalIdentity = setPayloads.some(
+        (p: Record<string, unknown>) =>
+          "vatNumber" in p || "fiscalCode" in p || "partitaIva" in p,
+      );
+      expect(wroteFiscalIdentity).toBe(false);
       expect(mockSendEmail).not.toHaveBeenCalled();
     });
 
@@ -1108,10 +1177,11 @@ describe("onboarding-actions", () => {
       const { verifyAdeCredentials } = await import("./onboarding-actions");
       await verifyAdeCredentials("biz-789");
 
-      // The last db.update(...).where(...) call targets adeCredentials.verifiedAt.
-      // Render the SQL fragment via the real PgDialect so we observe exactly
-      // what would be sent to postgres-js as bound parameters.
-      const whereArg = mockUpdateWhere.mock.calls.at(-1)?.[0];
+      // P1.1: l'UPDATE guardato di adeCredentials.verifiedAt è ora il PRIMO
+      // statement della transazione di finalizzazione, quindi la prima
+      // chiamata a db.update(...).where(...). Render del fragment SQL via il
+      // vero PgDialect per osservare i parametri inviati a postgres-js.
+      const whereArg = mockUpdateWhere.mock.calls[0]?.[0];
       const dialect = new PgDialect();
       const compiled = dialect.sqlToQuery(whereArg);
 

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -365,69 +365,96 @@ export async function verifyAdeCredentials(
     };
   }
 
+  // Fetch fiscal data from AdE while the session is still active. Best-effort:
+  // verification still succeeds (verifiedAt set) even if AdE doesn't return it;
+  // P.IVA/CF are then filled on a later run.
+  let fiscalData: Awaited<ReturnType<typeof adeClient.getFiscalData>> | null =
+    null;
   try {
-    // Fetch fiscal data from AdE while session is active
-    try {
-      const fiscalData = await adeClient.getFiscalData();
-      const vatNumber = fiscalData.identificativiFiscali.partitaIva;
-      const fiscalCode = fiscalData.identificativiFiscali.codiceFiscale;
-
-      // Wrap both DB writes in a transaction: if the profile update fails (e.g.
-      // unique constraint on partitaIva for trial-abuse detection), the businesses
-      // update must also be rolled back so neither record is left in a partial state.
-      await db.transaction(async (tx) => {
-        await tx
-          .update(businesses)
-          .set({ vatNumber, fiscalCode })
-          .where(eq(businesses.id, businessId));
-
-        // Anti-abuso trial: la P.IVA è UNIQUE su profiles per impedire trial multipli
-        // con email diverse ma stessa P.IVA. Vincolo DB garantisce atomicità.
-        await tx
-          .update(profiles)
-          .set({ partitaIva: vatNumber })
-          .where(eq(profiles.authUserId, user.id));
-      });
-    } catch (err) {
-      if (isUniqueConstraintViolation(err)) {
-        logger.warn({ businessId }, "P.IVA già in uso — possibile abuso trial");
-        return { error: "Questa P.IVA è già associata a un altro account." };
-      }
-      logger.error({ err, businessId }, "Failed to fetch fiscal data from AdE");
-      // Non-blocking per altri errori: verifica comunque riuscita, P.IVA/CF aggiunti in seguito
-    }
+    fiscalData = await adeClient.getFiscalData();
+  } catch (err) {
+    logger.error({ err, businessId }, "Failed to fetch fiscal data from AdE");
   } finally {
     await adeClient
       .logout()
       .catch((err) => logger.warn({ err }, "AdE logout failed"));
   }
 
-  // Mark credentials as verified, but only if they haven't been replaced since
-  // we read them (optimistic locking via updatedAt snapshot taken above).
+  // Finalize atomically AND optimistically in a single transaction guarded by
+  // the credential version snapshotted BEFORE talking to AdE. The guarded
+  // verifiedAt UPDATE is the FIRST statement: if the user replaced the
+  // credentials while AdE login/getFiscalData was in flight, it matches 0 rows
+  // and the whole transaction is abandoned — so fiscal identity from a STALE
+  // session is never written to businesses/profiles (review P1.1). Previously
+  // only verifiedAt was guarded while vatNumber/fiscalCode/partitaIva were
+  // written unconditionally, corrupting the business identity on a concurrent
+  // credential swap.
+  //
   // date_trunc to milliseconds: defaultNow() lets PostgreSQL set updatedAt via
   // NOW() (microsecond precision), but JS Date is only millisecond-precise.
   // Truncating before comparison prevents false mismatches on the first SELECT.
-  //
   // The snapshot is serialized as ISO string + `::timestamptz` cast: inside a
-  // raw `sql` template Drizzle has no column-type context to tell postgres-js
-  // how to bind a JS Date, so passing one directly crashes
-  // `Buffer.byteLength(<Date>)` in postgres-js. ISO string + explicit cast is
-  // safe and lossless (millisecond precision is preserved).
-  const updated = await db
-    .update(adeCredentials)
-    .set({ verifiedAt: new Date() })
-    .where(
-      and(
-        eq(adeCredentials.businessId, businessId),
-        sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion.toISOString()}::timestamptz`,
-      ),
-    )
-    .returning({ id: adeCredentials.id });
+  // raw `sql` template Drizzle has no column-type context to bind a JS Date and
+  // would crash `Buffer.byteLength(<Date>)` in postgres-js.
+  let credentialsChanged = false;
+  try {
+    await db.transaction(async (tx) => {
+      const updated = await tx
+        .update(adeCredentials)
+        .set({ verifiedAt: new Date() })
+        .where(
+          and(
+            eq(adeCredentials.businessId, businessId),
+            sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion.toISOString()}::timestamptz`,
+          ),
+        )
+        .returning({ id: adeCredentials.id });
 
-  if (updated.length === 0) {
-    // Credentials were changed while AdE login was in progress.
-    // Return success with the businessId — the user's new credentials
-    // are not verified yet and will be checked on the next operation.
+      if (updated.length === 0) {
+        // Optimistic-lock miss: credentials replaced during verification.
+        // Abort without writing any fiscal data from the stale session.
+        credentialsChanged = true;
+        return;
+      }
+
+      if (fiscalData) {
+        const vatNumber = fiscalData.identificativiFiscali.partitaIva;
+        const fiscalCode = fiscalData.identificativiFiscali.codiceFiscale;
+
+        await tx
+          .update(businesses)
+          .set({ vatNumber, fiscalCode })
+          .where(eq(businesses.id, businessId));
+
+        // Anti-abuso trial: la P.IVA è UNIQUE su profiles per impedire trial
+        // multipli con email diverse ma stessa P.IVA. Il vincolo DB fa fallire
+        // l'INSERT/UPDATE e l'intera transazione esegue rollback (verifiedAt
+        // incluso), così nessun dato resta in stato parziale.
+        await tx
+          .update(profiles)
+          .set({ partitaIva: vatNumber })
+          .where(eq(profiles.authUserId, user.id));
+      }
+    });
+  } catch (err) {
+    if (isUniqueConstraintViolation(err)) {
+      logger.warn({ businessId }, "P.IVA già in uso — possibile abuso trial");
+      return { error: "Questa P.IVA è già associata a un altro account." };
+    }
+    logger.error(
+      { err, businessId, critical: true },
+      "verifyAdeCredentials: finalizzazione DB fallita dopo verifica AdE",
+    );
+    return {
+      error:
+        "Verifica riuscita ma il salvataggio è fallito. Riprova tra qualche istante.",
+    };
+  }
+
+  if (credentialsChanged) {
+    // Credentials were replaced while AdE login was in progress: neither the
+    // fiscal identity nor verifiedAt was written. The new credentials will be
+    // verified on the next attempt.
     logger.warn(
       { businessId },
       "verifyAdeCredentials: credenziali modificate durante verifica, verifiedAt non impostato",


### PR DESCRIPTION
## Contesto

Finding **P1.1** della code review indipendente (fiscalmente critico). `verifyAdeCredentials` scriveva `vatNumber`/`fiscalCode` su `businesses` e `partitaIva` su `profiles` **prima** del controllo ottimistico su `adeCredentials.updatedAt`, che proteggeva **solo** l'UPDATE finale di `verifiedAt`.

**Scenario:** l'utente avvia la verifica delle credenziali A; mentre `login()`/`getFiscalData()` è in corso salva credenziali B (che resetta `verifiedAt`); la verifica A completa e scrive l'identità fiscale della sessione **stale** su `businesses`/`profiles`. Solo `verifiedAt` restava (correttamente) non impostato — ma l'account restava associato a dati fiscali non corrispondenti alle credenziali correnti, impattando intestazione scontrini, anti-abuso trial su P.IVA e audit fiscale.

## Fix

Un'unica **transazione di finalizzazione** guardata dalla versione delle credenziali snapshottata **prima** di contattare AdE:

1. L'UPDATE di `verifiedAt` (guardato da `date_trunc('milliseconds', updatedAt) = <snapshot ISO>::timestamptz`) è ora il **primo** statement della transazione.
2. Se matcha **0 righe** (credenziali sostituite durante la verifica) → la transazione viene abbandonata: **nessun dato fiscale dalla sessione stale** tocca `businesses`/`profiles`.
3. `getFiscalData()` + `logout()` restano **fuori** dalla transazione (best-effort: la verifica resta non bloccante se AdE non restituisce i dati).
4. La violazione UNIQUE su `profiles.partitaIva` (anti-abuso trial) fa il **rollback dell'intera transazione**, `verifiedAt` incluso.

## Test (TDD)

- **Nuova regressione**: `non scrive i dati fiscali su businesses/profiles se le credenziali cambiano durante la verifica (P1.1)` — optimistic-lock miss → solo l'UPDATE guardato di `verifiedAt` (poi rollback), **nessun** `set` con `vatNumber`/`fiscalCode`/`partitaIva`, warning loggato, `businessId` ritornato (non fatale).
- Aggiornati i 2 test che assumevano il vecchio ordinamento (`verifiedAt` come UPDATE separato **dopo** la transazione): ora l'ordine dei `.set()` è verifiedAt → businesses → profiles, e l'UPDATE guardato è la prima `.where()`.

Suite completa **2546 verdi**; `tsc` / ESLint / Prettier puliti.

## Note

Nessuna migration: fix solo applicativo. Gli altri P1 (P1.2 business duplicati, P1.3 recovery concorrente, P1.4 idempotency payload) restano a backlog in `PLAN.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vKN1KjSZ99yVMCRa8Y9Ya)_