### PR TITLE
Add BUILD_CHANNEL to distinguish dev builds in UI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -49,11 +49,17 @@ jobs:
           cache-from: type=gha,scope=dev-arm64
           cache-to: type=gha,mode=max,scope=dev-arm64
           build-args: |
+            BUILD_SHA=${{ github.sha }}
+            BUILD_CHANNEL=dev
             NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY_DEV || secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
             NEXT_PUBLIC_APP_URL=https://app-dev.scontrinozero.it
             NEXT_PUBLIC_APP_HOSTNAME=app-dev.scontrinozero.it
             NEXT_PUBLIC_MARKETING_HOSTNAME=dev.scontrinozero.it
             NEXT_PUBLIC_API_HOSTNAME=api-dev.scontrinozero.it
+          # BUILD_SHA=github.sha: dev traccia main e ribuilda a ogni push, quindi
+          # è esattamente il commit di main deployato. BUILD_CHANNEL=dev fa
+          # mostrare "build dev <sha>" nella card Informazioni (vs bare SHA prod).
+          # Entrambi letti a runtime (process.env) → niente NEXT_PUBLIC_, no bundle.
           # NEXT_PUBLIC_TURNSTILE_SITE_KEY: letta in un client component
           # (turnstile-widget.tsx) → inlinata nel bundle. Dev usa il SUO widget
           # Turnstile dedicato (secret `NEXT_PUBLIC_TURNSTILE_SITE_KEY_DEV`), così

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,12 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ARG BUILD_SHA
 ENV BUILD_SHA=$BUILD_SHA
 
+# Canale build: "dev" solo per l'immagine :dev (deploy-dev.yml), così la card
+# Informazioni mostra "build dev <sha>" invece del bare SHA di prod. Vuoto in
+# prod/sandbox/self-host.
+ARG BUILD_CHANNEL
+ENV BUILD_CHANNEL=$BUILD_CHANNEL
+
 RUN apk upgrade --no-cache && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -22,7 +22,7 @@ import { PlanBadge } from "@/components/billing/plan-badge";
 import { PlanSelection } from "@/components/billing/plan-selection";
 import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
 import { CONTACT_EMAIL } from "@/lib/contact";
-import { APP_VERSION, getBuildSha } from "@/lib/version";
+import { APP_VERSION, getBuildLabel } from "@/lib/version";
 
 export default async function SettingsPage({
   searchParams,
@@ -372,7 +372,7 @@ export default async function SettingsPage({
         </CardHeader>
         <CardContent className="text-muted-foreground space-y-2 text-sm">
           <p>
-            ScontrinoZero {APP_VERSION} &mdash; build {getBuildSha()}
+            ScontrinoZero {APP_VERSION} &mdash; build {getBuildLabel()}
           </p>
           <p>
             Per dubbi, domande o feedback contattaci:{" "}

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import pkg from "../../package.json";
-import { APP_VERSION, getBuildSha } from "./version";
+import { APP_VERSION, getBuildLabel, getBuildSha } from "./version";
 
 describe("APP_VERSION", () => {
   it("matches the version in package.json", () => {
@@ -24,5 +24,35 @@ describe("getBuildSha", () => {
   it("truncates a 40-char SHA to its first 7 characters", () => {
     vi.stubEnv("BUILD_SHA", "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678");
     expect(getBuildSha()).toBe("a1b2c3d");
+  });
+});
+
+describe("getBuildLabel", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the bare short SHA when not on the dev channel (prod)", () => {
+    vi.stubEnv("BUILD_CHANNEL", "");
+    vi.stubEnv("BUILD_SHA", "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678");
+    expect(getBuildLabel()).toBe("a1b2c3d");
+  });
+
+  it("returns 'dev' when nothing is injected (local/self-host)", () => {
+    vi.stubEnv("BUILD_CHANNEL", "");
+    vi.stubEnv("BUILD_SHA", "");
+    expect(getBuildLabel()).toBe("dev");
+  });
+
+  it("prefixes the short SHA with 'dev' on the dev channel", () => {
+    vi.stubEnv("BUILD_CHANNEL", "dev");
+    vi.stubEnv("BUILD_SHA", "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678");
+    expect(getBuildLabel()).toBe("dev a1b2c3d");
+  });
+
+  it("returns plain 'dev' on the dev channel without a SHA", () => {
+    vi.stubEnv("BUILD_CHANNEL", "dev");
+    vi.stubEnv("BUILD_SHA", "");
+    expect(getBuildLabel()).toBe("dev");
   });
 });

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -8,3 +8,18 @@ export function getBuildSha(): string {
   const sha = process.env.BUILD_SHA;
   return sha ? sha.slice(0, 7) : "dev";
 }
+
+/**
+ * Etichetta build mostrata nella card "Informazioni" delle impostazioni.
+ * Prod: solo lo SHA breve (es. "a1b2c3d"). Ambiente dev (immagine `:dev`,
+ * `BUILD_CHANNEL=dev` iniettato da deploy-dev.yml): SHA prefissato da "dev"
+ * (es. "dev a1b2c3d"), così resta distinguibile da prod a colpo d'occhio.
+ * Locale/self-host (nessuno SHA): "dev".
+ */
+export function getBuildLabel(): string {
+  const sha = getBuildSha();
+  if (process.env.BUILD_CHANNEL === "dev") {
+    return sha === "dev" ? "dev" : `dev ${sha}`;
+  }
+  return sha;
+}


### PR DESCRIPTION
## Summary

Introduces a new `getBuildLabel()` function to display build information in the Settings "Informazioni" card, distinguishing dev deployments from production at a glance.

## Changes

- **New `getBuildLabel()` function** (`src/lib/version.ts`):
  - Returns bare short SHA on production (e.g., `"a1b2c3d"`)
  - Returns `"dev <sha>"` on dev channel (`BUILD_CHANNEL=dev`) to visually distinguish from prod
  - Falls back to `"dev"` when no SHA is available (local/self-hosted)

- **Updated Settings page** (`src/app/dashboard/settings/page.tsx`):
  - Replaced `getBuildSha()` with `getBuildLabel()` in the build info display

- **Docker build args** (`Dockerfile`):
  - Added `BUILD_CHANNEL` ARG and ENV to support channel-specific labeling at runtime

- **Dev deployment workflow** (`.github/workflows/deploy-dev.yml`):
  - Injected `BUILD_SHA=${{ github.sha }}` and `BUILD_CHANNEL=dev` as build args
  - Added explanatory comments on why these are not `NEXT_PUBLIC_*` (read at runtime, not bundled)

- **Comprehensive test coverage** (`src/lib/version.test.ts`):
  - 4 test cases covering prod (bare SHA), dev channel (with/without SHA), and local (no SHA)

## Implementation Details

- `BUILD_CHANNEL` is intentionally **not** `NEXT_PUBLIC_*` because it's read at runtime via `process.env` in a server component, avoiding unnecessary bundling
- The function reuses `getBuildSha()` to maintain DRY principle and consistent short SHA logic
- Dev builds now display `"build dev a1b2c3d"` vs production's `"build a1b2c3d"`, making deployment environment immediately obvious in the UI

https://claude.ai/code/session_01RwG31tPqFqZxDcz11HM97z