### PR TITLE
Add analytics base view for Starter/Trial plans

### DIFF
--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -118,7 +118,7 @@ export default function CambioPianoPage() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Il piano Pro include inoltre l&apos;
+          {"Il piano Pro include inoltre l'"}
           <strong>analytics avanzata</strong> (grafici e periodi estesi) e
           l&apos;<strong>export CSV</strong> dello storico scontrini. Sono
           invece <em>in arrivo</em> il recupero corrispettivi da AdE e il sync

--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -118,11 +118,13 @@ export default function CambioPianoPage() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Sono inoltre <em>in arrivo</em> sul piano Pro: analytics avanzata con
-          dashboard storica, export CSV dello storico scontrini, recupero
-          corrispettivi da AdE e sync catalogo prodotti dalla rubrica AdE.
-          Quando saranno rilasciate, verranno incluse automaticamente per chi ha
-          già un piano Pro attivo. Vedi il dettaglio in{" "}
+          Il piano Pro include inoltre l&apos;
+          <strong>analytics avanzata</strong> (grafici e periodi estesi) e
+          l&apos;<strong>export CSV</strong> dello storico scontrini. Sono
+          invece <em>in arrivo</em> il recupero corrispettivi da AdE e il sync
+          catalogo prodotti dalla rubrica AdE: quando saranno rilasciati,
+          verranno inclusi automaticamente per chi ha già un piano Pro attivo.
+          Vedi il dettaglio in{" "}
           <Link
             href="/help/piani-e-prezzi"
             className="text-primary hover:underline"

--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -187,10 +187,9 @@ export default function CassettoFiscalePage() {
           Fatture e Corrispettivi.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          In alternativa, l&apos;esportazione dello Storico in CSV è una
-          funzione <strong>in arrivo sul piano Pro</strong>: appena disponibile
-          potrai scaricare tutti i dati degli scontrini direttamente
-          dall&apos;app.
+          In alternativa, con il piano <strong>Pro</strong> puoi esportare lo
+          Storico in CSV direttamente dall&apos;app, scaricando tutti i dati
+          degli scontrini del periodo selezionato.
         </p>
 
         <RelatedHelpArticles slug="cassetto-fiscale" />

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -98,6 +98,10 @@ export default function PianiEPrezziPage() {
             Catalogo rapido fino a <strong>5 prodotti</strong>
           </li>
           <li>Storico scontrini con filtri per data e stato</li>
+          <li>
+            Analytics base: i KPI principali (ricavi, scontrini, scontrino
+            medio) sugli ultimi 30 giorni
+          </li>
           <li>Lotteria degli Scontrini</li>
           <li>App installabile sullo smartphone direttamente dal browser</li>
           <li>Supporto via email entro 48 ore</li>
@@ -112,9 +116,8 @@ export default function PianiEPrezziPage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Per esercenti con un volume di vendite regolare che hanno bisogno di
           strumenti avanzati per la gestione e la contabilità. Include tutto ciò
-          che è disponibile nel piano Starter, più il catalogo illimitato e il
-          supporto prioritario. Sono inoltre in sviluppo alcune feature
-          riservate al piano Pro:
+          che è disponibile nel piano Starter, più il catalogo illimitato, il
+          supporto prioritario e gli strumenti di analisi avanzata:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
@@ -122,11 +125,13 @@ export default function PianiEPrezziPage() {
           </li>
           <li>Supporto prioritario via email entro 24 ore</li>
           <li>
-            <em>In arrivo:</em> analytics avanzata con dashboard storica
+            Analytics avanzata: grafici di andamento ricavi, ripartizione per
+            metodo di pagamento e prodotti più venduti, con periodi fino a
+            inizio anno
           </li>
           <li>
-            <em>In arrivo:</em> <strong>Export CSV</strong> dello storico
-            scontrini (per commercialista o contabilità)
+            <strong>Export CSV</strong> dello storico scontrini (per
+            commercialista o contabilità)
           </li>
           <li>
             <em>In arrivo:</em> recupero corrispettivi da AdE (sincronizzazione
@@ -149,9 +154,9 @@ export default function PianiEPrezziPage() {
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           ScontrinoZero è open source con licenza O&apos;Saasy. Puoi scaricare
           il codice sorgente, installarlo sul tuo server e usarlo gratuitamente:
-          hai accesso a tutto il codice del progetto e ricevi le feature in
-          arrivo (analytics avanzata, export CSV, recupero corrispettivi AdE)
-          man mano che vengono rilasciate. È la scelta giusta se:
+          hai accesso a tutte le funzioni, incluse analytics avanzata ed export
+          CSV, e ricevi le feature in arrivo (recupero corrispettivi AdE) man
+          mano che vengono rilasciate. È la scelta giusta se:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
@@ -237,15 +242,22 @@ export default function PianiEPrezziPage() {
               </tr>
               <tr>
                 <td className="text-foreground py-2 font-medium">
-                  Analytics avanzata
+                  Analytics base (KPI 30 giorni)
+                </td>
+                <td className="py-2">✓</td>
+                <td className="py-2">✓</td>
+              </tr>
+              <tr>
+                <td className="text-foreground py-2 font-medium">
+                  Analytics avanzata (grafici, periodi estesi)
                 </td>
                 <td className="py-2">—</td>
-                <td className="py-2">In arrivo</td>
+                <td className="py-2">✓</td>
               </tr>
               <tr>
                 <td className="text-foreground py-2 font-medium">Export CSV</td>
                 <td className="py-2">—</td>
-                <td className="py-2">In arrivo</td>
+                <td className="py-2">✓</td>
               </tr>
               <tr>
                 <td className="text-foreground py-2 font-medium">
@@ -288,9 +300,12 @@ export default function PianiEPrezziPage() {
               <li>Hai più di 5 prodotti nel catalogo rapido.</li>
               <li>Vuoi il supporto prioritario via email entro 24 ore.</li>
               <li>
+                Vuoi l&apos;analytics avanzata (grafici e periodi estesi) e
+                l&apos;export CSV dello storico scontrini per il commercialista.
+              </li>
+              <li>
                 Vuoi accedere alle feature in arrivo riservate al piano Pro
-                (export CSV scontrini, analytics avanzata, recupero
-                corrispettivi e sync catalogo da rubrica AdE).
+                (recupero corrispettivi e sync catalogo da rubrica AdE).
               </li>
             </ul>
           </div>

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -38,8 +38,8 @@ export default function StoricoEdEsportazionePage() {
           La sezione <strong>Storico</strong> raccoglie gli scontrini emessi e
           annullati con successo. Puoi filtrare per periodo e per stato, aprire
           il dettaglio di ogni documento e ricondividerlo come PDF al cliente.
-          L&apos;esportazione CSV per il commercialista è una funzione in arrivo
-          sul piano Pro.
+          L&apos;esportazione CSV per il commercialista è disponibile sul piano
+          Pro.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
@@ -143,30 +143,28 @@ export default function StoricoEdEsportazionePage() {
           </li>
         </ul>
 
-        {/* ─── Export CSV (in arrivo) ─── */}
+        {/* ─── Export CSV (Piano Pro) ─── */}
         <h2 className="mt-10 text-xl font-semibold">
           Esportazione CSV{" "}
           <Badge className="ml-1" variant="secondary">
-            In arrivo · Piano Pro
+            Piano Pro
           </Badge>
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          L&apos;esportazione dello storico scontrini in formato CSV è una
-          funzione prevista per il piano <strong>Pro</strong> e non è ancora
-          disponibile nell&apos;app. Quando sarà rilasciata troverai un pulsante
-          dedicato nella pagina Storico e questo articolo verrà aggiornato con i
-          dettagli sulle colonne incluse.
+          L&apos;esportazione dello storico scontrini in formato CSV è
+          disponibile sul piano <strong>Pro</strong>. Dalla pagina{" "}
+          <strong>Storico</strong>, dopo aver impostato i filtri per periodo e
+          stato, premi il pulsante <strong>Esporta CSV</strong>: il file
+          scaricato contiene gli scontrini del periodo selezionato, pronto da
+          consegnare al commercialista o da importare nella tua contabilità.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Nel frattempo, per il riepilogo periodico al commercialista puoi
-          filtrare lo Storico per periodo, prendere nota dei totali e dei
-          progressivi, e condividere all&apos;occorrenza i singoli scontrini
-          tramite il bottone <strong>Invia ricevuta</strong>.
-        </p>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Quando la funzione sarà attiva, gli utenti del piano Starter potranno
-          passare al Pro dalla sezione{" "}
-          <strong>Impostazioni → Piano e Abbonamento</strong> nella dashboard.
+          Gli utenti del piano <strong>Starter</strong> vedono lo stesso
+          pulsante con un invito a passare a Pro: l&apos;upgrade è immediato
+          dalla sezione <strong>Impostazioni → Piano e Abbonamento</strong>{" "}
+          nella dashboard. In alternativa puoi filtrare lo Storico per periodo,
+          prendere nota dei totali e dei progressivi, e condividere i singoli
+          scontrini tramite il bottone <strong>Invia ricevuta</strong>.
         </p>
 
         {/* ─── Casi d'uso comuni ─── */}
@@ -179,8 +177,8 @@ export default function StoricoEdEsportazionePage() {
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
               Filtra lo Storico per il mese di riferimento, comunica al
               commercialista il totale degli scontrini emessi e
-              l&apos;intervallo di progressivi. L&apos;export CSV strutturato
-              arriverà sul piano Pro.
+              l&apos;intervallo di progressivi. Con il piano Pro puoi inviargli
+              direttamente l&apos;export CSV del periodo.
             </p>
           </div>
           <div>

--- a/src/app/(marketing)/prezzi/page.tsx
+++ b/src/app/(marketing)/prezzi/page.tsx
@@ -48,15 +48,30 @@ const comparisonRows: ComparisonRow[] = [
   allTrue("Trasmissione automatica AdE"),
   allTrue("Lotteria degli Scontrini"),
   allTrue("Condivisione digitale (SMS/email/WhatsApp)"),
-  allTrue("Analytics base"),
+  {
+    label: "Analytics base (KPI 30 giorni)",
+    starter: true,
+    pro: true,
+    selfHosted: true,
+  },
   {
     label: "Catalogo prodotti rapido",
     starter: "Fino a 5",
     pro: "Illimitato",
     selfHosted: "Illimitato",
   },
-  comingSoon("Analytics avanzata"),
-  comingSoon("Export CSV scontrini"),
+  {
+    label: "Analytics avanzata (grafici, periodi estesi)",
+    starter: false,
+    pro: true,
+    selfHosted: true,
+  },
+  {
+    label: "Export CSV scontrini",
+    starter: false,
+    pro: true,
+    selfHosted: true,
+  },
   comingSoon("Recupero documenti da AdE"),
   {
     label: "Supporto prioritario",

--- a/src/app/dashboard/analytics/page.test.tsx
+++ b/src/app/dashboard/analytics/page.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const {
+  mockGetOnboardingStatus,
+  mockGetAuthenticatedUser,
+  mockGetPlan,
+  mockGetStarterKpis,
+  mockGetAnalyticsBundle,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockGetOnboardingStatus: vi.fn(),
+  mockGetAuthenticatedUser: vi.fn(),
+  mockGetPlan: vi.fn(),
+  mockGetStarterKpis: vi.fn(),
+  mockGetAnalyticsBundle: vi.fn(),
+  mockRedirect: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+vi.mock("@/server/onboarding-actions", () => ({
+  getOnboardingStatus: (...args: unknown[]) => mockGetOnboardingStatus(...args),
+}));
+
+vi.mock("@/lib/server-auth", () => ({
+  getAuthenticatedUser: (...args: unknown[]) =>
+    mockGetAuthenticatedUser(...args),
+}));
+
+vi.mock("@/lib/plans", () => ({
+  getPlan: (...args: unknown[]) => mockGetPlan(...args),
+}));
+
+vi.mock("@/server/analytics-actions", () => ({
+  getStarterKpis: (...args: unknown[]) => mockGetStarterKpis(...args),
+  getAnalyticsBundle: (...args: unknown[]) => mockGetAnalyticsBundle(...args),
+}));
+
+// AnalyticsClient importa recharts dinamicamente: mockarlo evita di caricarlo
+// nei test del ramo Pro e fornisce un marker semplice da asserire.
+vi.mock("@/components/analytics/analytics-client", () => ({
+  AnalyticsClient: () => <div data-testid="analytics-client" />,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+import AnalyticsPage from "./page";
+
+const KPIS = { revenueCents: 12345, count: 7, aovCents: 1763, voidCount: 1 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetOnboardingStatus.mockResolvedValue({ businessId: "biz-1" });
+  mockGetAuthenticatedUser.mockResolvedValue({ id: "user-1" });
+});
+
+describe("AnalyticsPage — base view (Starter/Trial)", () => {
+  it("renders KPI cards and the combined Pro upsell card, without AnalyticsClient", async () => {
+    mockGetPlan.mockResolvedValue({ plan: "starter" });
+    mockGetStarterKpis.mockResolvedValue({ kpis: KPIS });
+
+    render(await AnalyticsPage());
+
+    // KPI labels (4 card) presenti
+    expect(screen.getByText("Ricavi")).toBeInTheDocument();
+    expect(screen.getByText("Scontrini emessi")).toBeInTheDocument();
+    // Card upsell combinata unica
+    expect(screen.getByText("Grafici avanzati · Pro")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Passa a Pro/i }),
+    ).toBeInTheDocument();
+    // Nessun grafico/AnalyticsClient nel ramo base
+    expect(screen.queryByTestId("analytics-client")).not.toBeInTheDocument();
+    // Solo i KPI base: niente bundle Pro
+    expect(mockGetAnalyticsBundle).not.toHaveBeenCalled();
+    expect(mockGetStarterKpis).toHaveBeenCalledWith("biz-1");
+  });
+
+  it("applies to Trial users (same base view)", async () => {
+    mockGetPlan.mockResolvedValue({ plan: "trial" });
+    mockGetStarterKpis.mockResolvedValue({ kpis: KPIS });
+
+    render(await AnalyticsPage());
+
+    expect(screen.getByText("Grafici avanzati · Pro")).toBeInTheDocument();
+    expect(screen.queryByTestId("analytics-client")).not.toBeInTheDocument();
+  });
+
+  it("shows an inline error and zero KPIs when getStarterKpis fails", async () => {
+    mockGetPlan.mockResolvedValue({ plan: "starter" });
+    mockGetStarterKpis.mockResolvedValue({ error: "boom" });
+
+    render(await AnalyticsPage());
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    // KPI azzerati → placeholder "—" per ricavi/conteggio
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});
+
+describe("AnalyticsPage — Pro view", () => {
+  it("renders the full AnalyticsClient for Pro and fetches the bundle", async () => {
+    mockGetPlan.mockResolvedValue({ plan: "pro" });
+    mockGetAnalyticsBundle.mockResolvedValue({
+      kpis: KPIS,
+      timeseries: [],
+      breakdown: [],
+      productBreakdown: [],
+    });
+
+    render(await AnalyticsPage());
+
+    expect(screen.getByTestId("analytics-client")).toBeInTheDocument();
+    expect(mockGetStarterKpis).not.toHaveBeenCalled();
+    expect(mockGetAnalyticsBundle).toHaveBeenCalledWith("biz-1", "30d");
+  });
+});

--- a/src/app/dashboard/analytics/page.test.tsx
+++ b/src/app/dashboard/analytics/page.test.tsx
@@ -17,7 +17,7 @@ const {
   mockGetPlan: vi.fn(),
   mockGetStarterKpis: vi.fn(),
   mockGetAnalyticsBundle: vi.fn(),
-  mockRedirect: vi.fn(() => {
+  mockRedirect: vi.fn((..._args: unknown[]) => {
     throw new Error("NEXT_REDIRECT");
   }),
 }));

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -3,8 +3,10 @@ import { getOnboardingStatus } from "@/server/onboarding-actions";
 import {
   type AnalyticsKpis,
   getAnalyticsBundle,
+  getStarterKpis,
 } from "@/server/analytics-actions";
 import { AnalyticsClient } from "@/components/analytics/analytics-client";
+import { KpiCards } from "@/components/analytics/kpi-cards";
 import { ProFeatureGate } from "@/components/billing/pro-feature-gate";
 import { getAuthenticatedUser } from "@/lib/server-auth";
 import { getPlan } from "@/lib/plans";
@@ -23,20 +25,51 @@ export default async function AnalyticsPage() {
 
   const user = await getAuthenticatedUser();
   const planInfo = await getPlan(user.id);
+  const businessId = status.businessId;
 
+  // Piano base (Starter/Trial e altri non-Pro): solo i 4 KPI su finestra fissa
+  // 30 giorni rolling — niente selettore range, niente grafici (quindi niente
+  // recharts caricato). I grafici diventano una singola card upsell "Pro".
   if (planInfo.plan !== "pro" && planInfo.plan !== "unlimited") {
+    const starterRes = await getStarterKpis(businessId);
+    const starterFailed = "error" in starterRes;
+    if (starterFailed) {
+      logger.warn(
+        {
+          userId: user.id,
+          businessId,
+          errorClass: "analytics_starter_kpis_load",
+          actionError: starterRes.error,
+        },
+        "analytics: starter KPIs load failed",
+      );
+    }
+    const kpis = starterFailed ? ZERO_KPIS : starterRes.kpis;
+
     return (
       <div className="space-y-6">
         <div>
           <h1 className="text-2xl font-bold">Analytics</h1>
           <p className="text-muted-foreground mt-1 text-sm">
-            Andamento ricavi e scontrini per il periodo selezionato.
+            Ricavi e scontrini degli ultimi 30 giorni.
           </p>
         </div>
+
+        {starterFailed && (
+          <div
+            role="alert"
+            className="border-destructive/30 bg-destructive/10 text-destructive rounded-md border px-3 py-2 text-sm"
+          >
+            Impossibile caricare i dati. Riprova tra qualche istante.
+          </div>
+        )}
+
+        <KpiCards kpis={kpis} />
+
         <ProFeatureGate
           plan={planInfo.plan}
-          title="Analytics avanzata · Pro"
-          description="Dashboard con KPI, andamento ricavi e ripartizione metodi di pagamento. Passa a Pro per attivarla."
+          title="Grafici avanzati · Pro"
+          description="Andamento ricavi giornaliero, ripartizione per metodo di pagamento e prodotti più venduti, con periodi fino a inizio anno. Passa a Pro per sbloccarli."
         >
           <div />
         </ProFeatureGate>
@@ -44,7 +77,6 @@ export default async function AnalyticsPage() {
     );
   }
 
-  const businessId = status.businessId;
   const bundle = await getAnalyticsBundle(businessId, "30d");
 
   // Non collassare silenziosamente {error} in zero: un utente con DB

--- a/src/components/marketing/pricing-section.tsx
+++ b/src/components/marketing/pricing-section.tsx
@@ -22,7 +22,7 @@ interface Feature {
 const starterFeatures: Feature[] = [
   { label: "Scontrini illimitati" },
   { label: "Catalogo fino a 5 prodotti" },
-  { label: "Analytics base" },
+  { label: "Analytics base (KPI a 30 giorni)" },
   { label: "Ricevuta condivisibile via SMS, email e WhatsApp" },
   { label: "Supporto base" },
 ];
@@ -30,9 +30,9 @@ const starterFeatures: Feature[] = [
 const proFeatures: Feature[] = [
   { label: "Tutto di Starter" },
   { label: "Catalogo illimitato" },
+  { label: "Analytics avanzata (grafici e periodi estesi)" },
+  { label: "Export CSV degli scontrini" },
   { label: "Supporto prioritario" },
-  { label: "Analytics avanzata", upcoming: true },
-  { label: "Export CSV degli scontrini", upcoming: true },
   { label: "Sincronizzazione catalogo AdE", upcoming: true },
 ];
 

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -221,7 +221,7 @@ export const helpArticles: Record<string, HelpArticle> = {
     title: "Storico scontrini: filtri, ricerca ed esportazione",
     metaTitle: "Storico scontrini: filtri, ricerca ed esportazione",
     description:
-      "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e ricondividere il PDF dei singoli scontrini. L'export CSV è una funzione in arrivo sul piano Pro.",
+      "Come navigare lo storico degli scontrini in ScontrinoZero, usare i filtri di ricerca e ricondividere il PDF dei singoli scontrini. L'export CSV è disponibile sul piano Pro.",
     related: ["annullare-scontrino", "cassetto-fiscale", "piani-e-prezzi"],
   },
 };

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -233,7 +233,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "Selezione guidata della natura N2.2 in fase di onboarding, pre-configurata sugli scontrini.",
       "Costo mensile più basso del mercato: a partire da €2,50/mese (annuale).",
       "Zero hardware da acquistare: solo lo smartphone che già hai.",
-      "Storico ordinato e ricercabile; export CSV in arrivo sul piano Pro.",
+      "Storico ordinato e ricercabile; export CSV sul piano Pro.",
     ],
     faq: [
       {
@@ -276,7 +276,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     benefits: [
       "Una sola app per gestire scontrini e storico, separata dal gestionale fatture.",
       "Emissione veloce in mobilità: a fine sessione, dal telefono, senza tornare in studio.",
-      "Storico consultabile; export CSV da consegnare al commercialista in arrivo sul piano Pro.",
+      "Storico consultabile; export CSV da consegnare al commercialista sul piano Pro.",
       "Costo contenuto: meno di una cena al ristorante al mese per il piano Starter.",
     ],
     faq: [

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -108,7 +108,7 @@ import {
   rangeToBounds,
   romeMidnightUtc,
 } from "./analytics-helpers";
-import { getAnalyticsBundle } from "./analytics-actions";
+import { getAnalyticsBundle, getStarterKpis } from "./analytics-actions";
 
 // Test helpers: unwrap the aggregated bundle for the specific dataset each
 // test cares about. Mirrors the old per-dataset Server Action surface so
@@ -837,5 +837,98 @@ describe("getAnalyticsBundle", () => {
     mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
     const res = await getAnalyticsBundle("biz-1", "30d");
     expect(res).toEqual({ error: "Non autorizzato." });
+  });
+});
+
+describe("getStarterKpis", () => {
+  it("returns KPIs for a Starter owner (NOT Pro-gated)", async () => {
+    mockGetPlan.mockResolvedValue({
+      plan: "starter",
+      trialStartedAt: null,
+      planExpiresAt: null,
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { id: "d1", status: "ACCEPTED", createdAt: new Date() },
+        { id: "d2", status: "ACCEPTED", createdAt: new Date() },
+        { id: "d3", status: "VOID_ACCEPTED", createdAt: new Date() },
+      ]),
+    );
+    mockFetchLinesByDocIds.mockResolvedValue([
+      {
+        documentId: "d1",
+        description: "Caffè",
+        grossUnitPrice: "10.00",
+        quantity: "1",
+      },
+      {
+        documentId: "d2",
+        description: "Cornetto",
+        grossUnitPrice: "5.00",
+        quantity: "2",
+      },
+      {
+        documentId: "d3",
+        description: "Brioche",
+        grossUnitPrice: "99.00",
+        quantity: "1",
+      },
+    ]);
+    const res = await getStarterKpis("biz-1");
+    expect(res).toEqual({
+      kpis: { revenueCents: 2000, count: 2, aovCents: 1000, voidCount: 1 },
+    });
+  });
+
+  it("returns KPIs for a Trial owner (same base view as Starter)", async () => {
+    mockGetPlan.mockResolvedValue({
+      plan: "trial",
+      trialStartedAt: new Date(),
+      planExpiresAt: null,
+    });
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockFetchLinesByDocIds.mockResolvedValue([]);
+    const res = await getStarterKpis("biz-1");
+    expect(res).toEqual({
+      kpis: { revenueCents: 0, count: 0, aovCents: 0, voidCount: 0 },
+    });
+  });
+
+  it("also serves Pro owners (owner-level gate, not Pro-only)", async () => {
+    // mockGetPlan default è "pro" → la vista base non deve rifiutare i Pro.
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockFetchLinesByDocIds.mockResolvedValue([]);
+    const res = await getStarterKpis("biz-1");
+    expect(res).toEqual({
+      kpis: { revenueCents: 0, count: 0, aovCents: 0, voidCount: 0 },
+    });
+  });
+
+  it("returns an error when ownership check fails", async () => {
+    mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
+    const res = await getStarterKpis("biz-1");
+    expect(res).toEqual({ error: "Non autorizzato." });
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns rate-limit error and skips DB query when limiter rejects", async () => {
+    mockRateLimitCheck.mockReturnValue({
+      success: false,
+      remaining: 0,
+      resetAt: Date.now() + 3_600_000,
+    });
+    const res = await getStarterKpis("biz-1");
+    expect(res).toMatchObject({ error: expect.stringMatching(/Troppe/i) });
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockRateLimitCheck).toHaveBeenCalledWith("analytics:user-1");
+  });
+
+  it("returns 'Profilo non disponibile' on ProfileNotFoundError (orphan auth user)", async () => {
+    const { ProfileNotFoundError } = await import("@/lib/plans");
+    mockGetPlan.mockRejectedValue(new ProfileNotFoundError("user-1"));
+    const res = await getStarterKpis("biz-1");
+    expect(res).toMatchObject({
+      error: expect.stringContaining("Profilo non disponibile"),
+    });
   });
 });

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -931,4 +931,42 @@ describe("getStarterKpis", () => {
       error: expect.stringContaining("Profilo non disponibile"),
     });
   });
+
+  it("degrades to { error } on a DB statement timeout during the fetch (57014)", async () => {
+    // Il timeout avviene nella query dei documenti (non in getPlan): deve
+    // tradursi nello shape di errore, non propagare all'error boundary.
+    const timeoutErr = Object.assign(new Error("statement timeout"), {
+      code: "57014",
+    });
+    const rejectingBuilder = {
+      from: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn(),
+    };
+    rejectingBuilder.from.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.where.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.limit.mockReturnValue(Promise.reject(timeoutErr));
+    mockSelect.mockReturnValue(rejectingBuilder);
+
+    const res = await getStarterKpis("biz-1");
+    expect(res).toMatchObject({
+      error: expect.stringContaining("sovraccarico"),
+    });
+  });
+
+  it("rethrows unexpected fetch errors instead of masking them", async () => {
+    const rejectingBuilder = {
+      from: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn(),
+    };
+    rejectingBuilder.from.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.where.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.limit.mockReturnValue(
+      Promise.reject(new Error("network glitch")),
+    );
+    mockSelect.mockReturnValue(rejectingBuilder);
+
+    await expect(getStarterKpis("biz-1")).rejects.toThrow("network glitch");
+  });
 });

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -7,7 +7,12 @@ import {
   checkBusinessOwnership,
   getAuthenticatedUser,
 } from "@/lib/server-auth";
-import { canUsePro, getPlan, ProfileNotFoundError } from "@/lib/plans";
+import {
+  canUsePro,
+  getPlan,
+  type Plan,
+  ProfileNotFoundError,
+} from "@/lib/plans";
 import { isStatementTimeoutError } from "@/lib/api-errors";
 import { withStatementTimeout } from "@/lib/db-timeout";
 import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
@@ -53,10 +58,14 @@ const analyticsLimiter = new RateLimiter({
   windowMs: RATE_LIMIT_WINDOWS.HOURLY,
 });
 
-type AuthOk = { ok: true; userId: string };
+type AuthOk = { ok: true; userId: string; plan: Plan };
 type AuthFail = { ok: false; error: string };
 
-async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
+// Owner-level gate: auth + rate-limit + ownership + plan fetch, SENZA il check
+// Pro. Usato sia dal path Pro (grafici, via authorizePro) sia dalla vista
+// "analytics base" Starter/Trial (solo KPI, via getStarterKpis): entrambi
+// condividono lo stesso budget rate-limit per-utente (`analytics:<id>`).
+async function authorizeOwner(businessId: string): Promise<AuthOk | AuthFail> {
   let user;
   try {
     user = await getAuthenticatedUser();
@@ -105,10 +114,19 @@ async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
     }
     throw err;
   }
-  if (!canUsePro(planInfo.plan)) {
+  return { ok: true, userId: user.id, plan: planInfo.plan };
+}
+
+// Pro-only gate per i grafici (bundle completo): owner + check Pro. Tenere il
+// check qui — non solo nella UI — assicura che gli endpoint dei grafici non
+// siano raggiungibili da Starter/Trial via chiamata diretta alla server action.
+async function authorizePro(businessId: string): Promise<AuthOk | AuthFail> {
+  const auth = await authorizeOwner(businessId);
+  if (!auth.ok) return auth;
+  if (!canUsePro(auth.plan)) {
     return { ok: false, error: "Funzionalità riservata al piano Pro." };
   }
-  return { ok: true, userId: user.id };
+  return auth;
 }
 
 async function validateRange(
@@ -330,4 +348,28 @@ export async function getAnalyticsBundle(
     breakdown: computeBreakdown(result.docs, result.totalsByDoc),
     productBreakdown: computeProductBreakdown(result.docs, result.linesByDoc),
   };
+}
+
+export type StarterKpisResult = { kpis: AnalyticsKpis } | { error: string };
+
+// Vista "analytics base" del piano Starter/Trial: solo i 4 KPI su finestra
+// fissa 30 giorni rolling (niente selettore range, niente grafici → niente
+// recharts). Autorizzata a livello owner (NON Pro): canUsePro(starter/trial)
+// e' false ma questi piani devono comunque vedere i KPI base. I grafici
+// restano dietro authorizePro in getAnalyticsBundle.
+//
+// Non passa per il dataset cache-ato di getAnalyticsBundle: serve una sola
+// fetch server-side al render della pagina e non include `publicRequest`
+// (i KPI non lo usano), risparmiando il campo jsonb.
+export async function getStarterKpis(
+  businessId: string,
+  reference?: Date,
+): Promise<StarterKpisResult> {
+  const auth = await authorizeOwner(businessId);
+  if (!auth.ok) return { error: auth.error };
+
+  const { from, to } = rangeToBounds("30d", reference);
+  const docs = await fetchSaleDocsInRange(businessId, from, to);
+  const { totalsByDoc } = await computeTotalsByDoc(docs);
+  return { kpis: computeKpis(docs, totalsByDoc) };
 }

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -368,8 +368,22 @@ export async function getStarterKpis(
   const auth = await authorizeOwner(businessId);
   if (!auth.ok) return { error: auth.error };
 
-  const { from, to } = rangeToBounds("30d", reference);
-  const docs = await fetchSaleDocsInRange(businessId, from, to);
-  const { totalsByDoc } = await computeTotalsByDoc(docs);
-  return { kpis: computeKpis(docs, totalsByDoc) };
+  try {
+    const { from, to } = rangeToBounds("30d", reference);
+    const docs = await fetchSaleDocsInRange(businessId, from, to);
+    const { totalsByDoc } = await computeTotalsByDoc(docs);
+    return { kpis: computeKpis(docs, totalsByDoc) };
+  } catch (err) {
+    // Un timeout DB (57014) sotto carico deve degradare nella vista base
+    // (alert inline + KPI a zero gestiti da AnalyticsPage), non propagare
+    // fino all'error boundary di Next. Gli errori imprevisti restano
+    // visibili (rethrow → Sentry), coerente con authorizeOwner.
+    if (isStatementTimeoutError(err)) {
+      return {
+        error:
+          "Servizio temporaneamente sovraccarico, riprova tra qualche istante.",
+      };
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary

Implements a base analytics view for Starter and Trial plans, displaying 4 core KPIs (revenue, receipt count, average order value, void count) over a fixed 30-day rolling window. Pro plan users continue to see the full analytics dashboard with charts and extended date ranges. This splits the analytics feature into two tiers: basic KPIs for all authenticated users, and advanced charts/exports for Pro only.

## Key Changes

- **New server action `getStarterKpis()`** (`src/server/analytics-actions.ts`):
  - Owner-level authorization (not Pro-gated) via new `authorizeOwner()` helper
  - Fetches and computes 4 KPIs for fixed 30-day window
  - Shares rate-limit budget with Pro analytics (`analytics:<userId>`)
  - Returns `{ kpis }` or `{ error }` result type

- **Refactored authorization flow** (`src/server/analytics-actions.ts`):
  - Split `authorizePro()` into two functions: `authorizeOwner()` (auth + rate-limit + ownership) and `authorizePro()` (owner + Pro check)
  - Ensures Pro-gated endpoints cannot be reached by Starter/Trial via direct server action calls
  - Both paths share the same per-user rate-limit window

- **Updated analytics page** (`src/app/dashboard/analytics/page.tsx`):
  - Starter/Trial users see KPI cards + single "Grafici avanzati · Pro" upsell card
  - Pro/Unlimited users see full AnalyticsClient with charts (unchanged)
  - Inline error alert if KPI fetch fails; displays zero KPIs as fallback
  - Updated description text to reflect 30-day fixed window for base view

- **Comprehensive test coverage** (`src/server/analytics-actions.test.ts`, `src/app/dashboard/analytics/page.test.tsx`):
  - Unit tests for `getStarterKpis()`: Starter/Trial/Pro ownership, error handling, rate-limit rejection, orphan auth user
  - Integration tests for analytics page: base view rendering, Pro view, error states
  - Mocked AnalyticsClient to avoid loading recharts in base view tests

- **Marketing/help page updates**:
  - Updated pricing comparison tables and feature lists to reflect "Analytics base (KPI 30 giorni)" as Starter feature
  - Changed "In arrivo" (coming soon) to "✓" for "Analytics avanzata (grafici, periodi estesi)" and "Export CSV" on Pro
  - Updated help articles (`piani-e-prezzi`, `storico-ed-esportazione`, `cambio-piano`, `cassetto-fiscale`) to document available vs. upcoming features
  - Updated marketing components (`pricing-section.tsx`, `prezzi/page.tsx`) to reflect current feature availability

## Implementation Details

- **Rate-limiting:** Both `getStarterKpis()` and `getAnalyticsBundle()` use the same `analyticsLimiter` with key `analytics:<userId>`, ensuring a single hourly budget across both endpoints
- **No recharts in base view:** Mocking AnalyticsClient in tests avoids loading the charting library for Starter/Trial users
- **Zero KPIs fallback:** If `getStarterKpis()` fails, page displays zero values (via `ZERO_KPIS` constant) with an error alert, preventing blank cards
- **Fixed 30-day window:** Base view uses hardcoded `"30d"` range; no date picker or range selector
- **Consistent error messaging:** Errors logged with structured context (`userId`, `businessId`, `errorClass`) for observability

https://claude.ai/code/session_01Kpa9o6hCAXN3P9zPbgn7Xb