### PR TITLE
Remove noindex diagnostic breadcrumb from proxy middleware

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -600,28 +600,27 @@ describe("proxy", () => {
       );
     });
 
-    it("logs a proxyHostSource breadcrumb only when Host header and nextUrl.hostname differ", async () => {
+    it("never emits a proxyHostSource breadcrumb, even when Host header and nextUrl.hostname differ", async () => {
+      // Regression: in standalone dietro Cloudflare Tunnel nextUrl.hostname è
+      // sempre il bind address (0.0.0.0), quindi il vecchio breadcrumb
+      // diagnostico floodava i log con un warn per ogni richiesta. La sua root
+      // cause (noindex sull'apex) è già fixata: nessun segnale residuo.
       mockGetUser.mockResolvedValue({ data: { user: null } });
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { proxy } = await import("./proxy");
 
-      // Match: nessun breadcrumb proxyHostSource.
       await proxy(createRequestForHost("/", "scontrinozero.it"));
-      expect(
-        warnSpy.mock.calls.filter((c) =>
-          String(c[0]).includes("proxyHostSource"),
-        ),
-      ).toHaveLength(0);
-
-      // Mismatch: un solo breadcrumb proxyHostSource.
       await proxy(
         new NextRequest("https://internal.local/", {
           headers: { host: "scontrinozero.it" },
         }),
       );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("proxyHostSource"),
-      );
+
+      expect(
+        warnSpy.mock.calls.filter((c) =>
+          String(c[0]).includes("proxyHostSource"),
+        ),
+      ).toHaveLength(0);
       warnSpy.mockRestore();
     });
   });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -144,35 +144,7 @@ function applyNoindexHeader(
   return response;
 }
 
-/**
- * Breadcrumb diagnostico edge-safe: emette un `console.warn` strutturato (pino
- * NON è edge-compatibile) SOLO quando l'header `Host` e `nextUrl.hostname`
- * divergono. Serve a confermare in produzione la discrepanza dietro Cloudflare
- * Tunnel (root cause del noindex sull'apex) e resta come osservabilità. Gate
- * on-mismatch per non generare rumore sulle richieste normali.
- */
-function logHostSourceMismatch(request: NextRequest): void {
-  const hostHeader = (request.headers.get("host") || "")
-    .toLowerCase()
-    .replace(/:\d+$/, "");
-  const nextUrlHostname = (request.nextUrl.hostname || "")
-    .toLowerCase()
-    .replace(/:\d+$/, "");
-  if (hostHeader && nextUrlHostname && hostHeader !== nextUrlHostname) {
-    console.warn(
-      JSON.stringify({
-        level: "warn",
-        action: "proxyHostSource",
-        hostHeader,
-        nextUrlHostname,
-        msg: "host header differs from nextUrl.hostname; using host header",
-      }),
-    );
-  }
-}
-
 export async function proxy(request: NextRequest) {
-  logHostSourceMismatch(request);
   const redirect = hostnameRedirect(request);
   if (redirect) return redirect;
 


### PR DESCRIPTION
## Summary

Removes the `logHostSourceMismatch()` diagnostic function and its invocation from the proxy middleware. This function was emitting structured `console.warn` logs whenever the `Host` header differed from `nextUrl.hostname`, which was causing log spam in standalone deployments behind Cloudflare Tunnel (where `nextUrl.hostname` always resolves to the bind address `0.0.0.0`).

## Changes

- **Removed `logHostSourceMismatch()` function** from `src/proxy.ts` (lines 147–172)
  - This breadcrumb was intended as temporary observability for the noindex-on-apex issue
  - The root cause (noindex on apex domain) has already been fixed separately
  - The diagnostic signal is no longer needed and was generating noise in production logs

- **Removed function invocation** from `proxy()` export in `src/proxy.ts`
  - Deleted the `logHostSourceMismatch(request)` call at the start of the middleware

- **Updated test** in `src/proxy.test.ts`
  - Changed test title from "logs a proxyHostSource breadcrumb only when Host header and nextUrl.hostname differ" to "never emits a proxyHostSource breadcrumb, even when Host header and nextUrl.hostname differ"
  - Updated test logic to verify that **no** `proxyHostSource` breadcrumbs are emitted in any scenario
  - Added regression comment explaining why the breadcrumb was removed: in standalone mode behind Cloudflare Tunnel, the mismatch is constant and floods logs with a warn per request

## Implementation Details

The removal is safe because:
1. The underlying issue (noindex on apex) was already fixed via a separate change
2. The diagnostic was only useful during that specific investigation
3. In production (standalone behind Cloudflare Tunnel), the mismatch is constant and unavoidable, making the breadcrumb a source of log noise rather than actionable signal

https://claude.ai/code/session_019CYxtX4vm9CHDcqc2P8YFp