### PR TITLE
Add dev environment on Raspberry Pi with push-based auto-deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,82 @@
+name: Deploy (dev)
+
+# Ambiente dev su Raspberry Pi 5 (arm64). A differenza di prod/sandbox
+# (deploy tag-based vX.Y.Z, immagine linux/amd64), dev traccia `main`:
+# a ogni push (commit diretto o merge di PR) ricompila l'immagine arm64,
+# la pubblica su GHCR come :dev e notifica il Pi via webhook.
+on:
+  push:
+    branches:
+      - main
+
+# L'ultimo push su main vince: annulla eventuali build dev in corso.
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-deploy:
+    # Runner ARM nativo (gratis sui repo pubblici): build arm64 senza QEMU.
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (arm64, :dev)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          # Cache GHA isolata da quella di prod (amd64) per evitare collisioni.
+          cache-from: type=gha,scope=dev-arm64
+          cache-to: type=gha,mode=max,scope=dev-arm64
+          build-args: |
+            NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          # NEXT_PUBLIC_TURNSTILE_SITE_KEY è l'unica NEXT_PUBLIC_* letta in un
+          # client component (turnstile-widget.tsx) → inlinata nel bundle al
+          # build, quindi va passata. Dev riusa la stessa key di prod (il
+          # dominio dev è nell'allowlist Turnstile).
+          # Le altre NEXT_PUBLIC_* (Supabase, hostname, APP_URL) sono lette
+          # server-side a runtime in modalità standalone → bastano nel .env del Pi.
+          # Sentry OFF su dev: niente NEXT_PUBLIC_SENTRY_DSN (no DSN nel bundle)
+          # né SENTRY_AUTH_TOKEN/ORG/PROJECT (no upload source-map).
+
+      - name: Trigger Raspberry Pi deploy
+        env:
+          DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+          DEPLOY_HMAC_SECRET: ${{ secrets.DEPLOY_HMAC_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          BODY="$(printf '{"sha":"%s","ref":"%s"}' "${GITHUB_SHA}" "${GITHUB_REF_NAME}")"
+          # Firma HMAC-SHA256 del body — verificata da adnanh/webhook sul Pi.
+          SIG="$(printf '%s' "${BODY}" \
+            | openssl dgst -sha256 -hmac "${DEPLOY_HMAC_SECRET}" \
+            | sed 's/^.*=[[:space:]]*//')"
+          # CF Access service token: bloccato all'edge prima di arrivare al Pi.
+          curl --fail --silent --show-error --retry 3 --retry-delay 5 \
+            -X POST "${DEPLOY_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            -H "X-Hub-Signature-256: sha256=${SIG}" \
+            -d "${BODY}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,13 @@ Drizzle ORM · Supabase Auth · Stripe (`2026-02-25.clover`) · Resend · Sentry
 pino · Umami · SonarCloud · Vitest. Deploy Docker self-hosted su VPS dietro
 Cloudflare Tunnel.
 
-**Due ambienti** sulla stessa VPS:
+**Tre ambienti:**
 
-- **Produzione** — `scontrinozero.it` · `ADE_MODE=real` · Stripe live
-- **Sandbox** — `sandbox.scontrinozero.it` · `ADE_MODE=mock` · Stripe test
+- **Produzione** — `scontrinozero.it` · `ADE_MODE=real` · Stripe live · VPS
+- **Sandbox** — `sandbox.scontrinozero.it` · `ADE_MODE=mock` · Stripe test · VPS
+- **Dev** — `dev.scontrinozero.it` (+ `app-dev`/`api-dev`) · `ADE_MODE=mock` ·
+  Stripe test · Raspberry Pi 5 (arm64). Auto-deploy a ogni push su `main`.
+  Setup completo in `deploy/dev/README.md`.
 
 Versione corrente in `package.json`. Roadmap in `PLAN.md`. Storico release dai
 tag git (`git tag -l "v1.*"`).
@@ -152,6 +155,24 @@ VPS (Cloudflare Access SSH):
 passate come `--build-arg` al `docker build`. `APP_HOSTNAME` (senza
 `NEXT_PUBLIC_`) è runtime e sovrascrive l'hostname baked — usato per sandbox
 e self-hosting su dominio custom.
+
+> Nota: un'unica immagine Docker serve prod/sandbox/dev/self-hosted perché la
+> maggior parte delle `NEXT_PUBLIC_*` (Supabase, `APP_URL`, hostname) è letta
+> **server-side a runtime** in modalità standalone (no inlining nel bundle
+> client). Sono baked nel bundle SOLO quelle lette in un client component —
+> `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (`turnstile-widget.tsx`) e
+> `NEXT_PUBLIC_SENTRY_DSN` (`sentry.client.config.ts`) — che vanno quindi
+> passate come `--build-arg`. Coerente con regola 15.
+
+### Deploy dev (push-based, Raspberry Pi)
+
+A differenza di prod/sandbox (tag-based), **dev traccia `main`**: a ogni push
+(commit o merge di PR) `.github/workflows/deploy-dev.yml` builda l'immagine
+**arm64** su runner `ubuntu-24.04-arm`, la pubblica come `ghcr.io/dstmrk/
+scontrinozero:dev` e notifica il Pi via webhook firmato (HMAC + Cloudflare
+Access). Sul Pi `adnanh/webhook` (systemd) esegue `docker compose pull && up -d`.
+Stessa immagine di prod, solo arch diversa; tutte le differenze d'ambiente
+vivono nel `.env` runtime. File e istruzioni in `deploy/dev/`.
 
 ### Procedura aggiornamento T&C
 

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -1,0 +1,61 @@
+# ScontrinoZero — .env ambiente DEV (Raspberry Pi)
+#
+# Copia in `.env` nella stessa cartella e riempi con i valori DEV.
+# È lo stesso set di variabili di prod/sandbox (vedi .env.example nella root),
+# ma con valori dedicati a dev. Quasi tutte le NEXT_PUBLIC_* sono lette
+# server-side a RUNTIME (Next.js standalone legge la env del container):
+# cambiarle qui basta, NON serve ricompilare. UNICA eccezione baked al build:
+# NEXT_PUBLIC_TURNSTILE_SITE_KEY (letta in un client component) — passata come
+# build-arg nel workflow; dev riusa la stessa key di prod.
+#
+# Puoi partire dal tuo vecchio .env.local (quello che usavi con `npm run`):
+# le chiavi sono le stesse.
+
+# ---- Supabase (PROGETTO DEV, mai quello di prod) ----------------------------
+NEXT_PUBLIC_SUPABASE_URL=https://your-dev-project.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+SUPABASE_SECRET_KEY=sb_secret_...
+# ⚠️ DB DEV separato: le migrazioni girano in automatico all'avvio del container.
+DATABASE_URL=postgresql://postgres.[DEV_REF]:[PWD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
+
+# ---- Agenzia delle Entrate --------------------------------------------------
+ADE_MODE=mock
+
+# ---- Hostname (DEV) ---------------------------------------------------------
+# APP_HOSTNAME è l'override RUNTIME (come fa la sandbox). Marketing e API sono
+# NEXT_PUBLIC_* ma comunque runtime grazie a public-env.
+APP_HOSTNAME=app-dev.scontrinozero.it
+NEXT_PUBLIC_APP_URL=https://app-dev.scontrinozero.it
+NEXT_PUBLIC_APP_HOSTNAME=app-dev.scontrinozero.it
+NEXT_PUBLIC_MARKETING_HOSTNAME=dev.scontrinozero.it
+NEXT_PUBLIC_API_HOSTNAME=api-dev.scontrinozero.it
+
+# ---- Cloudflare Turnstile (stessa key di prod, dominio dev in allowlist) ----
+# La site key è baked al build (build-arg nel workflow): qui è solo informativa.
+# La secret key è server-side e va invece impostata a runtime.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=...
+TURNSTILE_SECRET_KEY=...
+
+# ---- Stripe (test mode) -----------------------------------------------------
+STRIPE_SECRET_KEY=sk_test_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_STARTER_MONTHLY=price_...
+STRIPE_PRICE_STARTER_YEARLY=price_...
+STRIPE_PRICE_PRO_MONTHLY=price_...
+STRIPE_PRICE_PRO_YEARLY=price_...
+
+# ---- Resend -----------------------------------------------------------------
+RESEND_API_KEY=re_...
+FROM_EMAIL=ScontrinoZero (dev) <noreply@mail.scontrinozero.it>
+NEW_SIGNUP_NOTIFICATION_EMAIL=
+
+# ---- Encryption -------------------------------------------------------------
+ENCRYPTION_KEY=your-64-char-hex-key-here
+ENCRYPTION_KEY_VERSION=1
+
+# ---- Logging ----------------------------------------------------------------
+LOG_LEVEL=debug
+
+# ---- Sentry: SPENTO su dev --------------------------------------------------
+# Lasciare NEXT_PUBLIC_SENTRY_DSN vuoto/assente disattiva Sentry a runtime.

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -1,0 +1,123 @@
+# Ambiente DEV — Raspberry Pi 5 (arm64)
+
+Deploy automatico di `dev.scontrinozero.it` (+ `app-dev` / `api-dev`) a **ogni
+push su `main`** (commit diretto o merge di PR).
+
+## Architettura
+
+```
+push/merge su main
+  └─ GitHub Actions (.github/workflows/deploy-dev.yml)
+        runner ubuntu-24.04-arm → build arm64 → push ghcr.io/dstmrk/scontrinozero:dev
+        curl firmato (HMAC + CF Access) all'endpoint di deploy
+  └─ Cloudflare Tunnel (cloudflared systemd sull'host)
+        deploy-dev.scontrinozero.it → http://localhost:9000
+  └─ adnanh/webhook (systemd) verifica la firma ed esegue deploy.sh
+        docker compose pull && up -d  →  container scontrinozero-dev riparte
+```
+
+L'immagine `:dev` è **identica** a prod/sandbox (stesso `Dockerfile`), solo
+compilata per arm64. Quasi tutte le differenze d'ambiente arrivano dal `.env`
+a runtime: in modalità `standalone` il codice server legge le `NEXT_PUBLIC_*`
+dalla env del container a ogni avvio/richiesta (Supabase, hostname, `APP_URL`).
+L'unica `NEXT_PUBLIC_*` baked nel bundle al build è
+`NEXT_PUBLIC_TURNSTILE_SITE_KEY` (letta in un client component): è passata come
+build-arg e dev riusa la stessa key di prod. Sentry è disattivato su dev (nessun
+`NEXT_PUBLIC_SENTRY_DSN` al build → DSN assente nel bundle).
+
+## Setup sul Pi (una tantum)
+
+> Sostituisci `pi` con il tuo utente reale (`whoami`) in tutti i path/file.
+
+1. **Dismetti il vecchio meccanismo**: ferma lo script di polling ogni 2 min e
+   l'`npm run` dentro code-server. Code-server resta, ma libera la porta 3000.
+
+2. **Cartella e file applicativi**:
+   ```bash
+   mkdir -p ~/docker-apps/scontrinozero-dev
+   cd ~/docker-apps/scontrinozero-dev
+   # copia da questa cartella del repo:
+   #   docker-compose.yml  deploy.sh  hooks.json
+   chmod +x deploy.sh
+   cp .env.example .env   # poi compila .env con i valori DEV
+   ```
+   Puoi riusare il tuo vecchio `.env.local` come `.env`: le chiavi coincidono.
+
+3. **Docker senza sudo** per il tuo utente:
+   ```bash
+   sudo usermod -aG docker pi   # poi ri-login
+   ```
+
+4. **Receiver webhook (systemd)**:
+   ```bash
+   sudo apt-get install -y webhook
+   # genera il secret HMAC (lo stesso che metterai nei GitHub Secrets):
+   echo "DEPLOY_HMAC_SECRET=$(openssl rand -hex 32)" > webhook.env
+   chmod 600 webhook.env
+   # installa il service (adatta 'pi' dentro al file prima di copiarlo):
+   sudo cp webhook.service /etc/systemd/system/scontrinozero-dev-webhook.service
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now scontrinozero-dev-webhook
+   ```
+   Il receiver ascolta solo su `127.0.0.1:9000`.
+
+5. **Cloudflared (systemd sull'host)** — aggiungi l'ingress *prima* della
+   catch-all `http_status:404`, poi crea la rotta DNS:
+   ```yaml
+   ingress:
+     - hostname: deploy-dev.scontrinozero.it
+       service: http://localhost:9000
+     # ... dev / app-dev / api-dev -> http://localhost:3000 ...
+     - service: http_status:404
+   ```
+   ```bash
+   cloudflared tunnel route dns <NOME_O_ID_TUNNEL> deploy-dev.scontrinozero.it
+   sudo systemctl restart cloudflared
+   ```
+   Proteggi `deploy-dev.scontrinozero.it` con una **Cloudflare Access
+   Application + Service Token**.
+
+6. **Primo avvio**:
+   ```bash
+   cd ~/docker-apps/scontrinozero-dev
+   docker compose up -d
+   ```
+
+## GitHub Secrets (repo dstmrk/scontrinozero)
+
+| Secret                    | Valore                                                                 |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `DEPLOY_WEBHOOK_URL`      | `https://deploy-dev.scontrinozero.it/hooks/scontrinozero-dev-deploy`   |
+| `DEPLOY_HMAC_SECRET`      | lo stesso valore messo in `webhook.env` sul Pi                         |
+| `CF_ACCESS_CLIENT_ID`     | Client ID del Service Token di Cloudflare Access                       |
+| `CF_ACCESS_CLIENT_SECRET` | Client Secret del Service Token di Cloudflare Access                   |
+
+`GITHUB_TOKEN` (push su GHCR) è automatico, nessun secret da creare.
+
+## Sicurezza del webhook (doppio livello)
+
+1. **Cloudflare Access** all'edge: senza il Service Token la richiesta non
+   raggiunge nemmeno il Pi.
+2. **HMAC-SHA256** sul body (`X-Hub-Signature-256`): `webhook` rifiuta ogni
+   richiesta non firmata con `DEPLOY_HMAC_SECRET`.
+
+## Verifica / debug
+
+```bash
+# stato container e receiver
+docker compose ps
+systemctl status scontrinozero-dev-webhook
+# log
+docker compose logs -f app
+journalctl -u scontrinozero-dev-webhook -f
+# test manuale del deploy (senza passare da GitHub)
+./deploy.sh
+```
+
+## Note
+
+- `app-dev.scontrinozero.it/` potrebbe mostrare la landing marketing invece di
+  redirigere a `/dashboard`: il redirect build-time in `next.config.ts` usa
+  l'hostname di default (prod), il runtime lo gestisce `src/proxy.ts`. È lo
+  stesso comportamento della sandbox — irrilevante in dev.
+- Sentry è disattivato su dev (nessun `NEXT_PUBLIC_SENTRY_DSN` nel `.env`).

--- a/deploy/dev/deploy.sh
+++ b/deploy/dev/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# ScontrinoZero — deploy dev sul Raspberry Pi.
+# Invocato da adnanh/webhook (vedi hooks.json) dopo ogni push su main:
+# scarica l'ultima immagine :dev da GHCR e riavvia il container.
+#
+# Idempotente: se l'immagine non è cambiata, `up -d` è un no-op.
+set -euo pipefail
+
+# Lavora sempre nella cartella dello script (dove sta docker-compose.yml + .env).
+cd "$(dirname "$(readlink -f "$0")")"
+
+log() { echo "[deploy-dev] $(date -Is) $*"; }
+
+log "pull immagine :dev"
+docker compose pull app
+
+log "restart container"
+docker compose up -d app
+
+# Libera spazio sulla SD: rimuove le vecchie :dev ormai dangling.
+docker image prune -f >/dev/null 2>&1 || true
+
+log "fatto"

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -1,0 +1,35 @@
+# ScontrinoZero — ambiente DEV (Raspberry Pi 5, arm64)
+#
+# Gira sullo stesso Docker host di code-server, ma come stack SEPARATO
+# (code-server torna a fare solo code-server: l'app NON gira più al suo interno).
+#
+# Posizione consigliata sul Pi: ~/docker-apps/scontrinozero-dev/
+# In quella cartella servono: questo file + .env + deploy.sh + hooks.json
+#
+# Aggiornato automaticamente da deploy.sh (invocato dal webhook) a ogni
+# push su main. Vedi README.md.
+services:
+  app:
+    image: ghcr.io/dstmrk/scontrinozero:dev
+    container_name: scontrinozero-dev
+    restart: always
+    # `docker compose up -d` da solo non riscarica l'immagine; deploy.sh fa
+    # `pull` esplicito, ma pull_policy: always è una rete di sicurezza.
+    pull_policy: always
+    # Stesso schema di env di prod/sandbox. Qui vanno i valori DEV:
+    # Supabase dev, ADE_MODE=mock, Stripe test, APP_HOSTNAME=app-dev...,
+    # NEXT_PUBLIC_MARKETING_HOSTNAME=dev..., NEXT_PUBLIC_API_HOSTNAME=api-dev...
+    # Vedi .env.example.
+    env_file: .env
+    ports:
+      # Solo localhost: è cloudflared (systemd, sull'host) a fare reverse proxy
+      # per dev.scontrinozero.it / app-dev / api-dev verso questa porta.
+      - "127.0.0.1:3000:3000"
+    # Pi 5 ha headroom: un filo più della prod (512m) per migrate + cold start.
+    mem_limit: 768m
+    cpus: "1.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/deploy/dev/hooks.json
+++ b/deploy/dev/hooks.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "scontrinozero-dev-deploy",
+    "execute-command": "/home/pi/docker-apps/scontrinozero-dev/deploy.sh",
+    "command-working-directory": "/home/pi/docker-apps/scontrinozero-dev",
+    "response-message": "deploy-dev triggered\n",
+    "include-command-output-in-response": false,
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hmac-sha256",
+        "secret": "{{ getenv \"DEPLOY_HMAC_SECRET\" }}",
+        "parameter": {
+          "source": "header",
+          "name": "X-Hub-Signature-256"
+        }
+      }
+    }
+  }
+]

--- a/deploy/dev/webhook.service
+++ b/deploy/dev/webhook.service
@@ -1,0 +1,35 @@
+# ScontrinoZero — receiver del deploy dev (adnanh/webhook).
+#
+# Installazione:
+#   1. sudo apt-get install -y webhook      # pacchetto Debian/RPi OS
+#   2. Sostituisci 'pi' con il tuo utente (output di `whoami`) ovunque qui sotto
+#   3. sudo cp webhook.service /etc/systemd/system/scontrinozero-dev-webhook.service
+#   4. sudo systemctl daemon-reload
+#   5. sudo systemctl enable --now scontrinozero-dev-webhook
+#
+# L'utente deve poter usare Docker senza sudo:
+#   sudo usermod -aG docker pi   (poi ri-login)
+#
+# Ascolta solo su 127.0.0.1:9000 — l'esposizione pubblica la fa cloudflared
+# (deploy-dev.scontrinozero.it -> http://localhost:9000), protetta da CF Access.
+[Unit]
+Description=ScontrinoZero dev deploy webhook
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+User=pi
+# File con DEPLOY_HMAC_SECRET=... (chmod 600, NON committato). Vedi README.
+EnvironmentFile=/home/pi/docker-apps/scontrinozero-dev/webhook.env
+ExecStart=/usr/bin/webhook \
+  -hooks /home/pi/docker-apps/scontrinozero-dev/hooks.json \
+  -ip 127.0.0.1 \
+  -port 9000 \
+  -template \
+  -verbose
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Adds a third environment (dev) running on Raspberry Pi 5 (arm64) with automatic deployment on every push to `main`. Unlike prod/sandbox (tag-based, amd64), dev tracks the main branch and uses a webhook-triggered deployment pipeline.

## Key changes

- **GitHub Actions workflow** (`.github/workflows/deploy-dev.yml`): Builds arm64 image on `ubuntu-24.04-arm` runner, publishes to GHCR as `:dev`, and triggers Pi deployment via signed webhook (HMAC-SHA256 + Cloudflare Access)
- **Webhook receiver** (`deploy/dev/webhook.service`): systemd service running `adnanh/webhook` on Pi, listening on `127.0.0.1:9000`, verifies HMAC signature and executes deploy script
- **Deploy script** (`deploy/dev/deploy.sh`): Pulls latest `:dev` image and restarts container via `docker compose`
- **Docker Compose** (`deploy/dev/docker-compose.yml`): Single-service stack with dev-specific resource limits (768m mem, 1.5 CPU) and runtime env configuration
- **Environment template** (`deploy/dev/.env.example`): Dev-specific Supabase, Stripe test, and hostname configuration
- **Setup documentation** (`deploy/dev/README.md`): Complete one-time setup instructions, architecture diagram, security model, and debugging guide
- **CLAUDE.md update**: Documents the three-environment setup and deploy-dev workflow

## Implementation details

- **Single Docker image for all environments**: Prod/sandbox/dev/self-hosted share the same `Dockerfile`. Most `NEXT_PUBLIC_*` vars (Supabase, `APP_URL`, hostname) are read **server-side at runtime** in standalone mode, not baked into the bundle. Only `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (used in client component `turnstile-widget.tsx`) is passed as `--build-arg`; dev reuses prod's Turnstile key (dev domain in allowlist).
- **Two-layer webhook security**: Cloudflare Access at the edge (Service Token required) + HMAC-SHA256 signature verification on body
- **Concurrency control**: Latest push to main cancels in-flight dev builds
- **Cache isolation**: GHA cache scoped to `dev-arm64` to avoid collisions with prod (amd64) cache
- **Idempotent deploy**: `docker compose pull && up -d` is a no-op if image unchanged; old dangling images cleaned up automatically
- **Sentry disabled on dev**: No `NEXT_PUBLIC_SENTRY_DSN` in build args or `.env` example

All environment differences (Supabase project, ADE_MODE, Stripe keys, hostnames) live in the `.env` file on the Pi—no rebuild needed to change them.

https://claude.ai/code/session_017bs9weg3hq3PDXPqDPoxyi