### PR TITLE
Consolidate SEO content strategy & update Pro plan feature status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,24 @@ tag git (`git tag -l "v1.*"`).
    autonomamente** dopo aver risolto un problema non triviale con lezione
    riusabile (debugging pattern, setup gotcha, wrong assumption). Non
    aspettare che lo chiedano.
-8. **Aggiornare pagine `/help`** se si modifica una funzionalità (label, menu,
-   stati, filtri, error flow, gating piani, nomi bottoni). `grep -rn "<termine>"
-src/app/\(marketing\)/help` prima di chiudere il task. Feature non ancora
-   implementate → riformulare al condizionale come roadmap.
+8. **Contenuti marketing & SEO.** I contenuti vivono in route dedicate con un
+   data file ciascuna: `/help` (operativo, `src/app/(marketing)/help`), `/guide`
+   (educativo, `src/lib/guide/articles.ts`), `/per/[slug]` (categorie,
+   `src/lib/per/categories.ts`), `/confronto` (`src/lib/confronto/comparisons.ts`),
+   `/strumenti/[slug]` (tool gratuiti backlink-magnet, `src/lib/strumenti/tools.ts`).
+   Regole sempre valide:
+   - **Niente promesse di feature non live** in _nessun_ copy marketing: feature
+     non implementate → condizionale/roadmap, mai al presente. Oggi sul Pro
+     restano "in arrivo" solo recupero corrispettivi AdE e sync catalogo AdE;
+     Analytics avanzata ed Export CSV sono **spedite e Pro-gated** (commit
+     ae1c481).
+   - **Slug separati `/help` vs `/guide`** sulle keyword condivise per evitare
+     canonical clash (es. `/help/regime-forfettario` ≠
+     `/guide/regime-forfettario-scontrini`); si linkano a vicenda.
+   - Se modifichi una funzionalità (label, menu, stati, filtri, error flow,
+     gating piani, nomi bottoni) aggiorna i contenuti: `grep -rn "<termine>"
+src/app/\(marketing\)` prima di chiudere il task.
+   - Contenuti generati via LLM con **review umana**, in italiano, target Italia.
 9. **Boundary delle API:** UUID validation con `isValidUuid()` + 400 prima del
    service; body size guard con `readJsonWithLimit(req, maxBytes)` + 413 prima
    di `JSON.parse`; email normalizzata con `normalizeEmail()` in `validation.ts`
@@ -233,7 +247,7 @@ prima dell'entrata in vigore.
 | Piano       | Mensile | Annuale | Note                                                                                                   |
 | ----------- | ------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | Starter     | €4.99   | €29.99  | Catalogo rapido max 5 prodotti, analytics base                                                         |
-| Pro         | €8.99   | €49.99  | Attivo: catalogo ∞, supporto prioritario. In arrivo: analytics avanzata, export CSV, recupero/sync AdE |
+| Pro         | €8.99   | €49.99  | Attivo: catalogo ∞, supporto prioritario, analytics avanzata, export CSV. In arrivo: recupero/sync AdE |
 | Self-hosted | €0      | €0      | Tutte le feature, gestione autonoma                                                                    |
 | Unlimited   | —       | —       | Invite-only, `plan='unlimited'` su `profiles`                                                          |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -248,25 +248,13 @@ Ogni sub-task è una PR separata con i suoi test (TDD), coverage on new code
 
 ---
 
-## Architettura contenuti SEO
+## Strategia SEO & lancio (GTM)
 
-**Tesi.** Budget marketing zero, dominio nuovo, prodotto live: l'unica leva sostenibile è SEO + lancio open source mirato. La SEO classica è lenta (3–9 mesi a regime), quindi va **avviata subito** ma accompagnata da leve veloci (tool gratuiti, lancio comunità) che generino primi backlink e traffico in giorni invece che in mesi.
+**Tesi.** Budget marketing zero, dominio nuovo, prodotto live: l'unica leva sostenibile è SEO + lancio open source mirato. La SEO classica è lenta (3–9 mesi a regime), quindi va **avviata subito** ma accompagnata da leve veloci (tool gratuiti su `/strumenti`, lancio comunità) che generino primi backlink e traffico in giorni invece che in mesi.
 
-**Architettura.**
+**Stato.** L'architettura dei contenuti è **già live**: `/guide` (educativo top-of-funnel), `/per/[slug]` (landing per categoria), `/confronto` (alta intenzione commerciale), `/strumenti/[slug]` (backlink-magnet), affiancati a `/help` (operativo). Gli **invarianti redazionali** (data file per route, niente promesse di feature non live, slug separati `/help` vs `/guide`, review umana) vivono in `CLAUDE.md` regola 8. Da qui resta da eseguire il **lancio**, non l'architettura.
 
-- `/help/*` — **operativo**: "come faccio X nel prodotto", middle-of-funnel, screenshot UI.
-- `/guide/*` — **educativo**: top-of-funnel SEO, "documento commerciale online: cos'è, normativa, esempi". Intercetta utenti che non conoscono ancora il prodotto.
-- `/per/[slug]` — **landing per categoria**, intercetta query "registratore di cassa per parrucchieri", "scontrini per ambulanti", ecc.
-- `/confronto` — **alta intenzione commerciale**, ScontrinoZero vs alternative (pagina unica consolidata: registratore telematico, fatturazione B2B, SaaS scontrino).
-- `/strumenti/[slug]` — **backlink magnets**: tool gratuiti che la gente linka spontaneamente.
-
-Slug separati tra `/help` e `/guide` evitano canonical clash su keyword condivise (es. `/help/regime-forfettario` ≠ `/guide/regime-forfettario-scontrini`); si linkano a vicenda.
-
-**Note operative.**
-
-- **Niente promesse di feature non ancora live nel marketing copy**: gli articoli SEO si basano solo su feature già rilasciate. Le 4 feature "in arrivo" sul Pro (Analytics avanzata, Export CSV, Recupero AdE, Sync catalogo) restano in roadmap.
-- **Tutti i contenuti generati via LLM con review umana**, in italiano, target Italia.
-- **Gate del lancio hard** è esplicito (sopra): ProductHunt/HN sono "one-shot a memoria lunga", vanno sparati solo quando il sito è pronto a convertire un picco e le promesse Pro sono onorate.
+**Gate di lancio (hard).** ProductHunt/HN sono "one-shot a memoria lunga": vanno sparati una volta sola, solo quando il sito è pronto a convertire un picco e le promesse Pro sono onorate. Non anticipare.
 
 ---
 


### PR DESCRIPTION
## Summary

Refactored SEO content architecture documentation and updated Pro plan feature status to reflect current implementation. Moved detailed content guidelines from `PLAN.md` into `CLAUDE.md` rule 8 as the authoritative source, and promoted "analytics avanzata" and "export CSV" from roadmap to active Pro features.

## Key changes

- **`CLAUDE.md` rule 8 (expanded):** Consolidated all content marketing guidelines into a single, comprehensive rule covering:
  - Route-to-datafile mapping (`/help`, `/guide`, `/per/[slug]`, `/confronto`, `/strumenti`)
  - Hard rule: no promises of unshipped features in marketing copy (only "recupero corrispettivi AdE" and "sync catalogo AdE" remain "in arrivo")
  - Slug separation strategy (`/help` vs `/guide`) to avoid canonical clash
  - Human review requirement for LLM-generated content
  - Grep workflow for updating content when modifying UI/features

- **`CLAUDE.md` pricing table:** Updated Pro plan from "In arrivo: analytics avanzata, export CSV, recupero/sync AdE" to "Attivo: catalogo ∞, supporto prioritario, analytics avanzata, export CSV. In arrivo: recupero/sync AdE" (commit ae1c481 reference)

- **`PLAN.md` SEO section:** Renamed "Architettura contenuti SEO" → "Strategia SEO & lancio (GTM)" and restructured:
  - Removed detailed route descriptions (now in `CLAUDE.md`)
  - Clarified that content architecture is **already live** (not a task)
  - Simplified launch gate: ProductHunt/HN are one-shot, fire only when ready to convert and Pro promises are honored
  - Moved operational notes into `CLAUDE.md` as the single source of truth

## Implementation notes

- No code changes; documentation-only refactor
- Consolidation improves maintainability: content rules now live in `CLAUDE.md` (always-active rules) rather than split across `PLAN.md` (roadmap)
- Feature status update (`analytics avanzata`, `export CSV` → active) aligns marketing copy with actual implementation

https://claude.ai/code/session_014TNDSzG2Vi74ED6BfgJ6qx