### PR TITLE
feat(plans): messaggio trial scaduto coerente + link "Attiva un piano"

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -228,7 +228,10 @@ export default async function SettingsPage({
       </Card>
 
       {planData && (
-        <Card>
+        // id="billing" → ancora del deep-link BILLING_SETTINGS_HREF
+        // (/dashboard/settings#billing). scroll-mt evita che la sticky header
+        // copra il titolo quando si atterra sull'ancora.
+        <Card id="billing" className="scroll-mt-20">
           <CardHeader>
             <CardTitle>Piano e Abbonamento</CardTitle>
           </CardHeader>

--- a/src/components/billing/trial-expired-message.test.tsx
+++ b/src/components/billing/trial-expired-message.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TrialExpiredMessage } from "./trial-expired-message";
+
+describe("TrialExpiredMessage", () => {
+  it("renders the trial-expired copy", () => {
+    render(<TrialExpiredMessage />);
+    expect(
+      screen.getByText(/il tuo periodo di prova è scaduto/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/per continuare/i)).toBeInTheDocument();
+  });
+
+  it('renders "Attiva un piano" as a link to the billing card', () => {
+    render(<TrialExpiredMessage />);
+    const link = screen.getByRole("link", { name: /attiva un piano/i });
+    expect(link).toHaveAttribute("href", "/dashboard/settings#billing");
+  });
+});

--- a/src/components/billing/trial-expired-message.tsx
+++ b/src/components/billing/trial-expired-message.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { BILLING_SETTINGS_HREF } from "@/lib/plans-shared";
+
+/**
+ * Messaggio "trial scaduto" con la frase "Attiva un piano" resa come link verso
+ * la card "Piano e Abbonamento" nelle Impostazioni (`BILLING_SETTINGS_HREF`).
+ *
+ * Sorgente unica del testo: il messaggio piano (`TRIAL_EXPIRED_MESSAGE`) torna
+ * dalle server action (cassa, annullo, catalogo) e i render site lo confrontano
+ * per uguaglianza per decidere se montare questo componente al posto del testo
+ * semplice. Link app→app (stesso origin) → `<Link>` di Next, non `appHref()`
+ * (la regola 15 vale solo per marketing→app).
+ *
+ * Ritorna un frammento inline: ogni call site lo avvolge nel proprio contenitore
+ * di alert (`<p role="alert">`, banner rosso, ecc.).
+ */
+export function TrialExpiredMessage() {
+  return (
+    <>
+      Il tuo periodo di prova è scaduto.{" "}
+      <Link href={BILLING_SETTINGS_HREF} className="font-medium underline">
+        Attiva un piano
+      </Link>{" "}
+      per continuare.
+    </>
+  );
+}

--- a/src/components/cassa/cassa-client.tsx
+++ b/src/components/cassa/cassa-client.tsx
@@ -17,6 +17,8 @@ import { Input } from "@/components/ui/input";
 import { formatCurrency } from "@/lib/utils";
 import { emitReceipt } from "@/server/receipt-actions";
 import { ChangeAdePasswordDialog } from "@/components/ade/change-ade-password-dialog";
+import { TrialExpiredMessage } from "@/components/billing/trial-expired-message";
+import { TRIAL_EXPIRED_MESSAGE } from "@/lib/plans-shared";
 
 type Step = "cart" | "add-item" | "summary" | "success";
 
@@ -309,16 +311,22 @@ export function CassaClient({
             className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm"
           >
             <p className="text-destructive">
-              {mutationError}
-              {mutationError.includes("Credenziali AdE non verificate") && (
+              {mutationError === TRIAL_EXPIRED_MESSAGE ? (
+                <TrialExpiredMessage />
+              ) : (
                 <>
-                  {" "}
-                  <Link
-                    href="/dashboard/settings"
-                    className="font-medium underline"
-                  >
-                    {"Verificale ora"}
-                  </Link>
+                  {mutationError}
+                  {mutationError.includes("Credenziali AdE non verificate") && (
+                    <>
+                      {" "}
+                      <Link
+                        href="/dashboard/settings"
+                        className="font-medium underline"
+                      >
+                        {"Verificale ora"}
+                      </Link>
+                    </>
+                  )}
                 </>
               )}
             </p>

--- a/src/components/catalogo/add-item-dialog.test.tsx
+++ b/src/components/catalogo/add-item-dialog.test.tsx
@@ -151,4 +151,46 @@ describe("AddItemDialog", () => {
 
     expect(onSuccess).not.toHaveBeenCalled();
   });
+
+  it("a trial scaduto mostra il link 'Attiva un piano' verso la card billing", async () => {
+    mockAddCatalogItem.mockResolvedValue({
+      error:
+        "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.",
+    });
+    render(<AddItemDialog {...DEFAULT_PROPS} />);
+
+    await act(async () => {
+      fireEvent.submit(
+        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+      );
+    });
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /attiva un piano/i });
+      expect(link).toHaveAttribute("href", "/dashboard/settings#billing");
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /il tuo periodo di prova è scaduto/i,
+    );
+  });
+
+  it("un errore generico resta testo semplice, senza link", async () => {
+    mockAddCatalogItem.mockResolvedValue({
+      error: "La descrizione è obbligatoria.",
+    });
+    render(<AddItemDialog {...DEFAULT_PROPS} />);
+
+    await act(async () => {
+      fireEvent.submit(
+        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("link", { name: /attiva un piano/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/catalogo/catalog-item-dialog.tsx
+++ b/src/components/catalogo/catalog-item-dialog.tsx
@@ -12,6 +12,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { VatSelector } from "@/components/cassa/vat-selector";
+import { TrialExpiredMessage } from "@/components/billing/trial-expired-message";
+import { TRIAL_EXPIRED_MESSAGE } from "@/lib/plans-shared";
 import type { VatCode } from "@/types/cassa";
 
 interface CatalogItemDialogProps {
@@ -107,7 +109,11 @@ export function CatalogItemDialog({
 
           {error && (
             <p role="alert" className="text-destructive text-sm">
-              {error}
+              {error === TRIAL_EXPIRED_MESSAGE ? (
+                <TrialExpiredMessage />
+              ) : (
+                error
+              )}
             </p>
           )}
 

--- a/src/components/storico/void-receipt-dialog.tsx
+++ b/src/components/storico/void-receipt-dialog.tsx
@@ -12,6 +12,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { TrialExpiredMessage } from "@/components/billing/trial-expired-message";
+import { TRIAL_EXPIRED_MESSAGE } from "@/lib/plans-shared";
 import { voidReceipt } from "@/server/void-actions";
 import type { ReceiptListItem, VoidReceiptResult } from "@/types/storico";
 import { VAT_LABELS } from "@/types/cassa";
@@ -120,7 +122,11 @@ export function VoidReceiptDialog({
             {/* Error: da server action (result.error) o eccezione imprevista */}
             {(mutation.data?.error ?? mutation.isError) && (
               <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-                {mutation.data?.error ?? "Errore imprevisto. Riprova."}
+                {mutation.data?.error === TRIAL_EXPIRED_MESSAGE ? (
+                  <TrialExpiredMessage />
+                ) : (
+                  (mutation.data?.error ?? "Errore imprevisto. Riprova.")
+                )}
               </div>
             )}
 

--- a/src/lib/plans-shared.ts
+++ b/src/lib/plans-shared.ts
@@ -55,6 +55,15 @@ export const TRIAL_DAYS = 30;
  */
 export const BILLING_SETTINGS_HREF = "/dashboard/settings#billing";
 
+/**
+ * Messaggio canonico mostrato quando il trial è scaduto, condiviso tra cassa
+ * (emissione), annullo scontrino e catalogo. Confrontare per uguaglianza
+ * (`error === TRIAL_EXPIRED_MESSAGE`) per decidere se rendere la frase
+ * "Attiva un piano" come link verso `BILLING_SETTINGS_HREF`.
+ */
+export const TRIAL_EXPIRED_MESSAGE =
+  "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.";
+
 /** Numero massimo di prodotti nel catalogo per piano Starter e trial */
 export const STARTER_CATALOG_LIMIT = 5;
 

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -15,6 +15,7 @@ export {
   PLAN_VALUES,
   STARTER_CATALOG_LIMIT,
   TRIAL_DAYS,
+  TRIAL_EXPIRED_MESSAGE,
   canAddCatalogItem,
   canEmit,
   canUseApi,

--- a/src/server/catalog-actions.test.ts
+++ b/src/server/catalog-actions.test.ts
@@ -48,10 +48,15 @@ vi.mock("@/lib/logger", () => ({
 
 const mockGetPlan = vi.fn();
 const mockCanAddCatalogItem = vi.fn();
+const mockIsTrialExpired = vi.fn();
+const TRIAL_EXPIRED_MESSAGE =
+  "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.";
 vi.mock("@/lib/plans", () => ({
   getPlan: (...args: unknown[]) => mockGetPlan(...args),
   canAddCatalogItem: (...args: unknown[]) => mockCanAddCatalogItem(...args),
+  isTrialExpired: (...args: unknown[]) => mockIsTrialExpired(...args),
   STARTER_CATALOG_LIMIT: 5,
+  TRIAL_EXPIRED_MESSAGE,
 }));
 
 // --- Fixtures ---
@@ -98,6 +103,7 @@ describe("catalog-actions", () => {
       planExpiresAt: null,
     });
     mockCanAddCatalogItem.mockReturnValue(true);
+    mockIsTrialExpired.mockReturnValue(false);
   });
 
   // ---------------------------------------------------------------------------
@@ -340,18 +346,53 @@ describe("catalog-actions", () => {
       expect(mockInsert).toHaveBeenCalledWith("catalog-items-table");
     });
 
-    it("ritorna errore con piano trial quando il limite è raggiunto", async () => {
+    it("trial ATTIVO al limite di 5 prodotti → messaggio 'massimo 5 prodotti'", async () => {
+      mockGetPlan.mockResolvedValue({
+        plan: "trial",
+        trialStartedAt: new Date("2026-06-01"),
+        planExpiresAt: null,
+      });
+      mockCanAddCatalogItem.mockReturnValue(false);
+      mockIsTrialExpired.mockReturnValue(false); // trial ancora attivo
+
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem(VALID_ADD_INPUT);
+
+      expect(result.error).toMatch(/Starter/i);
+      expect(result.error).not.toBe(TRIAL_EXPIRED_MESSAGE);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("trial SCADUTO → messaggio coerente con la cassa (trial scaduto)", async () => {
       mockGetPlan.mockResolvedValue({
         plan: "trial",
         trialStartedAt: new Date("2026-01-01"),
         planExpiresAt: null,
       });
       mockCanAddCatalogItem.mockReturnValue(false);
+      mockIsTrialExpired.mockReturnValue(true); // trial scaduto
 
       const { addCatalogItem } = await import("./catalog-actions");
       const result = await addCatalogItem(VALID_ADD_INPUT);
 
-      expect(result.error).toBeDefined();
+      expect(result.error).toBe(TRIAL_EXPIRED_MESSAGE);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("Starter (pagante) al limite → messaggio 'massimo 5', non quello del trial", async () => {
+      mockGetPlan.mockResolvedValue({
+        plan: "starter",
+        trialStartedAt: null,
+        planExpiresAt: null,
+      });
+      mockCanAddCatalogItem.mockReturnValue(false);
+      mockIsTrialExpired.mockReturnValue(true); // irrilevante: plan !== "trial"
+
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem(VALID_ADD_INPUT);
+
+      expect(result.error).toMatch(/Starter/i);
+      expect(result.error).not.toBe(TRIAL_EXPIRED_MESSAGE);
       expect(mockInsert).not.toHaveBeenCalled();
     });
   });

--- a/src/server/catalog-actions.ts
+++ b/src/server/catalog-actions.ts
@@ -7,7 +7,13 @@ import {
   checkBusinessOwnership,
   getAuthenticatedUser,
 } from "@/lib/server-auth";
-import { canAddCatalogItem, getPlan, STARTER_CATALOG_LIMIT } from "@/lib/plans";
+import {
+  canAddCatalogItem,
+  getPlan,
+  isTrialExpired,
+  STARTER_CATALOG_LIMIT,
+  TRIAL_EXPIRED_MESSAGE,
+} from "@/lib/plans";
 import { logger } from "@/lib/logger";
 import { VAT_CODES } from "@/types/cassa";
 import type { VatCode } from "@/types/cassa";
@@ -147,6 +153,12 @@ export async function addCatalogItem(
       existingItems.length,
     )
   ) {
+    // Trial scaduto: stesso messaggio della cassa (coerenza UX). Il limite di
+    // 5 prodotti su Starter / trial attivo resta invece il suo messaggio
+    // specifico — è un limite di piano corretto, non una scadenza.
+    if (planInfo.plan === "trial" && isTrialExpired(planInfo.trialStartedAt)) {
+      return { error: TRIAL_EXPIRED_MESSAGE };
+    }
     return {
       error: `Piano Starter: massimo ${STARTER_CATALOG_LIMIT} prodotti nel catalogo. Passa a Pro per catalogo illimitato.`,
     };

--- a/src/server/receipt-actions.ts
+++ b/src/server/receipt-actions.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod/v4";
 import { logger } from "@/lib/logger";
-import { getPlan, canEmit } from "@/lib/plans";
+import { getPlan, canEmit, TRIAL_EXPIRED_MESSAGE } from "@/lib/plans";
 import { RateLimiter } from "@/lib/rate-limit";
 import { refineLotteryCode } from "@/lib/receipts/lottery-code-schema";
 import {
@@ -62,10 +62,7 @@ export async function emitReceipt(
   // Enforce plan/trial gate server-side before any business logic
   const planInfo = await getPlan(user.id);
   if (!canEmit(planInfo.plan, planInfo.trialStartedAt)) {
-    return {
-      error:
-        "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.",
-    };
+    return { error: TRIAL_EXPIRED_MESSAGE };
   }
 
   // Runtime validation — same fiscal rules as API v1, applied to every

--- a/src/server/void-actions.ts
+++ b/src/server/void-actions.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod/v4";
 import { logger } from "@/lib/logger";
-import { getPlan, canEmit } from "@/lib/plans";
+import { getPlan, canEmit, TRIAL_EXPIRED_MESSAGE } from "@/lib/plans";
 import { RateLimiter } from "@/lib/rate-limit";
 import {
   checkBusinessOwnership,
@@ -42,10 +42,7 @@ export async function voidReceipt(
   // so it follows the same canEmit policy as receipt creation
   const planInfo = await getPlan(user.id);
   if (!canEmit(planInfo.plan, planInfo.trialStartedAt)) {
-    return {
-      error:
-        "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.",
-    };
+    return { error: TRIAL_EXPIRED_MESSAGE };
   }
 
   // Validate UUIDs before any DB query so malformed input returns an

--- a/tests/unit/server-receipt-actions.test.ts
+++ b/tests/unit/server-receipt-actions.test.ts
@@ -28,6 +28,8 @@ vi.mock("@/lib/server-auth", () => ({
 vi.mock("@/lib/plans", () => ({
   getPlan: mockGetPlan,
   canEmit: mockCanEmit,
+  TRIAL_EXPIRED_MESSAGE:
+    "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.",
 }));
 
 vi.mock("@/lib/rate-limit", () => ({

--- a/tests/unit/server-void-actions.test.ts
+++ b/tests/unit/server-void-actions.test.ts
@@ -32,6 +32,8 @@ vi.mock("@/lib/server-auth", () => ({
 vi.mock("@/lib/plans", () => ({
   getPlan: mockGetPlan,
   canEmit: mockCanEmit,
+  TRIAL_EXPIRED_MESSAGE:
+    "Il tuo periodo di prova è scaduto. Attiva un piano per continuare.",
 }));
 
 vi.mock("@/lib/rate-limit", () => ({


### PR DESCRIPTION
A trial scaduto il catalogo mostrava "Piano Starter: massimo 5 prodotti…"
mentre la cassa mostrava "Il tuo periodo di prova è scaduto. Attiva un
piano per continuare.". Allineo il catalogo al messaggio della cassa solo
quando il trial è effettivamente scaduto; il limite di 5 prodotti su
Starter / trial attivo mantiene il suo messaggio specifico (è un limite di
piano, non una scadenza).

Inoltre rendo la frase "Attiva un piano" cliccabile verso la card
"Piano e Abbonamento" nelle Impostazioni (/dashboard/settings#billing),
in cassa, annullo scontrino e catalogo.

- TRIAL_EXPIRED_MESSAGE: costante condivisa in plans-shared.ts (re-export
  da plans.ts), usata da receipt/void/catalog actions
- TrialExpiredMessage: componente condiviso che inietta il link verso
  BILLING_SETTINGS_HREF (Link Next, same-origin)
- addCatalogItem distingue trial scaduto dal limite 5 prodotti
- id="billing" sulla card Impostazioni per l'ancora del deep-link
- test: componente link, distinzione messaggi nel catalogo, render site

https://claude.ai/code/session_012EQ5oP9DuZ1XXT2TFv4sB3