### PR TITLE
fix(auth): valida action_link reset password contro l'host Supabase + redirect_to

### DIFF
--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -129,14 +129,18 @@ describe("auth-actions", () => {
     vi.clearAllMocks();
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
     mockRateLimiterCheck.mockReturnValue({ success: true, remaining: 4 });
     // Default: action="signup" (most-tested). signIn / resetPassword describe
     // blocks override this in nested beforeEach with the matching action.
     mockFetch.mockResolvedValue(captchaResponse("signup"));
+    // generateLink returns an action_link on the SUPABASE host, carrying the app
+    // host in the redirect_to param (the real GoTrue /auth/v1/verify shape).
     mockGenerateLink.mockResolvedValue({
       data: {
         properties: {
-          action_link: "https://app.scontrinozero.it/auth/recovery?token=abc",
+          action_link:
+            "https://test.supabase.co/auth/v1/verify?token=abc&type=recovery&redirect_to=https://app.scontrinozero.it/callback",
         },
       },
       error: null,
@@ -1256,6 +1260,7 @@ describe("auth-actions", () => {
       expect(mockGenerateLink).toHaveBeenCalledWith({
         type: "recovery",
         email: "test@example.com",
+        options: { redirectTo: "https://app.scontrinozero.it/callback" },
       });
     });
 
@@ -1345,11 +1350,12 @@ describe("auth-actions", () => {
       expect(redirectUrl).toBe("/verify-email");
     });
 
-    it("does not send email when action_link points to unexpected host", async () => {
+    it("does not send email when action_link host is not the Supabase host", async () => {
       mockGenerateLink.mockResolvedValue({
         data: {
           properties: {
-            action_link: "https://evil.example.com/auth/recovery?token=abc",
+            action_link:
+              "https://evil.example.com/auth/v1/verify?token=abc&redirect_to=https://app.scontrinozero.it/callback",
           },
         },
         error: null,
@@ -1373,7 +1379,85 @@ describe("auth-actions", () => {
       expect(mockSendEmail).not.toHaveBeenCalled();
     });
 
-    it("sends email when action_link matches expected hostname", async () => {
+    it("does not send email when redirect_to host is not the app host", async () => {
+      mockGenerateLink.mockResolvedValue({
+        data: {
+          properties: {
+            action_link:
+              "https://test.supabase.co/auth/v1/verify?token=abc&redirect_to=https://evil.example.com/callback",
+          },
+        },
+        error: null,
+      });
+
+      const { resetPassword } = await import("./auth-actions");
+
+      try {
+        await resetPassword(
+          formData({ email: "test@example.com", captchaToken: "valid-token" }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+        if (isRedirectError(err)) {
+          expect(err.url).toBe("/verify-email");
+        }
+      }
+
+      await Promise.resolve();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("does not send email when redirect_to is missing from action_link", async () => {
+      mockGenerateLink.mockResolvedValue({
+        data: {
+          properties: {
+            action_link: "https://test.supabase.co/auth/v1/verify?token=abc",
+          },
+        },
+        error: null,
+      });
+
+      const { resetPassword } = await import("./auth-actions");
+
+      try {
+        await resetPassword(
+          formData({ email: "test@example.com", captchaToken: "valid-token" }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+        if (isRedirectError(err)) {
+          expect(err.url).toBe("/verify-email");
+        }
+      }
+
+      await Promise.resolve();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("does not send email when NEXT_PUBLIC_SUPABASE_URL is missing", async () => {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+      const { resetPassword } = await import("./auth-actions");
+
+      try {
+        await resetPassword(
+          formData({ email: "test@example.com", captchaToken: "valid-token" }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+        if (isRedirectError(err)) {
+          expect(err.url).toBe("/verify-email");
+        }
+      }
+
+      await Promise.resolve();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("sends email when action_link is on the Supabase host and redirect_to on the app host", async () => {
       const { resetPassword } = await import("./auth-actions");
 
       try {
@@ -1390,7 +1474,7 @@ describe("auth-actions", () => {
       );
     });
 
-    it("APP_HOSTNAME takes precedence over NEXT_PUBLIC_APP_HOSTNAME for action_link validation", async () => {
+    it("APP_HOSTNAME takes precedence over NEXT_PUBLIC_APP_HOSTNAME for redirect_to validation", async () => {
       process.env.APP_HOSTNAME = "sandbox.scontrinozero.it";
       process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
       mockFetch.mockResolvedValueOnce(
@@ -1400,7 +1484,7 @@ describe("auth-actions", () => {
         data: {
           properties: {
             action_link:
-              "https://sandbox.scontrinozero.it/auth/recovery?token=abc",
+              "https://test.supabase.co/auth/v1/verify?token=abc&redirect_to=https://sandbox.scontrinozero.it/callback",
           },
         },
         error: null,
@@ -1415,6 +1499,12 @@ describe("auth-actions", () => {
         // redirect expected
       }
 
+      // redirectTo is built from APP_HOSTNAME (sandbox), not NEXT_PUBLIC_APP_HOSTNAME
+      expect(mockGenerateLink).toHaveBeenCalledWith({
+        type: "recovery",
+        email: "test@example.com",
+        options: { redirectTo: "https://sandbox.scontrinozero.it/callback" },
+      });
       await Promise.resolve();
       expect(mockSendEmail).toHaveBeenCalledWith(
         expect.objectContaining({ to: "test@example.com" }),
@@ -1423,10 +1513,10 @@ describe("auth-actions", () => {
       delete process.env.APP_HOSTNAME;
     });
 
-    it("falls back to hardcoded default hostname for action_link validation when both env vars are unset", async () => {
+    it("falls back to hardcoded default hostname for redirect_to validation when both env vars are unset", async () => {
       delete process.env.APP_HOSTNAME;
       delete process.env.NEXT_PUBLIC_APP_HOSTNAME;
-      // mockGenerateLink already returns action_link with "app.scontrinozero.it" by default
+      // default mockGenerateLink returns redirect_to on "app.scontrinozero.it"
 
       const { resetPassword } = await import("./auth-actions");
       try {

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -480,10 +480,20 @@ export async function resetPassword(
   const rateLimited = checkRateLimit(ip, "resetPassword");
   if (rateLimited) return rateLimited;
 
+  const appHostname =
+    process.env.APP_HOSTNAME ?? // runtime override (sandbox, self-hosted)
+    process.env.NEXT_PUBLIC_APP_HOSTNAME ?? // baked at build time
+    "app.scontrinozero.it";
+
   const supabaseAdmin = createAdminSupabaseClient();
   const { data, error } = await supabaseAdmin.auth.admin.generateLink({
     type: "recovery",
     email,
+    // Pin where the user lands after Supabase verifies the token. Must be in the
+    // Supabase Redirect URLs allow-list (the /callback route already is — used by
+    // signup/OAuth), otherwise GoTrue falls back to the Site URL. Makes the
+    // redirect_to validated below deterministic, not dependent on dashboard config.
+    options: { redirectTo: `https://${appHostname}/callback` },
   });
 
   if (error || !data.properties?.action_link) {
@@ -495,28 +505,48 @@ export async function resetPassword(
     redirect("/verify-email");
   }
 
-  // Defensive check: ensure the generated link points to our own domain.
-  // Parse the URL explicitly instead of using startsWith — a prefix check can be
-  // bypassed via subdomain spoofing (e.g., https://app.scontrinozero.it.evil.tld/).
-  const expectedHostname =
-    process.env.APP_HOSTNAME ?? // runtime override (sandbox, self-hosted)
-    process.env.NEXT_PUBLIC_APP_HOSTNAME ?? // baked at build time
-    "app.scontrinozero.it";
+  // Defensive check: the link the user clicks must point to OUR Supabase issuer
+  // (the /auth/v1/verify endpoint), and its embedded redirect_to must point back
+  // to OUR app domain. generateLink returns an action_link on the SUPABASE project
+  // host (e.g. <ref>.supabase.co), NOT on the app host — so the action_link is
+  // validated against NEXT_PUBLIC_SUPABASE_URL, while redirect_to carries the app
+  // host. Parse the URLs explicitly instead of using startsWith — a prefix check
+  // can be bypassed via subdomain spoofing (e.g., https://<host>.evil.tld/).
   const actionLink = data.properties.action_link;
+  let supabaseHostname: string | null = null;
+  try {
+    supabaseHostname = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL ?? "")
+      .hostname;
+  } catch {
+    // Missing or malformed NEXT_PUBLIC_SUPABASE_URL — treat as mismatch
+  }
   let parsedActionLink: URL | null = null;
   try {
     parsedActionLink = new URL(actionLink);
   } catch {
     // Malformed URL — treat as mismatch
   }
+  let parsedRedirectTo: URL | null = null;
+  try {
+    parsedRedirectTo = new URL(
+      parsedActionLink?.searchParams.get("redirect_to") ?? "",
+    );
+  } catch {
+    // Missing or malformed redirect_to — treat as mismatch
+  }
   if (
+    !supabaseHostname ||
     parsedActionLink?.protocol !== "https:" ||
-    parsedActionLink?.hostname !== expectedHostname
+    parsedActionLink.hostname !== supabaseHostname ||
+    parsedRedirectTo?.protocol !== "https:" ||
+    parsedRedirectTo.hostname !== appHostname
   ) {
     logger.error(
       {
-        hostname: parsedActionLink?.hostname ?? null,
-        expectedHostname,
+        actionLinkHostname: parsedActionLink?.hostname ?? null,
+        supabaseHostname,
+        redirectToHostname: parsedRedirectTo?.hostname ?? null,
+        appHostname,
         hasToken: true,
       },
       "Reset password: action_link hostname mismatch or invalid URL — email not sent",

--- a/tests/unit/auth-actions-reset-password.test.ts
+++ b/tests/unit/auth-actions-reset-password.test.ts
@@ -96,13 +96,17 @@ function setupRedirectThrows(): void {
 }
 
 const VALID_EMAIL = "user@example.com";
-const EXPECTED_HOSTNAME = "app.scontrinozero.it";
-const VALID_ACTION_LINK = `https://${EXPECTED_HOSTNAME}/auth/v1/verify?token=abc123`;
+const APP_HOSTNAME = "app.scontrinozero.it";
+const SUPABASE_HOSTNAME = "test.supabase.co";
+// generateLink returns a link on the SUPABASE host (/auth/v1/verify), carrying
+// the app host in the redirect_to param — the real GoTrue shape.
+const VALID_ACTION_LINK = `https://${SUPABASE_HOSTNAME}/auth/v1/verify?token=abc123&type=recovery&redirect_to=https://${APP_HOSTNAME}/callback`;
 
 describe("resetPassword — hostname validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NEXT_PUBLIC_APP_HOSTNAME = EXPECTED_HOSTNAME;
+    process.env.NEXT_PUBLIC_APP_HOSTNAME = APP_HOSTNAME;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = `https://${SUPABASE_HOSTNAME}`;
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     mockRateLimiterCheck.mockReturnValue({ success: true });
     mockSendEmail.mockResolvedValue(undefined);
@@ -111,14 +115,14 @@ describe("resetPassword — hostname validation", () => {
       ok: true,
       json: async () => ({
         success: true,
-        hostname: EXPECTED_HOSTNAME,
+        hostname: APP_HOSTNAME,
         action: "reset-password",
       }),
     });
     setupRedirectThrows();
   });
 
-  it("accepts a valid action link with the expected hostname and sends email", async () => {
+  it("accepts a link on the Supabase host with app-host redirect_to and sends email", async () => {
     mockSuccessfulGenerateLink(VALID_ACTION_LINK);
 
     const { resetPassword } = await import("@/server/auth-actions");
@@ -130,9 +134,9 @@ describe("resetPassword — hostname validation", () => {
     expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
-  it("blocks subdomain-spoofing URL (e.g., app.scontrinozero.it.evil.tld)", async () => {
+  it("blocks subdomain-spoofing of the Supabase host (e.g., test.supabase.co.evil.tld)", async () => {
     mockSuccessfulGenerateLink(
-      `https://${EXPECTED_HOSTNAME}.evil.tld/auth/v1/verify?token=abc`,
+      `https://${SUPABASE_HOSTNAME}.evil.tld/auth/v1/verify?token=abc&redirect_to=https://${APP_HOSTNAME}/callback`,
     );
 
     const { resetPassword } = await import("@/server/auth-actions");
@@ -143,8 +147,8 @@ describe("resetPassword — hostname validation", () => {
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockLoggerError).toHaveBeenCalledWith(
       expect.objectContaining({
-        hostname: `${EXPECTED_HOSTNAME}.evil.tld`,
-        expectedHostname: EXPECTED_HOSTNAME,
+        actionLinkHostname: `${SUPABASE_HOSTNAME}.evil.tld`,
+        supabaseHostname: SUPABASE_HOSTNAME,
         hasToken: true,
       }),
       expect.stringContaining("hostname mismatch"),
@@ -156,9 +160,9 @@ describe("resetPassword — hostname validation", () => {
     );
   });
 
-  it("blocks URL where expected hostname appears only in query string", async () => {
+  it("blocks subdomain-spoofing of the app host in redirect_to", async () => {
     mockSuccessfulGenerateLink(
-      `https://evil.com/?next=https://${EXPECTED_HOSTNAME}/reset`,
+      `https://${SUPABASE_HOSTNAME}/auth/v1/verify?token=abc&redirect_to=https://${APP_HOSTNAME}.evil.tld/callback`,
     );
 
     const { resetPassword } = await import("@/server/auth-actions");
@@ -168,14 +172,17 @@ describe("resetPassword — hostname validation", () => {
 
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockLoggerError).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedHostname: EXPECTED_HOSTNAME }),
+      expect.objectContaining({
+        redirectToHostname: `${APP_HOSTNAME}.evil.tld`,
+        appHostname: APP_HOSTNAME,
+      }),
       expect.stringContaining("hostname mismatch"),
     );
   });
 
-  it("blocks a URL served over plain HTTP (not HTTPS)", async () => {
+  it("blocks a link where the app host appears only in the action_link query string", async () => {
     mockSuccessfulGenerateLink(
-      `http://${EXPECTED_HOSTNAME}/auth/v1/verify?token=abc`,
+      `https://evil.com/?next=https://${APP_HOSTNAME}/reset`,
     );
 
     const { resetPassword } = await import("@/server/auth-actions");
@@ -185,7 +192,24 @@ describe("resetPassword — hostname validation", () => {
 
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockLoggerError).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedHostname: EXPECTED_HOSTNAME }),
+      expect.objectContaining({ supabaseHostname: SUPABASE_HOSTNAME }),
+      expect.stringContaining("hostname mismatch"),
+    );
+  });
+
+  it("blocks a link served over plain HTTP (not HTTPS)", async () => {
+    mockSuccessfulGenerateLink(
+      `http://${SUPABASE_HOSTNAME}/auth/v1/verify?token=abc&redirect_to=https://${APP_HOSTNAME}/callback`,
+    );
+
+    const { resetPassword } = await import("@/server/auth-actions");
+    await expect(resetPassword(makeFormData(VALID_EMAIL))).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ supabaseHostname: SUPABASE_HOSTNAME }),
       expect.stringContaining("hostname mismatch"),
     );
   });
@@ -201,6 +225,39 @@ describe("resetPassword — hostname validation", () => {
     expect(mockSendEmail).not.toHaveBeenCalled();
   });
 
+  it("blocks a link missing the redirect_to param", async () => {
+    mockSuccessfulGenerateLink(
+      `https://${SUPABASE_HOSTNAME}/auth/v1/verify?token=abc`,
+    );
+
+    const { resetPassword } = await import("@/server/auth-actions");
+    await expect(resetPassword(makeFormData(VALID_EMAIL))).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectToHostname: null }),
+      expect.stringContaining("hostname mismatch"),
+    );
+  });
+
+  it("blocks when NEXT_PUBLIC_SUPABASE_URL is missing", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    mockSuccessfulGenerateLink(VALID_ACTION_LINK);
+
+    const { resetPassword } = await import("@/server/auth-actions");
+    await expect(resetPassword(makeFormData(VALID_EMAIL))).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ supabaseHostname: null }),
+      expect.stringContaining("hostname mismatch"),
+    );
+  });
+
   it("blocks a malformed (non-URL) action link", async () => {
     mockSuccessfulGenerateLink("not-a-valid-url-at-all");
 
@@ -211,7 +268,7 @@ describe("resetPassword — hostname validation", () => {
 
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockLoggerError).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedHostname: EXPECTED_HOSTNAME }),
+      expect.objectContaining({ actionLinkHostname: null }),
       expect.stringContaining("invalid URL"),
     );
   });


### PR DESCRIPTION
generateLink({ type: "recovery" }) restituisce sempre un action_link
sull'host del progetto Supabase (<ref>.supabase.co/auth/v1/verify), mai
sull'host dell'app. Il check difensivo lo confrontava con APP_HOSTNAME
(app.scontrinozero.it), quindi falliva su ogni reset reale in produzione:
l'email non veniva mai inviata e si finiva su /verify-email.

Ora:
- generateLink riceve un redirectTo esplicito verso https://<appHost>/callback
  (deterministico, già in allow-list — usato da signup/OAuth);
- l'action_link è validato contro l'host di NEXT_PUBLIC_SUPABASE_URL (https);
- il redirect_to estratto è validato contro l'app host (https).

Aggiornati i test (mock action_link con la forma GoTrue reale + nuovi casi:
redirect_to host errato/mancante, NEXT_PUBLIC_SUPABASE_URL mancante).

Fixes SCONTRINOZERO-D

https://claude.ai/code/session_01JKB9C5EZDuCHMpdbasRwBo