### PR TITLE
feat(receipts): aggiungi pulsante "Mostra QR code" per la ricevuta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-day-picker": "^10.0.0",
         "react-dom": "19.2.7",
         "react-hook-form": "^7.77.0",
+        "react-qr-code": "^2.2.0",
         "recharts": "^3.8.1",
         "resend": "^6.12.4",
         "serwist": "^9.5.7",
@@ -2891,9 +2892,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2909,9 +2907,6 @@
       "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2929,9 +2924,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2947,9 +2939,6 @@
       "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -14054,7 +14043,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -14643,7 +14631,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15582,7 +15569,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -15594,7 +15580,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -15636,6 +15621,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+      "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.2",
@@ -15852,6 +15843,19 @@
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.2.0.tgz",
+      "integrity": "sha512-e5nS0UUN22K3Nf8KBRUzemfdJ6OmnN5w+kbnj1lvJaol9RyVRFeGl05bCkxSN2ZegbLxjjYjX1+mmAoX9+fAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qrcode-generator": "^2.0.4"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-day-picker": "^10.0.0",
     "react-dom": "19.2.7",
     "react-hook-form": "^7.77.0",
+    "react-qr-code": "^2.2.0",
     "recharts": "^3.8.1",
     "resend": "^6.12.4",
     "serwist": "^9.5.7",

--- a/src/app/(marketing)/help/primo-scontrino/page.tsx
+++ b/src/app/(marketing)/help/primo-scontrino/page.tsx
@@ -165,7 +165,7 @@ export default function PrimoScontrinoPage() {
           Passaggio 5 — Condividi lo scontrino col cliente
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Dalla schermata di successo hai due pulsanti:
+          Dalla schermata di successo hai tre pulsanti:
         </p>
         <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
           <li>
@@ -173,6 +173,12 @@ export default function PrimoScontrinoPage() {
             condivisione del sistema (WhatsApp, email, SMS…); da desktop copia
             negli appunti il link pubblico della ricevuta, nella forma{" "}
             <code>/r/&lt;id&gt;</code>.
+          </li>
+          <li>
+            <strong>Mostra QR code</strong> — apre un QR code con il link alla
+            ricevuta: se non hai il numero o l&apos;email del cliente, mostragli
+            lo schermo e lui lo inquadra per aprire la ricevuta sul proprio
+            telefono.
           </li>
           <li>
             <strong>Nuovo scontrino</strong> — azzera il carrello e torna alla

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -135,6 +135,12 @@ export default function StoricoEdEsportazionePage() {
             email o messaggio, e dalla pagina il cliente può salvare il PDF.
           </li>
           <li>
+            Premere <strong>Mostra QR code</strong> per visualizzare un QR code
+            con il link alla ricevuta: utile quando non hai il numero o
+            l&apos;email del cliente — basta mostrargli lo schermo e lui lo
+            inquadra per aprire la ricevuta.
+          </li>
+          <li>
             Premere <strong>Annulla scontrino</strong> per avviare la procedura
             di annullo, disponibile solo se lo scontrino è in stato{" "}
             <strong>Emesso</strong>. Verrà chiesta una conferma esplicita perché

--- a/src/components/cassa/receipt-success.test.tsx
+++ b/src/components/cassa/receipt-success.test.tsx
@@ -112,6 +112,32 @@ describe("ReceiptSuccess", () => {
     expect(screen.getByText("Invia ricevuta")).toBeInTheDocument();
   });
 
+  it("shows 'Mostra QR code' button when documentId is provided", () => {
+    render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
+
+    expect(screen.getByText("Mostra QR code")).toBeInTheDocument();
+  });
+
+  it("hides 'Mostra QR code' button when documentId is not provided", () => {
+    render(<ReceiptSuccess {...defaultProps} />);
+
+    expect(screen.queryByText("Mostra QR code")).not.toBeInTheDocument();
+  });
+
+  it("opens a dialog with the receipt QR code and URL on click", async () => {
+    render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mostra QR code"));
+    });
+
+    // The dialog renders the public receipt URL in plain text
+    expect(
+      screen.getByText((content) => content.includes("/r/doc-uuid-123")),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/inquadra il qr code/i)).toBeInTheDocument();
+  });
+
   it("uses navigator.share when available", async () => {
     Object.defineProperty(navigator, "share", {
       value: mockShare,

--- a/src/components/cassa/receipt-success.tsx
+++ b/src/components/cassa/receipt-success.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { CheckCircle2, Share2, Check, Copy } from "lucide-react";
+import { CheckCircle2, Share2, Check, Copy, QrCode } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ReceiptQrCode } from "@/components/receipts/receipt-qr-code";
 
 interface ReceiptSuccessProps {
   readonly documentId?: string;
@@ -18,6 +26,7 @@ export function ReceiptSuccess({
   onNewReceipt,
 }: ReceiptSuccessProps) {
   const [copied, setCopied] = useState(false);
+  const [qrOpen, setQrOpen] = useState(false);
 
   useEffect(() => {
     if (!copied) return;
@@ -86,26 +95,54 @@ export function ReceiptSuccess({
       )}
 
       {documentId && (
-        <Button
-          type="button"
-          variant="outline"
-          size="lg"
-          className="w-full"
-          onClick={handleShare}
-        >
-          {copied ? (
-            <>
-              <Check className="mr-2 h-4 w-4 text-green-600" />
-              <span className="text-green-600">Link copiato!</span>
-            </>
-          ) : (
-            <>
-              <Share2 className="mr-2 h-4 w-4" />
-              Invia ricevuta
-              <Copy className="text-muted-foreground ml-auto h-3.5 w-3.5" />
-            </>
-          )}
-        </Button>
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="w-full"
+            onClick={handleShare}
+          >
+            {copied ? (
+              <>
+                <Check className="mr-2 h-4 w-4 text-green-600" />
+                <span className="text-green-600">Link copiato!</span>
+              </>
+            ) : (
+              <>
+                <Share2 className="mr-2 h-4 w-4" />
+                Invia ricevuta
+                <Copy className="text-muted-foreground ml-auto h-3.5 w-3.5" />
+              </>
+            )}
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="w-full"
+            onClick={() => setQrOpen(true)}
+          >
+            <QrCode className="mr-2 h-4 w-4" />
+            Mostra QR code
+          </Button>
+
+          <Dialog open={qrOpen} onOpenChange={setQrOpen}>
+            <DialogContent className="sm:max-w-sm">
+              <DialogHeader>
+                <DialogTitle>Ricevuta</DialogTitle>
+                <DialogDescription>
+                  Mostra questo QR code all&apos;acquirente per fargli aprire la
+                  ricevuta.
+                </DialogDescription>
+              </DialogHeader>
+              <ReceiptQrCode
+                url={`${globalThis.location.origin}/r/${documentId}`}
+              />
+            </DialogContent>
+          </Dialog>
+        </>
       )}
 
       <Button type="button" size="lg" className="w-full" onClick={onNewReceipt}>

--- a/src/components/receipts/receipt-qr-code.test.tsx
+++ b/src/components/receipts/receipt-qr-code.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReceiptQrCode } from "./receipt-qr-code";
+
+describe("ReceiptQrCode", () => {
+  const url = "https://scontrinozero.it/r/doc-uuid-123";
+
+  it("renders the receipt URL as readable text", () => {
+    render(<ReceiptQrCode url={url} />);
+
+    expect(screen.getByText(url)).toBeInTheDocument();
+  });
+
+  it("renders an SVG QR code encoding the URL", () => {
+    const { container } = render(<ReceiptQrCode url={url} />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+
+  it("shows the scan instruction", () => {
+    render(<ReceiptQrCode url={url} />);
+
+    expect(screen.getByText(/inquadra il qr code/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/receipts/receipt-qr-code.tsx
+++ b/src/components/receipts/receipt-qr-code.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import QRCode from "react-qr-code";
+
+interface ReceiptQrCodeProps {
+  readonly url: string;
+}
+
+/**
+ * Superficie condivisa per mostrare la ricevuta come QR code, usata sia nella
+ * schermata di emissione (dentro un Dialog) sia nel dialog dello storico (come
+ * view interna). Il QR ha sfondo bianco forzato così resta leggibile anche in
+ * dark mode; l'URL è mostrato in chiaro sotto per verifica a occhio.
+ */
+export function ReceiptQrCode({ url }: ReceiptQrCodeProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-2">
+      <div className="rounded-xl bg-white p-4">
+        <QRCode
+          value={url}
+          size={200}
+          bgColor="#FFFFFF"
+          fgColor="#000000"
+          level="M"
+          style={{ height: "auto", maxWidth: "100%", width: "200px" }}
+        />
+      </div>
+      <p className="text-muted-foreground text-center text-sm">
+        Inquadra il QR code per aprire la ricevuta
+      </p>
+      <p className="text-muted-foreground font-mono text-xs break-all">{url}</p>
+    </div>
+  );
+}

--- a/src/components/storico/void-receipt-dialog.test.tsx
+++ b/src/components/storico/void-receipt-dialog.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { VoidReceiptDialog } from "./void-receipt-dialog";
+import type { ReceiptListItem } from "@/types/storico";
+
+vi.mock("@/server/void-actions", () => ({
+  voidReceipt: vi.fn(),
+}));
+
+// scrollIntoView richiesto da Radix UI Dialog
+beforeEach(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  vi.clearAllMocks();
+});
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+const ACCEPTED_RECEIPT: ReceiptListItem = {
+  id: "doc-uuid-123",
+  kind: "SALE",
+  status: "ACCEPTED",
+  adeProgressive: "DCW2026/5111-2188",
+  adeTransactionId: "trx-001",
+  createdAt: new Date("2026-01-01T10:00:00Z"),
+  total: "12.00",
+  lines: [
+    {
+      description: "Caffè espresso",
+      quantity: "2",
+      grossUnitPrice: "1.20",
+      vatCode: "22",
+    },
+  ],
+};
+
+const VOIDED_RECEIPT: ReceiptListItem = {
+  ...ACCEPTED_RECEIPT,
+  status: "VOID_ACCEPTED",
+};
+
+const defaultProps = {
+  businessId: "biz-1",
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+};
+
+describe("VoidReceiptDialog — QR code", () => {
+  it("shows 'Mostra QR code' for an ACCEPTED receipt", () => {
+    renderWithQuery(
+      <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
+    );
+
+    expect(screen.getByText("Mostra QR code")).toBeInTheDocument();
+  });
+
+  it("does not show 'Mostra QR code' for a voided receipt", () => {
+    renderWithQuery(
+      <VoidReceiptDialog {...defaultProps} receipt={VOIDED_RECEIPT} />,
+    );
+
+    expect(screen.queryByText("Mostra QR code")).not.toBeInTheDocument();
+  });
+
+  it("switches to the QR view showing the receipt URL on click", async () => {
+    renderWithQuery(
+      <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mostra QR code"));
+    });
+
+    expect(
+      screen.getByText((content) => content.includes("/r/doc-uuid-123")),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/inquadra il qr code/i)).toBeInTheDocument();
+    expect(screen.getByText("Indietro")).toBeInTheDocument();
+  });
+
+  it("goes back to the detail view from the QR view", async () => {
+    renderWithQuery(
+      <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mostra QR code"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Indietro"));
+    });
+
+    // Back in detail view: the void button is visible again
+    expect(screen.getByText("Annulla scontrino")).toBeInTheDocument();
+    expect(screen.queryByText("Indietro")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/storico/void-receipt-dialog.tsx
+++ b/src/components/storico/void-receipt-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { Send } from "lucide-react";
+import { Send, QrCode } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { ReceiptQrCode } from "@/components/receipts/receipt-qr-code";
 import { TrialExpiredMessage } from "@/components/billing/trial-expired-message";
 import { TRIAL_EXPIRED_MESSAGE } from "@/lib/plans-shared";
 import { voidReceipt } from "@/server/void-actions";
@@ -31,12 +32,13 @@ function formatVat(vatCode: string): string {
   return VAT_LABELS[vatCode as VatCode] ?? vatCode;
 }
 
-/** Tre stati del dialog:
+/** Stati del dialog:
  *  detail        — mostra le righe e i bottoni principali
  *  confirmingVoid — chiede conferma dell'annullo con il warning
  *  voidSuccess   — annullo completato con successo
+ *  qr            — mostra la ricevuta come QR code (no Dialog annidata)
  */
-type DialogView = "detail" | "confirmingVoid" | "voidSuccess";
+type DialogView = "detail" | "confirmingVoid" | "voidSuccess" | "qr";
 
 export function VoidReceiptDialog({
   receipt,
@@ -99,6 +101,26 @@ export function VoidReceiptDialog({
             </div>
             <DialogFooter>
               <Button onClick={onClose}>Chiudi</Button>
+            </DialogFooter>
+          </>
+        )}
+        {view === "qr" && (
+          // ── Stato 4: ricevuta come QR code ─────────────────────────────────
+          <>
+            <DialogHeader>
+              <DialogTitle>Ricevuta</DialogTitle>
+              <DialogDescription>
+                Mostra questo QR code all&apos;acquirente per fargli aprire la
+                ricevuta.
+              </DialogDescription>
+            </DialogHeader>
+            <ReceiptQrCode
+              url={`${globalThis.location.origin}/r/${receipt.id}`}
+            />
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setView("detail")}>
+                Indietro
+              </Button>
             </DialogFooter>
           </>
         )}
@@ -209,6 +231,10 @@ export function VoidReceiptDialog({
                       <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                       Invia ricevuta
                     </a>
+                  </Button>
+                  <Button variant="outline" onClick={() => setView("qr")}>
+                    <QrCode className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Mostra QR code
                   </Button>
                 </>
               )}


### PR DESCRIPTION
Accanto a "Invia ricevuta" (emissione + dettaglio storico) ora c'è un
pulsante "Mostra QR code" con icona QrCode: apre un QR che codifica
l'URL pubblico della ricevuta (/r/{id}), così il venditore può mostrarlo
all'acquirente quando non ha numero/email per condividere il link.

- nuovo componente condiviso ReceiptQrCode (react-qr-code, pure SVG)
- emissione: Dialog modale con il QR
- storico: nuova view "qr" nella macchina a stati del dialog esistente
  (niente Dialog annidata, resa identica all'emissione)
- aggiornati gli articoli help che descrivono i pulsanti ricevuta

https://claude.ai/code/session_01Q574GqF79iEsa4L33SN7t7