### PR TITLE
perf(proxy): salta il refresh sessione Supabase sulle route marketing pure (REVIEW.md #6)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -134,38 +134,6 @@ sempre preceduto da ~10 chiamate di auth.
 
 ---
 
-### 6. Middleware: session refresh Supabase eseguito anche sulle route marketing pure
-
-- **Categoria:** performance · **Severità:** Medium
-- **File:** `src/proxy.ts:171-199` (blocco auth), `src/proxy.ts:236-253` (matcher)
-
-**Problema.** Il matcher esclude static asset, `api/health`, `api/v1`, PWA asset —
-ma tutte le pagine marketing (`/`, `/guide/*`, `/prezzi`, `/per/*`, `/strumenti/*`,
-`/confronto`, `/help/*`…) passano per `createMiddlewareSupabaseClient` +
-`supabase.auth.getUser()`. L'esito viene usato solo per `PROTECTED_PREFIXES`
-(`/dashboard`, `/onboarding`) e `AUTH_ONLY_PATHS` (`/login`, `/register`,
-`/reset-password`): per ogni altra route il risultato è ignorato. Per i visitatori
-con cookie di sessione presenti, `getUser()` può innescare un token refresh
-(round-trip verso Supabase) su pagine SSG che non ne hanno bisogno.
-
-**Fix (non ambiguo).**
-
-1. In `proxy()`, calcolare prima `const needsAuth = PROTECTED_PREFIXES.some(p => pathname.startsWith(p)) || AUTH_ONLY_PATHS.some(p => pathname.startsWith(p));`
-2. Se `!needsAuth`, ritornare subito `applyNoindexHeader(NextResponse.next(), request)`
-   senza creare il client Supabase (il ramo "Supabase non configurato" resta com'è).
-3. **Non** restringere il matcher (il branch `hostnameRedirect` e il noindex header
-   devono continuare a girare su tutte le route): la condizione va nel corpo.
-4. **Edge case da coprire con test** (`src/proxy.test.ts` o equivalente esistente):
-   route marketing senza cookie → nessuna chiamata `getUser` (assert su mock);
-   `/dashboard` senza sessione → redirect `/login?redirect=...` invariato;
-   `/login` con sessione → redirect `/dashboard` invariato; il refresh cookie
-   continua a propagarsi sui redirect (righe 213-218, 225-230). Nota: le pagine
-   app _non_ protette non esistono oggi (tutto il dashboard è sotto
-   `/dashboard`), quindi non si perde il refresh-on-navigation; se in futuro si
-   aggiungono route app fuori da `/dashboard`, andranno incluse in `needsAuth`.
-
----
-
 ### 8. TTL/revoca per i link pubblici degli scontrini
 
 - **Categoria:** sicurezza · **Severità:** Medium · **Target indicativo:** v1.4.0+

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
+import { createMiddlewareSupabaseClient } from "@/lib/supabase/middleware";
 
 // Mock the middleware Supabase client
 const mockGetUser = vi.fn();
@@ -16,6 +17,8 @@ vi.mock("@/lib/supabase/middleware", () => ({
       };
     }),
 }));
+
+const mockCreateClient = vi.mocked(createMiddlewareSupabaseClient);
 
 function createRequest(pathname: string): NextRequest {
   return new NextRequest(new URL(pathname, "http://localhost:3000"));
@@ -91,6 +94,62 @@ describe("proxy", () => {
 
       const response = await proxy(createRequest("/"));
       expect(response.status).toBe(200);
+    });
+  });
+
+  // REVIEW.md #6: il refresh sessione Supabase (getUser → token refresh) deve
+  // girare SOLO sulle route che ne consumano l'esito (PROTECTED_PREFIXES +
+  // AUTH_ONLY_PATHS). Sulle pagine marketing/SSG il client non va nemmeno creato.
+  describe("skips Supabase session on public/marketing routes (REVIEW.md #6)", () => {
+    const PUBLIC_ROUTES = [
+      "/",
+      "/privacy",
+      "/help",
+      "/guide/regime-forfettario",
+      "/per/parrucchieri",
+      "/strumenti/scorporo-iva",
+      "/prezzi",
+    ] as const;
+
+    it.each(PUBLIC_ROUTES)(
+      "does not create the Supabase client nor call getUser for %s",
+      async (path) => {
+        const { proxy } = await import("./proxy");
+
+        const response = await proxy(createRequest(path));
+        expect(response.status).toBe(200);
+        expect(mockGetUser).not.toHaveBeenCalled();
+        expect(mockCreateClient).not.toHaveBeenCalled();
+      },
+    );
+
+    it("still calls getUser on a protected route (/dashboard)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: "user-123" } } });
+      const { proxy } = await import("./proxy");
+
+      await proxy(createRequest("/dashboard"));
+      expect(mockGetUser).toHaveBeenCalledTimes(1);
+      expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    });
+
+    it("still calls getUser on an auth-only route (/login)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      await proxy(createRequest("/login"));
+      expect(mockGetUser).toHaveBeenCalledTimes(1);
+      expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    });
+
+    it("still applies the noindex header on a non-prod host without touching the session", async () => {
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        new NextRequest("https://sandbox.scontrinozero.it/guide"),
+      );
+      expect(response.headers.get("X-Robots-Tag")).toBe("noindex, nofollow");
+      expect(mockGetUser).not.toHaveBeenCalled();
+      expect(mockCreateClient).not.toHaveBeenCalled();
     });
   });
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,19 @@ const PROTECTED_PREFIXES = ["/dashboard", "/onboarding"];
 const AUTH_ONLY_PATHS = ["/login", "/register", "/reset-password"];
 
 /**
+ * True per le sole route il cui esito dipende dalla sessione auth: i
+ * PROTECTED_PREFIXES (gate auth) e gli AUTH_ONLY_PATHS (redirect-se-loggato).
+ * Per ogni altra route (marketing/SSG) il middleware non deve nemmeno creare
+ * il client Supabase né chiamare getUser() — vedi `proxy()` (REVIEW.md #6).
+ */
+function pathNeedsAuthSession(pathname: string): boolean {
+  return (
+    PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+    AUTH_ONLY_PATHS.some((path) => pathname.startsWith(path))
+  );
+}
+
+/**
  * Routes served exclusively on the marketing domain.
  *
  * Source-of-truth per la separazione dei domini: tutto ciò che sul dominio
@@ -195,12 +208,9 @@ export async function proxy(request: NextRequest) {
   // noindex header (hostnameRedirect sopra è già girato su ogni route).
   // NB: oggi non esistono route app fuori da /dashboard, quindi non si perde
   // alcun refresh-on-navigation; una futura route app fuori dai prefissi sopra
-  // andrebbe aggiunta a `needsAuth`.
+  // andrebbe aggiunta a `pathNeedsAuthSession`.
   const { pathname } = request.nextUrl;
-  const needsAuth =
-    PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
-    AUTH_ONLY_PATHS.some((path) => pathname.startsWith(path));
-  if (!needsAuth) {
+  if (!pathNeedsAuthSession(pathname)) {
     return applyNoindexHeader(NextResponse.next(), request);
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -185,6 +185,25 @@ export async function proxy(request: NextRequest) {
     return applyNoindexHeader(NextResponse.next(), request);
   }
 
+  // Performance (REVIEW.md #6): le route marketing/pubbliche (/, /guide/*,
+  // /prezzi, /per/*, /strumenti/*, /help/*, …) non consumano mai la sessione
+  // Supabase — solo i PROTECTED_PREFIXES (gate auth) e gli AUTH_ONLY_PATHS
+  // (redirect-se-loggato) leggono `user`. Per ogni altra route il risultato di
+  // getUser() verrebbe ignorato, ma per un visitatore con cookie di sessione può
+  // innescare un token refresh (round-trip verso Supabase) su pagine SSG che non
+  // ne hanno bisogno. Salta del tutto la creazione del client e applica solo il
+  // noindex header (hostnameRedirect sopra è già girato su ogni route).
+  // NB: oggi non esistono route app fuori da /dashboard, quindi non si perde
+  // alcun refresh-on-navigation; una futura route app fuori dai prefissi sopra
+  // andrebbe aggiunta a `needsAuth`.
+  const { pathname } = request.nextUrl;
+  const needsAuth =
+    PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+    AUTH_ONLY_PATHS.some((path) => pathname.startsWith(path));
+  if (!needsAuth) {
+    return applyNoindexHeader(NextResponse.next(), request);
+  }
+
   const { supabase, response } = createMiddlewareSupabaseClient(request);
 
   // Refresh the session — MUST be called before getUser() to keep tokens valid.
@@ -215,7 +234,7 @@ export async function proxy(request: NextRequest) {
     );
   }
 
-  const { pathname, search } = request.nextUrl;
+  const { search } = request.nextUrl;
 
   // Protected routes: redirect to /login if not authenticated
   if (

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -174,6 +174,18 @@ function applyNoindexHeader(
   return response;
 }
 
+/**
+ * Estrae un `errorClass` stabile dall'errore lanciato da `getUser()` per il
+ * breadcrumb edge-safe del middleware. Un `AuthApiError` di @supabase/ssr porta
+ * un `code` (es. `refresh_token_not_found`); qualsiasi altro valore degrada a
+ * `auth_error`. Estratto da `proxy()` per tenerne bassa la Cognitive Complexity.
+ */
+function getMiddlewareAuthErrorClass(err: unknown): string {
+  return err && typeof err === "object" && "code" in err
+    ? String((err as { code?: unknown }).code)
+    : "auth_error";
+}
+
 export async function proxy(request: NextRequest) {
   const redirect = hostnameRedirect(request);
   if (redirect) return redirect;
@@ -230,15 +242,11 @@ export async function proxy(request: NextRequest) {
       data: { user },
     } = await supabase.auth.getUser());
   } catch (err) {
-    const errorClass =
-      err && typeof err === "object" && "code" in err
-        ? String((err as { code?: unknown }).code)
-        : "auth_error";
     console.warn(
       JSON.stringify({
         level: "warn",
         action: "middlewareGetUser",
-        errorClass,
+        errorClass: getMiddlewareAuthErrorClass(err),
         msg: "session refresh failed; treating request as unauthenticated",
       }),
     );


### PR DESCRIPTION
Solo PROTECTED_PREFIXES e AUTH_ONLY_PATHS consumano l'esito di getUser();
per ogni altra route (/, /guide/*, /prezzi, /per/*, /strumenti/*, /help/*, …)
il risultato veniva ignorato ma poteva innescare un token refresh verso
Supabase su pagine SSG. Ora il client non viene nemmeno creato: short-circuit
con applyNoindexHeader(NextResponse.next()).

hostnameRedirect e il noindex header continuano a girare su tutte le route
(la condizione vive nel corpo, non nel matcher). Test: niente getUser/client
su 7 route pubbliche, getUser invariato su /dashboard e /login, noindex
ancora applicato su host non-prod senza toccare la sessione.

https://claude.ai/code/session_015VzvW9PKWfM8vp5dd5RB9n