### PR TITLE
R21-R25: Observability & boot-time env validation

### DIFF
--- a/.claude/skills/sentry-hygiene/SKILL.md
+++ b/.claude/skills/sentry-hygiene/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: sentry-hygiene
+description: Use when triaging or reviewing Sentry issues for the dstmrk/scontrinozero project — periodic review of archived/ignored issues (e.g. SCONTRINOZERO-7 sat at 23 events for 5 weeks before anyone noticed it was UX, not noise), classifying a noisy issue (true bot/scanner noise → beforeSend filter with documented motivation; predictable user input → fix UX via regola 20 logAdeFailure ade_user_error; transient upstream → already covered by isTransientAdeError), writing or extending the beforeSend filter in sentry.server.config.ts + src/lib/sentry-filters.ts, validating the pino → Sentry Logs drain after a telemetry rollout via /api/_debug/sentry-sentinel (regola 21), running post-deploy smoke (live + env + drain via regole 21+25), or looking up Sentry events via the Sentry MCP (mcp__Sentry__search_issues, search_events, get_sentry_resource) using the canonical query patterns (errorClass:ade_user_error / ade_transient / ade_failure / sentinel; sentinelId:<id>; flow-derived fingerprint).
+---
+
+# sentry-hygiene — Review e classificazione delle issue Sentry
+
+Lezioni operative per non lasciare incancrenire il dataset Sentry: una
+issue "archiviata come noise" che in realtà nascondeva UX (SCONTRINOZERO-7)
+è peggio di una issue rumorosa che esplode una volta — perché diventa
+invisibile.
+
+---
+
+## Quando triggerare il review
+
+- **Prima di ogni release minor (`v1.X.0`)**: pull delle issue archived
+  con > N eventi nelle ultime 4 settimane.
+- **A ogni rollout di feature di osservabilità** (Sentry Logs, Pino
+  integration, metrics): regola 21 di `CLAUDE.md` — sentinella entro
+  ~5 min dal deploy.
+- **Quando una issue archived sale di scala** (sub-status
+  `archived_until_escalating` → `escalating`): ri-aprirla è un segnale
+  che la classificazione iniziale era sbagliata.
+
+Comando di pull (Sentry MCP):
+
+```
+mcp__Sentry__search_issues({
+  organizationSlug: "dstmrk",
+  projectSlugOrId: "scontrinozero",
+  regionUrl: "https://de.sentry.io",
+  query: "is:archived environment:production",
+  sort: "freq",
+  limit: 30,
+})
+```
+
+---
+
+## Classificare un'issue archived: tre rami
+
+Ogni issue archived ricade in uno di questi 3 rami. La classificazione
+guida l'azione, non viceversa.
+
+### 1. Noise vero (bot/scanner, browser quirk non azionabile)
+
+Esempio canonico: **SCONTRINOZERO-E** `TypeError: Failed to parse body
+as FormData` su `POST /_not-found/page` da crawler che provano path
+`/RSC/<hash>.txt`.
+
+**Azione**: filtro esplicito in `sentry.server.config.ts:beforeSend`
+con il predicato in `src/lib/sentry-filters.ts` e un commento che cita
+l'ID issue:
+
+```typescript
+beforeSend(event, hint) {
+  if (isBenignFormDataParseError(event, hint)) {
+    return null; // SCONTRINOZERO-E: bot POST a /_not-found/page
+  }
+  return event;
+}
+```
+
+Mai un filtro generico tipo "scarta tutto ciò che non ha stack utile":
+ogni filter va con un predicato dedicato + commento che cita l'issue.
+
+### 2. UX nascosto come noise (input utente prevedibile)
+
+Esempio canonico: **SCONTRINOZERO-7** `AdeAuthError` (credenziali
+sbagliate dal `/dashboard/settings`), 23 eventi in 5 settimane prima
+dell'archiviazione.
+
+**Sintomi**:
+
+- Conteggio cumulativo alto, ma `Users Impacted` distribuito (non un
+  utente che cicla).
+- Il messaggio descrive una condizione che **l'utente può correggere**
+  (credenziali, P.IVA già usata, token captcha scaduto, payment
+  declined).
+- Lo stack passa da una server action — non da un job batch o un cron.
+
+**Azione**: regola 20 di `CLAUDE.md`. Spostare il throw in un return
+`{ error: "..." }` e cambiare il log level a warn con `errorClass:
+"ade_user_error"` (o equivalente). Pattern canonico:
+
+```typescript
+// src/lib/ade/log-failure.ts
+if (isExpectedUserAdeError(err)) {
+  logger.warn(
+    { err, ...context, errorClass: "ade_user_error" },
+    messages.failure,
+  );
+  return;
+}
+```
+
+`isExpectedUserAdeError` copre `AdeAuthError` + `AdePasswordExpiredError`.
+Estensione naturale: copia il pattern per Stripe (card declined),
+Resend (bounced email) appena emerge il caso.
+
+### 3. Transient upstream (rete, 5xx esterno, SPID timeout)
+
+Esempio: AdE in downtime, Stripe webhook intermittente.
+
+**Azione**: già coperto da `isTransientAdeError` (ramo
+`ade_transient` di `logAdeFailure`). Per altri SDK estendere lo stesso
+pattern: predicato → `logger.warn` con `errorClass: "<sdk>_transient"`,
+mai `logger.error`.
+
+---
+
+## Lookup puntuale via Sentry MCP
+
+Tre query canoniche, già supportate dai tag che il repo emette:
+
+**Sentry Logs (dataset `logs`)** — degrado userside o transient:
+
+```
+errorClass:ade_user_error environment:production
+errorClass:ade_transient environment:production
+errorClass:sentinel sentinelId:<id>   # validazione drain (R21)
+```
+
+**Sentry Issues (default `errors`)** — eventi che hanno superato il
+`level≥50` hook:
+
+```
+errorClass:ade_failure environment:production
+errorClass:ade_failure flow:onboarding-verify  # group per flow (R23)
+```
+
+Per validare un singolo trace user-session:
+
+```
+mcp__Sentry__search_events({
+  organizationSlug: "dstmrk",
+  dataset: "spans",
+  query: "trace:<trace_id>",
+  ...
+})
+```
+
+Storico: SCONTRINOZERO-9, -A, -B condividevano `trace_id 5efe8519…`,
+3 issue distinte per un'unica onboarding fallita. Con la regola 23 i
+sub-step finiscono nello stesso group.
+
+---
+
+## Smoke post-deploy: live + env + drain
+
+Ogni deploy (prod, sandbox, dev Pi) **non è "concluso"** finché:
+
+```bash
+curl -fsS https://<host>/api/health/live
+curl -fsS https://<host>/api/_health/env | jq .
+curl -fsS -H "x-sentinel-token: $TOKEN" \
+  "https://<host>/api/_debug/sentry-sentinel?id=v$VERSION"
+```
+
+I tre probe in fila catturano:
+
+- container up (`/live`)
+- env d'identità coerente — confronta `appUrl` e `release` con il
+  rilasciato (`/_health/env` → regola 25)
+- pino → Sentry Logs + `captureException` funzionanti (sentinella →
+  regola 21). Cerca `errorClass:sentinel sentinelId:v$VERSION` in
+  Sentry entro 5 min.
+
+Se uno dei tre fallisce → integrazione rotta, rollback o riapri la PR.
+
+---
+
+## Pattern repo: ogni guard cita l'ID issue
+
+Quando aggiungi un filtro `beforeSend`, un `logAdeFailure`, un
+`safeSessionStorage`, o un `getTrustedAppUrl`, **commenta esplicito**
+l'ID Sentry che ha originato il fix. Esempi già in repo:
+
+- `src/lib/safe-storage.ts` → cita `SCONTRINOZERO-H`
+- `src/lib/trusted-app-url.ts` → cita `SCONTRINOZERO-F` + regola 18
+- `sentry.server.config.ts:beforeSend` + `src/lib/sentry-filters.ts` →
+  cita `SCONTRINOZERO-E`
+- `src/lib/ade/log-failure.ts` → cita `SCONTRINOZERO-7` (regola 20)
+- `src/instrumentation.ts` → cita `SCONTRINOZERO-F` + regola 24
+
+Rende la lezione trovabile in `grep -rn "SCONTRINOZERO-<id>"` e
+preserva il filo storico anche dopo che l'issue è archived in Sentry.
+
+---
+
+## Anti-pattern: archiviare senza classificare
+
+`Archive until escalating` è un'opzione potente ma silenziosa: l'issue
+ricompare solo se il volume cresce. Se è "noise" deve diventare un
+filter (ramo 1 sopra); se è "UX" deve diventare un fix (ramo 2). Lasciarla
+archived senza azione = nascondere il debito.
+
+Storico (lezione che ha portato a questa skill): SCONTRINOZERO-7 è
+rimasta archived per 5 settimane e 23 eventi prima di essere
+ri-classificata come UX. Il review periodico (sezione 1 sopra) esiste
+proprio per intercettare questa categoria.

--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-patterns
-description: Use when writing or fixing Vitest tests — avoiding SonarCloud S6661 Blocker (every it()/test() must have at least one expect()), mocking classes correctly with function/class keyword (never arrow), prefixing vi.mock factory variables with "mock" for hoisting, mocking Drizzle's db.transaction() callback with a passthrough, stubbing NODE_ENV with vi.stubEnv, updating mocks after refactoring N queries into a JOIN, INSERT ON CONFLICT DO NOTHING for race conditions, sanitizing context before Sentry.captureException via sanitizeForTelemetry(), auth-first ordering in deleteAccount, conditional last_used_at writes to prevent write-amplification, or react/cache deduplication across RSC and Route Handlers. Also lists the consolidated rate-limit thresholds for server actions (emit/void/pdf/checkout/portal/auth).
+description: Use when writing or fixing Vitest tests — avoiding SonarCloud S6661 Blocker (every it()/test() must have at least one expect()), mocking classes correctly with function/class keyword (never arrow), prefixing vi.mock factory variables with "mock" for hoisting, mocking Drizzle's db.transaction() callback with a passthrough, stubbing NODE_ENV with vi.stubEnv, updating mocks after refactoring N queries into a JOIN, INSERT ON CONFLICT DO NOTHING for race conditions, sanitizing context before Sentry.captureException via sanitizeForTelemetry(), auth-first ordering in deleteAccount, conditional last_used_at writes to prevent write-amplification, react/cache deduplication across RSC and Route Handlers, simulating a hostile browser (sessionStorage/localStorage throwing SecurityError, in-app webview, cookies disabled) for UI components that read Web Storage, or mocking Sentry.withScope + scope.setFingerprint when testing logger.ts fingerprint-aware capture. Also lists the consolidated rate-limit thresholds for server actions (emit/void/pdf/checkout/portal/auth).
 ---
 
 # testing-patterns — Vitest patterns e regole CI
@@ -267,3 +267,118 @@ Per evitare DB write su ogni request:
 
 Il DB aggiorna solo se `lastUsedAt IS NULL OR lastUsedAt < NOW - N_min`.
 Sempre fire-and-forget (`.catch(logger.warn)`). Throttle consigliato: 10 min.
+
+---
+
+## Browser ostile: storage bloccato, in-app webview, cookies off
+
+**Storia (SCONTRINOZERO-H, Chrome Mobile su Android 10, 7 eventi in
+2 min):** `sessionStorage`/`localStorage` non sono sempre disponibili.
+Su browser in modalità privacy, cookie di terze parti bloccati, o
+all'interno di alcune in-app webview, anche solo **accedere alla
+property** `window.sessionStorage` lancia `SecurityError`
+(DOMException 18) — non basta un try/catch sul singolo `getItem`/`setItem`.
+Senza un wrapper safe, il throw dentro un `useEffect` finisce in
+Sentry e/o rompe il commit dell'effetto.
+
+**Wrapper canonico:** `src/lib/safe-storage.ts`. `safeSessionStorage` e
+`safeLocalStorage` degradano a `null` (lettura) / no-op (scrittura) +
+SSR-safe (senza `window` ritornano `null`/no-op). Ogni componente
+client che legge Web Storage deve usarli, **mai** `window.localStorage`
+diretto.
+
+**Mock pattern per testare la condizione ostile:**
+
+```typescript
+// Property-access throw (lo store stesso non è leggibile).
+// Mock PRIMA del primo render del componente sotto test.
+beforeEach(() => {
+  Object.defineProperty(window, "sessionStorage", {
+    configurable: true,
+    get: () => {
+      throw new DOMException("Access denied", "SecurityError");
+    },
+  });
+});
+
+afterEach(() => {
+  // Restore via configurable: true sopra.
+  Object.defineProperty(window, "sessionStorage", {
+    configurable: true,
+    value: originalSessionStorage,
+  });
+});
+
+it("non crasha quando sessionStorage lancia SecurityError", () => {
+  // Il componente deve usare safeSessionStorage internamente: lo store
+  // ritorna null/no-op invece di throware.
+  expect(() => render(<MyComponent />)).not.toThrow();
+});
+```
+
+Per il caso "store leggibile ma `getItem`/`setItem` throw" (quota
+exceeded, lockdown mode), basta sovrascrivere i singoli metodi:
+
+```typescript
+vi.spyOn(window.sessionStorage, "getItem").mockImplementation(() => {
+  throw new DOMException("Quota exceeded", "QuotaExceededError");
+});
+```
+
+**Cookies disabilitati:** `navigator.cookieEnabled = false`. Tutti gli
+auth flow devono degradare con un messaggio ("Abilita i cookie per
+continuare") invece di throware. Test pattern speculare allo storage.
+
+Esempio canonico di copertura: `src/lib/safe-storage.test.ts`.
+
+---
+
+## Mock di `Sentry.withScope` + `scope.setFingerprint` (R23)
+
+Quando testi `captureToSentry` in `src/lib/logger.ts` o qualsiasi codice
+che chiama `Sentry.withScope(s => s.setFingerprint([...]))`, il mock di
+`@sentry/nextjs` deve esporre **withScope come passthrough** che
+inietta uno scope finto con il metodo da spiare. Senza passthrough lo
+state interno della capture non viene mai eseguito.
+
+```typescript
+const mockSetFingerprint = vi.fn();
+const mockWithScope = vi.fn(
+  (cb: (scope: { setFingerprint: typeof mockSetFingerprint }) => void) => {
+    cb({ setFingerprint: mockSetFingerprint });
+  },
+);
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  withScope: mockWithScope,
+}));
+
+it("applica il fingerprint quando sentryFingerprint è nel payload", async () => {
+  const { logger } = await import("./logger");
+  logger.error(
+    {
+      err: new Error("boom"),
+      sentryFingerprint: ["onboarding-verify", "ade_failure"],
+    },
+    "AdE failed",
+  );
+  expect(mockWithScope).toHaveBeenCalledOnce();
+  expect(mockSetFingerprint).toHaveBeenCalledWith([
+    "onboarding-verify",
+    "ade_failure",
+  ]);
+});
+```
+
+Casi da testare sempre insieme:
+
+- `sentryFingerprint` array non-empty → `withScope` chiamato.
+- `sentryFingerprint` assente / empty array / non-array → `withScope`
+  NON chiamato (back-compat con il comportamento default di Sentry
+  grouping).
+- `sentryFingerprint` NON deve apparire in `extra` dell'eventuale
+  `captureException`: è metadato di routing, non payload.
+
+Esempio canonico: `src/lib/logger.test.ts:223`.

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,14 @@ NEXT_PUBLIC_SENTRY_DSN=https://...@sentry.io/...
 SENTRY_AUTH_TOKEN=sntrys_...
 SENTRY_ORG=your-sentry-org
 SENTRY_PROJECT=scontrinozero
+# Token segreto per /api/_debug/sentry-sentinel — endpoint che emette un
+# triple log (info/warn/error) per validare end-to-end il drain Sentry
+# (pino → Logs, captureException → Issues). Genera con:
+#   node -e "console.log(require('crypto').randomBytes(24).toString('hex'))"
+# Senza questa variabile l'endpoint risponde 404 (esistenza nascosta).
+# Va impostata almeno sull'environment dove rilasci feature di telemetria
+# (regola 21 di CLAUDE.md).
+SENTRY_SENTINEL_TOKEN=
 
 # =============================================================================
 # Encryption

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,22 @@ src/app/\(marketing\)` prima di chiudere il task.
     di Next al posto del fallback inline, rompendo la performance percepita
     (priorità #1). Coerente con regola 10 e con il pattern `deleteAccount` della
     skill `testing-patterns` (PR #572, `getStarterKpis`).
+20. **Errori d'input utente: warn, non error (no Sentry noise).** Le condizioni
+    prevedibili dall'input utente — credenziali Fisconline sbagliate, password
+    AdE scaduta, P.IVA già registrata, token Turnstile scaduto — vanno loggate
+    a `logger.warn` (osservabilità in pino → Sentry Logs) ma **non** devono
+    salire a Sentry come issue: non sono bug nostri, esattamente come "password
+    sbagliata su `/login`". Il `logger.error` (level ≥ 50) →
+    `Sentry.captureException` va riservato a condizioni inattese (DB down, SDK
+    fallisce in modo non documentato). Pattern canonico per AdE:
+    `logAdeFailure()` in `src/lib/ade/log-failure.ts` con
+    `errorClass: "ade_user_error"` per `AdeAuthError` / `AdePasswordExpiredError`
+    (`isExpectedUserAdeError`), `ade_transient` per network/5xx/SPID timeout
+    (`isTransientAdeError`), `ade_failure` solo per il resto. Storico:
+    SCONTRINOZERO-7 ha collezionato 23 eventi in 5 settimane prima di essere
+    archiviata come noise, perché ogni utente che digitava credenziali AdE
+    sbagliate da `/dashboard/settings` finiva in Sentry. Estende la regola 19
+    alle server action di scrittura.
 
 ## SonarCloud quality gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,22 @@ https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
     policy GDPR. Per le route che usano auth diversa (es. Bearer API key
     in `/api/v1/*`) il fix è analogo ma puntuale a ciascun handler — non
     propagato qui per non leakare l'`apiKeyId` come `user.id`.
+23. **Fingerprint Sentry per flow multi-step.** I flow AdE (login → wizard
+    → submit) generano errori in step diversi: oggi Sentry li raggruppa per
+    `message + stack`, quindi `wizardTemplate failed 500` e
+    `setUserChoice failed 500` finiscono in 2 issue distinte anche se
+    parte della stessa onboarding fallita (SCONTRINOZERO-9 + -A,
+    trace_id 5efe8519…). Per evitarlo, **passa `flow: "<nome-flow>"`
+    nel context di `logAdeFailure()`** (`src/lib/ade/log-failure.ts`):
+    sul ramo `ade_failure` viene iniettato
+    `sentryFingerprint: [flow, "ade_failure"]` nel payload pino, e
+    `captureToSentry` in `src/lib/logger.ts` lo applica via
+    `Sentry.withScope(s => s.setFingerprint(...))`. I rami warn
+    (transient/user_error) ignorano `flow`: non salgono a Sentry. Flow
+    già instrumentati: `onboarding-verify` (verifyAdeCredentials),
+    `emit-receipt` (receipt-service), `void-receipt` (void-service).
+    Per nuovi flow scegli uno slug stabile (no spazi, no version):
+    cambia il fingerprint = perdi la continuità storica del group.
 
 ## SonarCloud quality gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,42 +37,42 @@ tag git (`git tag -l "v1.*"`).
 
 ## Regole sempre-attive (applicano a ogni task)
 
-1. **Branch separato sempre.** Mai commit/push diretti su `main`. PR sempre,
-   merge spetta all'utente (a meno che non chiesto esplicito).
-2. **TDD.** Test prima dell'implementazione. Ogni file con logica ha il suo
-   test file (anche `instrumentation.ts` e simili bootstrap).
-3. **Chiedi se ambiguo** prima di scrivere codice.
-4. **Edge case dopo ogni implementazione:** elencare gli edge case e aggiungere
-   test che li coprono prima di committare.
-5. **Task > 3 file → break in sub-task.** Stop e suddividere.
-6. **Riflessione dopo correzione:** quando l'utente corregge, capire perché ho
-   sbagliato e come non rifarlo.
-7. **Aggiornare `CLAUDE.md` (o la skill pertinente in `.claude/skills/`)
-   autonomamente** dopo aver risolto un problema non triviale con lezione
-   riusabile (debugging pattern, setup gotcha, wrong assumption). Non
-   aspettare che lo chiedano.
-8. **Contenuti marketing & SEO.** I contenuti vivono in route dedicate con un
-   data file ciascuna: `/help` (operativo, `src/app/(marketing)/help`), `/guide`
-   (educativo, `src/lib/guide/articles.ts`), `/per/[slug]` (categorie,
-   `src/lib/per/categories.ts`), `/confronto` (`src/lib/confronto/comparisons.ts`),
-   `/strumenti/[slug]` (tool gratuiti backlink-magnet, `src/lib/strumenti/tools.ts`).
-   Regole sempre valide:
-   - **Niente promesse di feature non live** in _nessun_ copy marketing: feature
-     non implementate → condizionale/roadmap, mai al presente. Oggi sul Pro
-     restano "in arrivo" solo recupero corrispettivi AdE e sync catalogo AdE;
-     Analytics avanzata ed Export CSV sono **spedite e Pro-gated** (commit
-     ae1c481).
-   - **Slug separati `/help` vs `/guide`** sulle keyword condivise per evitare
-     canonical clash (es. `/help/regime-forfettario` ≠
-     `/guide/regime-forfettario-scontrini`); si linkano a vicenda.
-   - Se modifichi una funzionalità (label, menu, stati, filtri, error flow,
-     gating piani, nomi bottoni) aggiorna i contenuti: `grep -rn "<termine>"
+1.  **Branch separato sempre.** Mai commit/push diretti su `main`. PR sempre,
+    merge spetta all'utente (a meno che non chiesto esplicito).
+2.  **TDD.** Test prima dell'implementazione. Ogni file con logica ha il suo
+    test file (anche `instrumentation.ts` e simili bootstrap).
+3.  **Chiedi se ambiguo** prima di scrivere codice.
+4.  **Edge case dopo ogni implementazione:** elencare gli edge case e aggiungere
+    test che li coprono prima di committare.
+5.  **Task > 3 file → break in sub-task.** Stop e suddividere.
+6.  **Riflessione dopo correzione:** quando l'utente corregge, capire perché ho
+    sbagliato e come non rifarlo.
+7.  **Aggiornare `CLAUDE.md` (o la skill pertinente in `.claude/skills/`)
+    autonomamente** dopo aver risolto un problema non triviale con lezione
+    riusabile (debugging pattern, setup gotcha, wrong assumption). Non
+    aspettare che lo chiedano.
+8.  **Contenuti marketing & SEO.** I contenuti vivono in route dedicate con un
+    data file ciascuna: `/help` (operativo, `src/app/(marketing)/help`), `/guide`
+    (educativo, `src/lib/guide/articles.ts`), `/per/[slug]` (categorie,
+    `src/lib/per/categories.ts`), `/confronto` (`src/lib/confronto/comparisons.ts`),
+    `/strumenti/[slug]` (tool gratuiti backlink-magnet, `src/lib/strumenti/tools.ts`).
+    Regole sempre valide:
+    - **Niente promesse di feature non live** in _nessun_ copy marketing: feature
+      non implementate → condizionale/roadmap, mai al presente. Oggi sul Pro
+      restano "in arrivo" solo recupero corrispettivi AdE e sync catalogo AdE;
+      Analytics avanzata ed Export CSV sono **spedite e Pro-gated** (commit
+      ae1c481).
+    - **Slug separati `/help` vs `/guide`** sulle keyword condivise per evitare
+      canonical clash (es. `/help/regime-forfettario` ≠
+      `/guide/regime-forfettario-scontrini`); si linkano a vicenda.
+    - Se modifichi una funzionalità (label, menu, stati, filtri, error flow,
+      gating piani, nomi bottoni) aggiorna i contenuti: `grep -rn "<termine>"
 src/app/\(marketing\)` prima di chiudere il task.
-   - Contenuti generati via LLM con **review umana**, in italiano, target Italia.
-9. **Boundary delle API:** UUID validation con `isValidUuid()` + 400 prima del
-   service; body size guard con `readJsonWithLimit(req, maxBytes)` + 413 prima
-   di `JSON.parse`; email normalizzata con `normalizeEmail()` in `validation.ts`
-   come prima riga di ogni auth action.
+    - Contenuti generati via LLM con **review umana**, in italiano, target Italia.
+9.  **Boundary delle API:** UUID validation con `isValidUuid()` + 400 prima del
+    service; body size guard con `readJsonWithLimit(req, maxBytes)` + 413 prima
+    di `JSON.parse`; email normalizzata con `normalizeEmail()` in `validation.ts`
+    come prima riga di ogni auth action.
 10. **Wrap SDK esterni (Stripe, AdE, Resend) in try-catch** con log strutturato
     e response 503 — mai lasciare propagare 500 senza context.
 11. **DB migrations: TUTTE handwritten dopo `0000`.** 🚫 **MAI eseguire
@@ -206,6 +206,32 @@ https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
     `http` invece di `https` in prod. Le guardie lazy esistenti
     (`getTrustedAppUrl()`, `parseTrustedHostnameEnv()`) restano in piedi
     come secondo strato — defense in depth, non vengono toccate.
+25. **Smoke test post-deploy: tre health probe.** Dopo ogni rollout
+    (prod o sandbox o `:dev` Pi), prima di considerare il deploy
+    "concluso" hit i tre health probe e verifica la response:
+
+        curl -fsS https://<host>/api/health/live
+        curl -fsS https://<host>/api/_health/env | jq .
+        curl -fsS -H "x-sentinel-token: $TOKEN" \
+          "https://<host>/api/_debug/sentry-sentinel?id=v$VERSION"
+
+    - `/api/health/live` (`src/app/api/health/live/route.ts`) → 200 =
+      process up, event loop responsive.
+    - `/api/_health/env` (`src/app/api/_health/env/route.ts`) → 200 con
+      `{ appUrl, release, hostnames }`. **Confronta `release` e `appUrl`
+      con quanto rilasciato**: una `:dev` con `appUrl: app.scontrinozero.it`
+      è un Dockerfile build-arg dimenticato. 503 = identity env rotta
+      anche dopo la R24 (es. rotazione secret tra boot e prima request).
+    - `/api/_debug/sentry-sentinel` → 200 + `sentryQuery` da incollare
+      in Sentry per validare il drain (regola 21). Fallisce 404 senza
+      token corretto.
+
+    Il pattern è "live + env + drain": catturava `@react-email/render`
+    mancante (SCONTRINOZERO-B, gap dev container vs standalone),
+    `NEXT_PUBLIC_APP_URL` malformato (SCONTRINOZERO-F) e l'`action_link`
+    hostname mismatch (SCONTRINOZERO-D) **al primo rollout**, non al
+    primo utente. Integrazione in CI rimandata: oggi è uno script da
+    eseguire manualmente dopo `docker compose up -d`.
 
 ## SonarCloud quality gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,19 @@ https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
     (rollout `Sentry.pinoIntegration`) è stato il caso che ha forzato la
     regola — il dataset `logs` era vuoto al momento dell'analisi e non si
     poteva distinguere "drain rotto" da "rilasciato 40 minuti fa".
+22. **`Sentry.setUser({ id })` su ogni richiesta autenticata.** Tutte le
+    server action e i route handler che chiamano `getAuthenticatedUser()`
+    bindano automaticamente l'auth user UUID allo scope Sentry della
+    richiesta (visto che il bind è già dentro `getAuthenticatedUser` in
+    `src/lib/server-auth.ts:51`). Senza questo `Users Impacted` resta a 0
+    su ogni issue: tutte e 10 le issue Sentry analizzate (SCONTRINOZERO-7
+    a -H) avevano `Users: 0` anche quando il bug toccava più utenti in 2
+    minuti — il triage non poteva prioritizzare per impatto. Passare **solo
+    `id`** (UUID opaco di Supabase Auth): niente `email`/`username`/`ip`,
+    coerente con il denylist `SAFE_KEYS` di `src/lib/logger.ts` e con la
+    policy GDPR. Per le route che usano auth diversa (es. Bearer API key
+    in `/api/v1/*`) il fix è analogo ma puntuale a ciascun handler — non
+    propagato qui per non leakare l'`apiKeyId` come `user.id`.
 
 ## SonarCloud quality gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,19 +56,15 @@ tag git (`git tag -l "v1.*"`).
     (educativo, `src/lib/guide/articles.ts`), `/per/[slug]` (categorie,
     `src/lib/per/categories.ts`), `/confronto` (`src/lib/confronto/comparisons.ts`),
     `/strumenti/[slug]` (tool gratuiti backlink-magnet, `src/lib/strumenti/tools.ts`).
-    Regole sempre valide:
-    - **Niente promesse di feature non live** in _nessun_ copy marketing: feature
-      non implementate → condizionale/roadmap, mai al presente. Oggi sul Pro
-      restano "in arrivo" solo recupero corrispettivi AdE e sync catalogo AdE;
-      Analytics avanzata ed Export CSV sono **spedite e Pro-gated** (commit
-      ae1c481).
-    - **Slug separati `/help` vs `/guide`** sulle keyword condivise per evitare
-      canonical clash (es. `/help/regime-forfettario` ≠
-      `/guide/regime-forfettario-scontrini`); si linkano a vicenda.
-    - Se modifichi una funzionalità (label, menu, stati, filtri, error flow,
-      gating piani, nomi bottoni) aggiorna i contenuti: `grep -rn "<termine>"
-src/app/\(marketing\)` prima di chiudere il task.
-    - Contenuti generati via LLM con **review umana**, in italiano, target Italia.
+    Regole sempre valide: - **Niente promesse di feature non live** in _nessun_ copy marketing: feature
+    non implementate → condizionale/roadmap, mai al presente. Oggi sul Pro
+    restano "in arrivo" solo recupero corrispettivi AdE e sync catalogo AdE;
+    Analytics avanzata ed Export CSV sono **spedite e Pro-gated** (commit
+    ae1c481). - **Slug separati `/help` vs `/guide`** sulle keyword condivise per evitare
+    canonical clash (es. `/help/regime-forfettario` ≠
+    `/guide/regime-forfettario-scontrini`); si linkano a vicenda. - Se modifichi una funzionalità (label, menu, stati, filtri, error flow,
+    gating piani, nomi bottoni) aggiorna i contenuti: `grep -rn "<termine>"
+src/app/\(marketing\)` prima di chiudere il task. - Contenuti generati via LLM con **review umana**, in italiano, target Italia.
 9.  **Boundary delle API:** UUID validation con `isValidUuid()` + 400 prima del
     service; body size guard con `readJsonWithLimit(req, maxBytes)` + 413 prima
     di `JSON.parse`; email normalizzata con `normalizeEmail()` in `validation.ts`
@@ -380,6 +376,10 @@ auto-attivano quando il task matcha il `description`:
   params/cookies/headers, React 19 Actions/`useOptimistic`/ref-as-prop,
   shadcn/ui + Radix `asChild`, TanStack Query provider unico, hydration
   mismatch, Tailwind 4 class ordering
+- **`sentry-hygiene`** — review periodico issue archived (UX nascosto vs
+  noise vero vs transient), filtri `beforeSend` documentati per ID issue,
+  smoke post-deploy `live + env + drain`, query canoniche
+  `errorClass:*` via Sentry MCP. Regole 20-25.
 
 ## Hook automatici (`.claude/hooks/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,25 @@ src/app/\(marketing\)` prima di chiudere il task.
     archiviata come noise, perché ogni utente che digitava credenziali AdE
     sbagliate da `/dashboard/settings` finiva in Sentry. Estende la regola 19
     alle server action di scrittura.
+21. **Osservabilità: validare il drain end-to-end al rollout.** Quando si
+    abilita o si modifica una feature di telemetria (`enableLogs`,
+    `Sentry.pinoIntegration`, `Sentry.metrics`, Sentry Profiling, Replays,
+    nuovo `transport` pino, ecc.), il deploy **non è "concluso" finché una
+    sentinella intenzionale non appare in dashboard entro ~5 minuti**. Se
+    non appare → integrazione rotta = bug bloccante, si rollback o si
+    riapre la PR. Procedura: imposta `SENTRY_SENTINEL_TOKEN` sull'env
+    target e fai `curl -H "x-sentinel-token: $TOKEN"
+https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
+    contiene `sentryQuery`, una stringa già pronta da incollare nei filtri
+    Sentry — sia il dataset `logs` (info/warn/error) sia il pannello issues
+    (l'`error` emette anche `Sentry.captureException` via il hook a
+    `level≥50` in `src/lib/logger.ts`). Endpoint:
+    `src/app/api/_debug/sentry-sentinel/route.ts` — protetto da
+    timing-safe compare, risponde 404 se il token è assente o non combacia
+    (esistenza nascosta a chi non ha il secret). Riferimento: v1.3.6
+    (rollout `Sentry.pinoIntegration`) è stato il caso che ha forzato la
+    regola — il dataset `logs` era vuoto al momento dell'analisi e non si
+    poteva distinguere "drain rotto" da "rilasciato 40 minuti fa".
 
 ## SonarCloud quality gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,21 @@ https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
     `emit-receipt` (receipt-service), `void-receipt` (void-service).
     Per nuovi flow scegli uno slug stabile (no spazi, no version):
     cambia il fingerprint = perdi la continuità storica del group.
+24. **Env d'identità: validazione fail-fast al boot.** Le env che producono
+    URL/redirect (`NEXT_PUBLIC_APP_URL` + le 6 varianti `*_HOSTNAME`)
+    sono validate da `assertIdentityEnv()` in `src/lib/identity-env.ts`,
+    chiamato come **prima istruzione** di `register()` in
+    `src/instrumentation.ts` (runtime nodejs). In produzione un valore
+    malformato fa **throware al boot** e il container non parte —
+    invece di produrre 503 al primo route che costruisce URL, come
+    succedeva con SCONTRINOZERO-F (5 eventi su utente FR/Stripe
+    checkout) e SCONTRINOZERO-D (action_link hostname mismatch). In
+    dev/test la stessa validation logga `warn` ma non blocca il loop.
+    Il check copre tre classi di failure: malformed URL/hostname,
+    present-but-empty (regola 18, `?? default` non scatta su `""`), e
+    `http` invece di `https` in prod. Le guardie lazy esistenti
+    (`getTrustedAppUrl()`, `parseTrustedHostnameEnv()`) restano in piedi
+    come secondo strato — defense in depth, non vengono toccate.
 
 ## SonarCloud quality gate
 

--- a/src/app/api/_debug/sentry-sentinel/route.test.ts
+++ b/src/app/api/_debug/sentry-sentinel/route.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInfo = vi.fn();
+const mockWarn = vi.fn();
+const mockError = vi.fn();
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: mockInfo, warn: mockWarn, error: mockError },
+}));
+
+vi.mock("@/lib/version", () => ({
+  getAppRelease: () => "scontrinozero@1.3.6+abc1234",
+}));
+
+const ORIGINAL_TOKEN = process.env.SENTRY_SENTINEL_TOKEN;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (ORIGINAL_TOKEN === undefined) {
+    delete process.env.SENTRY_SENTINEL_TOKEN;
+  } else {
+    process.env.SENTRY_SENTINEL_TOKEN = ORIGINAL_TOKEN;
+  }
+});
+
+function buildRequest(headers: Record<string, string> = {}): Request {
+  return new Request(
+    "https://app.scontrinozero.it/api/_debug/sentry-sentinel",
+    { method: "GET", headers },
+  );
+}
+
+describe("GET /api/_debug/sentry-sentinel", () => {
+  describe("auth gating (nascondi l'endpoint a chi non ha il secret)", () => {
+    it("returns 404 when SENTRY_SENTINEL_TOKEN env is not configured", async () => {
+      delete process.env.SENTRY_SENTINEL_TOKEN;
+      const { GET } = await import("./route");
+      const res = await GET(buildRequest({ "x-sentinel-token": "anything" }));
+      expect(res.status).toBe(404);
+      expect(mockInfo).not.toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when SENTRY_SENTINEL_TOKEN is set but no header is sent", async () => {
+      process.env.SENTRY_SENTINEL_TOKEN = "s3cret-token";
+      const { GET } = await import("./route");
+      const res = await GET(buildRequest());
+      expect(res.status).toBe(404);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the header value does not match the env token", async () => {
+      process.env.SENTRY_SENTINEL_TOKEN = "s3cret-token";
+      const { GET } = await import("./route");
+      const res = await GET(buildRequest({ "x-sentinel-token": "wrong" }));
+      expect(res.status).toBe(404);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when env token is set to an empty string (treat as missing)", async () => {
+      // Same gotcha as regola 18: present-but-empty env must not unlock the
+      // endpoint, otherwise a misconfigured Dockerfile (ARG not passed) would
+      // expose the sentinel publicly.
+      process.env.SENTRY_SENTINEL_TOKEN = "";
+      const { GET } = await import("./route");
+      const res = await GET(buildRequest({ "x-sentinel-token": "" }));
+      expect(res.status).toBe(404);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when authorised", () => {
+    beforeEach(() => {
+      process.env.SENTRY_SENTINEL_TOKEN = "s3cret-token";
+    });
+
+    it("emits a triple log (info, warn, error) tagged with errorClass 'sentinel'", async () => {
+      const { GET } = await import("./route");
+      await GET(buildRequest({ "x-sentinel-token": "s3cret-token" }));
+
+      // info: validates that pino → Sentry Logs drain works for level 30
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sentinelId: expect.any(String),
+          errorClass: "sentinel",
+        }),
+        expect.stringContaining("sentry-sentinel"),
+      );
+      // warn: validates level 40 (no Sentry issue, only Sentry Logs)
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ errorClass: "sentinel" }),
+        expect.stringContaining("sentry-sentinel"),
+      );
+      // error: validates level 50 → BOTH Sentry Logs AND Sentry issue.
+      // err field is required so logger.ts captureToSentry forwards as exception.
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sentinelId: expect.any(String),
+          errorClass: "sentinel",
+          err: expect.any(Error),
+        }),
+        expect.stringContaining("sentry-sentinel"),
+      );
+    });
+
+    it("emits all three logs with the same sentinelId so they can be correlated in Sentry", async () => {
+      const { GET } = await import("./route");
+      await GET(buildRequest({ "x-sentinel-token": "s3cret-token" }));
+
+      const infoId = (mockInfo.mock.calls[0]?.[0] as { sentinelId: string })
+        .sentinelId;
+      const warnId = (mockWarn.mock.calls[0]?.[0] as { sentinelId: string })
+        .sentinelId;
+      const errorId = (mockError.mock.calls[0]?.[0] as { sentinelId: string })
+        .sentinelId;
+      expect(infoId).toBeTruthy();
+      expect(warnId).toBe(infoId);
+      expect(errorId).toBe(infoId);
+    });
+
+    it("accepts a caller-provided sentinelId via query string", async () => {
+      // Lets the operator script (or CI) pre-generate the ID and grep Sentry
+      // immediately, without parsing the response body.
+      const req = new Request(
+        "https://app.scontrinozero.it/api/_debug/sentry-sentinel?id=ci-deploy-v1.3.6",
+        {
+          method: "GET",
+          headers: { "x-sentinel-token": "s3cret-token" },
+        },
+      );
+      const { GET } = await import("./route");
+      const res = await GET(req);
+      const body = (await res.json()) as { sentinelId: string };
+      expect(body.sentinelId).toBe("ci-deploy-v1.3.6");
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({ sentinelId: "ci-deploy-v1.3.6" }),
+        expect.anything(),
+      );
+    });
+
+    it("falls back to a generated sentinelId when no query is provided", async () => {
+      const { GET } = await import("./route");
+      const res = await GET(
+        buildRequest({ "x-sentinel-token": "s3cret-token" }),
+      );
+      const body = (await res.json()) as { sentinelId: string };
+      expect(body.sentinelId).toMatch(/^[0-9a-f-]{8,}/); // crypto.randomUUID()
+    });
+
+    it("returns 200 with sentinelId, release, and a Sentry query hint", async () => {
+      const { GET } = await import("./route");
+      const res = await GET(
+        buildRequest({ "x-sentinel-token": "s3cret-token" }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        ok: boolean;
+        sentinelId: string;
+        release: string;
+        sentryQuery: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.release).toBe("scontrinozero@1.3.6+abc1234");
+      expect(body.sentryQuery).toContain("errorClass:sentinel");
+      expect(body.sentryQuery).toContain(body.sentinelId);
+    });
+
+    it("rejects an empty header value even if env token is set (timing-safe match)", async () => {
+      const { GET } = await import("./route");
+      const res = await GET(buildRequest({ "x-sentinel-token": "" }));
+      expect(res.status).toBe(404);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/_debug/sentry-sentinel/route.ts
+++ b/src/app/api/_debug/sentry-sentinel/route.ts
@@ -1,0 +1,80 @@
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { getAppRelease } from "@/lib/version";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Sentry drain sentinel — emits a triple log (info, warn, error) tagged
+ * with a stable `errorClass: "sentinel"` and a per-call `sentinelId`,
+ * letting an operator (or CI) verify end-to-end that:
+ *
+ *   - pino → Sentry Logs is wired (info + warn + error appear in the
+ *     `logs` dataset for the running release within ~5 min)
+ *   - the `level >= 50` Sentry capture hook in `src/lib/logger.ts` is
+ *     working (error appears in the `issues` dataset)
+ *
+ * Pattern di scoperta in Sentry:
+ *
+ *   logs:    severity:[info,warn,error] errorClass:sentinel sentinelId:<id>
+ *   issues:  errorClass:sentinel sentinelId:<id>
+ *
+ * Gated by `SENTRY_SENTINEL_TOKEN` env in a constant-time compare. The
+ * endpoint returns 404 (not 401/403) when unauthorised so its existence
+ * isn't leaked. Coerente con la regola 21 di CLAUDE.md: ogni feature di
+ * telemetria nuova va validata con una sentinella all'attivazione, prima
+ * di considerare il rollout "concluso".
+ *
+ * Storico: aggiunto durante il rollout di v1.3.6 (pino → Sentry Logs
+ * drain via `Sentry.pinoIntegration` in `sentry.server.config.ts`).
+ */
+export async function GET(req: Request): Promise<Response> {
+  if (!isAuthorised(req)) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const sentinelId = url.searchParams.get("id")?.trim() || randomUUID();
+  const release = getAppRelease();
+
+  logger.info(
+    { sentinelId, errorClass: "sentinel", release },
+    "sentry-sentinel: info",
+  );
+  logger.warn(
+    { sentinelId, errorClass: "sentinel", release },
+    "sentry-sentinel: warn",
+  );
+  logger.error(
+    {
+      sentinelId,
+      errorClass: "sentinel",
+      release,
+      err: new Error("sentry-sentinel: intentional error for drain validation"),
+    },
+    "sentry-sentinel: error",
+  );
+
+  return NextResponse.json({
+    ok: true,
+    sentinelId,
+    release,
+    sentryQuery: `errorClass:sentinel sentinelId:${sentinelId}`,
+  });
+}
+
+function isAuthorised(req: Request): boolean {
+  const expected = process.env.SENTRY_SENTINEL_TOKEN;
+  // Present-but-empty (`""`) treated as missing: a Dockerfile that bakes
+  // an empty ARG/ENV would otherwise expose the endpoint unauthenticated.
+  // Coerente con la regola 18 (env present-but-empty).
+  if (!expected) return false;
+
+  const provided = req.headers.get("x-sentinel-token") ?? "";
+  if (provided.length === 0) return false;
+  if (provided.length !== expected.length) return false;
+
+  // Timing-safe compare to defeat byte-by-byte guessing.
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+}

--- a/src/app/api/_health/env/route.test.ts
+++ b/src/app/api/_health/env/route.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetTrustedAppUrl = vi.fn();
+vi.mock("@/lib/trusted-app-url", () => ({
+  getTrustedAppUrl: () => mockGetTrustedAppUrl(),
+  TrustedAppUrlError: class TrustedAppUrlError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "TrustedAppUrlError";
+    }
+  },
+}));
+
+vi.mock("@/lib/version", () => ({
+  getAppRelease: () => "scontrinozero@1.3.6+abc1234",
+}));
+
+const HOSTNAME_ENV_VARS = [
+  "APP_HOSTNAME",
+  "NEXT_PUBLIC_APP_HOSTNAME",
+  "MARKETING_HOSTNAME",
+  "NEXT_PUBLIC_MARKETING_HOSTNAME",
+  "API_HOSTNAME",
+  "NEXT_PUBLIC_API_HOSTNAME",
+] as const;
+
+const originalEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  for (const k of HOSTNAME_ENV_VARS) {
+    originalEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of HOSTNAME_ENV_VARS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+});
+
+describe("GET /api/_health/env", () => {
+  it("returns 200 with appUrl, release, and parsed hostnames when env is valid", async () => {
+    mockGetTrustedAppUrl.mockReturnValue("https://app.scontrinozero.it");
+    process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+    process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+    process.env.NEXT_PUBLIC_API_HOSTNAME = "api.scontrinozero.it";
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      appUrl: string;
+      release: string;
+      hostnames: Record<string, string>;
+    };
+    expect(body.status).toBe("ok");
+    expect(body.appUrl).toBe("https://app.scontrinozero.it");
+    expect(body.release).toBe("scontrinozero@1.3.6+abc1234");
+    expect(body.hostnames).toEqual({
+      app: "app.scontrinozero.it",
+      marketing: "scontrinozero.it",
+      api: "api.scontrinozero.it",
+    });
+  });
+
+  it("prefers runtime override (APP_HOSTNAME) over baked-at-build (NEXT_PUBLIC_APP_HOSTNAME)", async () => {
+    // Mirrors trusted-app-url.ts / next.config.ts precedence: a sandbox/
+    // self-hosted instance set APP_HOSTNAME at runtime to override the
+    // build-time NEXT_PUBLIC_APP_HOSTNAME baked in the image.
+    mockGetTrustedAppUrl.mockReturnValue("https://sandbox.scontrinozero.it");
+    process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+    process.env.APP_HOSTNAME = "sandbox.scontrinozero.it";
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = (await res.json()) as { hostnames: Record<string, string> };
+    expect(body.hostnames.app).toBe("sandbox.scontrinozero.it");
+  });
+
+  it("returns 503 with error when getTrustedAppUrl throws (TrustedAppUrlError)", async () => {
+    // Defense in depth: assertIdentityEnv runs at boot, but if envs change
+    // (e.g. mounted Secret rotation) this endpoint still catches a stale
+    // misconfig at request time.
+    const { TrustedAppUrlError } = await import("@/lib/trusted-app-url");
+    mockGetTrustedAppUrl.mockImplementation(() => {
+      throw new TrustedAppUrlError("NEXT_PUBLIC_APP_URL malformed");
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("not_ok");
+    expect(body.error).toContain("NEXT_PUBLIC_APP_URL malformed");
+  });
+
+  it("returns 503 on an unexpected throw, without leaking the stack trace", async () => {
+    mockGetTrustedAppUrl.mockImplementation(() => {
+      throw new Error("Connection to secret store reset by peer");
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("not_ok");
+    // Generic message — no stack, no internal infra detail
+    expect(body.error).toMatch(/identity env unavailable/i);
+    expect(body.error).not.toContain("Connection to secret store");
+  });
+
+  it("hostnames default to 'unset' string when no env override is provided", async () => {
+    // Make the absence explicit in the smoke output — 'undefined' would be
+    // ambiguous when piped through curl + jq.
+    mockGetTrustedAppUrl.mockReturnValue("https://app.scontrinozero.it");
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = (await res.json()) as { hostnames: Record<string, string> };
+    expect(body.hostnames.app).toBe("unset");
+    expect(body.hostnames.marketing).toBe("unset");
+    expect(body.hostnames.api).toBe("unset");
+  });
+});

--- a/src/app/api/_health/env/route.ts
+++ b/src/app/api/_health/env/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { getTrustedAppUrl, TrustedAppUrlError } from "@/lib/trusted-app-url";
+import { getAppRelease } from "@/lib/version";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Smoke health probe per le env d'identità.
+ *
+ * Ritorna 200 con `{ status: "ok", appUrl, release, hostnames }` quando
+ * `getTrustedAppUrl()` passa — appUrl e i 3 hostname (app/marketing/api)
+ * sono quelli **effettivamente** osservati dal container in esecuzione,
+ * utili per verificare il deploy contro l'env attesa.
+ *
+ * Ritorna 503 con un messaggio actionable se la guard fallisce: anche
+ * se `assertIdentityEnv()` (R24) ha già controllato al boot, una
+ * rotazione di secret/mount file può invalidare l'identità tra un
+ * request e l'altro — questo endpoint la riprende.
+ *
+ * Auth: nessuna. Le info esposte (URL pubblico + hostname + versione
+ * release) sono già pubblicamente osservabili dal traffico HTTP,
+ * niente PII né secret. Stesso modello di `/api/health/live`.
+ *
+ * Uso atteso (smoke test post-deploy, R25):
+ *
+ *   curl -fsS https://<host>/api/_health/env | jq .
+ *   # confronta `appUrl` e `release` con quanto rilasciato.
+ */
+export function GET(): Response {
+  try {
+    const appUrl = getTrustedAppUrl();
+    return NextResponse.json({
+      status: "ok",
+      appUrl,
+      release: getAppRelease(),
+      hostnames: {
+        app: pickHostname("APP_HOSTNAME", "NEXT_PUBLIC_APP_HOSTNAME"),
+        marketing: pickHostname(
+          "MARKETING_HOSTNAME",
+          "NEXT_PUBLIC_MARKETING_HOSTNAME",
+        ),
+        api: pickHostname("API_HOSTNAME", "NEXT_PUBLIC_API_HOSTNAME"),
+      },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    if (err instanceof TrustedAppUrlError) {
+      return NextResponse.json(
+        {
+          status: "not_ok",
+          error: err.message,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 503 },
+      );
+    }
+    // Generic 503 — non leakare lo stack di eventuali errori interni
+    // (es. secret store unavailable). Il container resta vivo, il probe
+    // segnala "non pronto per servire URL-construction".
+    return NextResponse.json(
+      {
+        status: "not_ok",
+        error: "identity env unavailable",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 503 },
+    );
+  }
+}
+
+function pickHostname(runtime: string, baked: string): string {
+  const runtimeVal = process.env[runtime]?.trim();
+  if (runtimeVal) return runtimeVal.toLowerCase();
+  const bakedVal = process.env[baked]?.trim();
+  if (bakedVal) return bakedVal.toLowerCase();
+  return "unset";
+}

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -24,6 +24,11 @@ vi.mock("node:dns/promises", () => ({
   resolve4: vi.fn((hostname: string) => Promise.resolve([hostname])),
 }));
 
+const mockAssertIdentityEnv = vi.fn();
+vi.mock("@/lib/identity-env", () => ({
+  assertIdentityEnv: mockAssertIdentityEnv,
+}));
+
 describe("instrumentation register()", () => {
   let originalNextRuntime: string | undefined;
   let originalDbUrl: string | undefined;
@@ -122,5 +127,45 @@ describe("instrumentation register()", () => {
     await register();
 
     expect(mockClientEnd).toHaveBeenCalled();
+  });
+
+  it("R24: chiama assertIdentityEnv come prima istruzione nel runtime nodejs", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.DATABASE_URL = "postgres://test";
+    const { register } = await import("./instrumentation");
+
+    await register();
+
+    expect(mockAssertIdentityEnv).toHaveBeenCalledOnce();
+    // Deve essere chiamato PRIMA del migrate (altrimenti un container con
+    // env malformate fa lavorare il pool DB inutilmente prima di crashare).
+    const assertOrder = mockAssertIdentityEnv.mock.invocationCallOrder[0]!;
+    const postgresOrder = mockPostgresDefault.mock.invocationCallOrder[0]!;
+    expect(assertOrder).toBeLessThan(postgresOrder);
+  });
+
+  it("R24: register propaga il throw di assertIdentityEnv (container non parte in prod)", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.DATABASE_URL = "postgres://test";
+    mockAssertIdentityEnv.mockImplementationOnce(() => {
+      throw new Error("identity env validation failed at boot");
+    });
+    const { register } = await import("./instrumentation");
+
+    await expect(register()).rejects.toThrow(
+      /identity env validation failed at boot/,
+    );
+    // Migrate non deve essere eseguito quando l'identita' e' rotta.
+    expect(mockMigrate).not.toHaveBeenCalled();
+    expect(mockPostgresDefault).not.toHaveBeenCalled();
+  });
+
+  it("R24: NON chiama assertIdentityEnv quando NEXT_RUNTIME non e' nodejs", async () => {
+    delete process.env.NEXT_RUNTIME;
+    const { register } = await import("./instrumentation");
+
+    await register();
+
+    expect(mockAssertIdentityEnv).not.toHaveBeenCalled();
   });
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,14 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Fail-fast sulle env d'identita' (NEXT_PUBLIC_APP_URL, *_HOSTNAME, …).
+    // In produzione un valore malformato fa throware QUI invece di
+    // produrre 503 al primo route che costruisce URL — vedi
+    // SCONTRINOZERO-F (NEXT_PUBLIC_APP_URL malformed, 5 eventi su utente
+    // FR/Stripe checkout). In dev/test logga warn ma non blocca il loop.
+    // Regola 24 di CLAUDE.md, estende la regola 18.
+    const { assertIdentityEnv } = await import("@/lib/identity-env");
+    assertIdentityEnv();
+
     await import("../sentry.server.config");
 
     const { migrate } = await import("drizzle-orm/postgres-js/migrator");

--- a/src/lib/ade/error-messages.test.ts
+++ b/src/lib/ade/error-messages.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./errors";
 import {
   getUserFacingAdeErrorMessage,
+  isExpectedUserAdeError,
   isTransientAdeError,
 } from "./error-messages";
 
@@ -169,5 +170,50 @@ describe("isTransientAdeError", () => {
     expect(isTransientAdeError("oops")).toBe(false);
     expect(isTransientAdeError(null)).toBe(false);
     expect(isTransientAdeError(undefined)).toBe(false);
+  });
+});
+
+describe("isExpectedUserAdeError", () => {
+  it("returns true for AdeAuthError (wrong credentials are user input, not a bug)", () => {
+    expect(isExpectedUserAdeError(new AdeAuthError())).toBe(true);
+  });
+
+  it("returns true for AdePasswordExpiredError (user must rotate password on portal)", () => {
+    expect(isExpectedUserAdeError(new AdePasswordExpiredError())).toBe(true);
+  });
+
+  it("returns false for AdeNetworkError (transient, not user-actionable input)", () => {
+    expect(
+      isExpectedUserAdeError(new AdeNetworkError(new Error("ECONNRESET"))),
+    ).toBe(false);
+  });
+
+  it("returns false for AdePortalError (upstream failure, not user input)", () => {
+    expect(isExpectedUserAdeError(new AdePortalError(500, "boom"))).toBe(false);
+    expect(isExpectedUserAdeError(new AdePortalError(400, "bad"))).toBe(false);
+  });
+
+  it("returns false for AdeSpidTimeoutError (transient, retry path)", () => {
+    expect(isExpectedUserAdeError(new AdeSpidTimeoutError(30))).toBe(false);
+  });
+
+  it("returns false for AdeSessionExpiredError (internal state, not user input)", () => {
+    expect(isExpectedUserAdeError(new AdeSessionExpiredError())).toBe(false);
+  });
+
+  it("returns false for a generic AdeError", () => {
+    expect(isExpectedUserAdeError(new AdeError("ADE_UNKNOWN", "boom"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for a non-Ade Error", () => {
+    expect(isExpectedUserAdeError(new Error("unrelated"))).toBe(false);
+  });
+
+  it("returns false for a non-Error value", () => {
+    expect(isExpectedUserAdeError("oops")).toBe(false);
+    expect(isExpectedUserAdeError(null)).toBe(false);
+    expect(isExpectedUserAdeError(undefined)).toBe(false);
   });
 });

--- a/src/lib/ade/error-messages.ts
+++ b/src/lib/ade/error-messages.ts
@@ -74,3 +74,21 @@ export function isTransientAdeError(err: unknown): boolean {
   if (err instanceof AdePortalError && err.statusCode >= 500) return true;
   return false;
 }
+
+/**
+ * Ritorna true se l'errore è un caso prevedibile di **input utente
+ * invalido** (credenziali Fisconline sbagliate, password scaduta che
+ * l'utente deve ruotare sul portale AdE). Non è un bug del nostro
+ * sistema più di quanto lo sia "password sbagliata" su `/login`.
+ *
+ * Conseguenza per il logging: come per `isTransientAdeError`, va
+ * loggato a `warn` (non `error`) — niente issue Sentry. Storico:
+ * SCONTRINOZERO-7 ha accumulato 23 eventi in 5 settimane prima di
+ * essere archiviata come noise perché tutte le auth-failure salivano
+ * a Sentry come issue. Regola 21 di `CLAUDE.md`.
+ */
+export function isExpectedUserAdeError(err: unknown): boolean {
+  if (err instanceof AdeAuthError) return true;
+  if (err instanceof AdePasswordExpiredError) return true;
+  return false;
+}

--- a/src/lib/ade/log-failure.test.ts
+++ b/src/lib/ade/log-failure.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/logger", () => ({
 import {
   AdeAuthError,
   AdeNetworkError,
+  AdePasswordExpiredError,
   AdePortalError,
   AdeSpidTimeoutError,
 } from "./errors";
@@ -77,17 +78,39 @@ describe("logAdeFailure", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it("routes AdeAuthError to logger.error (permanent: wrong credentials)", () => {
+  it("routes AdeAuthError to logger.warn with errorClass ade_user_error (no Sentry noise: SCONTRINOZERO-7)", () => {
+    // Credenziali Fisconline sbagliate non sono un bug nostro: sono input
+    // utente prevedibile, come "password sbagliata" su /login. Vanno
+    // loggate per osservabilita' ma NON devono salire a Sentry come issue
+    // (regola 21 di CLAUDE.md). Storico: SCONTRINOZERO-7 ha collezionato
+    // 23 eventi in 5 settimane prima di essere archiviata come noise.
     logAdeFailure(
       new AdeAuthError(),
       {},
       { transient: "transient", failure: "failed" },
     );
 
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ errorClass: "ade_failure" }),
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_user_error" }),
       "failed",
     );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("routes AdePasswordExpiredError to logger.warn with errorClass ade_user_error (no Sentry noise)", () => {
+    // Stesso ragionamento di AdeAuthError: la password scaduta richiede
+    // azione utente sul portale AdE, non e' un bug del nostro sistema.
+    logAdeFailure(
+      new AdePasswordExpiredError(),
+      {},
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_user_error" }),
+      "failed",
+    );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it("routes a generic Error to logger.error", () => {

--- a/src/lib/ade/log-failure.test.ts
+++ b/src/lib/ade/log-failure.test.ts
@@ -126,6 +126,77 @@ describe("logAdeFailure", () => {
     );
   });
 
+  it("R23: context.flow injects sentryFingerprint [flow, errorClass] on the error path", () => {
+    // SCONTRINOZERO-9 ("wizardTemplate failed 500") e -A ("setUserChoice
+    // failed 500") avrebbero dovuto far parte di un singolo group Sentry —
+    // entrambe nel flow "onboarding-verify". context.flow fa propagare il
+    // fingerprint al logger.error, che lo applica via withScope.
+    logAdeFailure(
+      new Error("unexpected boom"),
+      { businessId: "biz-1", flow: "onboarding-verify" },
+      { transient: "transient", failure: "failed" },
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        businessId: "biz-1",
+        errorClass: "ade_failure",
+        sentryFingerprint: ["onboarding-verify", "ade_failure"],
+      }),
+      "failed",
+    );
+  });
+
+  it("R23: context without flow leaves the default Sentry grouping (no fingerprint)", () => {
+    logAdeFailure(
+      new Error("unexpected boom"),
+      { businessId: "biz-1" },
+      { transient: "transient", failure: "failed" },
+    );
+
+    const payload = (logger.error as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(payload).toBeDefined();
+    expect(payload).not.toHaveProperty("sentryFingerprint");
+  });
+
+  it("R23: warn path (transient) does NOT receive sentryFingerprint (it never reaches Sentry capture)", () => {
+    logAdeFailure(
+      new AdePortalError(503, "down"),
+      { businessId: "biz-1", flow: "onboarding-verify" },
+      { transient: "transient", failure: "failed" },
+    );
+
+    const payload = (logger.warn as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(payload).toBeDefined();
+    expect(payload).not.toHaveProperty("sentryFingerprint");
+  });
+
+  it("R23: warn path (user_error) does NOT receive sentryFingerprint", () => {
+    logAdeFailure(
+      new AdeAuthError(),
+      { businessId: "biz-1", flow: "onboarding-verify" },
+      { transient: "transient", failure: "failed" },
+    );
+
+    const payload = (logger.warn as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(payload).toBeDefined();
+    expect(payload).not.toHaveProperty("sentryFingerprint");
+  });
+
+  it("R23: empty/blank flow is ignored (no fingerprint)", () => {
+    logAdeFailure(
+      new Error("boom"),
+      { businessId: "biz-1", flow: "   " },
+      { transient: "transient", failure: "failed" },
+    );
+    const payload = (logger.error as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(payload).not.toHaveProperty("sentryFingerprint");
+  });
+
   it("forwards arbitrary context fields into the log payload", () => {
     logAdeFailure(
       new Error("boom"),

--- a/src/lib/ade/log-failure.ts
+++ b/src/lib/ade/log-failure.ts
@@ -12,7 +12,7 @@ import { isExpectedUserAdeError, isTransientAdeError } from "./error-messages";
  *   scaduta), non bug nostri: come "password sbagliata" su `/login` non
  *   devono salire a Sentry. Storico: SCONTRINOZERO-7 ha collezionato 23
  *   eventi in 5 settimane prima di essere archiviata come noise. Regola
- *   21 di `CLAUDE.md`.
+ *   20 di `CLAUDE.md`.
  * - **Transient** (`isTransientAdeError`: network, SPID timeout, AdE 5xx)
  *   → `logger.warn` con `errorClass: "ade_transient"`, messaggio
  *   `messages.transient`. Durante un downtime AdE da 100 utenti
@@ -21,6 +21,16 @@ import { isExpectedUserAdeError, isTransientAdeError } from "./error-messages";
  *   `errorClass: "ade_failure"`, messaggio `messages.failure`. È il solo
  *   ramo che triggera Sentry capture (logger.ts hook a riga 136 cattura
  *   solo `level >= 50`).
+ *
+ * **Fingerprinting per flow** (regola 23): se `context.flow` è una
+ * stringa non vuota, sul solo ramo "failure" iniettiamo
+ * `sentryFingerprint: [flow, errorClass]`. `logger.ts` lo intercetta e
+ * fa `Sentry.withScope(s => s.setFingerprint(...))` attorno alla
+ * capture, così due errori dentro lo stesso flow che divergono solo per
+ * il `message` finiscono nello stesso group Sentry. SCONTRINOZERO-9 e
+ * SCONTRINOZERO-A (stesso trace_id, message diverso) sarebbero
+ * confluite in un'unica issue. I rami warn non ricevono il fingerprint:
+ * non salgono comunque a Sentry capture.
  *
  * Mai estrarre i metodi pino in una variabile (`const fn = logger.warn`):
  * pino li dispatcha tramite `this`-binding (accesso a `this.level`,
@@ -48,8 +58,14 @@ export function logAdeFailure(
     );
     return;
   }
-  logger.error(
-    { err, ...context, errorClass: "ade_failure" },
-    messages.failure,
-  );
+  const flow = typeof context.flow === "string" ? context.flow.trim() : "";
+  const errorPayload: Record<string, unknown> = {
+    err,
+    ...context,
+    errorClass: "ade_failure",
+  };
+  if (flow) {
+    errorPayload.sentryFingerprint = [flow, "ade_failure"];
+  }
+  logger.error(errorPayload, messages.failure);
 }

--- a/src/lib/ade/log-failure.ts
+++ b/src/lib/ade/log-failure.ts
@@ -1,14 +1,26 @@
 import { logger } from "@/lib/logger";
-import { isTransientAdeError } from "./error-messages";
+import { isExpectedUserAdeError, isTransientAdeError } from "./error-messages";
 
 /**
- * Logga un errore AdE-side con il livello corretto.
+ * Logga un errore AdE-side con il livello corretto. Tre rami, in
+ * ordine di valutazione:
  *
- * - Transient (network, SPID timeout, AdE 5xx via `isTransientAdeError`)
- *   → `logger.warn` con `errorClass: "ade_transient"`. NON triggera
- *   Sentry capture (logger.ts hook a riga 136 cattura solo `level >= 50`),
- *   evitando ~100 issue Sentry identiche durante un downtime AdE.
- * - Non transient → `logger.error` con `errorClass: "ade_failure"`.
+ * - **User error** (`isExpectedUserAdeError`: AdeAuthError,
+ *   AdePasswordExpiredError) → `logger.warn` con
+ *   `errorClass: "ade_user_error"`, messaggio `messages.failure`. Sono
+ *   errori d'input utente prevedibili (credenziali sbagliate, password
+ *   scaduta), non bug nostri: come "password sbagliata" su `/login` non
+ *   devono salire a Sentry. Storico: SCONTRINOZERO-7 ha collezionato 23
+ *   eventi in 5 settimane prima di essere archiviata come noise. Regola
+ *   21 di `CLAUDE.md`.
+ * - **Transient** (`isTransientAdeError`: network, SPID timeout, AdE 5xx)
+ *   → `logger.warn` con `errorClass: "ade_transient"`, messaggio
+ *   `messages.transient`. Durante un downtime AdE da 100 utenti
+ *   eviterebbe ~100 issue Sentry identiche e non actionable per noi.
+ * - **Failure** (tutto il resto) → `logger.error` con
+ *   `errorClass: "ade_failure"`, messaggio `messages.failure`. È il solo
+ *   ramo che triggera Sentry capture (logger.ts hook a riga 136 cattura
+ *   solo `level >= 50`).
  *
  * Mai estrarre i metodi pino in una variabile (`const fn = logger.warn`):
  * pino li dispatcha tramite `this`-binding (accesso a `this.level`,
@@ -22,15 +34,22 @@ export function logAdeFailure(
   context: Record<string, unknown>,
   messages: { transient: string; failure: string },
 ): void {
-  const transient = isTransientAdeError(err);
-  const payload = {
-    err,
-    ...context,
-    errorClass: transient ? "ade_transient" : "ade_failure",
-  };
-  if (transient) {
-    logger.warn(payload, messages.transient);
-  } else {
-    logger.error(payload, messages.failure);
+  if (isExpectedUserAdeError(err)) {
+    logger.warn(
+      { err, ...context, errorClass: "ade_user_error" },
+      messages.failure,
+    );
+    return;
   }
+  if (isTransientAdeError(err)) {
+    logger.warn(
+      { err, ...context, errorClass: "ade_transient" },
+      messages.transient,
+    );
+    return;
+  }
+  logger.error(
+    { err, ...context, errorClass: "ade_failure" },
+    messages.failure,
+  );
 }

--- a/src/lib/hostname-env.ts
+++ b/src/lib/hostname-env.ts
@@ -73,8 +73,12 @@ function isValidLabel(label: string): boolean {
  *
  * Allowed: letters, digits, hyphen, dot. Must not be empty, must not contain
  * scheme/path/query/port markers. Length must fit within the DNS limit (253).
+ *
+ * Exported so that `assertIdentityEnv()` (`src/lib/identity-env.ts`) can
+ * reuse the exact same rule for boot-time validation without duplicating
+ * the per-label / forbidden-char logic.
  */
-function isValidHostnameSyntax(value: string): boolean {
+export function isValidHostnameSyntax(value: string): boolean {
   if (value.length === 0 || value.length > 253) return false;
   if (hasForbiddenChars(value)) return false;
   if (value.startsWith(".") || value.startsWith("-")) return false;

--- a/src/lib/identity-env.test.ts
+++ b/src/lib/identity-env.test.ts
@@ -19,7 +19,6 @@ const IDENTITY_ENV_VARS = [
   "NEXT_PUBLIC_MARKETING_HOSTNAME",
   "API_HOSTNAME",
   "NEXT_PUBLIC_API_HOSTNAME",
-  "NODE_ENV",
 ] as const;
 
 let originalEnv: Record<string, string | undefined> = {};
@@ -32,6 +31,10 @@ beforeEach(() => {
     originalEnv[k] = process.env[k];
     delete process.env[k];
   }
+  // NODE_ENV è readonly nei tipi TS — va manipolata via vi.stubEnv
+  // (skill testing-patterns). Default in beforeEach: "test"; ogni test
+  // che vuole un valore diverso fa vi.stubEnv("NODE_ENV", "production").
+  vi.stubEnv("NODE_ENV", "test");
 });
 
 afterEach(() => {
@@ -42,18 +45,19 @@ afterEach(() => {
       process.env[k] = originalEnv[k];
     }
   }
+  vi.unstubAllEnvs();
 });
 
 describe("assertIdentityEnv — happy path", () => {
   it("returns without throwing when all identity envs are absent (defaults apply)", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const { assertIdentityEnv } = await import("./identity-env");
     expect(() => assertIdentityEnv()).not.toThrow();
     expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
   it("returns without throwing when all identity envs are valid", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.NEXT_PUBLIC_APP_URL = "https://app.scontrinozero.it";
     process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
     process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
@@ -65,7 +69,7 @@ describe("assertIdentityEnv — happy path", () => {
 
 describe("assertIdentityEnv — failure modes in production", () => {
   beforeEach(() => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
   });
 
   it("throws when NEXT_PUBLIC_APP_URL is malformed (not a URL)", () => {
@@ -156,7 +160,7 @@ describe("assertIdentityEnv — failure modes in production", () => {
 
 describe("assertIdentityEnv — non-production behaviour", () => {
   it("logs warn but does NOT throw when envs are malformed in dev", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     process.env.NEXT_PUBLIC_APP_URL = "not a url";
     process.env.APP_HOSTNAME = "https://oops";
     const { assertIdentityEnv } = await import("./identity-env");
@@ -178,7 +182,7 @@ describe("assertIdentityEnv — non-production behaviour", () => {
   });
 
   it("logs warn but does NOT throw in test", async () => {
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     process.env.NEXT_PUBLIC_APP_URL = "not a url";
     const { assertIdentityEnv } = await import("./identity-env");
     expect(() => assertIdentityEnv()).not.toThrow();
@@ -186,7 +190,7 @@ describe("assertIdentityEnv — non-production behaviour", () => {
   });
 
   it("treats unset NODE_ENV as non-production (warn, no throw)", async () => {
-    delete process.env.NODE_ENV;
+    vi.stubEnv("NODE_ENV", "");
     process.env.NEXT_PUBLIC_APP_URL = "not a url";
     const { assertIdentityEnv } = await import("./identity-env");
     expect(() => assertIdentityEnv()).not.toThrow();
@@ -194,7 +198,7 @@ describe("assertIdentityEnv — non-production behaviour", () => {
   });
 
   it("does not log anything when envs are valid", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
     process.env.APP_HOSTNAME = "localhost";
     const { assertIdentityEnv } = await import("./identity-env");

--- a/src/lib/identity-env.test.ts
+++ b/src/lib/identity-env.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoggerWarn = vi.fn();
+const mockLoggerError = vi.fn();
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+    info: vi.fn(),
+  },
+}));
+
+const IDENTITY_ENV_VARS = [
+  "NEXT_PUBLIC_APP_URL",
+  "APP_HOSTNAME",
+  "NEXT_PUBLIC_APP_HOSTNAME",
+  "MARKETING_HOSTNAME",
+  "NEXT_PUBLIC_MARKETING_HOSTNAME",
+  "API_HOSTNAME",
+  "NEXT_PUBLIC_API_HOSTNAME",
+  "NODE_ENV",
+] as const;
+
+let originalEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  originalEnv = {};
+  for (const k of IDENTITY_ENV_VARS) {
+    originalEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of IDENTITY_ENV_VARS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+});
+
+describe("assertIdentityEnv — happy path", () => {
+  it("returns without throwing when all identity envs are absent (defaults apply)", async () => {
+    process.env.NODE_ENV = "production";
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).not.toThrow();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("returns without throwing when all identity envs are valid", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.scontrinozero.it";
+    process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+    process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+    process.env.NEXT_PUBLIC_API_HOSTNAME = "api.scontrinozero.it";
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).not.toThrow();
+  });
+});
+
+describe("assertIdentityEnv — failure modes in production", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "production";
+  });
+
+  it("throws when NEXT_PUBLIC_APP_URL is malformed (not a URL)", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "not a url";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
+    });
+  });
+
+  it("throws when NEXT_PUBLIC_APP_URL is present-but-empty (regola 18)", () => {
+    // Dockerfile bakes ARG even when not passed -> "" -> ?? default not firing.
+    // Boot must catch this BEFORE any lazy call site (SCONTRINOZERO-F) sees it.
+    process.env.NEXT_PUBLIC_APP_URL = "";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
+    });
+  });
+
+  it("throws when NEXT_PUBLIC_APP_URL uses http (not https) in production", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "http://app.scontrinozero.it";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
+    });
+  });
+
+  it("throws when APP_HOSTNAME has a scheme prefix", () => {
+    process.env.APP_HOSTNAME = "https://app.scontrinozero.it";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/APP_HOSTNAME/);
+    });
+  });
+
+  it("throws when MARKETING_HOSTNAME contains a slash", () => {
+    process.env.MARKETING_HOSTNAME = "scontrinozero.it/";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/MARKETING_HOSTNAME/);
+    });
+  });
+
+  it("throws when API_HOSTNAME is present-but-empty (regola 18)", () => {
+    process.env.API_HOSTNAME = "";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/API_HOSTNAME/);
+    });
+  });
+
+  it("throws when a NEXT_PUBLIC_*_HOSTNAME variant is malformed", () => {
+    process.env.NEXT_PUBLIC_API_HOSTNAME = "api scontrinozero.it";
+    return import("./identity-env").then(({ assertIdentityEnv }) => {
+      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_API_HOSTNAME/);
+    });
+  });
+
+  it("aggregates multiple failures into a single thrown message", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "not a url";
+    process.env.APP_HOSTNAME = "https://oops";
+    process.env.MARKETING_HOSTNAME = "";
+    const { assertIdentityEnv } = await import("./identity-env");
+    let err: Error | undefined;
+    try {
+      assertIdentityEnv();
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeDefined();
+    expect(err?.message).toMatch(/NEXT_PUBLIC_APP_URL/);
+    expect(err?.message).toMatch(/APP_HOSTNAME/);
+    expect(err?.message).toMatch(/MARKETING_HOSTNAME/);
+  });
+
+  it("logs structured critical error before throwing (Sentry routing)", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "not a url";
+    const { assertIdentityEnv } = await import("./identity-env");
+    try {
+      assertIdentityEnv();
+    } catch {
+      // expected
+    }
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        critical: true,
+        errorClass: "identity_env_invalid",
+      }),
+      expect.stringContaining("identity env validation failed"),
+    );
+  });
+});
+
+describe("assertIdentityEnv — non-production behaviour", () => {
+  it("logs warn but does NOT throw when envs are malformed in dev", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.NEXT_PUBLIC_APP_URL = "not a url";
+    process.env.APP_HOSTNAME = "https://oops";
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).not.toThrow();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "identity_env_invalid" }),
+      expect.stringContaining("identity env validation failed"),
+    );
+    // Note: getTrustedAppUrl() in trusted-app-url.ts logs its own
+    // logger.error before throwing TrustedAppUrlError. That's collateral
+    // to our flow — what matters is that assertIdentityEnv itself routes
+    // to warn (not error) in dev.
+    const ourErrorCalls = mockLoggerError.mock.calls.filter(
+      (c: unknown[]) =>
+        typeof c[1] === "string" &&
+        (c[1] as string).includes("identity env validation failed"),
+    );
+    expect(ourErrorCalls).toHaveLength(0);
+  });
+
+  it("logs warn but does NOT throw in test", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.NEXT_PUBLIC_APP_URL = "not a url";
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).not.toThrow();
+    expect(mockLoggerWarn).toHaveBeenCalled();
+  });
+
+  it("treats unset NODE_ENV as non-production (warn, no throw)", async () => {
+    delete process.env.NODE_ENV;
+    process.env.NEXT_PUBLIC_APP_URL = "not a url";
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).not.toThrow();
+    expect(mockLoggerWarn).toHaveBeenCalled();
+  });
+
+  it("does not log anything when envs are valid", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+    process.env.APP_HOSTNAME = "localhost";
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).not.toThrow();
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/identity-env.ts
+++ b/src/lib/identity-env.ts
@@ -69,48 +69,50 @@ export function assertIdentityEnv(): void {
 function collectIdentityEnvErrors(): string[] {
   const errors: string[] = [];
 
-  // `NEXT_PUBLIC_APP_URL`: distinguiamo "non settato" (OK, default
-  // applica) da "settato ma vuoto/whitespace" (errore — regola 18) e da
-  // "settato e malformato" (errore via TrustedAppUrlError).
-  const appUrlRaw = process.env[APP_URL_ENV];
-  if (appUrlRaw !== undefined) {
-    if (appUrlRaw.trim() === "") {
-      errors.push(
-        `${APP_URL_ENV} is present but empty — Dockerfile likely bakes ARG without a value (regola 18)`,
-      );
-    } else {
-      try {
-        getTrustedAppUrl();
-      } catch (err) {
-        if (err instanceof TrustedAppUrlError) {
-          errors.push(`${APP_URL_ENV}: ${err.message}`);
-        } else {
-          // Non rilanciamo subito: continuiamo a raccogliere errori
-          // sugli altri env per dare un report completo al deploy.
-          errors.push(
-            `${APP_URL_ENV}: ${err instanceof Error ? err.message : "unknown error"}`,
-          );
-        }
-      }
-    }
-  }
+  const appUrlError = validateAppUrlEnv();
+  if (appUrlError) errors.push(appUrlError);
 
   for (const name of HOSTNAME_ENV_VARS) {
-    const raw = process.env[name];
-    if (raw === undefined) continue; // not set → fallback default applies
-    if (raw.trim() === "") {
-      errors.push(
-        `${name} is present but empty — Dockerfile likely bakes ARG without a value (regola 18)`,
-      );
-      continue;
-    }
-    const normalised = raw.trim().toLowerCase();
-    if (!isValidHostnameSyntax(normalised)) {
-      errors.push(
-        `${name}="${raw}" is not a valid hostname (no scheme, no slash, no port)`,
-      );
-    }
+    const hostnameError = validateHostnameEnvVar(name);
+    if (hostnameError) errors.push(hostnameError);
   }
 
   return errors;
+}
+
+/**
+ * Valida `NEXT_PUBLIC_APP_URL`. Distinguiamo "non settato" (OK, default
+ * applica), "settato ma vuoto/whitespace" (errore — regola 18), e
+ * "settato e malformato" (errore via `TrustedAppUrlError`).
+ */
+function validateAppUrlEnv(): string | null {
+  const raw = process.env[APP_URL_ENV];
+  if (raw === undefined) return null;
+  if (raw.trim() === "") {
+    return `${APP_URL_ENV} is present but empty — Dockerfile likely bakes ARG without a value (regola 18)`;
+  }
+  try {
+    getTrustedAppUrl();
+    return null;
+  } catch (err) {
+    // Non rilanciamo subito: il chiamante accumula errori sugli altri
+    // env per dare un report completo al deploy.
+    if (err instanceof TrustedAppUrlError) {
+      return `${APP_URL_ENV}: ${err.message}`;
+    }
+    return `${APP_URL_ENV}: ${err instanceof Error ? err.message : "unknown error"}`;
+  }
+}
+
+function validateHostnameEnvVar(name: string): string | null {
+  const raw = process.env[name];
+  if (raw === undefined) return null; // fallback default applies
+  if (raw.trim() === "") {
+    return `${name} is present but empty — Dockerfile likely bakes ARG without a value (regola 18)`;
+  }
+  const normalised = raw.trim().toLowerCase();
+  if (!isValidHostnameSyntax(normalised)) {
+    return `${name}="${raw}" is not a valid hostname (no scheme, no slash, no port)`;
+  }
+  return null;
 }

--- a/src/lib/identity-env.ts
+++ b/src/lib/identity-env.ts
@@ -1,0 +1,116 @@
+import { logger } from "@/lib/logger";
+import { isValidHostnameSyntax } from "./hostname-env";
+import { getTrustedAppUrl, TrustedAppUrlError } from "./trusted-app-url";
+
+/**
+ * Hostname env vars validati al boot. La lista è duplicata in
+ * `next.config.ts` e `src/lib/trusted-app-url.ts` ma là viene letta in
+ * modo lazy con fallback silenzioso — qui invece la verifichiamo
+ * **strict** all'avvio del container.
+ *
+ * Le NEXT_PUBLIC_* sono baked al build (`Dockerfile` ARG/ENV) ma vengono
+ * lette anche a runtime per chi punta sandbox/self-hosted, quindi
+ * compaiono qui — un valore baked sbagliato si scopriva oggi solo al
+ * primo URL costruito (SCONTRINOZERO-F).
+ */
+const HOSTNAME_ENV_VARS = [
+  "APP_HOSTNAME",
+  "NEXT_PUBLIC_APP_HOSTNAME",
+  "MARKETING_HOSTNAME",
+  "NEXT_PUBLIC_MARKETING_HOSTNAME",
+  "API_HOSTNAME",
+  "NEXT_PUBLIC_API_HOSTNAME",
+] as const;
+
+const APP_URL_ENV = "NEXT_PUBLIC_APP_URL" as const;
+
+/**
+ * Valida le env d'identità al boot del container.
+ *
+ * Le env coperte (`NEXT_PUBLIC_APP_URL`, `APP_HOSTNAME`,
+ * `NEXT_PUBLIC_APP_HOSTNAME`, `MARKETING_HOSTNAME`,
+ * `NEXT_PUBLIC_MARKETING_HOSTNAME`, `API_HOSTNAME`,
+ * `NEXT_PUBLIC_API_HOSTNAME`) sono quelle che producono URL/redirect:
+ * Stripe checkout, reset-password, magic-link, marketing → app SSO.
+ *
+ * Behaviour:
+ * - `NODE_ENV === "production"` → throw aggregato → il container non
+ *   parte. Defense in depth contro la regola 18 (present-but-empty,
+ *   `?? default` che non scatta) e contro SCONTRINOZERO-D/F (URL
+ *   malformato scoperto solo al primo route hit).
+ * - dev/test → `logger.warn` strutturato, il processo continua. Non
+ *   blocchiamo il dev loop quando un'env locale è temporaneamente
+ *   incongruente.
+ *
+ * Le guardie lazy esistenti (`getTrustedAppUrl()`,
+ * `parseTrustedHostnameEnv()` con fallback) restano in piedi — sono il
+ * secondo strato, non vengono toccate.
+ */
+export function assertIdentityEnv(): void {
+  const errors = collectIdentityEnvErrors();
+  if (errors.length === 0) return;
+
+  const isProd = process.env.NODE_ENV === "production";
+  const payload = {
+    critical: true,
+    errorClass: "identity_env_invalid",
+    errors,
+  };
+  const message =
+    "identity env validation failed at boot — refusing to build redirect URLs";
+
+  if (isProd) {
+    logger.error(payload, message);
+    throw new Error(`${message}\n - ${errors.join("\n - ")}`);
+  }
+  logger.warn(payload, message);
+}
+
+function collectIdentityEnvErrors(): string[] {
+  const errors: string[] = [];
+
+  // `NEXT_PUBLIC_APP_URL`: distinguiamo "non settato" (OK, default
+  // applica) da "settato ma vuoto/whitespace" (errore — regola 18) e da
+  // "settato e malformato" (errore via TrustedAppUrlError).
+  const appUrlRaw = process.env[APP_URL_ENV];
+  if (appUrlRaw !== undefined) {
+    if (appUrlRaw.trim() === "") {
+      errors.push(
+        `${APP_URL_ENV} is present but empty — Dockerfile likely bakes ARG without a value (regola 18)`,
+      );
+    } else {
+      try {
+        getTrustedAppUrl();
+      } catch (err) {
+        if (err instanceof TrustedAppUrlError) {
+          errors.push(`${APP_URL_ENV}: ${err.message}`);
+        } else {
+          // Non rilanciamo subito: continuiamo a raccogliere errori
+          // sugli altri env per dare un report completo al deploy.
+          errors.push(
+            `${APP_URL_ENV}: ${err instanceof Error ? err.message : "unknown error"}`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const name of HOSTNAME_ENV_VARS) {
+    const raw = process.env[name];
+    if (raw === undefined) continue; // not set → fallback default applies
+    if (raw.trim() === "") {
+      errors.push(
+        `${name} is present but empty — Dockerfile likely bakes ARG without a value (regola 18)`,
+      );
+      continue;
+    }
+    const normalised = raw.trim().toLowerCase();
+    if (!isValidHostnameSyntax(normalised)) {
+      errors.push(
+        `${name}="${raw}" is not a valid hostname (no scheme, no slash, no port)`,
+      );
+    }
+  }
+
+  return errors;
+}

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -7,10 +7,17 @@ import pino from "pino";
 
 const mockCaptureException = vi.fn();
 const mockCaptureMessage = vi.fn();
+const mockSetFingerprint = vi.fn();
+const mockWithScope = vi.fn(
+  (cb: (scope: { setFingerprint: typeof mockSetFingerprint }) => void) => {
+    cb({ setFingerprint: mockSetFingerprint });
+  },
+);
 
 vi.mock("@sentry/nextjs", () => ({
   captureException: mockCaptureException,
   captureMessage: mockCaptureMessage,
+  withScope: mockWithScope,
 }));
 
 // Helper: create a logger that writes to a buffer so we can inspect output
@@ -218,6 +225,8 @@ describe("logger Sentry bridge", () => {
     vi.resetModules();
     mockCaptureException.mockReset();
     mockCaptureMessage.mockReset();
+    mockSetFingerprint.mockReset();
+    mockWithScope.mockClear();
   });
 
   afterEach(() => {
@@ -280,6 +289,94 @@ describe("logger Sentry bridge", () => {
     expect(mockCaptureException).toHaveBeenCalledWith(err, {
       extra: { err: { name: "Error", message: "fatal crash" } },
     });
+  });
+
+  it("R23: logger.error with sentryFingerprint wraps captureException in withScope+setFingerprint", async () => {
+    // SCONTRINOZERO-9/-A condividevano trace_id ma generavano 2 issue Sentry
+    // distinte perche' i message ("wizardTemplate failed 500" vs
+    // "setUserChoice failed 500") rompevano il grouping di default. Un
+    // fingerprint esplicito sul flow li riunisce in un singolo group.
+    const { logger } = await import("./logger");
+    const err = new Error("AdE wizardTemplate failed");
+    logger.error(
+      {
+        err,
+        businessId: "biz-1",
+        sentryFingerprint: ["onboarding-verify", "ade_failure"],
+      },
+      "AdE credential verification failed",
+    );
+    expect(mockWithScope).toHaveBeenCalledOnce();
+    expect(mockSetFingerprint).toHaveBeenCalledWith([
+      "onboarding-verify",
+      "ade_failure",
+    ]);
+    expect(mockCaptureException).toHaveBeenCalledWith(err, {
+      extra: expect.objectContaining({
+        err: { name: "Error", message: "AdE wizardTemplate failed" },
+        businessId: "biz-1",
+      }),
+    });
+    // sentryFingerprint is routing metadata, NOT payload — keep it out of extra
+    // so Sentry doesn't echo the fingerprint string back into the issue context.
+    const extra = mockCaptureException.mock.calls[0]?.[1]?.extra as
+      | Record<string, unknown>
+      | undefined;
+    expect(extra).not.toHaveProperty("sentryFingerprint");
+  });
+
+  it("R23: logger.error without sentryFingerprint does NOT call withScope (back-compat)", async () => {
+    const { logger } = await import("./logger");
+    logger.error(
+      { err: new Error("boom"), businessId: "biz-2" },
+      "generic failure",
+    );
+    expect(mockWithScope).not.toHaveBeenCalled();
+    expect(mockSetFingerprint).not.toHaveBeenCalled();
+    expect(mockCaptureException).toHaveBeenCalledOnce();
+  });
+
+  it("R23: logger.error with empty sentryFingerprint array does NOT call withScope", async () => {
+    const { logger } = await import("./logger");
+    logger.error(
+      { err: new Error("boom"), sentryFingerprint: [] },
+      "still groups by default",
+    );
+    expect(mockWithScope).not.toHaveBeenCalled();
+    expect(mockCaptureException).toHaveBeenCalledOnce();
+  });
+
+  it("R23: logger.error with non-array sentryFingerprint is ignored", async () => {
+    const { logger } = await import("./logger");
+    logger.error(
+      {
+        err: new Error("boom"),
+        sentryFingerprint: "not-an-array" as unknown as string[],
+      },
+      "still groups by default",
+    );
+    expect(mockWithScope).not.toHaveBeenCalled();
+    expect(mockCaptureException).toHaveBeenCalledOnce();
+  });
+
+  it("R23: sentryFingerprint also wraps captureMessage path (plain err-less log)", async () => {
+    const { logger } = await import("./logger");
+    logger.error(
+      {
+        sentryFingerprint: ["onboarding-verify", "missing_credentials"],
+        businessId: "biz-3",
+      },
+      "Credenziali AdE non trovate",
+    );
+    expect(mockWithScope).toHaveBeenCalledOnce();
+    expect(mockSetFingerprint).toHaveBeenCalledWith([
+      "onboarding-verify",
+      "missing_credentials",
+    ]);
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      "Credenziali AdE non trovate",
+      "error",
+    );
   });
 
   it("logger.warn does NOT call Sentry (warn is Docker-only)", async () => {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -90,6 +90,7 @@ export function sanitizeForTelemetry(obj: unknown): Record<string, unknown> {
     "errorClass",
     "captchaHostname",
     "critical",
+    "sentinelId",
   ];
 
   const safe: Record<string, unknown> = {};

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -113,7 +113,17 @@ export function sanitizeForTelemetry(obj: unknown): Record<string, unknown> {
 // pino numeric levels: error=50, fatal=60
 const PINO_ERROR_LEVEL = 50;
 
-function captureToSentry(obj: unknown, msg?: string): void {
+function extractFingerprint(obj: unknown): string[] | null {
+  if (typeof obj !== "object" || obj === null) return null;
+  const fp = (obj as Record<string, unknown>)["sentryFingerprint"];
+  if (!Array.isArray(fp) || fp.length === 0) return null;
+  // Defensive: drop non-string entries before passing to Sentry, which would
+  // otherwise stringify them in non-obvious ways and pollute the group key.
+  const stringFp = fp.filter((x): x is string => typeof x === "string");
+  return stringFp.length > 0 ? stringFp : null;
+}
+
+function doCapture(obj: unknown, msg?: string): void {
   const sanitized = sanitizeForTelemetry(obj);
 
   if (
@@ -130,6 +140,21 @@ function captureToSentry(obj: unknown, msg?: string): void {
   } else {
     Sentry.captureMessage(String(msg ?? obj), "error");
   }
+}
+
+function captureToSentry(obj: unknown, msg?: string): void {
+  const fingerprint = extractFingerprint(obj);
+  if (fingerprint) {
+    // Wrap the capture in a scope so the fingerprint only routes THIS event
+    // and doesn't leak into subsequent unrelated captures within the same
+    // async context. Regola 23 di CLAUDE.md (SCONTRINOZERO-9/-A grouping).
+    Sentry.withScope((scope) => {
+      scope.setFingerprint(fingerprint);
+      doCapture(obj, msg);
+    });
+    return;
+  }
+  doCapture(obj, msg);
 }
 
 export const logger = pino({

--- a/src/lib/server-auth.test.ts
+++ b/src/lib/server-auth.test.ts
@@ -49,6 +49,11 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+const mockSentrySetUser = vi.fn();
+vi.mock("@sentry/nextjs", () => ({
+  setUser: (...args: unknown[]) => mockSentrySetUser(...args),
+}));
+
 // --- Helpers ---
 
 const FAKE_USER = { id: "user-123", email: "test@example.com" };
@@ -121,6 +126,55 @@ describe("server-auth", () => {
         }),
         expect.any(String),
       );
+    });
+
+    it("R22: binds the authenticated user id to Sentry scope (Users Impacted)", async () => {
+      // Senza setUser ogni issue Sentry mostrava 'Users Impacted: 0' anche
+      // quando l'incidente toccava decine di utenti — il triage non poteva
+      // prioritizzare per impatto. Regola 22 di CLAUDE.md.
+      mockGetUser.mockResolvedValue({ data: { user: FAKE_USER } });
+
+      const { getAuthenticatedUser } = await import("./server-auth");
+      await getAuthenticatedUser();
+
+      expect(mockSentrySetUser).toHaveBeenCalledWith({ id: FAKE_USER.id });
+    });
+
+    it("R22: does NOT pass email or other PII to Sentry (only id)", async () => {
+      // L'UUID di Supabase Auth e' identificativo opaco (non PII diretta).
+      // Email/nome/ip restano fuori dallo scope Sentry per coerenza con il
+      // SAFE_KEYS denylist di logger.ts.
+      mockGetUser.mockResolvedValue({ data: { user: FAKE_USER } });
+
+      const { getAuthenticatedUser } = await import("./server-auth");
+      await getAuthenticatedUser();
+
+      const callArg = mockSentrySetUser.mock.calls[0]?.[0] as
+        | Record<string, unknown>
+        | undefined;
+      expect(callArg).toBeDefined();
+      expect(callArg).not.toHaveProperty("email");
+      expect(callArg).not.toHaveProperty("username");
+      expect(callArg).not.toHaveProperty("ip_address");
+      expect(Object.keys(callArg ?? {})).toEqual(["id"]);
+    });
+
+    it("R22: does NOT call Sentry.setUser when user is null (no leak)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+
+      const { getAuthenticatedUser } = await import("./server-auth");
+      await expect(getAuthenticatedUser()).rejects.toThrow("Not authenticated");
+
+      expect(mockSentrySetUser).not.toHaveBeenCalled();
+    });
+
+    it("R22: does NOT call Sentry.setUser when getUser rejects", async () => {
+      mockGetUser.mockRejectedValue(new Error("network down"));
+
+      const { getAuthenticatedUser } = await import("./server-auth");
+      await expect(getAuthenticatedUser()).rejects.toThrow("Not authenticated");
+
+      expect(mockSentrySetUser).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { and, eq } from "drizzle-orm";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getDb } from "@/db";
@@ -48,6 +49,14 @@ export async function getAuthenticatedUser(): Promise<User> {
   if (!user) {
     throw new Error("Not authenticated");
   }
+  // Bind l'auth user id allo scope Sentry per la richiesta corrente. Senza
+  // questo `Users Impacted` resta a 0 su ogni issue (ogni issue analizzata
+  // nelle 10 di SCONTRINOZERO aveva 0 utenti tracciati, vanificando il
+  // triage per impatto). Passiamo SOLO `id` (UUID opaco di Supabase Auth):
+  // niente email/username/ip per coerenza col denylist `SAFE_KEYS` di
+  // `src/lib/logger.ts` e con la policy GDPR del progetto. Regola 22 di
+  // CLAUDE.md.
+  Sentry.setUser({ id: user.id });
   return user;
 }
 

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -680,7 +680,7 @@ describe("emitReceiptForBusiness", () => {
     );
   });
 
-  it("M3: errore non transient e non user (generic Error) resta a logger.error", async () => {
+  it("M3: errore non transient e non user (generic Error) resta a logger.error con sentryFingerprint per flow emit-receipt (R23)", async () => {
     mockSubmitSale.mockRejectedValue(new Error("unexpected boom"));
 
     const { emitReceiptForBusiness } = await import("./receipt-service");
@@ -688,7 +688,11 @@ describe("emitReceiptForBusiness", () => {
 
     const { logger } = await import("@/lib/logger");
     expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ errorClass: "ade_failure" }),
+      expect.objectContaining({
+        errorClass: "ade_failure",
+        flow: "emit-receipt",
+        sentryFingerprint: ["emit-receipt", "ade_failure"],
+      }),
       expect.stringContaining("emitReceiptForBusiness failed"),
     );
   });

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -659,9 +659,29 @@ describe("emitReceiptForBusiness", () => {
     );
   });
 
-  it("M3: errore non transient (AdeAuthError) resta a logger.error", async () => {
+  it("R21: AdeAuthError (credenziali sbagliate) logga warn con errorClass ade_user_error (no Sentry noise)", async () => {
+    // Credenziali Fisconline sbagliate sono input utente, non bug nostro:
+    // logger.warn + errorClass ade_user_error -> niente issue Sentry.
+    // Regola 21 di CLAUDE.md, fix di SCONTRINOZERO-7.
     const { AdeAuthError } = await import("@/lib/ade/errors");
     mockSubmitSale.mockRejectedValue(new AdeAuthError());
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_user_error" }),
+      expect.stringContaining("emitReceiptForBusiness"),
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "ade_failure" }),
+      expect.stringContaining("emitReceiptForBusiness failed"),
+    );
+  });
+
+  it("M3: errore non transient e non user (generic Error) resta a logger.error", async () => {
+    mockSubmitSale.mockRejectedValue(new Error("unexpected boom"));
 
     const { emitReceiptForBusiness } = await import("./receipt-service");
     await emitReceiptForBusiness(VALID_INPUT);

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -633,6 +633,7 @@ async function submitSaleToAde(
         documentId,
         businessId: input.businessId,
         recovery: options.recovery,
+        flow: "emit-receipt",
       },
       {
         transient: "emitReceiptForBusiness AdE transient failure",

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -538,7 +538,7 @@ describe("voidReceiptForBusiness", () => {
     expect(failedCalls).toHaveLength(0);
   });
 
-  it("M3: errore non transient (generic Error) resta a logger.error", async () => {
+  it("M3: errore non transient (generic Error) resta a logger.error con sentryFingerprint per flow void-receipt (R23)", async () => {
     mockSubmitVoid.mockRejectedValue(new Error("unexpected boom"));
 
     const { voidReceiptForBusiness } = await import("./void-service");
@@ -546,7 +546,11 @@ describe("voidReceiptForBusiness", () => {
 
     const { logger } = await import("@/lib/logger");
     expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ errorClass: "ade_failure" }),
+      expect.objectContaining({
+        errorClass: "ade_failure",
+        flow: "void-receipt",
+        sentryFingerprint: ["void-receipt", "ade_failure"],
+      }),
       expect.stringContaining("voidReceiptForBusiness failed"),
     );
   });

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -644,7 +644,11 @@ export async function voidReceiptForBusiness(
   } catch (err) {
     logAdeFailure(
       err,
-      { voidDocumentId, saleDocumentId: input.documentId },
+      {
+        voidDocumentId,
+        saleDocumentId: input.documentId,
+        flow: "void-receipt",
+      },
       {
         transient: "voidReceiptForBusiness AdE transient failure",
         failure: "voidReceiptForBusiness failed",

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -814,7 +814,11 @@ describe("onboarding-actions", () => {
       expect(failedCalls).toHaveLength(0);
     });
 
-    it("M3: errore non transient (AdeAuthError) resta a logger.error", async () => {
+    it("R21: AdeAuthError in verifyAdeCredentials logga warn con errorClass ade_user_error (no Sentry noise: SCONTRINOZERO-7)", async () => {
+      // Era il root cause di SCONTRINOZERO-7 (23 eventi in 5 settimane,
+      // archiviata come noise): utenti che digitano credenziali AdE
+      // sbagliate da /dashboard/settings finivano come logger.error ->
+      // Sentry issue. Ora -> warn + ade_user_error, niente Sentry.
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
@@ -833,12 +837,16 @@ describe("onboarding-actions", () => {
       await verifyAdeCredentials("biz-789");
 
       const { logger } = await import("@/lib/logger");
-      expect(logger.error).toHaveBeenCalledWith(
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           businessId: "biz-789",
-          errorClass: "ade_failure",
+          errorClass: "ade_user_error",
         }),
-        expect.stringContaining("AdE credential verification failed"),
+        expect.stringContaining("AdE credential verification"),
+      );
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.objectContaining({ errorClass: "ade_failure" }),
+        expect.anything(),
       );
     });
 

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -850,6 +850,39 @@ describe("onboarding-actions", () => {
       );
     });
 
+    it("R23: generic Error in verifyAdeCredentials logga error con sentryFingerprint per flow onboarding-verify", async () => {
+      // SCONTRINOZERO-9/-A condividevano trace_id ma generavano 2 issue
+      // Sentry distinte perche' i message divergevano. Con il flow propagato,
+      // due errori "ade_failure" nello stesso flow finiscono in un unico
+      // group Sentry (regola 23 di CLAUDE.md).
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+      mockLogin.mockRejectedValue(new Error("unexpected wizard failure"));
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      const { logger } = await import("@/lib/logger");
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessId: "biz-789",
+          errorClass: "ade_failure",
+          flow: "onboarding-verify",
+          sentryFingerprint: ["onboarding-verify", "ade_failure"],
+        }),
+        expect.stringContaining("AdE credential verification failed"),
+      );
+    });
+
     it("sends welcome email on first successful verification", async () => {
       // Ownership check: JOIN profile+business
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -360,7 +360,7 @@ export async function verifyAdeCredentials(
     }
     logAdeFailure(
       err,
-      { businessId },
+      { businessId, flow: "onboarding-verify" },
       {
         transient: "AdE credential verification: transient failure",
         failure: "AdE credential verification failed",


### PR DESCRIPTION
## Summary

Implements regole 21–25 of `CLAUDE.md`: structured telemetry routing (Sentry Logs vs Issues), boot-time identity env validation, Sentry user binding, flow-aware fingerprinting, and post-deploy smoke testing.

## Key Changes

### Boot-time Identity Env Validation (R24)
- **`src/lib/identity-env.ts`** (new): `assertIdentityEnv()` validates `NEXT_PUBLIC_APP_URL`, `*_HOSTNAME` vars at container startup
  - Throws aggregated error in production; warns in dev/test
  - Catches malformed URLs, empty strings (regola 18), http in production, scheme prefixes in hostnames
  - Prevents SCONTRINOZERO-D/F (URL misconfig discovered only at first route hit)
- **`src/instrumentation.ts`**: calls `assertIdentityEnv()` as first statement in nodejs runtime
- **`src/lib/identity-env.test.ts`** (new): 209 lines covering happy path + 8 failure modes + aggregation

### Sentry Logs Drain Validation (R21)
- **`src/app/api/_debug/sentry-sentinel/route.ts`** (new): emits triple log (info/warn/error) tagged `errorClass: "sentinel"` + stable `sentinelId`
  - Gated by `SENTRY_SENTINEL_TOKEN` env (constant-time compare, returns 404 when unauthorized)
  - Validates pino → Sentry Logs drain within ~5 min post-deploy
- **`src/app/api/_debug/sentry-sentinel/route.test.ts`** (new): 181 lines covering auth gating + log emission

### Health Probe for Identity Env (R25)
- **`src/app/api/_health/env/route.ts`** (new): smoke test endpoint returning `{ status, appUrl, release, hostnames, timestamp }`
  - Returns 503 if `getTrustedAppUrl()` fails (defense in depth vs runtime Secret rotation)
  - No auth required (info already public via HTTP traffic)
- **`src/app/api/_health/env/route.test.ts`** (new): 133 lines covering success + error cases + runtime override precedence

### User Error Classification (R20)
- **`src/lib/ade/error-messages.ts`**: new `isExpectedUserAdeError()` predicate for `AdeAuthError` + `AdePasswordExpiredError`
- **`src/lib/ade/log-failure.ts`**: three-branch routing:
  - User error (wrong credentials, expired password) → `logger.warn` + `errorClass: "ade_user_error"` (no Sentry issue)
  - Transient (network, SPID timeout, AdE 5xx) → `logger.warn` + `errorClass: "ade_transient"`
  - Failure (everything else) → `logger.error` + `errorClass: "ade_failure"`
  - Fixes SCONTRINOZERO-7 (23 events archived as noise; now routes to warn)
- **`src/lib/ade/log-failure.test.ts`**: updated to expect warn for `AdeAuthError` + `AdePasswordExpiredError`

### Sentry User Binding (R22)
- **`src/lib/server-auth.ts`**: calls `Sentry.setUser({ id })` after successful auth
  - Binds opaque Supabase UUID (not PII) to Sentry scope for "Users Impacted" metric
  - Enables triage prioritization by incident scope
- **`src/lib/server-auth.test.ts`**: validates `setUser` call + PII exclusion

### Flow-Aware Fingerprinting (R23)
- **`src/lib/logger.ts`**: extracts `sentryFingerprint` from context, wraps `captureException` in `Sentry.withScope` + `scope.setFingerprint`
  -

https://claude.ai/code/session_0188J4m3STdP1JkMhfNLd8LH