### PR TITLE
Remove temporary debug step from deploy-dev workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,35 +26,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      # ⚠️ TEMPORANEO — diagnostica secret deploy. Rimuovere dopo aver risolto
-      # il 403. Stampa SOLO lunghezze e check booleani: i valori restano
-      # mascherati da GitHub, nessun segreto in chiaro.
-      - name: "DEBUG (temp): secret sanity"
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-          DEPLOY_HMAC_SECRET: ${{ secrets.DEPLOY_HMAC_SECRET }}
-          DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
-        run: |
-          echo "id len     = ${#CF_ACCESS_CLIENT_ID}   (atteso ~39, deve finire in .access)"
-          echo "secret len = ${#CF_ACCESS_CLIENT_SECRET} (atteso 64)"
-          echo "hmac len   = ${#DEPLOY_HMAC_SECRET}     (atteso 64)"
-          echo "url len    = ${#DEPLOY_WEBHOOK_URL}"
-          case "$CF_ACCESS_CLIENT_ID" in
-            *.access) echo "id finisce in .access : yes" ;;
-            *) echo "id finisce in .access : NO (sospetto)" ;;
-          esac
-          case "$DEPLOY_WEBHOOK_URL" in
-            "https://deploy-dev.scontrinozero.it/hooks/scontrinozero-dev-deploy")
-              echo "url esatto            : yes" ;;
-            *) echo "url esatto            : NO (controlla host/path/trailing)" ;;
-          esac
-          # spazi/newline nascosti senza stampare i valori (atteso 0 ovunque)
-          tid="$(printf '%s' "$CF_ACCESS_CLIENT_ID" | tr -d '[:space:]')"
-          tse="$(printf '%s' "$CF_ACCESS_CLIENT_SECRET" | tr -d '[:space:]')"
-          thm="$(printf '%s' "$DEPLOY_HMAC_SECRET" | tr -d '[:space:]')"
-          echo "whitespace id/secret/hmac = $(( ${#CF_ACCESS_CLIENT_ID}-${#tid} )) / $(( ${#CF_ACCESS_CLIENT_SECRET}-${#tse} )) / $(( ${#DEPLOY_HMAC_SECRET}-${#thm} ))"
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -155,8 +155,19 @@ journalctl -u scontrinozero-dev-webhook -f
 - **`failed to bind host port 127.0.0.1:3000: address already in use`** al
   deploy: un vecchio processo (es. `next-server` via PM2 in code-server) tiene
   ancora la 3000. Liberala come al passo 1 del setup.
-- **`403` nello step del webhook (Action)**: è Cloudflare Access che rifiuta il
-  service token. La policy sull'app `deploy-dev.scontrinozero.it` deve essere
-  **Service Auth** (non "Allow"), con incluso il token i cui ID/secret sono nei
-  GitHub Secrets. Isola il livello con un POST locale su `http://127.0.0.1:9000`
-  (salta Cloudflare) vs uno su `https://deploy-dev...` (passa da Access).
+- **`403` nello step del webhook (Action)**: due possibili layer.
+  1. **Cloudflare Access**: la policy su `deploy-dev.scontrinozero.it` deve essere
+     **Service Auth** (non "Allow"), col token i cui ID/secret sono nei GitHub
+     Secrets. Se in *Zero Trust → Logs → Access* la richiesta **compare** come
+     Denied → è qui.
+  2. **Bot Fight Mode** (gira *prima* di Access): se in Access Logs **non compare
+     nulla**, è il layer bot a bloccare il runner GitHub (IP datacenter =
+     "automatizzato"). ⚠️ Sul **free plan** Bot Fight Mode è **zone-wide e NON
+     esentabile per-host** (lo skip per-host esiste solo con Super Bot Fight Mode,
+     Pro+). Opzioni: tenerlo **off** (l'endpoint è già protetto da Access token +
+     HMAC), oppure mettere il deploy su un **dominio/zona separata** con BFM off
+     (BFM è una toggle **per-zona**), o passare a un trigger **pull-based**
+     (Watchtower) che non ha richieste in ingresso.
+
+  Isola il livello con un POST locale su `http://127.0.0.1:9000` (salta
+  Cloudflare) vs uno su `https://deploy-dev...` (passa da edge → bot → Access).


### PR DESCRIPTION
The secret-length diagnostic added to chase the webhook 403 has served its
purpose: the 403 was Bot Fight Mode (free plan, zone-wide, blocks the GitHub
datacenter runner), not a malformed secret. Reverts the temp step and documents
the Bot Fight Mode gotcha + options (off / separate zone / pull-based) in the
dev README troubleshooting.