### PR TITLE
fix(billing): scroll all'ancora #billing su deep-link verso le impost…

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -21,6 +21,7 @@ import { ApiKeySection } from "@/components/settings/api-key-section";
 import { PlanBadge } from "@/components/billing/plan-badge";
 import { PlanSelection } from "@/components/billing/plan-selection";
 import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
+import { ScrollToHash } from "@/components/billing/scroll-to-hash";
 import { CONTACT_EMAIL } from "@/lib/contact";
 import { APP_VERSION, getBuildLabel } from "@/lib/version";
 
@@ -124,6 +125,7 @@ export default async function SettingsPage({
   return (
     <div className="space-y-6">
       <RefreshOnSuccess active={success === "1"} />
+      <ScrollToHash />
       <h1 className="text-2xl font-bold">Impostazioni</h1>
 
       <Card>

--- a/src/components/billing/scroll-to-hash.test.tsx
+++ b/src/components/billing/scroll-to-hash.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ScrollToHash } from "./scroll-to-hash";
+
+describe("ScrollToHash", () => {
+  afterEach(() => {
+    window.location.hash = "";
+    document.body.innerHTML = "";
+  });
+
+  it("scrolls to the element matching the URL hash on mount", () => {
+    const target = document.createElement("div");
+    target.id = "billing";
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    document.body.appendChild(target);
+    window.location.hash = "#billing";
+
+    render(<ScrollToHash />);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+  });
+
+  it("decodes percent-encoded hashes before lookup", () => {
+    const target = document.createElement("div");
+    target.id = "piano e abbonamento";
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    document.body.appendChild(target);
+    window.location.hash = "#piano%20e%20abbonamento";
+
+    render(<ScrollToHash />);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when there is no hash", () => {
+    window.location.hash = "";
+    const { container } = render(<ScrollToHash />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does nothing when no element matches the hash", () => {
+    window.location.hash = "#missing";
+    // Non deve lanciare: getElementById torna null, optional chaining no-op.
+    expect(() => render(<ScrollToHash />)).not.toThrow();
+  });
+});

--- a/src/components/billing/scroll-to-hash.test.tsx
+++ b/src/components/billing/scroll-to-hash.test.tsx
@@ -45,4 +45,24 @@ describe("ScrollToHash", () => {
     // Non deve lanciare: getElementById torna null, optional chaining no-op.
     expect(() => render(<ScrollToHash />)).not.toThrow();
   });
+
+  it("does not throw on a malformed percent-encoded hash", () => {
+    // decodeURIComponent("%E0%A4%A") lancia URIError: l'effect deve degradare
+    // al raw senza propagare (niente error boundary).
+    window.location.hash = "#%E0%A4%A";
+    expect(() => render(<ScrollToHash />)).not.toThrow();
+  });
+
+  it("falls back to the raw hash when decoding fails", () => {
+    const target = document.createElement("div");
+    target.id = "%E0%A4%A";
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    document.body.appendChild(target);
+    window.location.hash = "#%E0%A4%A";
+
+    render(<ScrollToHash />);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/billing/scroll-to-hash.tsx
+++ b/src/components/billing/scroll-to-hash.tsx
@@ -21,7 +21,15 @@ export function ScrollToHash() {
   useEffect(() => {
     const { hash } = window.location;
     if (!hash) return;
-    const id = decodeURIComponent(hash.slice(1));
+    const raw = hash.slice(1);
+    // Fragment malformato (es. `#%E0%A4%A`) → decodeURIComponent lancia URIError:
+    // degradare al raw invece di propagare (regola 19, no error boundary).
+    let id: string;
+    try {
+      id = decodeURIComponent(raw);
+    } catch {
+      id = raw;
+    }
     document.getElementById(id)?.scrollIntoView({ block: "start" });
   }, []);
 

--- a/src/components/billing/scroll-to-hash.tsx
+++ b/src/components/billing/scroll-to-hash.tsx
@@ -19,7 +19,7 @@ import { useEffect } from "react";
  */
 export function ScrollToHash() {
   useEffect(() => {
-    const { hash } = window.location;
+    const { hash } = globalThis.location;
     if (!hash) return;
     const raw = hash.slice(1);
     // Fragment malformato (es. `#%E0%A4%A`) → decodeURIComponent lancia URIError:

--- a/src/components/billing/scroll-to-hash.tsx
+++ b/src/components/billing/scroll-to-hash.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Scrolla, dopo il mount, all'elemento il cui `id` corrisponde a
+ * `window.location.hash`.
+ *
+ * Perché serve: lo scroll-to-hash dell'App Router non scatta in modo affidabile
+ * sulle navigazioni *soft* (`<Link>`) verso una route diversa. Navigando da
+ * catalogo/cassa/annullo (o dal gate Pro / export CSV) a
+ * `/dashboard/settings#billing`, Next aggiorna l'URL ma non porta lo scroll alla
+ * card "Piano e Abbonamento", anche se l'ancora `#billing` è già nell'HTML
+ * server-rendered. Eseguendo lo scroll lato client al mount copriamo sia la
+ * soft-navigation sia il reload, e ogni deep-link verso `BILLING_SETTINGS_HREF`
+ * atterra sulla sezione giusta.
+ *
+ * Generico: scrolla a qualunque hash presente, non solo `#billing`.
+ */
+export function ScrollToHash() {
+  useEffect(() => {
+    const { hash } = window.location;
+    if (!hash) return;
+    const id = decodeURIComponent(hash.slice(1));
+    document.getElementById(id)?.scrollIntoView({ block: "start" });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
…azioni

Lo scroll-to-hash dell'App Router non scatta in modo affidabile sulle soft-navigation (<Link>) tra route diverse: il link "Attiva un piano" (e gli altri deep-link verso BILLING_SETTINGS_HREF — gate Pro, export CSV) raggiungeva /dashboard/settings ma non portava alla card "Piano e Abbonamento". Aggiunge un client component ScrollToHash che al mount scrolla all'elemento indicato da window.location.hash.

https://claude.ai/code/session_012EQ5oP9DuZ1XXT2TFv4sB3