### PR TITLE
Add imperative reset to Turnstile widget for single-use token recovery

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { signIn, resendConfirmationEmail } from "@/server/auth-actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -34,6 +35,7 @@ export default function LoginPage() {
   // mostra il messaggio dedicato e offre il re-invio della conferma. Il captcha
   // viene resettato sull'action corretta ("resend-confirmation").
   const [mode, setMode] = useState<LoginMode>("login");
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
 
   const form = useForm<LoginData>({
     resolver: zodResolver(loginSchema),
@@ -53,6 +55,7 @@ export default function LoginPage() {
       if (result?.error) {
         form.setError("root", { message: result.error });
         setCaptchaToken(null);
+        turnstileRef.current?.reset(); // ri-emette il token: riabilita il submit
       }
     });
   }
@@ -76,6 +79,7 @@ export default function LoginPage() {
       if (result?.error) {
         form.setError("root", { message: result.error });
         setCaptchaToken(null); // token single-use, force re-solve
+        turnstileRef.current?.reset(); // ri-emette il token: riabilita il submit
       }
       // On success, signIn redirects to /dashboard
     });
@@ -103,7 +107,7 @@ export default function LoginPage() {
       <CardContent>
         <Form {...form}>
           <form
-            onSubmit={form.handleSubmit(handleSubmit)}
+            onSubmit={(e) => form.handleSubmit(handleSubmit)(e)}
             noValidate
             className="space-y-4"
           >
@@ -128,6 +132,7 @@ export default function LoginPage() {
 
             <TurnstileWidget
               key={mode}
+              ref={turnstileRef}
               onToken={setCaptchaToken}
               action={turnstileAction}
             />

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { Suspense, useState, useTransition } from "react";
+import { Suspense, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
-import { Turnstile } from "@marsidev/react-turnstile";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { signUp } from "@/server/auth-actions";
 import { passwordFieldSchema } from "@/lib/validation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { TurnstileWidget } from "@/components/turnstile-widget";
 import {
   Form,
   FormControl,
@@ -50,6 +51,7 @@ type RegisterData = z.infer<typeof registerSchema>;
 function RegisterForm() {
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
   // Source attribution (?ref=reddit, ?ref=indiehackers, ...) for soft-launch
   // tracking. Validated against allowlist server-side in signup-source.ts.
   // Suspense boundary in RegisterPage required by Next.js for useSearchParams
@@ -82,6 +84,7 @@ function RegisterForm() {
       if (result?.error) {
         form.setError("root", { message: result.error });
         setCaptchaToken(null); // token single-use, force re-solve
+        turnstileRef.current?.reset(); // ri-emette il token: riabilita il submit
       }
       // On success, signUp redirects to /verify-email
     });
@@ -95,7 +98,7 @@ function RegisterForm() {
       <CardContent>
         <Form {...form}>
           <form
-            onSubmit={form.handleSubmit(handleSubmit)}
+            onSubmit={(e) => form.handleSubmit(handleSubmit)(e)}
             noValidate
             className="space-y-4"
           >
@@ -211,15 +214,11 @@ function RegisterForm() {
               )}
             />
 
-            {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY && (
-              <Turnstile
-                siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
-                onSuccess={(token) => setCaptchaToken(token)}
-                onExpire={() => setCaptchaToken(null)}
-                onError={() => setCaptchaToken(null)}
-                options={{ theme: "auto", action: "signup" }}
-              />
-            )}
+            <TurnstileWidget
+              ref={turnstileRef}
+              onToken={setCaptchaToken}
+              action="signup"
+            />
 
             {form.formState.errors.root && (
               <p className="text-destructive text-sm" role="alert">

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { resetPassword } from "@/server/auth-actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,6 +21,7 @@ type ResetData = z.infer<typeof resetSchema>;
 export default function ResetPasswordPage() {
   const [isPending, startTransition] = useTransition();
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
 
   const form = useForm<ResetData>({
     resolver: zodResolver(resetSchema),
@@ -36,6 +38,7 @@ export default function ResetPasswordPage() {
       if (result?.error) {
         form.setError("root", { message: result.error });
         setCaptchaToken(null); // token single-use, force re-solve
+        turnstileRef.current?.reset(); // ri-emette il token: riabilita il submit
       }
       // On success, resetPassword redirects or shows confirmation
     });
@@ -54,7 +57,7 @@ export default function ResetPasswordPage() {
 
         <Form {...form}>
           <form
-            onSubmit={form.handleSubmit(handleSubmit)}
+            onSubmit={(e) => form.handleSubmit(handleSubmit)(e)}
             noValidate
             className="space-y-4"
           >
@@ -68,6 +71,7 @@ export default function ResetPasswordPage() {
             />
 
             <TurnstileWidget
+              ref={turnstileRef}
               onToken={setCaptchaToken}
               action="reset-password"
             />

--- a/src/components/turnstile-widget.test.tsx
+++ b/src/components/turnstile-widget.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { createRef } from "react";
 import { render } from "@testing-library/react";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 
 type TurnstileProps = {
   siteKey: string;
   onSuccess: (token: string) => void;
   onExpire: () => void;
   onError: () => void;
+  ref?: React.Ref<TurnstileInstance | null>;
 };
 
 const mockTurnstile = vi.fn();
@@ -63,5 +66,26 @@ describe("TurnstileWidget", () => {
 
     props.onError();
     expect(onToken).toHaveBeenLastCalledWith(null);
+  });
+
+  it("inoltra il ref al Turnstile sottostante (per reset imperativo)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "test-site-key");
+    const { TurnstileWidget } = await import("./turnstile-widget");
+    const onToken = vi.fn();
+    const ref = createRef<TurnstileInstance | null>();
+    render(<TurnstileWidget onToken={onToken} ref={ref} />);
+    const props = mockTurnstile.mock.calls[0][0] as TurnstileProps;
+    expect(props.ref).toBe(ref);
+  });
+
+  it("non monta nulla (ref incluso) senza siteKey: reset è un no-op sicuro", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "");
+    const { TurnstileWidget } = await import("./turnstile-widget");
+    const onToken = vi.fn();
+    const ref = createRef<TurnstileInstance | null>();
+    render(<TurnstileWidget onToken={onToken} ref={ref} />);
+    expect(mockTurnstile).not.toHaveBeenCalled();
+    expect(ref.current).toBeNull();
+    expect(() => ref.current?.reset()).not.toThrow();
   });
 });

--- a/src/components/turnstile-widget.tsx
+++ b/src/components/turnstile-widget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Turnstile } from "@marsidev/react-turnstile";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
+import type { Ref } from "react";
 
 /**
  * Widget Turnstile riusabile per i form auth (signUp, signIn, resetPassword).
@@ -15,18 +16,28 @@ import { Turnstile } from "@marsidev/react-turnstile";
  * "reset-password") riflessa nel token e verificata server-side da
  * `verifyCaptcha`. Impedisce il replay cross-flow di un token catturato su
  * un endpoint (es. signup) verso un altro (es. signin).
+ *
+ * Il prop `ref` espone l'istanza Turnstile (`reset()`, ...) ai form auth: il
+ * token è single-use, quindi dopo un errore il parent fa `ref.current?.reset()`
+ * per ri-emettere subito un nuovo token e riabilitare il pulsante di submit
+ * (altrimenti `captchaToken` resterebbe `null` fino alla scadenza ~5 min). Se
+ * la siteKey manca il widget non si monta: il ref resta `null` e il reset è un
+ * no-op sicuro (self-hosted/test).
  */
 export function TurnstileWidget({
   onToken,
   action,
+  ref,
 }: {
   readonly onToken: (token: string | null) => void;
   readonly action?: string;
+  readonly ref?: Ref<TurnstileInstance | null>;
 }) {
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
   if (!siteKey) return null;
   return (
     <Turnstile
+      ref={ref}
       siteKey={siteKey}
       onSuccess={(token) => onToken(token)}
       onExpire={() => onToken(null)}


### PR DESCRIPTION
## Summary

Expose the underlying Turnstile instance via a `ref` prop to auth forms, enabling imperative `reset()` calls when captcha validation fails. This allows immediate token re-emission without waiting for the ~5-minute expiry, improving UX on error flows.

## Changes

- **`TurnstileWidget` component:** Added optional `ref` prop (type `Ref<TurnstileInstance | null>`) forwarded to the underlying `<Turnstile>` component. Widget gracefully handles missing siteKey by returning `null` (ref stays `null`, reset is a safe no-op).

- **Auth forms (register, login, reset-password):** 
  - Created `useRef<TurnstileInstance | null>` to hold the Turnstile instance
  - Pass ref to `<TurnstileWidget>`
  - Call `turnstileRef.current?.reset()` in error handlers after clearing `captchaToken` state, re-emitting a fresh token and re-enabling the submit button
  - Fixed form submission handler pattern: `onSubmit={(e) => form.handleSubmit(handleSubmit)(e)}` to ensure proper event handling

- **Tests:** Added two test cases:
  - Verify ref is correctly forwarded to the underlying Turnstile component
  - Verify safe no-op behavior when siteKey is missing (ref stays `null`, reset doesn't throw)

## Implementation Details

- Token is single-use per Cloudflare Turnstile spec: after a failed validation, the token becomes invalid
- Without reset, `captchaToken` would remain `null` until the widget's internal expiry (~5 min), blocking form submission
- The ref pattern is optional and backward-compatible; forms without ref still work (token expires naturally)
- Self-hosted/test environments without `NEXT_PUBLIC_TURNSTILE_SITE_KEY` are safe: widget unmounts, ref is `null`, calling `reset()` is a no-op

https://claude.ai/code/session_01ThbkfkWw28ZJH6tDmPJqEt