### PR TITLE
Rename "Dashboard" to "Catalogo" in header navigation

### DIFF
--- a/src/app/(marketing)/help/primo-scontrino/page.tsx
+++ b/src/app/(marketing)/help/primo-scontrino/page.tsx
@@ -97,8 +97,8 @@ export default function PrimoScontrinoPage() {
           </li>
           <li>
             <strong>Prodotti dal catalogo</strong> — tocca un prodotto salvato
-            in precedenza nella Dashboard per inserirlo nel carrello con prezzo
-            e IVA già compilati (piano Starter: fino a 5 prodotti nel catalogo;
+            in precedenza nel Catalogo per inserirlo nel carrello con prezzo e
+            IVA già compilati (piano Starter: fino a 5 prodotti nel catalogo;
             piano Pro: illimitati).
           </li>
         </ul>

--- a/src/components/dashboard/header-nav.test.tsx
+++ b/src/components/dashboard/header-nav.test.tsx
@@ -32,7 +32,7 @@ describe("HeaderNav", () => {
     mockUsePathname.mockReturnValue("/dashboard");
     render(<HeaderNav />);
 
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Catalogo")).toBeInTheDocument();
     expect(screen.getByText("Cassa")).toBeInTheDocument();
     expect(screen.getByText("Storico")).toBeInTheDocument();
     expect(screen.getByText("Analytics")).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe("HeaderNav", () => {
     mockUsePathname.mockReturnValue("/dashboard");
     render(<HeaderNav />);
 
-    expect(screen.getByText("Dashboard").closest("a")).toHaveAttribute(
+    expect(screen.getByText("Catalogo").closest("a")).toHaveAttribute(
       "href",
       "/dashboard",
     );
@@ -65,20 +65,20 @@ describe("HeaderNav", () => {
     );
   });
 
-  it("Dashboard è attivo su /dashboard (match esatto)", () => {
+  it("Catalogo è attivo su /dashboard (match esatto)", () => {
     mockUsePathname.mockReturnValue("/dashboard");
     render(<HeaderNav />);
 
-    const dashLink = screen.getByText("Dashboard").closest("a");
+    const dashLink = screen.getByText("Catalogo").closest("a");
     expect(dashLink?.className).toContain("font-semibold");
     expect(dashLink?.className).toContain("text-foreground");
   });
 
-  it("Dashboard NON è attivo su /dashboard/cassa (match esatto, non prefix)", () => {
+  it("Catalogo NON è attivo su /dashboard/cassa (match esatto, non prefix)", () => {
     mockUsePathname.mockReturnValue("/dashboard/cassa");
     render(<HeaderNav />);
 
-    const dashLink = screen.getByText("Dashboard").closest("a");
+    const dashLink = screen.getByText("Catalogo").closest("a");
     expect(dashLink?.className).not.toContain("font-semibold");
     expect(dashLink?.className).toContain("text-muted-foreground");
   });
@@ -134,7 +134,7 @@ describe("HeaderNav", () => {
     mockUsePathname.mockReturnValue("/dashboard/cassa");
     render(<HeaderNav />);
 
-    const inactiveLinks = ["Dashboard", "Storico", "Analytics", "Impostazioni"];
+    const inactiveLinks = ["Catalogo", "Storico", "Analytics", "Impostazioni"];
     for (const label of inactiveLinks) {
       const link = screen.getByText(label).closest("a");
       expect(link?.className).toContain("text-muted-foreground");

--- a/src/components/dashboard/header-nav.tsx
+++ b/src/components/dashboard/header-nav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const NAV_ITEMS = [
-  { href: "/dashboard", label: "Dashboard", exact: true },
+  { href: "/dashboard", label: "Catalogo", exact: true },
   { href: "/dashboard/cassa", label: "Cassa", exact: false },
   { href: "/dashboard/storico", label: "Storico", exact: false },
   { href: "/dashboard/analytics", label: "Analytics", exact: false },


### PR DESCRIPTION
## Summary
Rename the first navigation item in the header from "Dashboard" to "Catalogo" to better reflect the purpose of the section (product catalog management).

## Changes
- **`src/components/dashboard/header-nav.tsx`**: Updated the `NAV_ITEMS` array to change the label from "Dashboard" to "Catalogo" for the `/dashboard` route
- **`src/components/dashboard/header-nav.test.tsx`**: Updated all test assertions and descriptions to reference "Catalogo" instead of "Dashboard" (6 test cases affected)
- **`src/app/(marketing)/help/primo-scontrino/page.tsx`**: Updated help documentation text to reference "Catalogo" instead of "Dashboard" for consistency with the UI change

## Implementation Details
- The route itself (`/dashboard`) remains unchanged; only the display label is updated
- All navigation logic (exact matching, active state styling) remains intact
- Help documentation updated to maintain consistency between UI and user-facing documentation

https://claude.ai/code/session_01Y2rVK1ZJusMfrwaf2bb2MX