### PR TITLE
Analytics base (KPI) per Starter + copy Pro per Export CSV e Analytics avanzata

### DIFF
--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -113,6 +113,14 @@ export default function CambioPianoPage() {
             Catalogo rapido <strong>illimitato</strong> (Starter è limitato a 5
             prodotti)
           </li>
+          <li>
+            <strong>Analytics avanzata</strong> con grafico ricavi giornaliero e
+            ripartizione per metodo di pagamento
+          </li>
+          <li>
+            <strong>Export CSV</strong> dello storico scontrini per il
+            commercialista
+          </li>
           <li>Supporto prioritario via email entro 24 ore</li>
           <li>
             Accesso alla <strong>Developer API</strong> per emettere scontrini
@@ -120,11 +128,10 @@ export default function CambioPianoPage() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Sono inoltre <em>in arrivo</em> sul piano Pro: analytics avanzata con
-          dashboard storica, export CSV dello storico scontrini, recupero
-          corrispettivi da AdE e sync catalogo prodotti dalla rubrica AdE.
-          Quando saranno rilasciate, verranno incluse automaticamente per chi ha
-          già un piano Pro attivo. Vedi il dettaglio in{" "}
+          Sono inoltre <em>in arrivo</em> sul piano Pro: recupero corrispettivi
+          da AdE e sync catalogo prodotti dalla rubrica AdE. Quando saranno
+          rilasciate, verranno incluse automaticamente per chi ha già un piano
+          Pro attivo. Vedi il dettaglio in{" "}
           <Link
             href="/help/piani-e-prezzi"
             className="text-primary hover:underline"

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -115,22 +115,21 @@ export default function PianiEPrezziPage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Per esercenti con un volume di vendite regolare che hanno bisogno di
           strumenti avanzati per la gestione e la contabilità. Include tutto ciò
-          che è disponibile nel piano Starter, più il catalogo illimitato e il
-          supporto prioritario. Sono inoltre in sviluppo alcune feature
-          riservate al piano Pro:
+          che è disponibile nel piano Starter, più le funzioni riservate al
+          piano Pro:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
             Catalogo rapido <strong>illimitato</strong>
           </li>
+          <li>
+            Analytics avanzata con grafico ricavi e ripartizione pagamenti
+          </li>
+          <li>
+            <strong>Export CSV</strong> dello storico scontrini (per
+            commercialista o contabilità)
+          </li>
           <li>Supporto prioritario via email entro 24 ore</li>
-          <li>
-            <em>In arrivo:</em> analytics avanzata con dashboard storica
-          </li>
-          <li>
-            <em>In arrivo:</em> <strong>Export CSV</strong> dello storico
-            scontrini (per commercialista o contabilità)
-          </li>
           <li>
             <em>In arrivo:</em> recupero corrispettivi da AdE (sincronizzazione
             dati storici)
@@ -153,8 +152,8 @@ export default function PianiEPrezziPage() {
           ScontrinoZero è open source con licenza O&apos;Saasy. Puoi scaricare
           il codice sorgente, installarlo sul tuo server e usarlo gratuitamente:
           hai accesso a tutto il codice del progetto e ricevi le feature in
-          arrivo (analytics avanzata, export CSV, recupero corrispettivi AdE)
-          man mano che vengono rilasciate. È la scelta giusta se:
+          arrivo (recupero corrispettivi AdE, sync catalogo) man mano che
+          vengono rilasciate. È la scelta giusta se:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
@@ -243,12 +242,12 @@ export default function PianiEPrezziPage() {
                   Analytics avanzata
                 </td>
                 <td className="py-2">—</td>
-                <td className="py-2">In arrivo</td>
+                <td className="py-2">✓</td>
               </tr>
               <tr>
                 <td className="text-foreground py-2 font-medium">Export CSV</td>
                 <td className="py-2">—</td>
-                <td className="py-2">In arrivo</td>
+                <td className="py-2">✓</td>
               </tr>
               <tr>
                 <td className="text-foreground py-2 font-medium">
@@ -289,11 +288,14 @@ export default function PianiEPrezziPage() {
             <ul className="text-muted-foreground mt-1 list-disc space-y-1 pl-5 text-sm leading-relaxed">
               <li>Hai un negozio aperto tutti i giorni.</li>
               <li>Hai più di 5 prodotti nel catalogo rapido.</li>
+              <li>
+                Vuoi l&apos;analytics avanzata e l&apos;export CSV dello storico
+                scontrini.
+              </li>
               <li>Vuoi il supporto prioritario via email entro 24 ore.</li>
               <li>
                 Vuoi accedere alle feature in arrivo riservate al piano Pro
-                (export CSV scontrini, analytics avanzata, recupero
-                corrispettivi e sync catalogo da rubrica AdE).
+                (recupero corrispettivi e sync catalogo da rubrica AdE).
               </li>
             </ul>
           </div>

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   title:
     "Storico scontrini: filtri, ricerca ed esportazione | ScontrinoZero Help",
   description:
-    "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e ricondividere il PDF dei singoli scontrini. L'export CSV è una funzione in arrivo sul piano Pro.",
+    "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e ricondividere il PDF dei singoli scontrini. L'export CSV è disponibile sul piano Pro.",
 };
 
 export default function StoricoEdEsportazionePage() {
@@ -41,8 +41,8 @@ export default function StoricoEdEsportazionePage() {
           La sezione <strong>Storico</strong> raccoglie gli scontrini emessi e
           annullati con successo. Puoi filtrare per periodo e per stato, aprire
           il dettaglio di ogni documento e ricondividerlo come PDF al cliente.
-          L&apos;esportazione CSV per il commercialista è una funzione in arrivo
-          sul piano Pro.
+          L&apos;esportazione CSV per il commercialista è disponibile sul piano
+          Pro.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -146,29 +146,24 @@ export default function StoricoEdEsportazionePage() {
           </li>
         </ul>
 
-        {/* ─── Export CSV (in arrivo) ─── */}
+        {/* ─── Export CSV (Piano Pro) ─── */}
         <h2 className="mt-10 text-xl font-semibold">
-          Esportazione CSV{" "}
+          {"Esportazione CSV "}
           <Badge className="ml-1" variant="secondary">
-            In arrivo · Piano Pro
+            Piano Pro
           </Badge>
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          L&apos;esportazione dello storico scontrini in formato CSV è una
-          funzione prevista per il piano <strong>Pro</strong> e non è ancora
-          disponibile nell&apos;app. Quando sarà rilasciata troverai un pulsante
-          dedicato nella pagina Storico e questo articolo verrà aggiornato con i
-          dettagli sulle colonne incluse.
+          Con il piano <strong>Pro</strong> trovi il pulsante{" "}
+          <strong>Esporta CSV</strong> nella pagina Storico: scarica gli
+          scontrini del periodo e dello stato selezionati in un file CSV pronto
+          da consegnare al commercialista o da importare nel gestionale
+          contabile. L&apos;esportazione rispetta i filtri attivi (intervallo di
+          date e stato del documento).
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Nel frattempo, per il riepilogo periodico al commercialista puoi
-          filtrare lo Storico per periodo, prendere nota dei totali e dei
-          progressivi, e condividere all&apos;occorrenza i singoli scontrini
-          tramite il bottone <strong>Invia ricevuta</strong>.
-        </p>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Quando la funzione sarà attiva, gli utenti del piano Starter potranno
-          passare al Pro dalla sezione{" "}
+          Sul piano <strong>Starter</strong> il pulsante è visibile ma rimanda
+          all&apos;upgrade: puoi passare al Pro dalla sezione{" "}
           <strong>Impostazioni → Piano e Abbonamento</strong> nella dashboard.
         </p>
 
@@ -180,10 +175,11 @@ export default function StoricoEdEsportazionePage() {
               Riepilogo mensile per il commercialista
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Filtra lo Storico per il mese di riferimento, comunica al
-              commercialista il totale degli scontrini emessi e
-              l&apos;intervallo di progressivi. L&apos;export CSV strutturato
-              arriverà sul piano Pro.
+              Filtra lo Storico per il mese di riferimento e, con il piano Pro,
+              premi <strong>Esporta CSV</strong> per scaricare l&apos;elenco
+              completo da inviare al commercialista. Sul piano Starter puoi
+              comunque comunicare il totale degli scontrini emessi e
+              l&apos;intervallo di progressivi.
             </p>
           </div>
           <div>

--- a/src/app/(marketing)/prezzi/page.tsx
+++ b/src/app/(marketing)/prezzi/page.tsx
@@ -42,6 +42,12 @@ const hostedOnly = (label: string): ComparisonRow => ({
   pro: true,
   selfHosted: false,
 });
+const proPlus = (label: string): ComparisonRow => ({
+  label,
+  starter: false,
+  pro: true,
+  selfHosted: true,
+});
 
 const comparisonRows: ComparisonRow[] = [
   allTrue("Scontrini illimitati"),
@@ -55,8 +61,8 @@ const comparisonRows: ComparisonRow[] = [
     pro: "Illimitato",
     selfHosted: "Illimitato",
   },
-  comingSoon("Analytics avanzata"),
-  comingSoon("Export CSV scontrini"),
+  proPlus("Analytics avanzata"),
+  proPlus("Export CSV scontrini"),
   comingSoon("Recupero documenti da AdE"),
   {
     label: "Supporto prioritario",

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -9,9 +9,8 @@ import {
   getRevenueTimeseries,
 } from "@/server/analytics-actions";
 import { AnalyticsClient } from "@/components/analytics/analytics-client";
-import { ProFeatureGate } from "@/components/billing/pro-feature-gate";
 import { getAuthenticatedUser } from "@/lib/server-auth";
-import { getPlan } from "@/lib/plans";
+import { canUsePro, getPlan } from "@/lib/plans";
 
 const ZERO_KPIS: AnalyticsKpis = {
   revenueCents: 0,
@@ -26,45 +25,28 @@ export default async function AnalyticsPage() {
 
   const user = await getAuthenticatedUser();
   const planInfo = await getPlan(user.id);
-
-  if (planInfo.plan !== "pro" && planInfo.plan !== "unlimited") {
-    return (
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-2xl font-bold">Analytics</h1>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Andamento ricavi e scontrini per il periodo selezionato.
-          </p>
-        </div>
-        <ProFeatureGate
-          plan={planInfo.plan}
-          title="Analytics avanzata · Pro"
-          description="Dashboard con KPI, andamento ricavi e ripartizione metodi di pagamento. Passa a Pro per attivarla."
-        >
-          <div />
-        </ProFeatureGate>
-      </div>
-    );
-  }
-
   const businessId = status.businessId;
-  const [kpis, timeseries, breakdown] = await Promise.all([
-    getAnalyticsKpis(businessId, "30d"),
-    getRevenueTimeseries(businessId, "30d"),
-    getPaymentBreakdown(businessId, "30d"),
-  ]);
 
+  // KPI base: disponibili a ogni piano (Starter incluso).
+  const kpis = await getAnalyticsKpis(businessId, "30d");
   const safeKpis: AnalyticsKpis = "error" in kpis ? ZERO_KPIS : kpis;
-  const safeTimeseries: RevenuePoint[] = Array.isArray(timeseries)
-    ? timeseries
-    : [];
-  const safeBreakdown: PaymentBreakdownEntry[] = Array.isArray(breakdown)
-    ? breakdown
-    : [];
+
+  // Grafico ricavi + ripartizione pagamenti: solo Pro/Unlimited.
+  let safeTimeseries: RevenuePoint[] = [];
+  let safeBreakdown: PaymentBreakdownEntry[] = [];
+  if (canUsePro(planInfo.plan)) {
+    const [timeseries, breakdown] = await Promise.all([
+      getRevenueTimeseries(businessId, "30d"),
+      getPaymentBreakdown(businessId, "30d"),
+    ]);
+    safeTimeseries = Array.isArray(timeseries) ? timeseries : [];
+    safeBreakdown = Array.isArray(breakdown) ? breakdown : [];
+  }
 
   return (
     <AnalyticsClient
       businessId={businessId}
+      plan={planInfo.plan}
       initialRange="30d"
       initialKpis={safeKpis}
       initialTimeseries={safeTimeseries}

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -14,6 +14,7 @@ import {
 import { KpiCards } from "./kpi-cards";
 import { PaymentBreakdown } from "./payment-breakdown";
 import { RevenueSparkline } from "./revenue-sparkline";
+import { ProFeatureGate } from "@/components/billing/pro-feature-gate";
 import {
   Select,
   SelectContent,
@@ -22,9 +23,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type Plan, canUsePro } from "@/lib/plans-shared";
 
 interface AnalyticsClientProps {
   readonly businessId: string;
+  readonly plan: Plan;
   readonly initialRange: AnalyticsRange;
   readonly initialKpis: AnalyticsKpis;
   readonly initialTimeseries: RevenuePoint[];
@@ -40,11 +43,13 @@ const ZERO_KPIS: AnalyticsKpis = {
 
 export function AnalyticsClient({
   businessId,
+  plan,
   initialRange,
   initialKpis,
   initialTimeseries,
   initialBreakdown,
 }: AnalyticsClientProps) {
+  const isPro = canUsePro(plan);
   const [range, setRange] = useState<AnalyticsRange>(initialRange);
   const [kpis, setKpis] = useState<AnalyticsKpis>(initialKpis);
   const [timeseries, setTimeseries] =
@@ -75,45 +80,61 @@ export function AnalyticsClient({
         <div>
           <h1 className="text-2xl font-bold">Analytics</h1>
           <p className="text-muted-foreground mt-1 text-sm">
-            Andamento ricavi e scontrini per il periodo selezionato.
+            {isPro
+              ? "Andamento ricavi e scontrini per il periodo selezionato."
+              : "Riepilogo degli ultimi 30 giorni."}
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          {isPending && (
-            <Loader2 className="text-muted-foreground size-4 animate-spin" />
-          )}
-          <Select value={range} onValueChange={handleRangeChange}>
-            <SelectTrigger className="h-9 w-[160px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="7d">Ultimi 7 giorni</SelectItem>
-              <SelectItem value="30d">Ultimi 30 giorni</SelectItem>
-              <SelectItem value="90d">Ultimi 90 giorni</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        {isPro ? (
+          <div className="flex items-center gap-2">
+            {isPending && (
+              <Loader2 className="text-muted-foreground size-4 animate-spin" />
+            )}
+            <Select value={range} onValueChange={handleRangeChange}>
+              <SelectTrigger className="h-9 w-[160px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="7d">Ultimi 7 giorni</SelectItem>
+                <SelectItem value="30d">Ultimi 30 giorni</SelectItem>
+                <SelectItem value="90d">Ultimi 90 giorni</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : (
+          <span className="text-muted-foreground text-sm">
+            Ultimi 30 giorni
+          </span>
+        )}
       </div>
 
       <KpiCards kpis={kpis} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Ricavi giornalieri</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <RevenueSparkline data={timeseries} />
-        </CardContent>
-      </Card>
+      <ProFeatureGate
+        plan={plan}
+        title="Grafici e ripartizione · Pro"
+        description="Andamento ricavi giornaliero e ripartizione per metodo di pagamento. Passa a Pro per sbloccarli."
+      >
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Ricavi giornalieri</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <RevenueSparkline data={timeseries} />
+            </CardContent>
+          </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Metodi di pagamento</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <PaymentBreakdown data={breakdown} />
-        </CardContent>
-      </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Metodi di pagamento</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PaymentBreakdown data={breakdown} />
+            </CardContent>
+          </Card>
+        </div>
+      </ProFeatureGate>
     </div>
   );
 }

--- a/src/components/marketing/pricing-section.tsx
+++ b/src/components/marketing/pricing-section.tsx
@@ -30,6 +30,8 @@ const starterFeatures: Feature[] = [
 const proFeatures: Feature[] = [
   { label: "Tutto di Starter" },
   { label: "Catalogo illimitato" },
+  { label: "Analytics avanzata" },
+  { label: "Export CSV scontrini" },
   { label: "Supporto prioritario" },
 ];
 
@@ -166,9 +168,8 @@ export function PricingSection() {
                 ))}
               </ul>
               <p className="text-muted-foreground mt-4 text-xs">
-                Analytics avanzata, export CSV e sincronizzazione catalogo AdE
-                sono in sviluppo e saranno inclusi nel piano Pro non appena
-                disponibili.
+                La sincronizzazione del catalogo da AdE è in sviluppo e sarà
+                inclusa nel piano Pro non appena disponibile.
               </p>
             </CardContent>
           </Card>

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -233,7 +233,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "Selezione guidata della natura N2.2 in fase di onboarding, pre-configurata sugli scontrini.",
       "Costo mensile più basso del mercato: a partire da €2,50/mese (annuale).",
       "Zero hardware da acquistare: solo lo smartphone che già hai.",
-      "Storico ordinato e ricercabile; export CSV in arrivo sul piano Pro.",
+      "Storico ordinato e ricercabile; export CSV sul piano Pro.",
     ],
     faq: [
       {
@@ -276,7 +276,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     benefits: [
       "Una sola app per gestire scontrini e storico, separata dal gestionale fatture.",
       "Emissione veloce in mobilità: a fine sessione, dal telefono, senza tornare in studio.",
-      "Storico consultabile; export CSV da consegnare al commercialista in arrivo sul piano Pro.",
+      "Storico consultabile; export CSV da consegnare al commercialista sul piano Pro.",
       "Costo contenuto: meno di una cena al ristorante al mese per il piano Starter.",
     ],
     faq: [

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -222,14 +222,21 @@ describe("getAnalyticsKpis", () => {
     expect(res).toEqual({ error: "Non autorizzato." });
   });
 
-  it("returns an error when the plan is not Pro", async () => {
+  it("returns KPIs to a non-Pro owner (analytics base)", async () => {
     mockGetPlan.mockResolvedValue({
       plan: "starter",
       trialStartedAt: null,
       planExpiresAt: null,
     });
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockFetchLinesByDocIds.mockResolvedValue([]);
     const res = await getAnalyticsKpis("biz-1", "30d");
-    expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
+    expect(res).toEqual({
+      revenueCents: 0,
+      count: 0,
+      aovCents: 0,
+      voidCount: 0,
+    });
   });
 
   it("returns an error for an invalid range", async () => {
@@ -292,6 +299,16 @@ describe("getAnalyticsKpis", () => {
 });
 
 describe("getRevenueTimeseries", () => {
+  it("returns an error when the plan is not Pro", async () => {
+    mockGetPlan.mockResolvedValue({
+      plan: "starter",
+      trialStartedAt: null,
+      planExpiresAt: null,
+    });
+    const res = await getRevenueTimeseries("biz-1", "30d");
+    expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
+  });
+
   it("buckets a midnight-Rome receipt by the correct fiscal day (DST fix)", async () => {
     // 2026-05-18T22:30Z = 00:30 Rome del 19 maggio (CEST). Deve finire
     // nel bucket "2026-05-19" (giorno fiscale), non in "2026-05-18".
@@ -385,6 +402,16 @@ describe("getRevenueTimeseries", () => {
 });
 
 describe("getPaymentBreakdown", () => {
+  it("returns an error when the plan is not Pro", async () => {
+    mockGetPlan.mockResolvedValue({
+      plan: "starter",
+      trialStartedAt: null,
+      planExpiresAt: null,
+    });
+    const res = await getPaymentBreakdown("biz-1", "30d");
+    expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
+  });
+
   it("groups ACCEPTED documents by paymentMethod with cents totals", async () => {
     mockSelect.mockReturnValue(
       makeSelectBuilder([

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -41,7 +41,9 @@ export type {
 type AuthOk = { ok: true; userId: string };
 type AuthFail = { ok: false; error: string };
 
-async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
+// Base authorization: any authenticated owner. Used by the "Analytics base"
+// KPIs available to every plan (Starter included).
+async function authorizeOwner(businessId: string): Promise<AuthOk | AuthFail> {
   let user;
   try {
     user = await getAuthenticatedUser();
@@ -56,11 +58,19 @@ async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
     );
     return { ok: false, error: ownershipError.error };
   }
-  const planInfo = await getPlan(user.id);
+  return { ok: true, userId: user.id };
+}
+
+// Pro authorization: owner + plan gate. Used by the advanced widgets
+// (timeseries, payment breakdown) reserved to Pro/Unlimited.
+async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
+  const base = await authorizeOwner(businessId);
+  if (!base.ok) return base;
+  const planInfo = await getPlan(base.userId);
   if (!canUsePro(planInfo.plan)) {
     return { ok: false, error: "Funzionalità riservata al piano Pro." };
   }
-  return { ok: true, userId: user.id };
+  return { ok: true, userId: base.userId };
 }
 
 async function validateRange(
@@ -136,7 +146,7 @@ export async function getAnalyticsKpis(
 ): Promise<AnalyticsKpis | { error: string }> {
   const rangeCheck = await validateRange(range);
   if (!rangeCheck.ok) return { error: rangeCheck.error };
-  const auth = await authorizePro(businessId);
+  const auth = await authorizeOwner(businessId);
   if (!auth.ok) return { error: auth.error };
 
   const { from, to } = rangeToBounds(range);


### PR DESCRIPTION
## Summary

- **A — Analytics base per Starter**: lo Starter (e ogni owner autenticato non-Pro: trial, ecc.) ora vede le **4 card KPI** sugli ultimi 30 giorni. Pro/Unlimited mantengono la dashboard completa (KPI + grafico ricavi + ripartizione pagamenti + selettore range 7/30/90gg). Split dell'autorizzazione come **confine di sicurezza**: `getAnalyticsKpis` usa `authorizeOwner` (auth + ownership), mentre `getRevenueTimeseries`/`getPaymentBreakdown` restano dietro `authorizePro` anche se invocate direttamente. Per lo Starter, al posto dei grafici, una card upsell "Sblocca con Pro" (ProFeatureGate).
- **B — Allineamento copy marketing/help**: Analytics avanzata ed Export CSV scontrini sono **già implementate** e gated su Pro → spostate da "in arrivo" a feature **attive del piano Pro** su landing/prezzi/help. Restano "in arrivo": recupero corrispettivi/documenti da AdE e sync catalogo AdE.

## Test plan

- [x] `npm run test:coverage` — analytics-actions: 24/24 verdi; nessun test rotto dalle modifiche (le uniche failure, `pwa-install-prompt.test.tsx`, sono pre-esistenti e non correlate: `localStorage.clear is not a function`, env di test)
- [x] `npm run type-check` — nessun errore
- [x] `npx prettier --check` sui 10 file modificati — ok
- [ ] Verifica manuale `/dashboard/analytics` con account **Starter/trial**: 4 KPI (ultimi 30gg), nessun selettore range, card upsell al posto dei grafici
- [ ] Verifica manuale con account **Pro/Unlimited**: dashboard completa invariata
- [ ] Verifica sicurezza: come Starter, chiamata diretta a `getRevenueTimeseries`/`getPaymentBreakdown` ritorna `{error}` (gating Pro intatto)
- [ ] Ispezione visiva `/prezzi`, `/help/storico-ed-esportazione`, `/help/piani-e-prezzi`, `/help/cambio-piano`: Export CSV + Analytics avanzata mostrate come Pro attive; AdE recupero/sync ancora "in arrivo"

🤖 Generated with [Claude Code](https://claude.com/claude-code)