### PR TITLE
Improve CSV export UX for non-Pro plans with dialog

### DIFF
--- a/src/app/dashboard/storico/export-csv-button.test.tsx
+++ b/src/app/dashboard/storico/export-csv-button.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ExportCsvButton } from "./export-csv-button";
 
@@ -36,34 +36,7 @@ describe("ExportCsvButton", () => {
     );
   });
 
-  it("renders an upsell link to settings#billing for non-Pro plans", () => {
-    render(
-      <ExportCsvButton
-        plan="starter"
-        dateFrom="2026-01-01"
-        dateTo="2026-05-19"
-        status={null}
-      />,
-    );
-    const link = screen.getByRole("link", { name: /esporta csv/i });
-    expect(link).toHaveAttribute("href", "/dashboard/settings#billing");
-    expect(link).not.toHaveAttribute("download");
-  });
-
-  it("marks the upsell link with title to hint the Pro requirement", () => {
-    render(
-      <ExportCsvButton
-        plan="trial"
-        dateFrom="2026-01-01"
-        dateTo="2026-05-19"
-        status={null}
-      />,
-    );
-    const link = screen.getByRole("link", { name: /esporta csv/i });
-    expect(link.getAttribute("title")?.toLowerCase()).toContain("pro");
-  });
-
-  it("renders the upsell link for unlimited treated as pro (same behaviour)", () => {
+  it("renders the download link for unlimited treated as pro (same behaviour)", () => {
     render(
       <ExportCsvButton
         plan="unlimited"
@@ -77,5 +50,60 @@ describe("ExportCsvButton", () => {
       "href",
       "/api/export/receipts?from=2026-01-01&to=2026-05-19",
     );
+    expect(link).toHaveAttribute("download");
+  });
+
+  it("renders a Pro-marked trigger button (not a link) for non-Pro plans", () => {
+    render(
+      <ExportCsvButton
+        plan="starter"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    // It's a button trigger, not a direct download/upsell link.
+    const trigger = screen.getByRole("button", { name: /esporta csv/i });
+    expect(trigger).toBeInTheDocument();
+    // The "Pro" badge is visible before any interaction.
+    expect(trigger).toHaveTextContent(/pro/i);
+    // No upsell link is rendered yet — it lives inside the closed dialog.
+    expect(
+      screen.queryByRole("link", { name: /passa a pro/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens an explanatory dialog linking to settings#billing on click (starter)", () => {
+    render(
+      <ExportCsvButton
+        plan="starter"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /esporta csv/i }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+
+    const upsell = screen.getByRole("link", { name: /passa a pro/i });
+    expect(upsell).toHaveAttribute("href", "/dashboard/settings#billing");
+    expect(upsell).not.toHaveAttribute("download");
+  });
+
+  it("treats trial like a non-Pro plan (same upsell dialog)", () => {
+    render(
+      <ExportCsvButton
+        plan="trial"
+        dateFrom="2026-01-01"
+        dateTo="2026-05-19"
+        status={null}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /esporta csv/i }));
+
+    const upsell = screen.getByRole("link", { name: /passa a pro/i });
+    expect(upsell).toHaveAttribute("href", "/dashboard/settings#billing");
   });
 });

--- a/src/app/dashboard/storico/export-csv-button.tsx
+++ b/src/app/dashboard/storico/export-csv-button.tsx
@@ -1,6 +1,19 @@
+"use client";
+
 import Link from "next/link";
-import { Download } from "lucide-react";
+import { Download, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   BILLING_SETTINGS_HREF,
   canUsePro,
@@ -34,15 +47,38 @@ export function ExportCsvButton(props: ExportCsvButtonProps) {
     );
   }
 
+  // Non-Pro (starter/trial): segnale visivo "Pro" + dialog esplicativo invece
+  // del redirect silenzioso alle impostazioni.
   return (
-    <Button asChild variant="outline">
-      <Link
-        href={BILLING_SETTINGS_HREF}
-        title="Esportazione CSV disponibile sul piano Pro"
-      >
-        <Download className="size-4" aria-hidden />
-        Esporta CSV
-      </Link>
-    </Button>
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" aria-label="Esporta CSV — funzionalità Pro">
+          <Download className="size-4" aria-hidden />
+          Esporta CSV
+          <Badge variant="secondary">Pro</Badge>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="size-4" aria-hidden />
+            Esportazione CSV è una funzionalità Pro
+          </DialogTitle>
+          <DialogDescription>
+            L&apos;export dello storico in formato CSV è incluso nel piano Pro.
+            Passa a Pro per scaricare i tuoi corrispettivi e usarli in
+            contabilità o nei tuoi report.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Annulla</Button>
+          </DialogClose>
+          <Button asChild>
+            <Link href={BILLING_SETTINGS_HREF}>Passa a Pro</Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary

Refactored the ExportCsvButton component to provide a better user experience for non-Pro plans. Instead of silently redirecting to billing settings, non-Pro users now see a Pro-badged button that opens an explanatory dialog with a clear call-to-action to upgrade.

## Key Changes

- **Component behavior:** Converted non-Pro export button from a direct link to a dialog trigger
  - Pro/unlimited plans: Direct download link (unchanged)
  - Starter/trial plans: Button with "Pro" badge → opens dialog with upgrade explanation
  
- **UI improvements:**
  - Added `Badge` component showing "Pro" label on the button
  - Integrated `Dialog` component with clear messaging about the Pro requirement
  - Dialog includes descriptive text about CSV export use cases (accounting, reporting)
  - Two-button footer: "Annulla" (cancel) and "Passa a Pro" (upgrade link)
  - Added `Sparkles` icon to dialog header for visual emphasis

- **Test coverage:** Updated test suite to reflect new behavior
  - Renamed tests to clarify intent (e.g., "renders a Pro-marked trigger button")
  - Added `fireEvent` import for click interactions
  - Tests now verify button rendering, dialog opening, and upsell link presence
  - Confirmed "unlimited" plan still gets direct download (same as Pro)
  - Confirmed "trial" plan gets same upsell dialog as "starter"

- **Code structure:** Added `"use client"` directive and imported Dialog components from shadcn/ui

## Implementation Details

- The component now uses a Dialog wrapper with DialogTrigger for non-Pro plans
- Dialog content is only rendered when opened (not in DOM until interaction)
- Maintains existing behavior for Pro/unlimited: direct `/api/export/receipts` download link
- Upsell link points to `/dashboard/settings#billing` (unchanged)
- Improved accessibility with proper ARIA labels and semantic HTML

https://claude.ai/code/session_01HCVSzt7bN2ETeA3rTFFM3A