### PR TITLE
fix: interventi da audit Lighthouse (SEO noindex, a11y tabelle, meta PWA)

### DIFF
--- a/src/app/(marketing)/confronto/page.tsx
+++ b/src/app/(marketing)/confronto/page.tsx
@@ -137,13 +137,13 @@ export default function ConfrontoPage() {
             <table className="w-full text-sm">
               <thead className="bg-muted/50">
                 <tr>
-                  <th className="px-4 py-3 text-left font-semibold">
+                  <th scope="col" className="px-4 py-3 text-left font-semibold">
                     {"Servizio"}
                   </th>
-                  <th className="px-4 py-3 text-left font-semibold">
+                  <th scope="col" className="px-4 py-3 text-left font-semibold">
                     {"Prezzo dichiarato"}
                   </th>
-                  <th className="px-4 py-3 text-left font-semibold">
+                  <th scope="col" className="px-4 py-3 text-left font-semibold">
                     {"Trial"}
                   </th>
                 </tr>
@@ -151,7 +151,7 @@ export default function ConfrontoPage() {
               <tbody className="divide-y">
                 {c.saasCompetitors.map((s) => (
                   <tr key={s.url} className="align-top">
-                    <td className="px-4 py-3">
+                    <th scope="row" className="px-4 py-3 text-left font-normal">
                       <a
                         href={s.url}
                         target="_blank"
@@ -166,7 +166,7 @@ export default function ConfrontoPage() {
                       <span className="text-muted-foreground mt-1 block text-xs leading-relaxed">
                         {s.notes}
                       </span>
-                    </td>
+                    </th>
                     <td className="text-muted-foreground px-4 py-3 text-sm">
                       {s.pricing}
                     </td>
@@ -176,7 +176,7 @@ export default function ConfrontoPage() {
                   </tr>
                 ))}
                 <tr className="bg-primary/5 align-top">
-                  <td className="px-4 py-3">
+                  <th scope="row" className="px-4 py-3 text-left font-normal">
                     <span className="text-primary font-semibold">
                       {"ScontrinoZero"}
                     </span>
@@ -188,7 +188,7 @@ export default function ConfrontoPage() {
                         "Open source: lo installi gratis sul tuo computer o server. Pensato per lo smartphone, con la possibilità di installare l'app dal browser. Codice ispezionabile su GitHub."
                       }
                     </span>
-                  </td>
+                  </th>
                   <td className="text-primary px-4 py-3 text-sm font-semibold">
                     {"Starter 29,99 €/anno · Pro 49,99 €/anno"}
                     <span className="text-muted-foreground mt-0.5 block text-xs font-normal">

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Dipendenze pesanti non rilevanti per il metadata: mock per poter importare il
+// modulo senza caricare font/woff2, provider e CSS.
+vi.mock("next/font/local", () => ({
+  default: () => ({ variable: "--font-mock", className: "mock" }),
+}));
+vi.mock("@/components/providers", () => ({
+  Providers: ({ children }: { children: unknown }) => children,
+}));
+vi.mock("@/components/json-ld", () => ({
+  JsonLd: () => null,
+  softwareApplicationJsonLd: {},
+  organizationJsonLd: {},
+}));
+vi.mock("./globals.css", () => ({}));
+
+import { metadata } from "./layout";
+
+describe("RootLayout metadata", () => {
+  it("dichiara il meta standard mobile-web-app-capable (non deprecato)", () => {
+    expect(metadata.other?.["mobile-web-app-capable"]).toBe("yes");
+  });
+
+  it("mantiene l'apple-mobile-web-app-capable per compat iOS", () => {
+    expect(metadata.other?.["apple-mobile-web-app-capable"]).toBe("yes");
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,6 +60,9 @@ export const metadata: Metadata = {
     follow: true,
   },
   other: {
+    // Standard cross-browser (sostituisce l'`apple-mobile-web-app-capable`
+    // deprecato; quest'ultimo resta per compat con iOS Safari datati).
+    "mobile-web-app-capable": "yes",
     "apple-mobile-web-app-capable": "yes",
     "apple-mobile-web-app-status-bar-style": "default",
     "apple-mobile-web-app-title": "ScontrinoZero",

--- a/src/components/marketing/comparison-table.test.tsx
+++ b/src/components/marketing/comparison-table.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { ComparisonTable, type ComparisonRow } from "./comparison-table";
+
+const rows: readonly ComparisonRow[] = [
+  { label: "Canone mensile", competitor: "€19", ours: "€4,99" },
+  {
+    label: "Trial senza carta",
+    competitor: false,
+    ours: true,
+    note: "30 giorni",
+  },
+];
+
+describe("ComparisonTable", () => {
+  it("dà scope=col a ogni intestazione di colonna (td-has-header)", () => {
+    render(<ComparisonTable competitorLabel="Concorrente" rows={rows} />);
+    const colHeaders = screen.getAllByRole("columnheader");
+    // Tre colonne: etichetta vuota, concorrente, ScontrinoZero.
+    expect(colHeaders).toHaveLength(3);
+    for (const th of colHeaders) {
+      expect(th.getAttribute("scope")).toBe("col");
+    }
+  });
+
+  it("rende la prima cella di ogni riga come row header (th scope=row)", () => {
+    render(<ComparisonTable competitorLabel="Concorrente" rows={rows} />);
+    const rowHeaders = screen.getAllByRole("rowheader");
+    const labels = rowHeaders.map((th) => th.getAttribute("scope"));
+    expect(labels.every((s) => s === "row")).toBe(true);
+    // Le etichette di riga restano i row header.
+    expect(
+      screen.getByRole("rowheader", { name: /canone mensile/i }),
+    ).toBeTruthy();
+  });
+
+  it("rende il footer label come row header quando presente", () => {
+    render(
+      <ComparisonTable
+        competitorLabel="Concorrente"
+        rows={rows}
+        footer={{ label: "Risparmio annuo", value: "€168" }}
+      />,
+    );
+    const footerHeader = screen.getByRole("rowheader", {
+      name: /risparmio annuo/i,
+    });
+    expect(footerHeader.getAttribute("scope")).toBe("row");
+  });
+
+  it("preserva il contenuto delle celle dati (valori e note)", () => {
+    render(
+      <ComparisonTable
+        competitorLabel="Concorrente"
+        rows={rows}
+        oursLabel="ScontrinoZero"
+      />,
+    );
+    expect(screen.getByText("€4,99")).toBeTruthy();
+    expect(screen.getByText("30 giorni")).toBeTruthy();
+    // La riga "Trial" booleana rende un'icona (check) nella cella nostra.
+    const trialRow = screen
+      .getByRole("rowheader", { name: /trial senza carta/i })
+      .closest("tr")!;
+    expect(within(trialRow).getAllByRole("cell").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/marketing/comparison-table.tsx
+++ b/src/components/marketing/comparison-table.tsx
@@ -42,11 +42,14 @@ export function ComparisonTable({
       <table className="w-full text-sm">
         <thead>
           <tr className="bg-muted/50">
-            <th className="px-4 py-3 text-left font-semibold"></th>
-            <th className="px-4 py-3 text-center font-semibold">
+            <th scope="col" className="px-4 py-3 text-left font-semibold"></th>
+            <th scope="col" className="px-4 py-3 text-center font-semibold">
               {competitorLabel}
             </th>
-            <th className="text-primary px-4 py-3 text-center font-semibold">
+            <th
+              scope="col"
+              className="text-primary px-4 py-3 text-center font-semibold"
+            >
               {oursLabel}
             </th>
           </tr>
@@ -54,14 +57,14 @@ export function ComparisonTable({
         <tbody className="divide-y">
           {rows.map((row) => (
             <tr key={row.label}>
-              <td className="px-4 py-3">
+              <th scope="row" className="px-4 py-3 text-left font-normal">
                 {row.label}
                 {row.note && (
                   <span className="text-muted-foreground mt-0.5 block text-xs">
                     {row.note}
                   </span>
                 )}
-              </td>
+              </th>
               <td className="text-muted-foreground px-4 py-3 text-center">
                 {renderCell(row.competitor, "competitor")}
               </td>
@@ -74,7 +77,9 @@ export function ComparisonTable({
         {footer && (
           <tfoot>
             <tr className="bg-muted/50 font-semibold">
-              <td className="px-4 py-3">{footer.label}</td>
+              <th scope="row" className="px-4 py-3 text-left">
+                {footer.label}
+              </th>
               <td className="px-4 py-3 text-center"></td>
               <td className="text-primary px-4 py-3 text-center">
                 {footer.value}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -567,20 +567,62 @@ describe("proxy", () => {
       }
     });
 
-    it("ignores a spoofed Host header when nextUrl.hostname differs", async () => {
+    it("uses the Host header as source of truth: marketing apex in header, internal nextUrl.hostname → marketing redirect", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
       const { proxy } = await import("./proxy");
 
-      // The actual URL is on the marketing domain; an attacker-controlled Host
-      // header claiming to be the app domain must not change routing decisions.
-      const req = new NextRequest("https://scontrinozero.it/dashboard", {
-        headers: { host: "app.scontrinozero.it" },
+      // Riproduce il caso produzione dietro Cloudflare Tunnel: nextUrl.hostname
+      // riflette l'origin interno, ma l'header Host porta l'apex marketing reale.
+      // Il routing deve seguire l'header → /login su marketing redirige ad app.
+      const req = new NextRequest("https://internal.local/login", {
+        headers: { host: "scontrinozero.it" },
       });
       const response = await proxy(req);
       expect(response.status).toBe(307);
       const location = new URL(response.headers.get("location")!);
-      // Decision is based on nextUrl.hostname (marketing) → redirect to app.
       expect(location.hostname).toBe("app.scontrinozero.it");
-      expect(location.pathname).toBe("/dashboard");
+      expect(location.pathname).toBe("/login");
+    });
+
+    it("classifies by the Host header (app) even when nextUrl.hostname is marketing", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      // Header dice app → / su dominio app redirige a /dashboard, a prescindere
+      // dall'host dell'URL parsato.
+      const req = new NextRequest("https://scontrinozero.it/", {
+        headers: { host: "app.scontrinozero.it" },
+      });
+      const response = await proxy(req);
+      expect(response.status).toBe(307);
+      expect(new URL(response.headers.get("location")!).pathname).toBe(
+        "/dashboard",
+      );
+    });
+
+    it("logs a proxyHostSource breadcrumb only when Host header and nextUrl.hostname differ", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { proxy } = await import("./proxy");
+
+      // Match: nessun breadcrumb proxyHostSource.
+      await proxy(createRequestForHost("/", "scontrinozero.it"));
+      expect(
+        warnSpy.mock.calls.filter((c) =>
+          String(c[0]).includes("proxyHostSource"),
+        ),
+      ).toHaveLength(0);
+
+      // Mismatch: un solo breadcrumb proxyHostSource.
+      await proxy(
+        new NextRequest("https://internal.local/", {
+          headers: { host: "scontrinozero.it" },
+        }),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("proxyHostSource"),
+      );
+      warnSpy.mockRestore();
     });
   });
 
@@ -591,6 +633,21 @@ describe("proxy", () => {
 
       const response = await proxy(
         new NextRequest("https://scontrinozero.it/"),
+      );
+      expect(response.headers.get("X-Robots-Tag")).toBeNull();
+    });
+
+    it("does NOT add noindex when the Host header is the marketing apex even if nextUrl.hostname is the internal origin", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      // Caso produzione dietro Cloudflare Tunnel: l'header Host è l'apex
+      // marketing indicizzabile → la landing pubblica NON deve essere noindex,
+      // anche se nextUrl.hostname riflette l'origin interno.
+      const response = await proxy(
+        new NextRequest("https://internal.local/", {
+          headers: { host: "scontrinozero.it" },
+        }),
       );
       expect(response.headers.get("X-Robots-Tag")).toBeNull();
     });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,26 +19,48 @@ const MARKETING_ONLY_ROUTES = [
 ];
 
 /**
+ * Risolve l'hostname pubblico della richiesta dall'header `Host`.
+ *
+ * Dietro Cloudflare l'header `Host` è la source-of-truth attendibile: l'edge lo
+ * riscrive in base all'hostname effettivamente servito (SNI), quindi un client
+ * non può falsificarlo per ingannare il routing. È la stessa sorgente usata da
+ * `robots.ts` (`headers().get("host")`) e, a differenza di
+ * `request.nextUrl.hostname`, resta corretta in produzione standalone dietro il
+ * Cloudflare Tunnel: lì `nextUrl.hostname` può riflettere l'origin interno e
+ * NON l'apex marketing, causando `X-Robots-Tag: noindex` sulle pagine pubbliche
+ * e il mancato redirect del dominio marketing.
+ *
+ * Fallback a `nextUrl.hostname` solo se l'header è assente (richieste sintetiche
+ * senza Host). Sempre normalizzato: lowercase + porta rimossa.
+ */
+function resolvePublicHostname(request: NextRequest): string {
+  const fromHeader = request.headers.get("host");
+  const raw =
+    fromHeader && fromHeader.length > 0
+      ? fromHeader
+      : request.nextUrl.hostname || "";
+  return raw.toLowerCase().replace(/:\d+$/, "");
+}
+
+/**
  * Redirects based on hostname to enforce domain separation.
  *
  * Trust model:
- * - Primary source is `request.nextUrl.hostname` (Next.js parses this from the
- *   incoming URL — same byte source as the Host header but normalised).
+ * - Primary source is the `Host` header via `resolvePublicHostname()` — dietro
+ *   Cloudflare è attendibile e coerente con `robots.ts`. `nextUrl.hostname` è
+ *   solo fallback quando l'header manca.
  * - Hostname matching is done against an explicit allowlist (app, marketing,
  *   www-marketing, api). Anything outside the allowlist is left untouched
- *   (safe-deny: no implicit cross-domain redirect on unknown hosts), so a
- *   spoofed Host header never triggers a redirect to an arbitrary destination.
+ *   (safe-deny: no implicit cross-domain redirect on unknown hosts).
+ * - I target dei redirect sono costruiti SOLO da env trusted
+ *   (`https://${appHostname}`), mai dall'host della richiesta → anche
+ *   accettando l'header `Host` non si introduce alcun open-redirect.
  * - Skipped in local development where both domains share localhost:3000.
  */
 function hostnameRedirect(request: NextRequest): NextResponse | null {
   if (process.env.NODE_ENV === "development") return null;
 
-  // request.nextUrl.hostname is Next.js's parsed view of the request URL —
-  // already lowercased and without port. We strip a stray port defensively
-  // (some platforms surface "host:port" in nextUrl.hostname).
-  const hostname = (request.nextUrl.hostname || "")
-    .toLowerCase()
-    .replace(/:\d+$/, "");
+  const hostname = resolvePublicHostname(request);
   const { pathname, search } = request.nextUrl;
   // Trusted hostnames must be parsed/validated: a malformed env var
   // (scheme leak, trailing slash, spaces, …) would otherwise alter routing
@@ -107,21 +129,50 @@ function hostnameRedirect(request: NextRequest): NextResponse | null {
  * autorevole di de-indicizzazione: a differenza del solo `Disallow` in
  * robots.txt, garantisce che le pagine già note non restino nell'indice.
  * Applicato solo alle risposte HTML pass-through (non ai redirect 3xx).
+ *
+ * L'host è risolto dall'header `Host` (`resolvePublicHostname`), coerente con
+ * `robots.ts`: in produzione `nextUrl.hostname` può non essere l'apex marketing
+ * e marcherebbe per errore la landing pubblica come `noindex`.
  */
 function applyNoindexHeader(
   response: NextResponse,
   request: NextRequest,
 ): NextResponse {
-  const hostname = (request.nextUrl.hostname || "")
-    .toLowerCase()
-    .replace(/:\d+$/, "");
-  if (!isIndexableHost(hostname)) {
+  if (!isIndexableHost(resolvePublicHostname(request))) {
     response.headers.set("X-Robots-Tag", "noindex, nofollow");
   }
   return response;
 }
 
+/**
+ * Breadcrumb diagnostico edge-safe: emette un `console.warn` strutturato (pino
+ * NON è edge-compatibile) SOLO quando l'header `Host` e `nextUrl.hostname`
+ * divergono. Serve a confermare in produzione la discrepanza dietro Cloudflare
+ * Tunnel (root cause del noindex sull'apex) e resta come osservabilità. Gate
+ * on-mismatch per non generare rumore sulle richieste normali.
+ */
+function logHostSourceMismatch(request: NextRequest): void {
+  const hostHeader = (request.headers.get("host") || "")
+    .toLowerCase()
+    .replace(/:\d+$/, "");
+  const nextUrlHostname = (request.nextUrl.hostname || "")
+    .toLowerCase()
+    .replace(/:\d+$/, "");
+  if (hostHeader && nextUrlHostname && hostHeader !== nextUrlHostname) {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        action: "proxyHostSource",
+        hostHeader,
+        nextUrlHostname,
+        msg: "host header differs from nextUrl.hostname; using host header",
+      }),
+    );
+  }
+}
+
 export async function proxy(request: NextRequest) {
+  logHostSourceMismatch(request);
   const redirect = hostnameRedirect(request);
   if (redirect) return redirect;
 


### PR DESCRIPTION
## Contesto

Triage di un audit Lighthouse mobile su `scontrinozero.it/` (Perf 0.83 · A11y 0.96 · Best Practices 0.81 · **SEO 0.69**). Molti "fallimenti" sono rumore esterno (script Cloudflare challenge per le deprecations/cache/modern-http; un'estensione del browser per "Minify JS"; banner `beforeinstallprompt` PWA intenzionale) e **non** vanno toccati. Qui sono affrontati solo i problemi reali e nel nostro controllo. Tre commit separati, indipendenti.

## 1. 🔴 SEO — niente più `noindex` sulle pagine marketing (causa dello 0.69)

In produzione l'apex `scontrinozero.it/` (e `/guide`, `/login`, …) rispondeva `200` con `x-robots-tag: noindex, nofollow` — header **autoritativo** che tiene le pagine fuori dall'indice nonostante `robots.txt` (`Allow: /` + sitemap) e il meta `index, follow`.

**Root cause** (confermata via `curl` in produzione + eliminazione logica): il proxy leggeva l'host da `request.nextUrl.hostname`, che dietro Cloudflare Tunnel **non** è l'apex marketing → `isIndexableHost()` falliva → noindex. Invece `robots.ts` legge l'host dall'header `Host` (corretto) → per questo il `robots.txt` era già indicizzabile. La stessa causa rompeva anche i redirect del dominio marketing (es. `scontrinozero.it/login` non redirezionava ad app). L'env `NEXT_PUBLIC_MARKETING_HOSTNAME` è corretto (altrimenti anche `robots.txt` sarebbe `Disallow: /`).

**Fix** (`src/proxy.ts`): nuovo helper `resolvePublicHostname()` che legge l'host dall'header `Host` (fallback a `nextUrl.hostname` se assente), usato sia in `hostnameRedirect()` sia in `applyNoindexHeader()`. Aggiunto un breadcrumb diagnostico edge-safe `proxyHostSource` (`console.warn` solo on-mismatch) per confermare la discrepanza nei log di produzione.

**Nota sicurezza / trust-model:** dietro Cloudflare l'header `Host` è attendibile (lo riscrive l'edge in base all'hostname servito; il client non può falsificarlo). Tutti i target di redirect restano costruiti da env trusted (`https://${appHostname}`), mai dall'host della richiesta → nessun open-redirect. Il test deliberato precedente (`ignores a spoofed Host header…`) è stato riscritto per il nuovo modello.

## 2. 🟡 A11y — `td-has-header` nelle tabelle di confronto

Le tabelle large (≥3 colonne) richiedono header associati alle celle. Aggiunto `scope="col"` alle intestazioni e convertita la prima cella di ogni riga (etichetta/servizio = row header) in `<th scope="row">` in `comparison-table.tsx` e `confronto/page.tsx`. Nessun cambio di stile/colore.

## 3. 🟢 PWA — meta `mobile-web-app-capable`

Aggiunto il meta standard `mobile-web-app-capable: yes` accanto all'`apple-*` deprecato (mantenuto per iOS) in `layout.tsx`.

## Fuori scope (per decisione esplicita)

- **Contrasto colore** `--primary` (#009689, 3.7:1 su bianco): rimane un potenziale fail WCAG AA, **non** toccato in questa PR.
- **Performance** (chunk JS legacy/unused, CSS render-blocking): non in scope.

## Test

- `proxy.test.ts`: riscritto il test del trust-model + nuovi casi (header marketing/internal nextUrl → no noindex e redirect corretto; classificazione per header; breadcrumb solo on-mismatch).
- `comparison-table.test.tsx` (nuovo): scope col/row e contenuto celle.
- `layout.test.tsx` (nuovo): presenza dei due meta.
- Suite completa verde: **2853 test / 190 file**, coverage 95.46%.

## Verifica post-deploy (regole 13 + 25)

```bash
curl -sSI https://scontrinozero.it/        # atteso: NIENTE x-robots-tag noindex
curl -sSI https://scontrinozero.it/guide   # atteso: NIENTE x-robots-tag noindex
curl -sSI https://scontrinozero.it/login   # atteso: 307 → app.scontrinozero.it
curl -sSI https://app.scontrinozero.it/    # atteso: 307 → /dashboard (invariato)
```
Inoltre controllare nei log di produzione l'evento `proxyHostSource` per confermare la discrepanza host reale.

https://claude.ai/code/session_01RasKVtrLSXBVDqfHaWeuZa

---
_Generated by [Claude Code](https://claude.ai/code/session_01RasKVtrLSXBVDqfHaWeuZa)_