### PR TITLE
Add SonarQube scan wrapper with retry & CDN 403 tolerance

### DIFF
--- a/.claude/skills/sonar-quality-gate/SKILL.md
+++ b/.claude/skills/sonar-quality-gate/SKILL.md
@@ -109,6 +109,33 @@ le righe esatte con `grep -n`.
 
 ---
 
+## Scan Sonar in CI: wrapper, non l'action
+
+Il job `sonar` di `ci.yml` **non** usa più `SonarSource/sonarqube-scan-action`
+direttamente: gira `scripts/ci/sonar-scan.sh`. Motivo: l'action non ha retry e
+riscarica il CLI da `binaries.sonarsource.com` a ogni run; quel CDN risponde a
+volte **HTTP 403** in modo intermittente (flakiness lato Sonar, nessun problema
+nel nostro codice) e faceva fallire il job — fastidioso su `main` post-merge
+(notifiche). Il wrapper:
+
+1. scarica il CLI con **retry + backoff** (il 403 sparisce quasi sempre al 2°
+   tentativo);
+2. se il **download** fallisce su tutti i tentativi → `::warning::` + `exit 0`
+   (job verde, niente notifica). Tollera **solo** la fase di download;
+3. se lo **scan** fallisce (config/auth/analisi reale) → exit non-zero, job
+   rosso. I problemi veri restano visibili.
+
+PR/branch decoration: auto-rilevati dallo scanner dall'ambiente GitHub Actions
+(no `sonar.pullrequest.*`). Il `-linux-x64.zip` include la JRE. Versione CLI
+pinnata in `SCANNER_VERSION` (bump = una riga). Logica coperta da
+`scripts/ci/test-sonar-scan.sh` (gira nel job `sonar-script-tests` quando cambia
+`scripts/ci/**` o `ci.yml`). Trade-off noto: niente verifica OpenPGP del binario
+(solo TLS dall'host ufficiale).
+
+⚠️ Se devi tornare all'action o cambiare il comportamento di tolleranza, ricorda
+che questo job **non** enforce il quality gate (è un check separato della
+SonarCloud GitHub App): il suo unico failure mode ripetibile è il download.
+
 ## Debug di CI failure opachi
 
 Quando un CI fail (SonarCloud, Gitleaks, ecc.) **non è visibile** nel diff PR o

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       migrations: ${{ steps.f.outputs.migrations }}
       hooks: ${{ steps.f.outputs.hooks }}
       workflows: ${{ steps.f.outputs.workflows }}
+      ci_scripts: ${{ steps.f.outputs.ci_scripts }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       # Filtri "semplici" — predicate-quantifier di default (`some`).
@@ -52,6 +53,9 @@ jobs:
               - '.claude/hooks/**'
             workflows:
               - '.github/workflows/**'
+            ci_scripts:
+              - 'scripts/ci/**'
+              - '.github/workflows/ci.yml'
       # Filtro "src/** escluso marketing": serve `predicate-quantifier: every`
       # per far valere le negazioni. Con `some` (default), un file marketing
       # matcherebbe comunque `src/**` e setterebbe il flag a true.
@@ -102,6 +106,19 @@ jobs:
         run: |
           bash .claude/hooks/test-block-push-to-main.sh
           bash .claude/hooks/test-block-drizzle-generate.sh
+
+  # Testa il wrapper dello scan Sonar (retry + tolleranza 403 del CDN).
+  # Gira solo quando cambia scripts/ci/** o ci.yml. Rete-di-sicurezza: una
+  # regressione che ingoiasse i fallimenti *reali* dello scan (perdita silente
+  # del quality gate) o che tornasse a fallire sul 403 deve far rosso la CI.
+  sonar-script-tests:
+    needs: changes
+    if: needs.changes.outputs.ci_scripts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run sonar-scan wrapper tests
+        run: bash scripts/ci/test-sonar-scan.sh
 
   # Scansione segreti — gira su tutti i push/PR (indipendente dal diff)
   secret-scan:
@@ -258,10 +275,16 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: test-execution-report
-      - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+      # Wrapper around the scanner CLI instead of SonarSource/sonarqube-scan-action:
+      # that action has no retry and re-downloads the CLI from binaries.sonarsource.com
+      # every run, so an intermittent HTTP 403 from Sonar's CDN sinks the job (and
+      # spams notifications on main). The wrapper retries the download and, if the
+      # CDN stays unreachable, skips with a warning instead of failing — real scan
+      # errors still turn the job red. Logic covered by scripts/ci/test-sonar-scan.sh.
+      - name: SonarQube Cloud scan (retry + tolerate CDN 403)
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: bash scripts/ci/sonar-scan.sh
 
   # Build parte quando lint, type-check e test sono verdi (test puo' essere skippato
   # su marketing-only: GitHub Actions tratta "skipped" come "success" in needs:).

--- a/scripts/ci/sonar-scan.sh
+++ b/scripts/ci/sonar-scan.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# CI wrapper around the SonarQube Cloud scan.
+#
+# Why this exists
+# ---------------
+# SonarSource's CDN (binaries.sonarsource.com) intermittently answers the
+# scanner-CLI download with HTTP 403. It is infrastructure flakiness on Sonar's
+# side, unrelated to our code, yet it fails the `sonar` CI job — and on `main`
+# after a merge it spams failure notifications. The official
+# `sonarqube-scan-action` has no built-in retry and re-downloads the CLI on
+# every run, so a single bad response from the CDN sinks the whole job.
+#
+# Behaviour
+# ---------
+#   1. Download the scanner CLI, retrying up to MAX_ATTEMPTS with exponential
+#      backoff. A second attempt clears almost every intermittent 403.
+#   2. If *every* attempt fails to fetch the CLI (transient CDN/network error,
+#      e.g. the 403), print a warning annotation and exit 0 — the job stays
+#      green. We tolerate ONLY the download phase.
+#   3. Once the CLI is in place, run the scan. A failure *here* is a real
+#      problem (bad config, auth, analysis error) and propagates a non-zero
+#      exit, so genuine issues still turn the job red.
+#
+# Branch/PR decoration is auto-detected by the scanner from the GitHub Actions
+# environment, so no sonar.pullrequest.* parameters are needed. The
+# `-linux-x64` distribution bundles its own JRE, so no system Java is required.
+#
+# Note: unlike the official action this does not OpenPGP-verify the binary; the
+# zip is still fetched over TLS from the official host. Acceptable trade-off for
+# this project — revisit if supply-chain posture tightens.
+#
+# The download/extract/scan steps are functions so test-sonar-scan.sh can stub
+# them; main() runs only when the script is executed directly, not when sourced.
+
+set -uo pipefail
+
+SCANNER_VERSION="${SCANNER_VERSION:-8.0.1.6346}"
+SONAR_BINARIES_URL="${SONAR_BINARIES_URL:-https://binaries.sonarsource.com/Distribution/sonar-scanner-cli}"
+SONAR_HOST_URL="${SONAR_HOST_URL:-https://sonarcloud.io}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+# Attempt N waits BACKOFF_BASE * 2^(N-1) seconds. Set to 0 in tests.
+BACKOFF_BASE="${BACKOFF_BASE:-2}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
+
+ZIP_NAME="sonar-scanner-cli-${SCANNER_VERSION}-linux-x64.zip"
+SCANNER_HOME="${WORK_DIR}/sonar-scanner-${SCANNER_VERSION}-linux-x64"
+
+log() { printf '%s\n' "$*" >&2; }
+
+# Download + extract the CLI. Returns 0 on success, non-zero on any
+# download/extract failure so the caller can retry and ultimately tolerate.
+fetch_scanner() {
+  local url="${SONAR_BINARIES_URL}/${ZIP_NAME}"
+  local zip="${WORK_DIR}/${ZIP_NAME}"
+  local code
+  # Without --fail curl returns 0 even on 403 (it writes the error body), so we
+  # inspect the HTTP status code explicitly. A non-zero curl exit means a
+  # network/TLS error, which is equally a transient download failure.
+  code=$(curl -sSL -o "$zip" -w '%{http_code}' "$url") || {
+    log "curl error fetching ${url}"
+    return 1
+  }
+  log "Scanner download HTTP status: ${code} (${url})"
+  [ "$code" = "200" ] || return 1
+  unzip -q -o "$zip" -d "$WORK_DIR" || return 1
+}
+
+# Run the actual scan. SONAR_TOKEN is read from the environment by the CLI.
+run_scan() {
+  "${SCANNER_HOME}/bin/sonar-scanner" -Dsonar.host.url="${SONAR_HOST_URL}"
+}
+
+main() {
+  local attempt=1 delay
+  while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+    if fetch_scanner; then
+      log "Scanner CLI ready (attempt ${attempt}/${MAX_ATTEMPTS}); running scan."
+      run_scan
+      return $?
+    fi
+    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+      delay=$(( BACKOFF_BASE * (1 << (attempt - 1)) ))
+      log "Scanner download failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delay}s..."
+      sleep "$delay"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  # Every attempt failed to even fetch the CLI: transient CDN/network flakiness
+  # (typically HTTP 403). Pass the job rather than spam failure notifications.
+  printf '::warning::%s\n' "SonarQube scan skipped: could not download the scanner CLI from ${SONAR_BINARIES_URL} after ${MAX_ATTEMPTS} attempts (transient CDN error, e.g. HTTP 403). Not failing the job."
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/ci/test-sonar-scan.sh
+++ b/scripts/ci/test-sonar-scan.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Tests for scripts/ci/sonar-scan.sh
+#
+# Verifies the retry/tolerate decision without touching the network, by sourcing
+# the script and stubbing its fetch_scanner / run_scan functions. Run from repo
+# root:
+#   ./scripts/ci/test-sonar-scan.sh
+#
+# Defense-in-depth: if the tolerate logic regressed to swallow *scan* failures
+# we'd silently lose the quality gate; if it regressed to fail on a download
+# 403 we'd be back to notification spam. Both must be caught here.
+
+# Scenario strings below are literal code handed to `eval`; single quotes are
+# intentional so nothing expands before then.
+# shellcheck disable=SC2016
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SCAN="$SCRIPT_DIR/sonar-scan.sh"
+
+if [ ! -f "$SCAN" ]; then
+  echo "FAIL: script not found: $SCAN" >&2
+  exit 1
+fi
+
+failures=0
+
+# Source the script in a clean subshell, apply a scenario (which overrides
+# fetch_scanner / run_scan), run main, and capture combined output via $out and
+# exit code via $rc. BACKOFF_BASE=0 keeps retries instant.
+run_main() {
+  local scenario="$1"
+  out=$( {
+    BACKOFF_BASE=0 MAX_ATTEMPTS=3
+    export BACKOFF_BASE MAX_ATTEMPTS
+    # shellcheck disable=SC1090
+    source "$SCAN"
+    eval "$scenario"
+    main
+  } 2>&1 )
+  rc=$?
+}
+
+assert_rc() {
+  local label="$1" want="$2"
+  if [ "$rc" -ne "$want" ]; then
+    echo "FAIL [$label]: expected exit $want but got $rc" >&2
+    echo "       output: $out" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2"
+  case "$out" in
+    *"$needle"*) ;;
+    *)
+      echo "FAIL [$label]: output missing '$needle'" >&2
+      echo "       output: $out" >&2
+      failures=$((failures + 1))
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2"
+  case "$out" in
+    *"$needle"*)
+      echo "FAIL [$label]: output unexpectedly contains '$needle'" >&2
+      echo "       output: $out" >&2
+      failures=$((failures + 1))
+      ;;
+  esac
+}
+
+# 1. Download fails on every attempt -> tolerate (exit 0, warning, no scan).
+run_main '
+fetch_scanner() { return 1; }
+run_scan() { echo "SCAN RAN"; return 0; }
+'
+assert_rc "persistent 403 tolerated" 0
+assert_contains "persistent 403 tolerated" "::warning::"
+assert_not_contains "persistent 403 tolerated" "SCAN RAN"
+
+# 2. Download flaky (fails twice, succeeds on attempt 3) -> scan runs, passes.
+run_main '
+fetch_scanner() {
+  FETCH_TRIES=$(( ${FETCH_TRIES:-0} + 1 ))
+  [ "$FETCH_TRIES" -ge 3 ]
+}
+run_scan() { echo "SCAN RAN"; return 0; }
+'
+assert_rc "flaky download recovers" 0
+assert_contains "flaky download recovers" "SCAN RAN"
+assert_not_contains "flaky download recovers" "::warning::"
+
+# 3. Download OK but the scan itself fails -> real failure, job red.
+run_main '
+fetch_scanner() { return 0; }
+run_scan() { echo "SCAN RAN"; return 7; }
+'
+assert_rc "real scan failure propagates" 7
+assert_contains "real scan failure propagates" "SCAN RAN"
+assert_not_contains "real scan failure propagates" "::warning::"
+
+# 4. Happy path: download OK on first attempt, scan passes.
+run_main '
+fetch_scanner() { return 0; }
+run_scan() { echo "SCAN RAN"; return 0; }
+'
+assert_rc "happy path" 0
+assert_contains "happy path" "SCAN RAN"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures test(s) failed." >&2
+  exit 1
+fi
+
+echo "All sonar-scan wrapper tests passed."


### PR DESCRIPTION
## Summary

Replace the direct use of `SonarSource/sonarqube-scan-action` with a custom wrapper script (`scripts/ci/sonar-scan.sh`) that retries the scanner CLI download and gracefully tolerates transient CDN failures, while still propagating real scan errors.

## Problem

SonarSource's CDN (`binaries.sonarsource.com`) intermittently responds with HTTP 403 to scanner-CLI downloads due to infrastructure flakiness on their side. The official `sonarqube-scan-action` has no built-in retry and re-downloads on every run, causing the `sonar` CI job to fail on every CDN hiccup — particularly disruptive on `main` post-merge (notification spam).

## Solution

**New files:**
- `scripts/ci/sonar-scan.sh` — Wrapper that:
  1. Downloads the scanner CLI with **exponential backoff retry** (up to `MAX_ATTEMPTS=3`); a second attempt clears almost every intermittent 403
  2. If **download** fails on all attempts → emit `::warning::` annotation and exit 0 (job stays green, no notification spam). Tolerates **only** the download phase
  3. If **scan** fails (real config/auth/analysis error) → propagate non-zero exit (job turns red). Genuine issues remain visible
  
- `scripts/ci/test-sonar-scan.sh` — Comprehensive test suite covering:
  - Persistent download failure → tolerated with warning, scan skipped
  - Flaky download (fails twice, succeeds on attempt 3) → scan runs and passes
  - Real scan failure → propagates exit code, no warning
  - Happy path → download succeeds immediately, scan runs

**Modified files:**
- `.github/workflows/ci.yml`:
  - Add `ci_scripts` change filter (triggers on `scripts/ci/**` or `ci.yml` changes)
  - New `sonar-script-tests` job that runs the test suite when CI scripts change
  - Replace `SonarSource/sonarqube-scan-action` step with `bash scripts/ci/sonar-scan.sh`
  
- `.claude/skills/sonar-quality-gate/SKILL.md` — Document the wrapper behavior, retry logic, and trade-offs (no OpenPGP verification, TLS-only)

## Implementation Details

- **Retry logic:** Exponential backoff with `BACKOFF_BASE * 2^(N-1)` seconds between attempts; configurable for testing (`BACKOFF_BASE=0` in tests)
- **HTTP status inspection:** Explicit `curl -w '%{http_code}'` check (curl returns 0 even on 403 without `--fail`)
- **Testability:** Functions (`fetch_scanner`, `run_scan`) are stubbed in tests; `main()` only runs when script is executed directly, not sourced
- **Environment:** Branch/PR decoration auto-detected by scanner from GitHub Actions env; `-linux-x64` distribution bundles its own JRE (no system Java required)
- **Version pinning:** Scanner version in `SCANNER_VERSION` env var (single-line bump)

## Notes

- Quality gate enforcement is a separate SonarCloud GitHub App check; this job's only repeatable failure mode is the download
- Trade-off: no OpenPGP verification of the binary (TLS from official host only) — acceptable for this project
- Defense-in-depth: test suite catches both regressions (swallowing real scan failures, or failing on 403) before they reach production

https://claude.ai/code/session_01SgFirMCgNQUNko8HYnGBTA