### PR TITLE
Bump version to 1.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Patch release incrementing the version number from 1.3.8 to 1.3.9 in `package.json`.

## Changes
- Updated `package.json` version field to `1.3.9`

## Notes
This is a routine version bump. The lockfile changes are transitive dependency resolution artifacts from the version update.

https://claude.ai/code/session_01LapvPsQa65vNPTMZPgrFb5