### PR TITLE
Filter benign FormData parse errors from Sentry

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
+import { isBenignFormDataParseError } from "@/lib/sentry-filters";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  beforeSend(event, hint) {
+    // Rumore da bot che fanno POST a path inesistenti (issue SCONTRINOZERO-E)
+    if (isBenignFormDataParseError(event, hint)) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
+import { isBenignFormDataParseError } from "@/lib/sentry-filters";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  beforeSend(event, hint) {
+    // Rumore da bot che fanno POST a path inesistenti (issue SCONTRINOZERO-E)
+    if (isBenignFormDataParseError(event, hint)) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/src/lib/sentry-filters.test.ts
+++ b/src/lib/sentry-filters.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+import { isBenignFormDataParseError } from "./sentry-filters";
+
+function makeEvent(
+  transaction: string | undefined,
+  exceptionValue?: string,
+): ErrorEvent {
+  return {
+    type: undefined,
+    transaction,
+    exception: exceptionValue
+      ? { values: [{ type: "TypeError", value: exceptionValue }] }
+      : undefined,
+  } as ErrorEvent;
+}
+
+describe("isBenignFormDataParseError", () => {
+  it("scarta il TypeError FormData sulla route not-found (sonda bot)", () => {
+    const event = makeEvent("POST /_not-found/page");
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to parse body as FormData."),
+    };
+
+    expect(isBenignFormDataParseError(event, hint)).toBe(true);
+  });
+
+  it("legge il messaggio dall'exception dell'evento se manca originalException", () => {
+    const event = makeEvent(
+      "POST /_not-found/page",
+      "Failed to parse body as FormData.",
+    );
+
+    expect(isBenignFormDataParseError(event)).toBe(true);
+  });
+
+  it("non scarta lo stesso errore su una transaction reale (possibile bug)", () => {
+    const event = makeEvent("POST /api/v1/receipts");
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to parse body as FormData."),
+    };
+
+    expect(isBenignFormDataParseError(event, hint)).toBe(false);
+  });
+
+  it("non scarta altri errori sulla route not-found", () => {
+    const event = makeEvent("POST /_not-found/page");
+    const hint: EventHint = {
+      originalException: new Error("Database connection refused"),
+    };
+
+    expect(isBenignFormDataParseError(event, hint)).toBe(false);
+  });
+
+  it("gestisce transaction mancante senza lanciare", () => {
+    const event = makeEvent(undefined);
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to parse body as FormData."),
+    };
+
+    expect(isBenignFormDataParseError(event, hint)).toBe(false);
+  });
+
+  it("gestisce originalException stringa", () => {
+    const event = makeEvent("POST /_not-found/page");
+    const hint: EventHint = {
+      originalException: "Failed to parse body as FormData.",
+    };
+
+    expect(isBenignFormDataParseError(event, hint)).toBe(true);
+  });
+
+  it("non scarta eventi senza messaggio di errore", () => {
+    const event = makeEvent("POST /_not-found/page");
+
+    expect(isBenignFormDataParseError(event)).toBe(false);
+  });
+});

--- a/src/lib/sentry-filters.ts
+++ b/src/lib/sentry-filters.ts
@@ -1,0 +1,41 @@
+import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+
+/**
+ * Messaggio lanciato da Next.js/undici quando un POST con body non-FormData
+ * colpisce l'handler delle Server Actions. In pratica generato solo da bot che
+ * sondano path inesistenti (es. `POST /RSC/<random>.txt` → `/_not-found/page`):
+ * non è mai un flusso legittimo dell'app, la richiesta finirebbe comunque in
+ * 404 e l'errore non è azionabile. Lo filtriamo per non inquinare Sentry
+ * (issue SCONTRINOZERO-E).
+ */
+const FORMDATA_PARSE_MESSAGE = "Failed to parse body as FormData";
+
+function extractErrorMessage(event: ErrorEvent, hint?: EventHint): string {
+  const original = hint?.originalException;
+  if (original instanceof Error) {
+    return original.message;
+  }
+  if (typeof original === "string") {
+    return original;
+  }
+  return event.exception?.values?.[0]?.value ?? "";
+}
+
+/**
+ * True se l'evento è il benigno `TypeError: Failed to parse body as FormData`
+ * generato da una richiesta verso la route not-found (sonda bot). Lo scope è
+ * volutamente limitato alla transaction `/_not-found`: su una Server Action
+ * reale lo stesso messaggio potrebbe segnalare un bug e va lasciato passare.
+ */
+export function isBenignFormDataParseError(
+  event: ErrorEvent,
+  hint?: EventHint,
+): boolean {
+  const message = extractErrorMessage(event, hint);
+  if (!message.includes(FORMDATA_PARSE_MESSAGE)) {
+    return false;
+  }
+
+  const transaction = event.transaction ?? "";
+  return transaction.includes("/_not-found");
+}


### PR DESCRIPTION
## Summary

Adds a Sentry event filter to suppress noisy `TypeError: Failed to parse body as FormData` errors that originate from bot probes hitting non-existent paths (issue SCONTRINOZERO-E). These errors are not actionable and only pollute the error tracking dashboard.

## Changes

- **New filter function** (`src/lib/sentry-filters.ts`): `isBenignFormDataParseError()` identifies FormData parse errors on the `/_not-found` route by checking both the error message and transaction name. Extracts error messages from multiple sources (Error object, string, or event exception values) to handle different hint formats.

- **Comprehensive test suite** (`src/lib/sentry-filters.test.ts`): 7 test cases covering:
  - Detection of FormData errors on `/_not-found` (bot probes)
  - Fallback to event exception when `originalException` is missing
  - Non-suppression of the same error on real Server Action routes (potential bugs)
  - Non-suppression of other errors on `/_not-found`
  - Graceful handling of missing transaction, string exceptions, and empty events

- **Integration into Sentry config**: Applied the filter via `beforeSend()` hook in both `sentry.edge.config.ts` and `sentry.server.config.ts` to return `null` (drop event) when the filter matches.

## Implementation details

- The filter is intentionally scoped to `/_not-found` transactions only: the same FormData parse error on a real Server Action route could indicate a legitimate bug and must not be filtered.
- Error message extraction handles three cases: `Error.message`, string exceptions, and event exception values, ensuring robustness across different Sentry hint formats.
- All edge cases (missing transaction, missing exception, string vs Error objects) are tested and handled without throwing.

https://claude.ai/code/session_01Bzoe8AhcHgWBRzPSJrqC7C