### PR TITLE
feat: add runtime announcement config helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,20 @@ NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
 TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 
 # =============================================================================
+# Announcement banner (avvisi globali in cima all'app autenticata)
+# =============================================================================
+# Mostra un banner persistente nella dashboard (es. manutenzione programmata).
+# Lette a RUNTIME: per accendere/spegnere basta editare il .env e riavviare il
+# container (docker compose up -d) — NESSUN rebuild. NON usare il prefisso
+# NEXT_PUBLIC_ (sarebbe baked al build, vedi regola 18 in CLAUDE.md).
+#
+# Messaggio del banner. Vuoto/assente = nessun banner.
+# ANNOUNCEMENT_MESSAGE=Manutenzione programmata oggi 20:00–22:00. Servizio rallentato.
+# Livello: info (default) | warning | critical. 'critical' non è chiudibile
+# dall'utente; info/warning sì (il dismiss è persistito finché il testo non cambia).
+# ANNOUNCEMENT_LEVEL=warning
+
+# =============================================================================
 # Development / build
 # =============================================================================
 # Suppress @serwist/next informational warning about Turbopack (Next.js 16

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,9 +5,11 @@ import { LogOut, Settings } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getOnboardingStatus } from "@/server/onboarding-actions";
 import { signOut } from "@/server/auth-actions";
+import { getAnnouncement } from "@/lib/announcement";
 import { Button } from "@/components/ui/button";
 import { BottomNav } from "@/components/dashboard/bottom-nav";
 import { HeaderNav } from "@/components/dashboard/header-nav";
+import { AnnouncementBanner } from "@/components/announcement/announcement-banner";
 import { PwaInstallPrompt } from "@/components/pwa/install-prompt";
 
 export default async function DashboardLayout({
@@ -30,8 +32,11 @@ export default async function DashboardLayout({
     redirect("/onboarding");
   }
 
+  const announcement = getAnnouncement();
+
   return (
     <div className="flex min-h-screen flex-col">
+      {announcement && <AnnouncementBanner {...announcement} />}
       <header className="bg-background border-b">
         <div className="container mx-auto flex items-center justify-between px-4 py-3">
           <Link

--- a/src/components/announcement/announcement-banner.test.tsx
+++ b/src/components/announcement/announcement-banner.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnnouncementBanner } from "./announcement-banner";
+
+const DISMISS_KEY = "announcement-dismissed:abc123";
+
+describe("AnnouncementBanner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("rende il messaggio dell'annuncio", () => {
+    render(
+      <AnnouncementBanner
+        message="Manutenzione programmata"
+        level="warning"
+        dismissible
+        dismissKey={DISMISS_KEY}
+      />,
+    );
+
+    expect(screen.getByText("Manutenzione programmata")).toBeInTheDocument();
+  });
+
+  it("chiude il banner e persiste il dismiss in localStorage", () => {
+    render(
+      <AnnouncementBanner
+        message="Avviso"
+        level="info"
+        dismissible
+        dismissKey={DISMISS_KEY}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Chiudi"));
+
+    expect(screen.queryByText("Avviso")).not.toBeInTheDocument();
+    expect(localStorage.getItem(DISMISS_KEY)).toBe("1");
+  });
+
+  it("non rende nulla se già dismesso in precedenza", () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+
+    const { container } = render(
+      <AnnouncementBanner
+        message="Avviso"
+        level="info"
+        dismissible
+        dismissKey={DISMISS_KEY}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("un dismissKey diverso fa ricomparire il banner", () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+
+    render(
+      <AnnouncementBanner
+        message="Nuovo avviso"
+        level="info"
+        dismissible
+        dismissKey="announcement-dismissed:different"
+      />,
+    );
+
+    expect(screen.getByText("Nuovo avviso")).toBeInTheDocument();
+  });
+
+  it("livello critical: nessun bottone Chiudi e ignora il dismiss salvato", () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+
+    render(
+      <AnnouncementBanner
+        message="Incidente in corso"
+        level="critical"
+        dismissible={false}
+        dismissKey={DISMISS_KEY}
+      />,
+    );
+
+    expect(screen.getByText("Incidente in corso")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Chiudi")).not.toBeInTheDocument();
+  });
+
+  it("non lancia se l'accesso a localStorage è negato (SecurityError)", () => {
+    vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+      throw new DOMException("Access is denied", "SecurityError");
+    });
+
+    expect(() =>
+      render(
+        <AnnouncementBanner
+          message="Avviso"
+          level="info"
+          dismissible
+          dismissKey={DISMISS_KEY}
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/components/announcement/announcement-banner.tsx
+++ b/src/components/announcement/announcement-banner.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Info, OctagonAlert, TriangleAlert, X } from "lucide-react";
+import type { AnnouncementLevel } from "@/lib/announcement";
+import { safeLocalStorage } from "@/lib/safe-storage";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+interface AnnouncementBannerProps {
+  readonly message: string;
+  readonly level: AnnouncementLevel;
+  readonly dismissible: boolean;
+  readonly dismissKey: string;
+}
+
+const LEVEL_ICON = {
+  info: Info,
+  warning: TriangleAlert,
+  critical: OctagonAlert,
+} as const;
+
+export function AnnouncementBanner({
+  message,
+  level,
+  dismissible,
+  dismissKey,
+}: AnnouncementBannerProps) {
+  // Lazy initializer: legge il dismiss salvato una sola volta al primo render
+  // client, senza setState-in-effect (stesso pattern di PwaInstallPrompt).
+  // SSR-safe e tollerante allo storage bloccato via safeLocalStorage.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (globalThis.window === undefined) return false;
+    return safeLocalStorage.getItem(dismissKey) === "1";
+  });
+
+  if (dismissible && dismissed) return null;
+
+  const handleDismiss = () => {
+    safeLocalStorage.setItem(dismissKey, "1");
+    setDismissed(true);
+  };
+
+  const Icon = LEVEL_ICON[level];
+
+  return (
+    <Alert variant={level} className="rounded-none border-x-0 border-t-0">
+      <Icon aria-hidden="true" />
+      <AlertDescription className="flex w-full items-center gap-2">
+        <span className="flex-1">{message}</span>
+        {dismissible ? (
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Chiudi"
+            className="-my-1 shrink-0 rounded-md p-1 opacity-70 transition-opacity hover:opacity-100"
+          >
+            <X className="size-4" />
+          </button>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        info: "border-border bg-card text-card-foreground",
+        warning:
+          "border-amber-500/40 bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200",
+        critical:
+          "border-destructive/40 bg-destructive/10 text-destructive dark:bg-destructive/20",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant = "info",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      data-variant={variant}
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, alertVariants };

--- a/src/lib/announcement.test.ts
+++ b/src/lib/announcement.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAnnouncement } from "./announcement";
+import { logger } from "@/lib/logger";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+describe("getAnnouncement", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("ritorna null quando ANNOUNCEMENT_MESSAGE è assente", () => {
+    expect(getAnnouncement()).toBeNull();
+  });
+
+  it("ritorna null quando il messaggio è vuoto", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "");
+    expect(getAnnouncement()).toBeNull();
+  });
+
+  it("ritorna null quando il messaggio è solo spazi", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "   ");
+    expect(getAnnouncement()).toBeNull();
+  });
+
+  it("ritorna l'annuncio con messaggio trimmato e livello info di default", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "  Manutenzione  ");
+
+    const result = getAnnouncement();
+
+    expect(result).toMatchObject({
+      message: "Manutenzione",
+      level: "info",
+      dismissible: true,
+    });
+    expect(result?.dismissKey).toMatch(/^announcement-dismissed:/);
+  });
+
+  it.each(["info", "warning", "critical"] as const)(
+    "accetta il livello valido %s",
+    (level) => {
+      vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Avviso");
+      vi.stubEnv("ANNOUNCEMENT_LEVEL", level);
+
+      expect(getAnnouncement()?.level).toBe(level);
+    },
+  );
+
+  it("normalizza il livello case-insensitive", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Avviso");
+    vi.stubEnv("ANNOUNCEMENT_LEVEL", "WARNING");
+
+    expect(getAnnouncement()?.level).toBe("warning");
+  });
+
+  it("degrada a info e logga un warn su livello non riconosciuto", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Avviso");
+    vi.stubEnv("ANNOUNCEMENT_LEVEL", "boom");
+
+    expect(getAnnouncement()?.level).toBe("info");
+    expect(logger.warn).toHaveBeenCalledOnce();
+  });
+
+  it("rende critical non dismissibile", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Incidente in corso");
+    vi.stubEnv("ANNOUNCEMENT_LEVEL", "critical");
+
+    expect(getAnnouncement()?.dismissible).toBe(false);
+  });
+
+  it("produce una dismissKey stabile a parità di messaggio", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Stesso messaggio");
+    const first = getAnnouncement()?.dismissKey;
+
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Stesso messaggio");
+    const second = getAnnouncement()?.dismissKey;
+
+    expect(first).toBe(second);
+  });
+
+  it("produce una dismissKey diversa al cambio messaggio", () => {
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Messaggio uno");
+    const first = getAnnouncement()?.dismissKey;
+
+    vi.stubEnv("ANNOUNCEMENT_MESSAGE", "Messaggio due");
+    const second = getAnnouncement()?.dismissKey;
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/src/lib/announcement.ts
+++ b/src/lib/announcement.ts
@@ -47,8 +47,8 @@ function normalizeLevel(raw: string | undefined): AnnouncementLevel {
  */
 function hashMessage(message: string): string {
   let hash = 5381;
-  for (let i = 0; i < message.length; i++) {
-    hash = (hash * 33) ^ message.charCodeAt(i);
+  for (const char of message) {
+    hash = (hash * 33) ^ (char.codePointAt(0) ?? 0);
   }
   return (hash >>> 0).toString(36);
 }

--- a/src/lib/announcement.ts
+++ b/src/lib/announcement.ts
@@ -1,0 +1,72 @@
+import { logger } from "@/lib/logger";
+
+/**
+ * Banner annunci globale per l'app autenticata (es. manutenzione programmata).
+ *
+ * Guidato da env var **a runtime** (NON `NEXT_PUBLIC_*`, che sarebbero baked al
+ * build): per accendere/spegnere basta editare il `.env` del container e
+ * riavviarlo (`docker compose up -d`), senza rebuild. Allineato al pattern di
+ * `NEW_SIGNUP_NOTIFICATION_EMAIL` (no-op quando la var è assente).
+ *
+ *   ANNOUNCEMENT_MESSAGE  testo del banner; assente/vuoto = nessun banner
+ *   ANNOUNCEMENT_LEVEL    info | warning | critical (default info)
+ *
+ * `critical` non è chiudibile dall'utente; `info`/`warning` sì, e il dismiss è
+ * persistito client-side su una chiave derivata dal contenuto del messaggio →
+ * cambiando annuncio il banner ricompare anche per chi aveva chiuso il vecchio.
+ */
+
+export type AnnouncementLevel = "info" | "warning" | "critical";
+
+const LEVELS: readonly AnnouncementLevel[] = ["info", "warning", "critical"];
+
+export interface Announcement {
+  message: string;
+  level: AnnouncementLevel;
+  dismissible: boolean;
+  dismissKey: string;
+}
+
+function normalizeLevel(raw: string | undefined): AnnouncementLevel {
+  if (!raw) return "info";
+  const value = raw.trim().toLowerCase();
+  if ((LEVELS as readonly string[]).includes(value)) {
+    return value as AnnouncementLevel;
+  }
+  logger.warn(
+    { announcementLevel: raw },
+    "Unrecognized ANNOUNCEMENT_LEVEL, defaulting to 'info'",
+  );
+  return "info";
+}
+
+/**
+ * Hash deterministico (djb2) del messaggio → chiave di dismiss stabile.
+ * Non serve robustezza crittografica: serve solo che la stessa stringa produca
+ * sempre la stessa chiave e che un messaggio diverso ne produca una diversa.
+ */
+function hashMessage(message: string): string {
+  let hash = 5381;
+  for (let i = 0; i < message.length; i++) {
+    hash = (hash * 33) ^ message.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * Legge la configurazione del banner dalle env a runtime.
+ * Ritorna `null` quando non c'è nessun annuncio attivo (var assente o vuota).
+ */
+export function getAnnouncement(): Announcement | null {
+  const message = process.env.ANNOUNCEMENT_MESSAGE?.trim();
+  if (!message) return null;
+
+  const level = normalizeLevel(process.env.ANNOUNCEMENT_LEVEL);
+
+  return {
+    message,
+    level,
+    dismissible: level !== "critical",
+    dismissKey: `announcement-dismissed:${hashMessage(message)}`,
+  };
+}


### PR DESCRIPTION
Read ANNOUNCEMENT_MESSAGE/ANNOUNCEMENT_LEVEL at runtime (not NEXT_PUBLIC_,
so toggling needs only a container restart, no rebuild). Returns null when
no message is set; normalizes the level (info|warning|critical, defaulting
to info with a warn log on unknown values); critical is non-dismissible.
The dismiss key is derived from a stable hash of the message so changing
the announcement re-shows the banner to users who dismissed the old one.

https://claude.ai/code/session_01Nw5ZnjDo9kZWKfLwaNxmgy