### PR TITLE
Dev environment: bake identity hostnames at build time

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -50,12 +50,18 @@ jobs:
           cache-to: type=gha,mode=max,scope=dev-arm64
           build-args: |
             NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-          # NEXT_PUBLIC_TURNSTILE_SITE_KEY è l'unica NEXT_PUBLIC_* letta in un
-          # client component (turnstile-widget.tsx) → inlinata nel bundle al
-          # build, quindi va passata. Dev riusa la stessa key di prod (il
-          # dominio dev è nell'allowlist Turnstile).
-          # Le altre NEXT_PUBLIC_* (Supabase, hostname, APP_URL) sono lette
-          # server-side a runtime in modalità standalone → bastano nel .env del Pi.
+            NEXT_PUBLIC_APP_URL=https://app-dev.scontrinozero.it
+            NEXT_PUBLIC_APP_HOSTNAME=app-dev.scontrinozero.it
+            NEXT_PUBLIC_MARKETING_HOSTNAME=dev.scontrinozero.it
+            NEXT_PUBLIC_API_HOSTNAME=api-dev.scontrinozero.it
+          # NEXT_PUBLIC_TURNSTILE_SITE_KEY: letta in un client component
+          # (turnstile-widget.tsx) → inlinata nel bundle. Dev riusa la key di prod.
+          # NEXT_PUBLIC_APP_URL/APP_HOSTNAME/MARKETING/API: valutati al build
+          # (marketing SSG, next.config redirects/headers, metadataBase) e nel
+          # bundle client (appHref in header.tsx). Bakati coi valori dev così i
+          # link Accedi/Registrati, il redirect /→/dashboard e il CORS puntano a
+          # app-dev (non al default prod). Non sono segreti → letterali qui.
+          # Supabase/Stripe/ecc. restano runtime (solo nel .env del Pi).
           # Sentry OFF su dev: niente NEXT_PUBLIC_SENTRY_DSN (no DSN nel bundle)
           # né SENTRY_AUTH_TOKEN/ORG/PROJECT (no upload source-map).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,13 +156,18 @@ passate come `--build-arg` al `docker build`. `APP_HOSTNAME` (senza
 `NEXT_PUBLIC_`) è runtime e sovrascrive l'hostname baked — usato per sandbox
 e self-hosting su dominio custom.
 
-> Nota: un'unica immagine Docker serve prod/sandbox/dev/self-hosted perché la
-> maggior parte delle `NEXT_PUBLIC_*` (Supabase, `APP_URL`, hostname) è letta
-> **server-side a runtime** in modalità standalone (no inlining nel bundle
-> client). Sono baked nel bundle SOLO quelle lette in un client component —
+> Nota: un'unica immagine Docker serve prod/sandbox/dev/self-hosted. Molte
+> `NEXT_PUBLIC_*` (Supabase, Stripe) sono lette **server-side a runtime** in
+> standalone e bastano nel `.env`. MA quelle d'**identità** (`NEXT_PUBLIC_APP_URL`,
+> `_APP_HOSTNAME`, `_MARKETING_HOSTNAME`, `_API_HOSTNAME`) sono valutate anche al
+> **build** (marketing SSG, `next.config` redirects/headers, `metadataBase`) e
+> finiscono nel bundle client (`appHref` in `header.tsx`, client component):
+> vanno passate come `--build-arg` se servono valori non-prod. Il `Dockerfile`
+> le accetta; prod **non** le passa (→ default `app.scontrinozero.it`),
+> l'immagine `:dev` sì (→ `app-dev`). Sandbox condivide l'immagine prod → su
+> questi link resta sul default prod (limite noto). Idem
 > `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (`turnstile-widget.tsx`) e
-> `NEXT_PUBLIC_SENTRY_DSN` (`sentry.client.config.ts`) — che vanno quindi
-> passate come `--build-arg`. Coerente con regola 15.
+> `NEXT_PUBLIC_SENTRY_DSN` (`sentry.client.config.ts`). Coerente con regola 15.
 
 ### Deploy dev (push-based, Raspberry Pi)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,21 @@ ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_TURNSTILE_SITE_KEY=$NEXT_PUBLIC_TURNSTILE_SITE_KEY
 
+# Identity hostnames/URL — valutati sia al BUILD (marketing SSG, next.config
+# redirects/headers, metadataBase) sia nel bundle client (appHref in
+# header.tsx). Prod/sandbox NON li passano → restano vuoti → fallback al
+# default app.scontrinozero.it (corretto per prod). L'immagine :dev li passa
+# coi valori dev così link auth, redirect /→/dashboard e CORS puntano a
+# app-dev. Vedi deploy/dev/. (Coerente con CLAUDE.md regola 15.)
+ARG NEXT_PUBLIC_APP_URL
+ARG NEXT_PUBLIC_APP_HOSTNAME
+ARG NEXT_PUBLIC_MARKETING_HOSTNAME
+ARG NEXT_PUBLIC_API_HOSTNAME
+ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_APP_HOSTNAME=$NEXT_PUBLIC_APP_HOSTNAME
+ENV NEXT_PUBLIC_MARKETING_HOSTNAME=$NEXT_PUBLIC_MARKETING_HOSTNAME
+ENV NEXT_PUBLIC_API_HOSTNAME=$NEXT_PUBLIC_API_HOSTNAME
+
 # Sentry plugin vars — servono per uploadare le source maps
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -16,14 +16,20 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-dev-project.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 SUPABASE_SECRET_KEY=sb_secret_...
 # ⚠️ DB DEV separato: le migrazioni girano in automatico all'avvio del container.
+# DATABASE_URL → transaction pooler (porta 6543), usato dall'app a runtime.
 DATABASE_URL=postgresql://postgres.[DEV_REF]:[PWD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
+# DATABASE_URL_DIRECT → session pooler (porta 5432), usato da migrate.ts.
+# ⚠️ NON usare l'host diretto db.<ref>.supabase.co: è IPv6-only, e il container
+# gira sulla bridge Docker SENZA IPv6 → getaddrinfo EAI_AGAIN e le migrazioni
+# vanno in loop. Il session pooler è IPv4 e supporta i lock/DDL delle migrazioni.
+DATABASE_URL_DIRECT=postgresql://postgres.[DEV_REF]:[PWD]@aws-0-[REGION].pooler.supabase.com:5432/postgres
 
 # ---- Agenzia delle Entrate --------------------------------------------------
 ADE_MODE=mock
 
 # ---- Hostname (DEV) ---------------------------------------------------------
 # APP_HOSTNAME è l'override RUNTIME (come fa la sandbox). Marketing e API sono
-# NEXT_PUBLIC_* ma comunque runtime grazie a public-env.
+# NEXT_PUBLIC_* ma lette server-side a runtime in modalità standalone.
 APP_HOSTNAME=app-dev.scontrinozero.it
 NEXT_PUBLIC_APP_URL=https://app-dev.scontrinozero.it
 NEXT_PUBLIC_APP_HOSTNAME=app-dev.scontrinozero.it

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -28,8 +28,10 @@ DATABASE_URL_DIRECT=postgresql://postgres.[DEV_REF]:[PWD]@aws-0-[REGION].pooler.
 ADE_MODE=mock
 
 # ---- Hostname (DEV) ---------------------------------------------------------
-# APP_HOSTNAME è l'override RUNTIME (come fa la sandbox). Marketing e API sono
-# NEXT_PUBLIC_* ma lette server-side a runtime in modalità standalone.
+# APP_HOSTNAME è l'override RUNTIME (come fa la sandbox), usato server-side.
+# I NEXT_PUBLIC_* d'identità qui sotto sono ANCHE bakati al build nell'immagine
+# :dev (build-arg nel workflow) per il layer SSG/next.config/client (appHref).
+# Tienili allineati a quei valori: qui servono per i read server-side a runtime.
 APP_HOSTNAME=app-dev.scontrinozero.it
 NEXT_PUBLIC_APP_URL=https://app-dev.scontrinozero.it
 NEXT_PUBLIC_APP_HOSTNAME=app-dev.scontrinozero.it

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -29,8 +29,20 @@ build-arg e dev riusa la stessa key di prod. Sentry è disattivato su dev (nessu
 
 > Sostituisci `pi` con il tuo utente reale (`whoami`) in tutti i path/file.
 
-1. **Dismetti il vecchio meccanismo**: ferma lo script di polling ogni 2 min e
-   l'`npm run` dentro code-server. Code-server resta, ma libera la porta 3000.
+1. **Dismetti il vecchio meccanismo** e libera la porta 3000. Verifica chi la
+   tiene:
+   ```bash
+   sudo ss -ltnp | grep ':3000'
+   ```
+   Se l'app girava via **PM2 dentro il container code-server** (utente `coder`,
+   node via nvm), rimuovila da PM2 (a prova di reboot):
+   ```bash
+   # path di node usato dal demone PM2:
+   ND=$(dirname "$(sudo readlink /proc/$(pgrep -f 'PM2 ' | head -1)/exe)")
+   docker exec -u coder -e PATH="$ND:/usr/bin:/bin" code-server pm2 delete all
+   docker exec -u coder -e PATH="$ND:/usr/bin:/bin" code-server pm2 save
+   ```
+   Code-server resta come editor; smette solo di far girare l'app.
 
 2. **Cartella e file applicativi**:
    ```bash
@@ -119,5 +131,27 @@ journalctl -u scontrinozero-dev-webhook -f
 - `app-dev.scontrinozero.it/` potrebbe mostrare la landing marketing invece di
   redirigere a `/dashboard`: il redirect build-time in `next.config.ts` usa
   l'hostname di default (prod), il runtime lo gestisce `src/proxy.ts`. È lo
-  stesso comportamento della sandbox — irrilevante in dev.
+  stesso comportamento della sandbox — irrilevante in dev. (Stesso discorso per
+  `Access-Control-Allow-Origin` / `report-uri` CSP, valutati in `headers()` a
+  build-time: puntano a prod ma per le chiamate same-origin dell'app è ininfluente.)
 - Sentry è disattivato su dev (nessun `NEXT_PUBLIC_SENTRY_DSN` nel `.env`).
+
+### Troubleshooting
+
+- **`hooks.json` è un Go template** (webhook gira con `-template`): le virgolette
+  dentro `{{ getenv "DEPLOY_HMAC_SECRET" }}` sono volutamente **semplici**, perciò
+  il file non è JSON valido a sé stante — webhook lo renderizza prima del parse.
+  Con virgolette escapate (`\"`) fallisce con `unexpected "\\" in operand` e carica
+  0 hook (`Hook not found` su ogni richiesta).
+- **Migrazioni in loop con `getaddrinfo EAI_AGAIN`** all'avvio del container:
+  `DATABASE_URL_DIRECT` punta all'host diretto `db.<ref>.supabase.co`, che è
+  **IPv6-only**, mentre il container gira sulla bridge Docker senza IPv6. Usa il
+  **session pooler** (porta 5432, IPv4). Vedi `.env.example`.
+- **`failed to bind host port 127.0.0.1:3000: address already in use`** al
+  deploy: un vecchio processo (es. `next-server` via PM2 in code-server) tiene
+  ancora la 3000. Liberala come al passo 1 del setup.
+- **`403` nello step del webhook (Action)**: è Cloudflare Access che rifiuta il
+  service token. La policy sull'app `deploy-dev.scontrinozero.it` deve essere
+  **Service Auth** (non "Allow"), con incluso il token i cui ID/secret sono nei
+  GitHub Secrets. Isola il livello con un POST locale su `http://127.0.0.1:9000`
+  (salta Cloudflare) vs uno su `https://deploy-dev...` (passa da Access).

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -16,14 +16,20 @@ push/merge su main
         docker compose pull && up -d  →  container scontrinozero-dev riparte
 ```
 
-L'immagine `:dev` è **identica** a prod/sandbox (stesso `Dockerfile`), solo
-compilata per arm64. Quasi tutte le differenze d'ambiente arrivano dal `.env`
-a runtime: in modalità `standalone` il codice server legge le `NEXT_PUBLIC_*`
-dalla env del container a ogni avvio/richiesta (Supabase, hostname, `APP_URL`).
-L'unica `NEXT_PUBLIC_*` baked nel bundle al build è
-`NEXT_PUBLIC_TURNSTILE_SITE_KEY` (letta in un client component): è passata come
-build-arg e dev riusa la stessa key di prod. Sentry è disattivato su dev (nessun
-`NEXT_PUBLIC_SENTRY_DSN` al build → DSN assente nel bundle).
+L'immagine `:dev` usa lo stesso `Dockerfile` di prod/sandbox, compilata per
+arm64. Le differenze di runtime (Supabase, Stripe, `ADE_MODE`, secret) arrivano
+dal `.env` del container. Vengono invece **bakati al build** (build-arg nel
+workflow) i `NEXT_PUBLIC_*` che Next.js valuta a build time o inserisce nel
+bundle client:
+
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (client component) — stessa key di prod;
+- `NEXT_PUBLIC_APP_URL` / `_APP_HOSTNAME` / `_MARKETING_HOSTNAME` /
+  `_API_HOSTNAME` — coi valori **dev**, così marketing SSG, redirect
+  `/`→`/dashboard`, header CORS e i link auth (`appHref` in `header.tsx`)
+  puntano a `app-dev` e non al default prod.
+
+Sentry è disattivato su dev (nessun `NEXT_PUBLIC_SENTRY_DSN` al build → DSN
+assente nel bundle).
 
 ## Setup sul Pi (una tantum)
 
@@ -128,12 +134,11 @@ journalctl -u scontrinozero-dev-webhook -f
 
 ## Note
 
-- `app-dev.scontrinozero.it/` potrebbe mostrare la landing marketing invece di
-  redirigere a `/dashboard`: il redirect build-time in `next.config.ts` usa
-  l'hostname di default (prod), il runtime lo gestisce `src/proxy.ts`. È lo
-  stesso comportamento della sandbox — irrilevante in dev. (Stesso discorso per
-  `Access-Control-Allow-Origin` / `report-uri` CSP, valutati in `headers()` a
-  build-time: puntano a prod ma per le chiamate same-origin dell'app è ininfluente.)
+- Redirect `/`→`/dashboard`, header CORS e link auth (`appHref`) puntano
+  correttamente a `app-dev`: i `NEXT_PUBLIC_APP_URL`/`_APP_HOSTNAME` sono bakati
+  al build nell'immagine `:dev` (vedi Architettura). La **sandbox**, che
+  condivide l'immagine prod, su questi resta sul default prod — bug latente noto,
+  fuori dallo scope dev.
 - Sentry è disattivato su dev (nessun `NEXT_PUBLIC_SENTRY_DSN` nel `.env`).
 
 ### Troubleshooting

--- a/deploy/dev/hooks.json
+++ b/deploy/dev/hooks.json
@@ -8,7 +8,7 @@
     "trigger-rule": {
       "match": {
         "type": "payload-hmac-sha256",
-        "secret": "{{ getenv \"DEPLOY_HMAC_SECRET\" }}",
+        "secret": "{{ getenv "DEPLOY_HMAC_SECRET" }}",
         "parameter": {
           "source": "header",
           "name": "X-Hub-Signature-256"


### PR DESCRIPTION
## Summary

Configure the dev Docker image to bake identity-related `NEXT_PUBLIC_*` variables (`APP_URL`, `APP_HOSTNAME`, `MARKETING_HOSTNAME`, `API_HOSTNAME`) at build time via workflow build-args. This ensures auth links, the `/`→`/dashboard` redirect, CORS headers, and marketing SSG all correctly point to `app-dev` instead of the prod default.

## Key changes

- **Dockerfile**: Added four new `ARG`/`ENV` declarations for identity hostnames, passed as build-args by the dev workflow (prod/sandbox don't pass them, so they remain empty and fall back to prod defaults).
- **`.github/workflows/deploy-dev.yml`**: Pass `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_APP_HOSTNAME`, `NEXT_PUBLIC_MARKETING_HOSTNAME`, `NEXT_PUBLIC_API_HOSTNAME` as build-args with dev values. Added detailed comments explaining why these are baked (evaluated at build time by marketing SSG, `next.config` redirects/headers, `metadataBase`, and client component `appHref` in `header.tsx`).
- **`deploy/dev/.env.example`**: Clarified that identity `NEXT_PUBLIC_*` are now baked at build AND present at runtime (for server-side reads). Added warning about `DATABASE_URL_DIRECT` requiring the session pooler (port 5432, IPv4) instead of the direct host (IPv6-only, causes `EAI_AGAIN` in Docker).
- **`deploy/dev/hooks.json`**: Fixed Go template syntax — changed escaped double quotes to single quotes in `{{ getenv "DEPLOY_HMAC_SECRET" }}` (webhook renders as Go template before JSON parse).
- **`deploy/dev/README.md`**: Expanded architecture explanation, added detailed setup step 1 with commands to identify and remove old PM2 processes, added troubleshooting section covering template syntax, IPv6 pooler issue, port conflicts, and Cloudflare Access 403 errors.
- **`CLAUDE.md`**: Updated rule 15 and deploy section to clarify that identity hostnames are evaluated at build time (not just runtime) and must be passed as build-args for non-prod environments.

## Implementation details

- Identity hostnames (`NEXT_PUBLIC_APP_URL`, `_APP_HOSTNAME`, `_MARKETING_HOSTNAME`, `_API_HOSTNAME`) are now treated as build-time constants for the dev image, ensuring consistent behavior across marketing SSG, Next.js config redirects/headers, and client-side auth links.
- Supabase, Stripe, and other secrets remain runtime-only (in `.env`), not baked.
- Prod and sandbox continue to use the same image without passing these build-args, so they default to prod values.
- The dev workflow now explicitly documents why each variable is baked and what it controls.

https://claude.ai/code/session_017bs9weg3hq3PDXPqDPoxyi