### PR TITLE
Add hook test suite and CI integration for PreToolUse guards

### DIFF
--- a/.claude/hooks/block-drizzle-generate.sh
+++ b/.claude/hooks/block-drizzle-generate.sh
@@ -8,9 +8,13 @@ set -euo pipefail
 
 cmd=$(jq -r '.tool_input.command // ""')
 
-if printf '%s' "$cmd" | grep -qE 'drizzle-kit[[:space:]]+generate'; then
+# Catch both the raw binary invocation (`drizzle-kit generate`, also
+# `generate:<dialect>`) and the first-party npm/pnpm/yarn/bun script wrapper
+# `db:generate` (package.json), which expands to `drizzle-kit generate` but
+# would otherwise slip past a regex that only sees the wrapper command.
+if printf '%s' "$cmd" | grep -qE 'drizzle-kit[[:space:]]+generate|(npm|pnpm|yarn|bun)([[:space:]]+run)?[[:space:]]+db:generate'; then
   echo "Blocked by .claude/hooks/block-drizzle-generate.sh:" >&2
-  echo "  \`drizzle-kit generate\` is forbidden in this repo (CLAUDE.md regola 11)." >&2
+  echo "  \`drizzle-kit generate\` (and the \`db:generate\` script) is forbidden in this repo (CLAUDE.md regola 11)." >&2
   echo "  Migrations after 0000 are handwritten. See skill 'db-migrations' for the workflow." >&2
   exit 2
 fi

--- a/.claude/hooks/test-block-drizzle-generate.sh
+++ b/.claude/hooks/test-block-drizzle-generate.sh
@@ -70,6 +70,21 @@ assert_block "npx drizzle-kit   generate"
 assert_block "drizzle-kit generate:pg"
 assert_block "cd packages/db && npx drizzle-kit generate"
 
+# --- BLOCK cases: the first-party `db:generate` script wrapper, which
+# expands to `drizzle-kit generate` (package.json). Without these the suite
+# gives a false green: the most likely real invocation slips through. ---
+assert_block "npm run db:generate"
+assert_block "npm run db:generate -- --name foo"
+assert_block "pnpm db:generate"
+assert_block "pnpm run db:generate"
+assert_block "yarn db:generate"
+assert_block "yarn run db:generate"
+assert_block "bun run db:generate"
+
+# The sibling db:* scripts must stay allowed (they are not `generate`).
+assert_pass "npm run db:migrate"
+assert_pass "npm run db:push"
+
 if [ "$failures" -gt 0 ]; then
   echo "$failures test(s) failed." >&2
   exit 1

--- a/.claude/hooks/test-block-drizzle-generate.sh
+++ b/.claude/hooks/test-block-drizzle-generate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tests for .claude/hooks/block-drizzle-generate.sh
+#
+# Runs the hook with synthetic Bash tool invocations and asserts the
+# expected exit code (2 = block, 0 = pass). Run from repo root:
+#   ./.claude/hooks/test-block-drizzle-generate.sh
+#
+# This is a defense-in-depth net for CLAUDE.md regola 11: a regex that
+# fails to block `drizzle-kit generate` (under any runner, with extra
+# whitespace, or with a `generate:<dialect>` suffix) would let a
+# regenerated migration conflict with the handwritten journal.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+HOOK="$SCRIPT_DIR/block-drizzle-generate.sh"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found: $HOOK" >&2
+  exit 1
+fi
+
+failures=0
+
+# Run the hook in a subshell with the given fake Bash command on stdin.
+# Returns the hook's exit code via the global $rc. We can't use `local`
+# at the top level so we use a global.
+run_hook() {
+  local cmd="$1"
+  local payload
+  payload=$(printf '%s' "$cmd" | python3 -c '
+import json, sys
+print(json.dumps({"tool_input": {"command": sys.stdin.read()}}))')
+  printf '%s' "$payload" | bash "$HOOK" >/dev/null 2>&1
+  rc=$?
+}
+
+assert_block() {
+  local cmd="$1"
+  run_hook "$cmd"
+  if [ "$rc" -ne 2 ]; then
+    echo "FAIL: expected BLOCK (exit 2) but got exit $rc for: $cmd" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_pass() {
+  local cmd="$1"
+  run_hook "$cmd"
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: expected PASS (exit 0) but got exit $rc for: $cmd" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# --- PASS cases: legitimate drizzle/db operations that must not be blocked ---
+assert_pass "drizzle-kit migrate"
+assert_pass "drizzle-kit push"
+assert_pass "drizzle-kit studio"
+assert_pass "npm run db:studio"
+assert_pass "npx tsx scripts/migrate.ts"
+assert_pass "node scripts/check-migrations.mjs"
+assert_pass "git status"
+
+# --- BLOCK cases: any invocation of `drizzle-kit generate` ---
+assert_block "drizzle-kit generate"
+assert_block "npx drizzle-kit generate"
+assert_block "pnpm drizzle-kit generate"
+assert_block "npx drizzle-kit   generate"
+assert_block "drizzle-kit generate:pg"
+assert_block "cd packages/db && npx drizzle-kit generate"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures test(s) failed." >&2
+  exit 1
+fi
+
+echo "All block-drizzle-generate hook tests passed."

--- a/.claude/skills/stripe-webhooks/SKILL.md
+++ b/.claude/skills/stripe-webhooks/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: stripe-webhooks
-description: Use when working with Stripe billing — handling API version `2026-02-25.clover` breaking changes (Invoice.subscription moved to invoice.parent?.subscription_details?.subscription, Subscription.current_period_end moved to items[0]), registering the 8 required webhook events (checkout.session.completed/expired, customer.subscription.updated/deleted, invoice.paid/payment_failed/payment_action_required, charge.dispute.created), debugging "pending" subscription rows after checkout, or implementing stale-pending recovery thresholds for idempotent AdE mutations (getStalePendingThresholdMs in receipt-service/void-service). Files: src/server/stripe/, src/app/api/stripe/, webhook handler.
+description: Use when working with Stripe billing — handling API version `2026-04-22.dahlia` breaking changes (Invoice.subscription moved to invoice.parent?.subscription_details?.subscription, Subscription.current_period_end moved to items[0]), registering the 8 required webhook events (checkout.session.completed/expired, customer.subscription.updated/deleted, invoice.paid/payment_failed/payment_action_required, charge.dispute.created), debugging "pending" subscription rows after checkout, or implementing stale-pending recovery thresholds for idempotent AdE mutations (getStalePendingThresholdMs in receipt-service/void-service). Files: src/server/stripe/, src/app/api/stripe/, webhook handler.
 ---
 
 # stripe-webhooks — Stripe API version, webhook events, recovery patterns
 
-## API version `2026-02-25.clover` — breaking changes
+## API version `2026-04-22.dahlia` — breaking changes
 
-SDK: `stripe` npm v20.4.1.
+SDK: `stripe` npm v22.x.
 
 - `Invoice.subscription` **rimosso** →
   `invoice.parent?.subscription_details?.subscription`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       marketing: ${{ steps.f.outputs.marketing }}
       lockfile: ${{ steps.f.outputs.lockfile }}
       migrations: ${{ steps.f.outputs.migrations }}
+      hooks: ${{ steps.f.outputs.hooks }}
       workflows: ${{ steps.f.outputs.workflows }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -47,6 +48,8 @@ jobs:
             migrations:
               - 'supabase/migrations/**'
               - 'scripts/check-migrations.mjs'
+            hooks:
+              - '.claude/hooks/**'
             workflows:
               - '.github/workflows/**'
       # Filtro "src/** escluso marketing": serve `predicate-quantifier: every`
@@ -84,6 +87,21 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check migration journal consistency
         run: node scripts/check-migrations.mjs
+
+  # Esegue le suite di test degli hook PreToolUse (.claude/hooks/).
+  # Gira solo quando cambia .claude/hooks/**. Difesa-in-profondità per le
+  # regole 1 e 11 di CLAUDE.md: un regex che smette di bloccare push su main
+  # o `drizzle-kit generate` deve fallire la CI, non passare silenzioso.
+  hook-tests:
+    needs: changes
+    if: needs.changes.outputs.hooks == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run hook test suites
+        run: |
+          bash .claude/hooks/test-block-push-to-main.sh
+          bash .claude/hooks/test-block-drizzle-generate.sh
 
   # Scansione segreti — gira su tutti i push/PR (indipendente dal diff)
   secret-scan:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ via "Documento Commerciale Online", senza registratore telematico fisico.
 
 **Stack:** Next.js 16 (App Router) · React 19 · TypeScript strict · Tailwind 4 ·
 shadcn/ui · TanStack Query/Table · PWA (Serwist) · Supabase Cloud (Postgres) ·
-Drizzle ORM · Supabase Auth · Stripe (`2026-02-25.clover`) · Resend · Sentry ·
+Drizzle ORM · Supabase Auth · Stripe (`2026-04-22.dahlia`) · Resend · Sentry ·
 pino · Umami · SonarCloud · Vitest. Deploy Docker self-hosted su VPS dietro
 Cloudflare Tunnel.
 
@@ -137,7 +137,7 @@ src/app/\(marketing\)` prima di chiudere il task.
 Regole specifiche ricorrenti (S6861 readonly props, S6772 JSX spacing, S7780
 template literals, S5852/S5122 hotspots, Gitleaks placeholder) → skill `sonar-quality-gate`.
 
-## Stripe API version `2026-02-25.clover` — breaking changes
+## Stripe API version `2026-04-22.dahlia` — breaking changes
 
 - `Invoice.subscription` rimosso → `invoice.parent?.subscription_details?.subscription`
 - `Subscription.current_period_end` → `subscription.items.data[0]?.current_period_end`
@@ -265,7 +265,7 @@ auto-attivano quando il task matcha il `description`:
   Drizzle raw `sql\`\``con`Date`, race / idempotency per-tenant
 - **`security-patterns`** — `CF-Connecting-IP`, UUID/body/email guards,
   hostname validation, double-gate rate limit, CSP, prototype-safe lookup
-- **`stripe-webhooks`** — API `2026-02-25.clover`, 8 webhook events,
+- **`stripe-webhooks`** — API `2026-04-22.dahlia`, 8 webhook events,
   stale-pending recovery AdE
 - **`ade-integration`** — integrazione HTTP diretta, mock strategy, HAR
   analysis, rotazione `ENCRYPTION_KEY`


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for PreToolUse hook guards and integrates hook test execution into the CI pipeline. This implements defense-in-depth validation for CLAUDE.md rules 1 and 11 (blocking `drizzle-kit generate` and direct pushes to `main`).

## Changes

- **New test suite:** `.claude/hooks/test-block-drizzle-generate.sh`
  - Tests the `block-drizzle-generate.sh` hook with synthetic Bash tool invocations
  - Validates that the hook correctly blocks all variants of `drizzle-kit generate` (with package managers, extra whitespace, dialect suffixes)
  - Validates that legitimate drizzle operations (`migrate`, `push`, `studio`) and other commands pass through
  - Exit code semantics: 2 = block, 0 = pass

- **CI integration:** `.github/workflows/ci.yml`
  - Added `hooks` output to the `changes` job to detect modifications in `.claude/hooks/**`
  - New `hook-tests` job that runs all hook test suites when hook files change
  - Ensures hook regex failures are caught immediately in CI rather than silently passing

- **Documentation updates:**
  - Updated Stripe API version from `2026-02-25.clover` to `2026-04-22.dahlia` in `CLAUDE.md` and skill file
  - Updated SDK version reference to `stripe` npm v22.x

## Implementation Details

The test harness simulates Claude's Bash tool invocation format by:
1. Encoding the command as JSON with `tool_input.command` structure
2. Piping the payload to the hook script
3. Capturing exit codes to assert block/pass behavior

This ensures the regex patterns in the hook remain effective as the codebase evolves, preventing accidental regeneration of migrations that could conflict with handwritten journal entries (rule 11).

https://claude.ai/code/session_01KFk9QEQ9JPfDFThnm6FNjr