### PR TITLE
Add per-IP rate limiting to public receipt page /r/[documentId]

### DIFF
--- a/src/app/r/[documentId]/page.test.tsx
+++ b/src/app/r/[documentId]/page.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ERROR_MESSAGES } from "@/lib/error-messages";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const mockFetchPublicReceipt = vi.hoisted(() => vi.fn());
+const mockHeaders = vi.hoisted(() => vi.fn());
+const mockNotFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+);
+
+vi.mock("@/lib/receipts/fetch-public-receipt", () => ({
+  fetchPublicReceipt: (...args: unknown[]) => mockFetchPublicReceipt(...args),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: (...args: unknown[]) => mockHeaders(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: (...args: unknown[]) => mockNotFound(...args),
+}));
+
+// Note: get-client-ip and rate-limit use real implementations.
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const VALID_DOC_ID = "123e4567-e89b-12d3-a456-426614174000";
+
+const MOCK_RECEIPT_DATA = {
+  doc: {
+    id: "doc-1",
+    publicRequest: { paymentMethod: "PC" },
+    adeProgressive: "ABC-123",
+    createdAt: new Date("2026-01-01T10:00:00Z"),
+  },
+  biz: {
+    businessName: "Bar Mario",
+    address: "Via Roma 1",
+    city: "Milano",
+    province: "MI",
+    zipCode: "20100",
+    vatNumber: "12345678901",
+  },
+  lines: [],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("PublicReceiptPage rate limiting", () => {
+  // Fresh import per test: the rate limiter is a module-level singleton, so
+  // vi.resetModules() resets the 60-request budget between cases.
+  let PublicReceiptPage: typeof import("./page").default;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "1.2.3.4" }),
+    );
+    vi.resetModules();
+    ({ default: PublicReceiptPage } = await import("./page"));
+  });
+
+  function renderPage(documentId = VALID_DOC_ID) {
+    return PublicReceiptPage({ params: Promise.resolve({ documentId }) });
+  }
+
+  it("renders the receipt when under the rate limit", async () => {
+    mockFetchPublicReceipt.mockResolvedValue(MOCK_RECEIPT_DATA);
+
+    render(await renderPage());
+
+    expect(screen.getByText("Bar Mario")).toBeInTheDocument();
+    expect(mockFetchPublicReceipt).toHaveBeenCalledWith(VALID_DOC_ID);
+  });
+
+  it("renders the rate-limit message after exceeding 60 requests per IP", async () => {
+    mockFetchPublicReceipt.mockResolvedValue(MOCK_RECEIPT_DATA);
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "9.9.9.9" }),
+    );
+
+    // Exhaust the 60-request budget for this IP (advance the limiter without
+    // mounting — testing-library does not auto-clean DOM between renders within
+    // a single test).
+    for (let i = 0; i < 60; i++) {
+      await renderPage();
+    }
+
+    render(await renderPage());
+
+    expect(
+      screen.getByText(ERROR_MESSAGES.RATE_LIMIT_PUBLIC_MINUTES),
+    ).toBeInTheDocument();
+  });
+
+  it("does not query the DB once the limit is exceeded", async () => {
+    mockFetchPublicReceipt.mockResolvedValue(MOCK_RECEIPT_DATA);
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "8.8.8.8" }),
+    );
+
+    for (let i = 0; i < 60; i++) {
+      await renderPage();
+    }
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "8.8.8.8" }),
+    );
+
+    await renderPage();
+
+    expect(mockFetchPublicReceipt).not.toHaveBeenCalled();
+  });
+
+  it("keys the limit per IP — a different IP gets its own budget", async () => {
+    mockFetchPublicReceipt.mockResolvedValue(MOCK_RECEIPT_DATA);
+
+    // Exhaust IP 1.1.1.1.
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "1.1.1.1" }),
+    );
+    for (let i = 0; i < 61; i++) {
+      await renderPage();
+    }
+
+    // A distinct IP is unaffected.
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "2.2.2.2" }),
+    );
+    render(await renderPage());
+
+    expect(screen.getByText("Bar Mario")).toBeInTheDocument();
+    expect(mockFetchPublicReceipt).toHaveBeenCalledWith(VALID_DOC_ID);
+  });
+});

--- a/src/app/r/[documentId]/page.test.tsx
+++ b/src/app/r/[documentId]/page.test.tsx
@@ -21,7 +21,7 @@ vi.mock("next/headers", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  notFound: (...args: unknown[]) => mockNotFound(...args),
+  notFound: () => mockNotFound(),
 }));
 
 // Note: get-client-ip and rate-limit use real implementations.

--- a/src/app/r/[documentId]/page.tsx
+++ b/src/app/r/[documentId]/page.tsx
@@ -1,7 +1,11 @@
 import { notFound } from "next/navigation";
+import { headers } from "next/headers";
 import { Download } from "lucide-react";
 import type { Metadata } from "next";
 import { fetchPublicReceipt } from "@/lib/receipts/fetch-public-receipt";
+import { getClientIp } from "@/lib/get-client-ip";
+import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
+import { ERROR_MESSAGES } from "@/lib/error-messages";
 import { computeReceiptTotals } from "@/lib/receipts/document-lines";
 import { formatFiscalDateTime } from "@/lib/date-utils";
 import { PAYMENT_LABELS, formatReceiptPrice } from "@/lib/receipt-format";
@@ -19,6 +23,14 @@ export const metadata: Metadata = {
   title: "Documento Commerciale | ScontrinoZero",
   robots: { index: false, follow: false },
 };
+
+// Rate limit: 60 richieste/ora per IP — parità con la sibling route /pdf.
+// Bucket separato (chiave `receipt-page:`) così che le viste della pagina e i
+// download PDF abbiano budget indipendenti.
+const pageLimiter = new RateLimiter({
+  maxRequests: 60,
+  windowMs: RATE_LIMIT_WINDOWS.HOURLY,
+});
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -38,6 +50,22 @@ export default async function PublicReceiptPage({
   readonly params: Promise<{ documentId: string }>;
 }) {
   const { documentId } = await params;
+
+  // Rate-limit per-IP PRIMA della query DB non autenticata (fetchPublicReceipt).
+  // headers() è async in Next 16. Un RSC non può restituire un 429 reale come una
+  // Route Handler, ma la pagina è robots:noindex: rendiamo un blocco "troppe
+  // richieste" (HTTP 200) saltando la query — l'obiettivo anti-abuso è raggiunto.
+  const ip = getClientIp(await headers());
+  if (!pageLimiter.check(`receipt-page:${ip}`).success) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+        <p className="text-center text-sm text-gray-600">
+          {ERROR_MESSAGES.RATE_LIMIT_PUBLIC_MINUTES}
+        </p>
+      </div>
+    );
+  }
+
   const data = await fetchPublicReceipt(documentId);
 
   if (!data) notFound();


### PR DESCRIPTION
The public receipt HTML page ran an unauthenticated DB query
(fetchPublicReceipt) on every hit with no rate limiting, while its sibling
PDF route already capped 60 req/h per IP. Add parity: gate per-IP before the
DB query using the existing RateLimiter, getClientIp and
ERROR_MESSAGES.RATE_LIMIT_PUBLIC_MINUTES.

A Server Component can't return a real 429, but the page is robots:noindex,
so on exceed it renders a "troppe richieste" block (HTTP 200) while skipping
the DB query — the anti-abuse goal is met. Separate bucket (receipt-page:)
keeps page-view and PDF-download budgets independent.

https://claude.ai/code/session_01Psxsus5fJP9rxztf2SZsX4