### PR TITLE
Add caching & timeouts: SonarScanner CLI, Next.js build, workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,8 @@ test-report.xml
 LICENSE.md
 CLAUDE.md
 ROADMAP.md
+docs
+.claude
 
 # Git
 .git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   # Smart skip: only run if relevant files changed
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       code: ${{ steps.agg.outputs.code }}
       marketing: ${{ steps.f.outputs.marketing }}
@@ -87,6 +88,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check migration journal consistency
@@ -100,6 +102,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.hooks == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run hook test suites
@@ -115,6 +118,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ci_scripts == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run sonar-scan wrapper tests
@@ -123,6 +127,7 @@ jobs:
   # Scansione segreti — gira su tutti i push/PR (indipendente dal diff)
   secret-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -141,6 +146,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Download actionlint
@@ -154,6 +160,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.lockfile == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -178,6 +185,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.marketing == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -200,6 +208,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.marketing == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -225,6 +234,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -262,6 +272,11 @@ jobs:
     needs: [changes, test]
     if: needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Single source of truth per la cache key; sonar-scan.sh la legge e
+      # scarica questa stessa versione su cache miss.
+      SCANNER_VERSION: "8.0.1.6346"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -275,15 +290,27 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: test-execution-report
+      # Cache della scanner CLI (~50MB dal CDN flaky di Sonar) e della plugin
+      # cache dello scanner: su hit lo script salta il download — meno tempo
+      # sul percorso critico e zero esposizione ai 403 intermittenti del CDN.
+      - name: Cache SonarScanner CLI + plugin cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
+        with:
+          path: |
+            ~/.sonar-scanner
+            ~/.sonar/cache
+          key: sonar-scanner-${{ runner.os }}-${{ env.SCANNER_VERSION }}
       # Wrapper around the scanner CLI instead of SonarSource/sonarqube-scan-action:
       # that action has no retry and re-downloads the CLI from binaries.sonarsource.com
       # every run, so an intermittent HTTP 403 from Sonar's CDN sinks the job (and
       # spams notifications on main). The wrapper retries the download and, if the
       # CDN stays unreachable, skips with a warning instead of failing — real scan
       # errors still turn the job red. Logic covered by scripts/ci/test-sonar-scan.sh.
-      - name: SonarQube Cloud scan (retry + tolerate CDN 403)
+      - name: SonarQube Cloud scan (cached CLI, retry + tolerate CDN 403)
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # Dir fissa (ripristinata dalla cache) al posto del mktemp di default.
+          WORK_DIR: /home/runner/.sonar-scanner
         run: bash scripts/ci/sonar-scan.sh
 
   # Build parte quando lint, type-check e test sono verdi (test puo' essere skippato
@@ -292,6 +319,7 @@ jobs:
     needs: [changes, lint, type-check, test]
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.marketing == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # NEXT_PUBLIC_* vars are baked into the client bundle at build time.
     # Use test values so the build succeeds in CI without production secrets.
     env:
@@ -314,5 +342,15 @@ jobs:
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
+      # Cache incrementale di Next.js (pattern ufficiale): key esatta su
+      # lockfile+sorgenti, restore-key di fallback sul solo lockfile così
+      # ogni build riparte dalla cache più recente compatibile.
+      - name: Cache Next.js build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'next.config.ts') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
       - name: Build
         run: npm run build

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,6 +8,24 @@ on:
   push:
     branches:
       - main
+    # Salta il rebuild per push che NON possono cambiare l'immagine Docker:
+    # *.md, .github/, tests/ e *.test.* sono già esclusi da .dockerignore;
+    # docs/ e .claude/ entrano nel builder via COPY . . ma `next build` non
+    # li legge e il runner stage non li copia. Se in futuro qualcosa al build
+    # leggesse contenuti da docs/, togliere la riga corrispondente. NON
+    # aggiungere scripts/** (migrate.ts è bundlato nell'immagine) né
+    # supabase/** (migrations copiate nel runner stage).
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".claude/**"
+      - ".github/**"
+      - "tests/**"
+      - "**/*.test.ts"
+      - "**/*.test.tsx"
+  # Scappatoia manuale: un push ignorato (o una modifica a questo stesso
+  # workflow, che paths-ignore esclude via .github/**) si può deployare a mano.
+  workflow_dispatch:
 
 # L'ultimo push su main vince: annulla eventuali build dev in corso.
 concurrency:
@@ -22,6 +40,7 @@ jobs:
   build-and-deploy:
     # Runner ARM nativo (gratis sui repo pubblici): build arm64 senza QEMU.
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   check-ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       checks: read
     steps:
@@ -62,6 +63,7 @@ jobs:
   build-image:
     needs: [check-ci]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -117,6 +119,7 @@ jobs:
   smoke-test:
     needs: [build-image]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     env:
@@ -185,6 +188,7 @@ jobs:
   push-image:
     needs: [build-image, smoke-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ FROM node:22-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
+# Cache mount: riusa la cache npm tra build sullo STESSO builder (locale /
+# self-hosted). N.B. i cache mount NON sono persistiti da cache-to type=gha:
+# sui runner CI effimeri il mount parte vuoto — lì copre la layer cache.
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts --prefer-offline
 
 # =============================================================================
 # Stage 2: Build
@@ -51,7 +54,12 @@ ENV SENTRY_PROJECT=$SENTRY_PROJECT
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NO_UPDATE_NOTIFIER=1
 # SENTRY_AUTH_TOKEN passato come BuildKit secret (non scritto in nessun layer)
-RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN npm run build
+# Cache mount su .next/cache: build incrementale Next tra build sullo stesso
+# builder (locale / self-hosted). Come sopra: non persistito da type=gha — se
+# in futuro servisse in CI, vedi reproducible-containers/buildkit-cache-dance.
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+    --mount=type=cache,target=/app/.next/cache \
+    npm run build
 
 RUN npx esbuild scripts/migrate.ts \
     --bundle \

--- a/scripts/ci/sonar-scan.sh
+++ b/scripts/ci/sonar-scan.sh
@@ -12,12 +12,17 @@
 #
 # Behaviour
 # ---------
-#   1. Download the scanner CLI, retrying up to MAX_ATTEMPTS with exponential
-#      backoff. A second attempt clears almost every intermittent 403.
-#   2. If *every* attempt fails to fetch the CLI (transient CDN/network error,
+#   1. If a previously extracted CLI is already usable in WORK_DIR (warm
+#      actions/cache in CI: the job restores WORK_DIR keyed on
+#      SCANNER_VERSION), skip the download entirely and run the scan. A cache
+#      hit also removes the CDN from the critical path altogether.
+#   2. Otherwise download the scanner CLI, retrying up to MAX_ATTEMPTS with
+#      exponential backoff. A second attempt clears almost every intermittent
+#      403.
+#   3. If *every* attempt fails to fetch the CLI (transient CDN/network error,
 #      e.g. the 403), print a warning annotation and exit 0 — the job stays
 #      green. We tolerate ONLY the download phase.
-#   3. Once the CLI is in place, run the scan. A failure *here* is a real
+#   4. Once the CLI is in place, run the scan. A failure *here* is a real
 #      problem (bad config, auth, analysis error) and propagates a non-zero
 #      exit, so genuine issues still turn the job red.
 #
@@ -47,12 +52,18 @@ SCANNER_HOME="${WORK_DIR}/sonar-scanner-${SCANNER_VERSION}-linux-x64"
 
 log() { printf '%s\n' "$*" >&2; }
 
+# True when a previously extracted CLI is usable (warm actions/cache). The
+# executable bit distinguishes a complete extraction from a stale/partial one.
+scanner_cached() { [ -x "${SCANNER_HOME}/bin/sonar-scanner" ]; }
+
 # Download + extract the CLI. Returns 0 on success, non-zero on any
 # download/extract failure so the caller can retry and ultimately tolerate.
 fetch_scanner() {
   local url="${SONAR_BINARIES_URL}/${ZIP_NAME}"
   local zip="${WORK_DIR}/${ZIP_NAME}"
   local code
+  # WORK_DIR may be a fixed, not-yet-existing cache dir (CI) instead of mktemp.
+  mkdir -p "$WORK_DIR" || return 1
   # Without --fail curl returns 0 even on 403 (it writes the error body), so we
   # inspect the HTTP status code explicitly. A non-zero curl exit means a
   # network/TLS error, which is equally a transient download failure.
@@ -62,6 +73,9 @@ fetch_scanner() {
   }
   log "Scanner download HTTP status: ${code} (${url})"
   [ "$code" = "200" ] || return 1
+  # Drop any stale/partial extraction so a failed unzip can't masquerade as a
+  # cache hit on the next run.
+  rm -rf "$SCANNER_HOME"
   unzip -q -o "$zip" -d "$WORK_DIR" || return 1
 }
 
@@ -72,6 +86,11 @@ run_scan() {
 
 main() {
   local attempt=1 delay
+  if scanner_cached; then
+    log "Scanner CLI ${SCANNER_VERSION} already in ${WORK_DIR} (cache hit); skipping download."
+    run_scan
+    return $?
+  fi
   while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
     if fetch_scanner; then
       log "Scanner CLI ready (attempt ${attempt}/${MAX_ATTEMPTS}); running scan."

--- a/scripts/ci/test-sonar-scan.sh
+++ b/scripts/ci/test-sonar-scan.sh
@@ -111,6 +111,60 @@ run_scan() { echo "SCAN RAN"; return 0; }
 assert_rc "happy path" 0
 assert_contains "happy path" "SCAN RAN"
 
+# 5. Warm cache (actions/cache hit): CLI already extracted -> scan runs,
+#    NO download attempted.
+run_main '
+scanner_cached() { return 0; }
+fetch_scanner() { echo "FETCH RAN"; return 0; }
+run_scan() { echo "SCAN RAN"; return 0; }
+'
+assert_rc "cache hit skips download" 0
+assert_contains "cache hit skips download" "SCAN RAN"
+assert_not_contains "cache hit skips download" "FETCH RAN"
+
+# 6. Warm cache but the scan fails -> real failure still propagates,
+#    no tolerate warning.
+run_main '
+scanner_cached() { return 0; }
+fetch_scanner() { echo "FETCH RAN"; return 0; }
+run_scan() { echo "SCAN RAN"; return 7; }
+'
+assert_rc "cache hit scan failure propagates" 7
+assert_not_contains "cache hit scan failure propagates" "::warning::"
+
+# 7. Cold cache (explicit miss) -> download path runs, then scan.
+run_main '
+scanner_cached() { return 1; }
+fetch_scanner() { echo "FETCH RAN"; return 0; }
+run_scan() { echo "SCAN RAN"; return 0; }
+'
+assert_rc "cache miss downloads then scans" 0
+assert_contains "cache miss downloads then scans" "FETCH RAN"
+assert_contains "cache miss downloads then scans" "SCAN RAN"
+
+# 8. Real-FS scanner_cached: a stale/partial extraction (binary present but
+#    not executable) must read as a miss; an executable binary as a hit.
+tmp=$(mktemp -d)
+out=$( {
+  WORK_DIR="$tmp"
+  export WORK_DIR
+  # shellcheck disable=SC1090
+  source "$SCAN"
+  mkdir -p "${SCANNER_HOME}/bin"
+  : > "${SCANNER_HOME}/bin/sonar-scanner"
+  scanner_cached && echo "RESULT=HIT" || echo "RESULT=MISS"
+  chmod +x "${SCANNER_HOME}/bin/sonar-scanner"
+  scanner_cached && echo "RESULT=HIT" || echo "RESULT=MISS"
+} 2>&1 )
+case "$out" in
+  *"RESULT=MISS"*"RESULT=HIT"*) ;;
+  *)
+    echo "FAIL [stale cache detection]: expected MISS then HIT, got: $out" >&2
+    failures=$((failures + 1))
+    ;;
+esac
+rm -rf "$tmp"
+
 if [ "$failures" -gt 0 ]; then
   echo "$failures test(s) failed." >&2
   exit 1

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,21 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
+
+// I .test.ts che richiedono un DOM (window/sessionStorage/renderHook): girano
+// nel progetto jsdom insieme a tutti i .test.tsx. Ogni altro .test.ts è
+// server-side e gira nel più economico environment node — il pragma per-file
+// `@vitest-environment` resta supportato e vince comunque sul progetto.
+const JSDOM_TS_TESTS = [
+  "src/hooks/use-cassa.test.ts",
+  "src/lib/safe-storage.test.ts",
+  "src/lib/pwa/install-prompt-store.test.ts",
+];
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: "jsdom",
     testTimeout: 15000,
-    setupFiles: ["./tests/setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}", "tests/**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
@@ -60,6 +67,32 @@ export default defineConfig({
     outputFile: {
       "vitest-sonar-reporter": "test-report.xml",
     },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "node",
+          environment: "node",
+          include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+          // L'override di `exclude` scarta i default di Vitest (node_modules,
+          // dist, ...): vanno re-inclusi esplicitamente.
+          exclude: [...configDefaults.exclude, ...JSDOM_TS_TESTS],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "jsdom",
+          environment: "jsdom",
+          setupFiles: ["./tests/setup.ts"],
+          include: [
+            "src/**/*.test.tsx",
+            "tests/**/*.test.tsx",
+            ...JSDOM_TS_TESTS,
+          ],
+        },
+      },
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Improves CI/CD reliability and performance by introducing caching for expensive operations (SonarScanner CLI, Next.js build cache) and adding explicit timeout guards to all workflow jobs to prevent hung runners.

## Key Changes

### SonarScanner CLI Caching & Retry Logic
- **`scripts/ci/sonar-scan.sh`**: Refactored to check for a cached, previously-extracted CLI before attempting download
  - New `scanner_cached()` function detects warm cache by checking executable bit on `sonar-scanner` binary (distinguishes complete extraction from stale/partial state)
  - `main()` now skips download entirely on cache hit, removing CDN from critical path
  - `fetch_scanner()` now creates `WORK_DIR` if missing (supports fixed cache dir in CI) and cleans stale extractions before unzip
  - Maintains existing retry logic and CDN 403 tolerance for download failures
- **`scripts/ci/test-sonar-scan.sh`**: Added 4 new test cases covering cache hit/miss scenarios and stale cache detection on real filesystem

### GitHub Actions Workflow Updates
- **`.github/workflows/ci.yml`**:
  - Added `timeout-minutes` to all jobs (5–15 min depending on job type) to prevent hung runners
  - `sonar-scan` job: Added `actions/cache` step to persist `~/.sonar-scanner` and `~/.sonar/cache` keyed on `SCANNER_VERSION`
  - Introduced `SCANNER_VERSION` env var (8.0.1.6346) as single source of truth for cache key and download version
  - Set `WORK_DIR=/home/runner/.sonar-scanner` to use fixed cache dir instead of mktemp
- **`.github/workflows/deploy.yml`**: Added `timeout-minutes` to all jobs
- **`.github/workflows/deploy-dev.yml`**: 
  - Added `timeout-minutes: 30` to build job
  - Added `paths-ignore` to skip rebuild on docs, tests, markdown, and CI config changes
  - Added `workflow_dispatch` for manual deploy trigger

### Vitest Configuration Refactor
- **`vitest.config.ts`**: Split test environment into two projects
  - `node` project: runs `.test.ts` files (server-side, no DOM) in lightweight Node environment
  - `jsdom` project: runs `.test.tsx` files + DOM-requiring `.test.ts` files (hooks, storage, PWA) in jsdom
  - Reduces test execution time by avoiding unnecessary DOM setup for server-side tests
  - Maintains per-file `@vitest-environment` pragma override support

### Next.js Build Caching
- **`.github/workflows/ci.yml`**: Added `actions/cache` for `.next/cache` with fallback restore key on lockfile changes
- **`Dockerfile`**: Added BuildKit cache mounts for npm and Next.js build cache to enable incremental builds on self-hosted runners

### Docker & Ignore Updates
- **`.dockerignore`**: Added `docs/` and `.claude/` to reduce image size (not used at runtime)
- **`Dockerfile`**: 
  - Added `--mount=type=cache` for npm install (reuses cache between builds on same builder)
  - Added `--mount=type=cache` for `.next/cache` (incremental Next.js builds)
  - Added `--prefer-offline` flag to npm ci

## Implementation Details

- **Cache key strategy**: SonarScanner uses `sonar-scanner-${{ runner.os }}-${{ env.SCANNER_VERSION }}` to invalidate on version bumps; Next.js uses lockfile + source file hashes with lockfile-only fallback for compatibility
- **Executable bit check**: Distinguishes a complete extraction from a partial/corrupted one (e.g., binary present but not executable after failed unzip)
- **Stale cache cleanup**: `fetch_scanner()` removes old `SCANNER_HOME` before unzip to prevent masquerading failed downloads as cache hits on retry
- **Timeout coverage**: All jobs now have explicit timeouts; secret-scan

https://claude.ai/code/session_018BZv3N8KPait78fBpgLfAe