### PR TITLE
Correggi REVIEW.md #30: P.IVA trasmessa non tracciata per-scontrino

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -731,20 +731,38 @@ una P.IVA diversa ora bloccato), `verifyAdeCredentials` sovrascriveva
 credenziali. Poiché gli scontrini non salvano uno snapshot fiscale e leggono **live**
 `businesses.vatNumber` (storico, PDF, pagina pubblica, CSV), un eventuale account che
 in passato avesse cambiato credenziali verso un soggetto diverso ora mostrerebbe la
-**P.IVA errata** sugli scontrini emessi sotto la P.IVA originale — divergenza tra
-documento trasmesso all'AdE (immutabile in `commercial_documents.adeResponse`) e
-documento ri-renderizzato.
+**P.IVA errata** sugli scontrini emessi sotto la P.IVA originale.
 
-**Fix (indagine).**
+**⚠️ La P.IVA trasmessa NON è tracciata per-scontrino.**
+`commercial_documents.adeResponse` contiene solo `AdeResponse` =
+`{ esito, idtrx, progressivo, errori }` (`src/lib/ade/types.ts:162`), **non** il
+`cedentePrestatore`. Tutte le copie della P.IVA nel DB sono live e già sovrascritte
+insieme (`businesses.vat_number`/`fiscal_code`, `profiles.partita_iva`);
+`ade_credentials` tiene solo le credenziali correnti. Di conseguenza **non è
+possibile identificare con certezza dal nostro DB quali scontrini furono emessi
+sotto una P.IVA precedente**: l'unica fonte di verità sulla P.IVA trasmessa è
+l'AdE (i documenti sono archiviati lì sotto la vecchia P.IVA).
 
-1. Individuare gli account potenzialmente impattati: confrontare la `partitaIva` dentro
-   `commercial_documents.adeResponse` (cedente/prestatore trasmesso) con
-   `businesses.vatNumber` corrente per la stessa `business_id`; un mismatch indica una
-   sovrascrittura storica.
-2. Se l'insieme è vuoto → chiudere la voce (la prevenzione basta).
-3. Se non vuoto → decidere la strategia (es. snapshot fiscale per-riga sullo scontrino
-   a partire dall'`adeResponse`, oppure separazione del business storico). Valutare con
-   l'utente: tocca dati fiscali, non automatizzabile alla cieca (regola 13).
+**Fix (indagine).** Solo un **set di candidati sospetti** da verificare poi
+manualmente contro l'AdE — nessun rilevamento definitivo via SQL:
+
+1. **Segnale forte (da calibrare sul dato reale):** salto all'indietro del
+   `progressivo` AdE (`ade_progressive`) nella storia di uno stesso `business_id`,
+   non al confine d'anno. L'AdE assegna i progressivi per cedente: un reset a metà
+   storia suggerisce un cambio di soggetto fiscale. Prima campionare il formato del
+   campo (`SELECT business_id, ade_progressive, created_at FROM commercial_documents
+WHERE kind='SALE' AND status='ACCEPTED' AND ade_progressive IS NOT NULL ORDER BY
+business_id, created_at`) poi disegnare l'euristica del salto.
+2. **Segnale debole:** `ade_credentials.updated_at` successivo al primo scontrino —
+   cattura anche le legittime rotazioni password (molti falsi positivi), usabile
+   solo come filtro grossolano.
+3. Per ogni candidato, **cross-check manuale contro l'AdE** (P.IVA effettiva sotto
+   cui risultano i documenti) prima di qualsiasi azione.
+4. Se nessun candidato → chiudere la voce (la prevenzione basta).
+5. Se confermati → decidere la strategia con l'utente: tocca dati fiscali, non
+   automatizzabile alla cieca (regola 13). Opzione strutturale a monte: aggiungere
+   uno **snapshot fiscale per-scontrino** (P.IVA/CF del cedente all'emissione) così
+   da rendere futuri cambi tracciabili e i PDF storici fedeli.
 
 ---
 


### PR DESCRIPTION
adeResponse memorizza solo AdeResponse { esito, idtrx, progressivo, errori }, non il cedentePrestatore: la P.IVA realmente trasmessa non è salvata per documento, quindi la bonifica non è rilevabile in modo definitivo dal DB. Sostituito il passo di rilevamento errato (confronto adeResponse.partitaIva) con un set di candidati sospetti via salto del progressivo AdE, da verificare manualmente contro l'AdE. Annotata l'opzione strutturale dello snapshot fiscale per-scontrino.

https://claude.ai/code/session_015mxNWbuvdt7T1XQVeV4CRn