### PR TITLE
Bump version to 1.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Patch release bump to version 1.3.7.

## Changes
- Updated `package.json` version from `1.3.6` to `1.3.7`

## Notes
This is a routine version bump. The lockfile was automatically updated as a transitive dependency resolution artifact.

https://claude.ai/code/session_019gQtbKsU1Efxh5NGudn3Lh