### PR TITLE
Add dedicated Turnstile widget for dev environment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -49,13 +49,20 @@ jobs:
           cache-from: type=gha,scope=dev-arm64
           cache-to: type=gha,mode=max,scope=dev-arm64
           build-args: |
-            NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+            NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY_DEV || secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
             NEXT_PUBLIC_APP_URL=https://app-dev.scontrinozero.it
             NEXT_PUBLIC_APP_HOSTNAME=app-dev.scontrinozero.it
             NEXT_PUBLIC_MARKETING_HOSTNAME=dev.scontrinozero.it
             NEXT_PUBLIC_API_HOSTNAME=api-dev.scontrinozero.it
           # NEXT_PUBLIC_TURNSTILE_SITE_KEY: letta in un client component
-          # (turnstile-widget.tsx) → inlinata nel bundle. Dev riusa la key di prod.
+          # (turnstile-widget.tsx) → inlinata nel bundle. Dev usa il SUO widget
+          # Turnstile dedicato (secret `NEXT_PUBLIC_TURNSTILE_SITE_KEY_DEV`), così
+          # site key bakata e `TURNSTILE_SECRET_KEY` runtime sul Pi appartengono
+          # allo stesso widget — altrimenti siteverify rifiuta il token
+          # (`invalid-input-secret`/`invalid-input-response`). Fallback alla key
+          # di prod se il secret dev non è ancora configurato (no key vuota nel
+          # bundle). ⚠️ La `TURNSTILE_SECRET_KEY` nel `.env` del Pi DEVE essere
+          # la secret di QUESTO stesso widget dev.
           # NEXT_PUBLIC_APP_URL/APP_HOSTNAME/MARKETING/API: valutati al build
           # (marketing SSG, next.config redirects/headers, metadataBase) e nel
           # bundle client (appHref in header.tsx). Bakati coi valori dev così i

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,16 @@ e self-hosting su dominio custom.
 > questi link resta sul default prod (limite noto). Idem
 > `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (`turnstile-widget.tsx`) e
 > `NEXT_PUBLIC_SENTRY_DSN` (`sentry.client.config.ts`). Coerente con regola 15.
+>
+> **Turnstile per dev:** `:dev` baka un **widget Turnstile dedicato** (secret
+> `NEXT_PUBLIC_TURNSTILE_SITE_KEY_DEV` in `deploy-dev.yml`, fallback alla key
+> prod se assente). ⚠️ Site key bakata e `TURNSTILE_SECRET_KEY` runtime nel
+> `.env` del Pi **devono essere dello stesso widget**: la `NEXT_PUBLIC_*` è
+> baked → la riga `NEXT_PUBLIC_TURNSTILE_SITE_KEY` nel `.env` del Pi è ignorata.
+> Mismatch → siteverify risponde `invalid-input-secret` (secret non
+> riconosciuta) o `invalid-input-response` (token di un altro widget), e ogni
+> login fallisce con "Verifica CAPTCHA fallita". Diagnosi dall'`errorClass` in
+> `auth-actions.ts` (`captcha_verification_failed`).
 
 ### Deploy dev (push-based, Raspberry Pi)
 


### PR DESCRIPTION
## Summary

Configure the dev environment to use a dedicated Turnstile CAPTCHA widget instead of reusing the production key. This ensures that the site key baked into the bundle and the secret key used at runtime on the Raspberry Pi belong to the same widget, preventing `siteverify` failures.

## Changes

- **`deploy-dev.yml`:** Updated `NEXT_PUBLIC_TURNSTILE_SITE_KEY` build arg to use `NEXT_PUBLIC_TURNSTILE_SITE_KEY_DEV` secret with fallback to production key if not yet configured
- **`CLAUDE.md`:** Added detailed documentation explaining:
  - Why dev requires a dedicated widget (site key is baked at build time, secret is runtime)
  - The mismatch problem: misaligned keys cause `invalid-input-secret` or `invalid-input-response` errors
  - How to diagnose failures via `captcha_verification_failed` in `auth-actions.ts`
  - The requirement that `TURNSTILE_SECRET_KEY` in the Pi's `.env` must match the dev widget

## Implementation Details

The site key is baked into the Next.js bundle during Docker build (via `--build-arg`), while the secret key is read at runtime from the Pi's `.env`. If these belong to different Turnstile widgets, Cloudflare's `siteverify` API rejects the token. The fallback to production key ensures dev continues to work if the dev secret hasn't been configured yet, but operators must update the Pi's `.env` to use the matching dev secret once available.

https://claude.ai/code/session_01CEmyy1mHpWRw8NRg625krV