### PR TITLE
fix(sentry): filtra errori di rete client-side (SCONTRINOZERO-J)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,12 @@ src/app/\(marketing\)` prima di chiudere il task. - Contenuti generati via LLM c
     SCONTRINOZERO-7 ha collezionato 23 eventi in 5 settimane prima di essere
     archiviata come noise, perché ogni utente che digitava credenziali AdE
     sbagliate da `/dashboard/settings` finiva in Sentry. Estende la regola 19
-    alle server action di scrittura.
+    alle server action di scrittura. **Lato client** lo stesso principio si
+    applica tramite `beforeSend` in `sentry.client.config.ts`: i fallimenti di
+    rete browser (`TypeError: Load failed` su iOS, `Failed to fetch` su Chrome)
+    generati da `fetchServerAction` sono sempre transitori (connessione mobile
+    caduta) — filtrati da `isClientNetworkFailure()` in
+    `src/lib/sentry-filters.ts` (SCONTRINOZERO-J).
 21. **Osservabilità: validare il drain end-to-end al rollout.** Quando si
     abilita o si modifica una feature di telemetria (`enableLogs`,
     `Sentry.pinoIntegration`, `Sentry.metrics`, Sentry Profiling, Replays,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { isClientNetworkFailure } from "@/lib/sentry-filters";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -8,4 +9,11 @@ Sentry.init({
   replaysSessionSampleRate: 0,
   integrations: [Sentry.replayIntegration()],
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  beforeSend(event, hint) {
+    // Rumore di rete transiente su mobile (issue SCONTRINOZERO-J)
+    if (isClientNetworkFailure(event, hint)) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/src/lib/sentry-filters.test.ts
+++ b/src/lib/sentry-filters.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ErrorEvent, EventHint } from "@sentry/nextjs";
-import { isBenignFormDataParseError } from "./sentry-filters";
+import {
+  isBenignFormDataParseError,
+  isClientNetworkFailure,
+} from "./sentry-filters";
 
 function makeEvent(
   transaction: string | undefined,
@@ -74,5 +77,62 @@ describe("isBenignFormDataParseError", () => {
     const event = makeEvent("POST /_not-found/page");
 
     expect(isBenignFormDataParseError(event)).toBe(false);
+  });
+});
+
+describe("isClientNetworkFailure", () => {
+  it('filtra "Load failed" da originalException Error (iOS/Safari)', () => {
+    const event = makeEvent("/login");
+    const hint: EventHint = {
+      originalException: new TypeError("Load failed"),
+    };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(true);
+  });
+
+  it('filtra "Failed to fetch" da originalException Error (Chrome/Firefox)', () => {
+    const event = makeEvent("/login");
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to fetch"),
+    };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(true);
+  });
+
+  it("filtra quando il messaggio è in originalException stringa", () => {
+    const event = makeEvent("/login");
+    const hint: EventHint = { originalException: "Load failed" };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(true);
+  });
+
+  it("filtra quando il messaggio è nell'exception dell'evento (senza hint)", () => {
+    const event = makeEvent("/login", "Load failed");
+
+    expect(isClientNetworkFailure(event)).toBe(true);
+  });
+
+  it('non filtra "Network request failed" (messaggio non standard)', () => {
+    const event = makeEvent("/login");
+    const hint: EventHint = {
+      originalException: new TypeError("Network request failed"),
+    };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(false);
+  });
+
+  it("non filtra errori applicativi diversi dai fallimenti di rete", () => {
+    const event = makeEvent("/login");
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to parse body as FormData"),
+    };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(false);
+  });
+
+  it("non filtra eventi senza messaggio di errore", () => {
+    const event = makeEvent("/login");
+
+    expect(isClientNetworkFailure(event)).toBe(false);
   });
 });

--- a/src/lib/sentry-filters.ts
+++ b/src/lib/sentry-filters.ts
@@ -29,7 +29,7 @@ export function extractErrorMessage(
  * (TCP/TLS drop, nessuna connessione, app iOS in background).
  * Non vengono mai generati da codice applicativo — sono sempre non azionabili.
  */
-const NETWORK_FAILURE_MESSAGES = ["Load failed", "Failed to fetch"];
+const NETWORK_FAILURE_MESSAGES = new Set(["Load failed", "Failed to fetch"]);
 
 /**
  * True se l'evento è un fallimento di rete client-side — il browser non è
@@ -41,7 +41,7 @@ export function isClientNetworkFailure(
   hint?: EventHint,
 ): boolean {
   const message = extractErrorMessage(event, hint);
-  return NETWORK_FAILURE_MESSAGES.includes(message);
+  return NETWORK_FAILURE_MESSAGES.has(message);
 }
 
 /**

--- a/src/lib/sentry-filters.ts
+++ b/src/lib/sentry-filters.ts
@@ -10,7 +10,10 @@ import type { ErrorEvent, EventHint } from "@sentry/nextjs";
  */
 const FORMDATA_PARSE_MESSAGE = "Failed to parse body as FormData";
 
-function extractErrorMessage(event: ErrorEvent, hint?: EventHint): string {
+export function extractErrorMessage(
+  event: ErrorEvent,
+  hint?: EventHint,
+): string {
   const original = hint?.originalException;
   if (original instanceof Error) {
     return original.message;
@@ -19,6 +22,26 @@ function extractErrorMessage(event: ErrorEvent, hint?: EventHint): string {
     return original;
   }
   return event.exception?.values?.[0]?.value ?? "";
+}
+
+/**
+ * Messaggi nativi del browser per fallimenti di rete a livello di trasporto
+ * (TCP/TLS drop, nessuna connessione, app iOS in background).
+ * Non vengono mai generati da codice applicativo — sono sempre non azionabili.
+ */
+const NETWORK_FAILURE_MESSAGES = ["Load failed", "Failed to fetch"];
+
+/**
+ * True se l'evento è un fallimento di rete client-side — il browser non è
+ * riuscito a completare la chiamata fetch() prima di ricevere una risposta.
+ * Tipico su mobile con connessione instabile (issue SCONTRINOZERO-J).
+ */
+export function isClientNetworkFailure(
+  event: ErrorEvent,
+  hint?: EventHint,
+): boolean {
+  const message = extractErrorMessage(event, hint);
+  return NETWORK_FAILURE_MESSAGES.includes(message);
 }
 
 /**


### PR DESCRIPTION
TypeError: Load failed / Failed to fetch in fetchServerAction sono
fallimenti TCP/TLS browser su mobile — non bug applicativi. Aggiunge
isClientNetworkFailure() a sentry-filters.ts e beforeSend al client
config, stesso pattern di SCONTRINOZERO-E lato server.

https://claude.ai/code/session_01QqB39dyNSSSvuRit1qxDhR