### PR TITLE
Fix marketing content routes domain routing regression

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -344,6 +344,78 @@ describe("proxy", () => {
       expect(location.pathname).toBe("/help");
     });
 
+    // Le pagine di contenuto marketing (oltre a privacy/termini/cookie/help)
+    // devono restare sul dominio marketing: regressione del bug per cui
+    // /prezzi, /funzionalita, /guide, /per, /confronto, /strumenti finivano su
+    // app.scontrinozero.it perché assenti da MARKETING_ONLY_ROUTES.
+    const MARKETING_CONTENT_ROUTES = [
+      "/confronto",
+      "/funzionalita",
+      "/guide",
+      "/per",
+      "/prezzi",
+    ] as const;
+
+    it.each(MARKETING_CONTENT_ROUTES)(
+      "allows %s on marketing domain (marketing content route)",
+      async (path) => {
+        mockGetUser.mockResolvedValue({ data: { user: null } });
+        const { proxy } = await import("./proxy");
+
+        const response = await proxy(
+          createRequestForHost(path, "scontrinozero.it"),
+        );
+        expect(response.status).toBe(200);
+      },
+    );
+
+    it.each(MARKETING_CONTENT_ROUTES)(
+      "redirects %s on app domain to marketing domain",
+      async (path) => {
+        const { proxy } = await import("./proxy");
+
+        const response = await proxy(
+          createRequestForHost(path, "app.scontrinozero.it"),
+        );
+        expect(response.status).toBe(307);
+        const location = new URL(response.headers.get("location")!);
+        expect(location.hostname).toBe("scontrinozero.it");
+        expect(location.pathname).toBe(path);
+      },
+    );
+
+    it("allows a dynamic marketing subroute on marketing domain (/guide/[slug])", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/guide/regime-forfettario", "scontrinozero.it"),
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("allows /strumenti/scorporo-iva on marketing domain (tool subroute)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/strumenti/scorporo-iva", "scontrinozero.it"),
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("redirects /strumenti/scorporo-iva on app domain to marketing domain", async () => {
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/strumenti/scorporo-iva", "app.scontrinozero.it"),
+      );
+      expect(response.status).toBe(307);
+      const location = new URL(response.headers.get("location")!);
+      expect(location.hostname).toBe("scontrinozero.it");
+      expect(location.pathname).toBe("/strumenti/scorporo-iva");
+    });
+
     it("redirects /dashboard on marketing domain to app domain", async () => {
       const { proxy } = await import("./proxy");
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,12 +10,29 @@ const PROTECTED_PREFIXES = ["/dashboard", "/onboarding"];
 /** Routes only for unauthenticated users (redirect to dashboard if logged in) */
 const AUTH_ONLY_PATHS = ["/login", "/register", "/reset-password"];
 
-/** Routes served exclusively on the marketing domain */
+/**
+ * Routes served exclusively on the marketing domain.
+ *
+ * Source-of-truth per la separazione dei domini: tutto ciò che sul dominio
+ * marketing non è `/` e non è qui dentro viene rimbalzato sul dominio app
+ * (vedi `hostnameRedirect`). Ogni nuova route top-level in
+ * `src/app/(marketing)/` DEVE essere aggiunta qui, altrimenti finisce per
+ * errore su app.scontrinozero.it. Il match in `hostnameRedirect` usa
+ * `pathname === r || pathname.startsWith(`${r}/`)`, quindi il prefisso
+ * top-level copre anche le route dinamiche (`/guide/[slug]`, `/per/[slug]`,
+ * `/strumenti/[slug]`).
+ */
 const MARKETING_ONLY_ROUTES = [
-  "/privacy",
-  "/termini",
+  "/confronto",
   "/cookie-policy",
+  "/funzionalita",
+  "/guide",
   "/help",
+  "/per",
+  "/prezzi",
+  "/privacy",
+  "/strumenti",
+  "/termini",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fixes a regression where marketing content routes (`/prezzi`, `/funzionalita`, `/guide`, `/per`, `/confronto`, `/strumenti`) were incorrectly being routed to `app.scontrinozero.it` instead of staying on the marketing domain `scontrinozero.it`.

## Changes

- **`src/proxy.ts`**: Added missing marketing content routes to `MARKETING_ONLY_ROUTES` constant:
  - `/confronto` (comparison pages)
  - `/funzionalita` (features)
  - `/guide` (educational content)
  - `/per` (category pages)
  - `/prezzi` (pricing)
  - `/strumenti` (free tools)
  
  Also added comprehensive documentation explaining that `MARKETING_ONLY_ROUTES` is the source-of-truth for domain separation, and that every new top-level route in `src/app/(marketing)/` must be added here. The route matching covers both top-level paths and dynamic subroutes (e.g., `/guide/[slug]`, `/strumenti/[slug]`).

- **`src/proxy.test.ts`**: Added comprehensive test coverage:
  - Parameterized tests for all marketing content routes ensuring they return 200 on marketing domain
  - Parameterized tests verifying 307 redirects from app domain to marketing domain
  - Specific tests for dynamic subroutes (`/guide/[slug]`)
  - Specific tests for tool subroutes (`/strumenti/scorporo-iva`)

## Implementation Details

The fix leverages the existing `hostnameRedirect` logic which uses `pathname === r || pathname.startsWith(`${r}/`)` matching, so adding a route prefix automatically covers all its dynamic subroutes without additional configuration.

Routes are alphabetically sorted in `MARKETING_ONLY_ROUTES` for maintainability.

https://claude.ai/code/session_01FEvyjJaUK69oQtEDcKpB8V