### PR TITLE
docs: add navigable codebase map to cut upfront exploration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       marketing: ${{ steps.f.outputs.marketing }}
       lockfile: ${{ steps.f.outputs.lockfile }}
       migrations: ${{ steps.f.outputs.migrations }}
+      arch_docs: ${{ steps.f.outputs.arch_docs }}
       hooks: ${{ steps.f.outputs.hooks }}
       workflows: ${{ steps.f.outputs.workflows }}
       ci_scripts: ${{ steps.f.outputs.ci_scripts }}
@@ -50,6 +51,10 @@ jobs:
             migrations:
               - 'supabase/migrations/**'
               - 'scripts/check-migrations.mjs'
+            arch_docs:
+              - 'docs/architecture/**'
+              - 'scripts/check-architecture-docs.mjs'
+              - 'src/**'
             hooks:
               - '.claude/hooks/**'
             workflows:
@@ -93,6 +98,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check migration journal consistency
         run: node scripts/check-migrations.mjs
+
+  # Verifica che ogni path citato in docs/architecture/ esista ancora su disco
+  # (anti-drift della mappa codebase, CLAUDE.md regola 26). Gira quando cambiano
+  # i doc, lo script, o src/** (un rename in src/ può orfanare un riferimento).
+  arch-docs-check:
+    needs: changes
+    if: needs.changes.outputs.arch_docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check architecture docs references
+        run: node scripts/check-architecture-docs.mjs
 
   # Esegue le suite di test degli hook PreToolUse (.claude/hooks/).
   # Gira solo quando cambia .claude/hooks/**. Difesa-in-profondità per le

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,18 @@ del fix, aggiungere lì i nuovi finding). Storico release dai tag git
   richiede `serverExternalPackages: ["pdfkit"]` in `next.config.ts`. Dipendenze
   minime, Next standalone, Docker slim, un solo container (next-app + cloudflared).
 
+## Mappa codebase — leggi prima di esplorare
+
+Prima di un'esplorazione a tappeto (grep/glob diffusi per capire _dove_ stanno
+le cose o _come_ scorrono i dati), **leggi `docs/architecture/INDEX.md`**: è la
+mappa navigazionale (albero `src/`, tabella "Dove vivo X?", indice server
+actions, moduli cross-cutting). Scendi ai deep-dive solo quando servono:
+`docs/architecture/data-flows.md` (flussi end-to-end) e
+`docs/architecture/config-manifest.md` (soglie/limiti/gate → puntatori ai file).
+Le skill in `.claude/skills/` restano _prescrittive_ (come fare X); la mappa è
+_descrittiva_ (dove sta X). Serve a ridurre il costo-token dell'esplorazione
+iniziale.
+
 ## Regole sempre-attive (applicano a ogni task)
 
 1.  **Branch separato sempre.** Mai commit/push diretti su `main`. PR sempre,
@@ -247,6 +259,16 @@ https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
     primo utente. Integrazione in CI rimandata: oggi è uno script da
     eseguire manualmente dopo `docker compose up -d`.
 
+26. **Mappa codebase: tienila viva.** Quando sposti/rinomini/aggiungi un modulo
+    cross-cutting, cambi un data flow o una soglia/limite/gate, aggiorna
+    `docs/architecture/*` **nello stesso PR** ed esegui `npm run arch:check`
+    prima di chiudere il task. Stesso spirito della regola 7 (aggiornamento
+    autonomo della doc): una mappa obsoleta è peggio di nessuna mappa — fuorvia
+    chi la legge al posto di esplorare. Il validatore
+    `scripts/check-architecture-docs.mjs` fallisce se un path citato nella mappa
+    (in `code span`) non esiste più su disco; cita ogni path come span isolato
+    (i token con `*`/`{}` sono ignorati come illustrativi).
+
 ## SonarCloud quality gate
 
 - Coverage on new code ≥ **80%**
@@ -293,6 +315,7 @@ popolate senza default. Dettaglio + bootstrap su DB pre-esistente nella skill
 npm run lint                # ESLint / TypeScript
 npx prettier --check src/   # ⚠️ dopo modifiche a classi Tailwind: prettier --write
 npm run test:coverage       # tutti i test verdi, coverage non in calo
+npm run arch:check          # path citati in docs/architecture/ esistono ancora
 ```
 
 Controlli manuali:
@@ -407,6 +430,8 @@ auto-attivano quando il task matcha il `description`:
 
 Altri riferimenti già nel repo:
 
+- **`docs/architecture/INDEX.md`** — mappa codebase (leggi prima di esplorare);
+  deep-dive `docs/architecture/data-flows.md` e `docs/architecture/config-manifest.md`
 - **`PLAN.md`** — roadmap funzionalità
 - **`REVIEW.md`** — registro bug noti / tech debt prioritizzato (file:riga, fix)
 - **`DEVELOPER.md`** — Developer API (Tier 1/2)

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -1,0 +1,123 @@
+# Mappa codebase — INDEX
+
+> **Leggi questo file PRIMA di esplorare la codebase.** È una mappa
+> _navigazionale_: dice **dove vivono le cose**, così non serve un grep/glob a
+> tappeto a ogni task. Per i flussi end-to-end → `docs/architecture/data-flows.md`;
+> per soglie/limiti/gate → `docs/architecture/config-manifest.md`. Le **skill**
+> in `.claude/skills/` restano la fonte _prescrittiva_ ("come fare X nel dominio
+> Y"); questa mappa è _descrittiva_ ("dove sta X").
+>
+> ⚠️ **Tieni vivo questo file.** Quando sposti/rinomini/aggiungi un modulo
+> cross-cutting, cambi un flusso o una soglia, aggiorna la mappa nello stesso PR
+> ed esegui `npm run arch:check` (CLAUDE.md regola 26). Le citazioni di path qui
+> sotto sono validate da `scripts/check-architecture-docs.mjs`: ogni path in
+> `code span` deve esistere su disco.
+
+## Stack in una riga
+
+Next.js 16 (App Router) · React 19 · TS strict · Tailwind 4 · shadcn/ui ·
+Drizzle ORM su Supabase Postgres · Supabase Auth · Stripe · Resend · Sentry +
+pino · PWA Serwist. Monolite SSR + Server Actions, nessun backend separato.
+Dettaglio stack/ambienti in `CLAUDE.md`.
+
+## Albero `src/` (scopo per directory)
+
+```
+src/
+  app/            App Router. Route group + route handler API.
+    (auth)/         login, register, reset-password (cross-origin → app.*)
+    (marketing)/    sito pubblico SSG/SEO (/help, /guide, /per, /confronto, /strumenti, /termini)
+    dashboard/      area autenticata: cassa, storico, analytics, settings
+    onboarding/     wizard collegamento credenziali AdE
+    api/            route handler (vedi sotto)
+    r/              pagina pubblica scontrino (QR / link)
+    sitemap.ts robots.ts manifest.ts layout.tsx global-error.tsx
+  components/     React. Sottocartelle per dominio (cassa, storico, analytics,
+                  catalogo, billing, settings, ade, receipts, marketing, help,
+                  pwa, dashboard, announcement) + ui/ (shadcn) + providers.tsx
+  db/             Drizzle: connessione (index.ts) + schema/ (una tabella per file)
+  emails/         template React Email (Resend)
+  hooks/          React hooks condivisi
+  lib/            utility e logica condivisa client+server (vedi sotto)
+  server/         Server Actions ("use server"): *-actions.ts
+  types/          definizioni TypeScript condivise
+  instrumentation.ts proxy.ts sw.ts
+```
+
+Route handler sotto `src/app/api/`: `src/app/api/v1` (Developer API pubblica,
+Bearer key), `src/app/api/stripe` (webhook), `src/app/api/health` (liveness),
+`src/app/api/_health` (env probe), `src/app/api/_debug` (sentry-sentinel),
+`src/app/api/documents`, `src/app/api/export`, `src/app/api/csp-report`.
+
+Sottocartelle di `src/lib/`: `src/lib/ade` (integrazione AdE HTTP),
+`src/lib/services` (orchestrazione emit/void/recovery), `src/lib/receipts`
+(totali, PDF, CSV, lotteria), `src/lib/supabase` (client browser/server/admin +
+middleware), `src/lib/pdf`, `src/lib/pwa`, e i data file marketing
+`src/lib/guide` `src/lib/help` `src/lib/per` `src/lib/confronto`
+`src/lib/strumenti`.
+
+## Dove vivo X? (i punti che oggi costringono a grep)
+
+| Cerchi…                                           | Vai a                                                                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Auth della richiesta (user UUID, bind Sentry)     | `src/lib/server-auth.ts` (`getAuthenticatedUser`)                                                                         |
+| Client Supabase (browser/server/admin/middleware) | `src/lib/supabase/server.ts`, `src/lib/supabase/client.ts`, `src/lib/supabase/admin.ts`, `src/lib/supabase/middleware.ts` |
+| Azioni auth (login/register/reset, T&C version)   | `src/server/auth-actions.ts`                                                                                              |
+| Plan gate / feature flag per piano                | `src/lib/plans.ts` + `src/lib/plans-shared.ts`                                                                            |
+| Totali scontrino (cents per-riga, canonico)       | `src/lib/receipts/document-lines.ts` (`calcInputLinesTotalCents`, `calcDocTotal`)                                         |
+| Orchestrazione emissione / annullo                | `src/lib/services/receipt-service.ts`, `src/lib/services/void-service.ts`                                                 |
+| Recovery stale-pending AdE                        | `src/lib/services/ade-recovery.ts`, `src/lib/services/request-hash.ts`                                                    |
+| Integrazione AdE (client reale/mock, adapter)     | `src/lib/ade/index.ts`, `src/lib/ade/real-client.ts`, `src/lib/ade/mock-client.ts`                                        |
+| Classi errore AdE + logging tipato                | `src/lib/ade/errors.ts`, `src/lib/ade/log-failure.ts`                                                                     |
+| Logger pino → Sentry (hook level≥50)              | `src/lib/logger.ts`                                                                                                       |
+| Filtri Sentry client (network noise)              | `src/lib/sentry-filters.ts`, `sentry.client.config.ts`                                                                    |
+| Env d'identità (URL/hostname, fail-fast)          | `src/lib/identity-env.ts`, `src/lib/hostname-env.ts`, `src/lib/trusted-app-url.ts`                                        |
+| Link marketing → app (cross-origin)               | `src/lib/marketing-to-app-href.ts` (`appHref`)                                                                            |
+| Rate limit                                        | `src/lib/rate-limit.ts`; client IP → `src/lib/get-client-ip.ts`                                                           |
+| Validazione boundary (UUID/email/body)            | `src/lib/validation.ts`, `src/lib/uuid.ts`, `src/lib/request-utils.ts`, `src/lib/api-errors.ts`                           |
+| Crittografia credenziali AdE (AES-256-GCM)        | `src/lib/crypto.ts`                                                                                                       |
+| CSP / security headers                            | `src/lib/csp.ts`, `src/lib/security-headers.ts`                                                                           |
+| Developer API (auth Bearer + handler)             | `src/app/api/v1/receipts`, `src/lib/api-auth.ts`, `src/lib/api-keys.ts`                                                   |
+| Stripe (SDK wrapper + webhook)                    | `src/lib/stripe.ts`, `src/app/api/stripe`                                                                                 |
+| Schema DB (una tabella per file)                  | `src/db/schema` (es. `src/db/schema/profiles.ts`, `src/db/schema/commercial-documents.ts`)                                |
+| Contenuti marketing/SEO (data file)               | `src/lib/guide`, `src/lib/help`, `src/lib/per`, `src/lib/confronto`, `src/lib/strumenti`                                  |
+| Health/diagnostica post-deploy                    | `src/app/api/health`, `src/app/api/_health`, `src/app/api/_debug`                                                         |
+
+## Indice Server Actions (`src/server/*-actions.ts`)
+
+Tutte sono `"use server"`; sulle azioni di lettura vale "degradare, non lanciare"
+(CLAUDE.md regola 19).
+
+| File                               | Responsabilità                                                |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `src/server/auth-actions.ts`       | login, registrazione, reset password, accettazione T&C        |
+| `src/server/onboarding-actions.ts` | wizard collegamento credenziali AdE                           |
+| `src/server/receipt-actions.ts`    | emissione scontrino (cassa)                                   |
+| `src/server/void-actions.ts`       | annullo documento                                             |
+| `src/server/storico-actions.ts`    | elenco/ricerca documenti emessi                               |
+| `src/server/analytics-actions.ts`  | KPI e analytics (helper in `src/server/analytics-helpers.ts`) |
+| `src/server/catalog-actions.ts`    | catalogo prodotti rapidi                                      |
+| `src/server/export-actions.ts`     | export CSV (Pro-gated)                                        |
+| `src/server/billing-actions.ts`    | checkout / customer portal Stripe                             |
+| `src/server/profile-actions.ts`    | impostazioni profilo/attività                                 |
+| `src/server/account-actions.ts`    | gestione account (es. cancellazione)                          |
+| `src/server/api-key-actions.ts`    | gestione API key Developer                                    |
+
+## Moduli cross-cutting (toccati da quasi ogni feature)
+
+- `src/lib/server-auth.ts` — gate auth + `Sentry.setUser` per richiesta (regola 22)
+- `src/lib/logger.ts` — unico logger; `error` (≥50) → `Sentry.captureException`
+- `src/lib/plans.ts` / `src/lib/plans-shared.ts` — gate piani, fonte di verità
+- `src/lib/receipts/document-lines.ts` — aritmetica monetaria canonica (regola 17)
+- `src/lib/ade/log-failure.ts` — classificazione errori AdE (regole 20/23)
+- `src/lib/identity-env.ts` — validazione env d'identità al boot (regola 24)
+- `src/db/schema/index.ts` — barrel dello schema Drizzle
+
+## Altri riferimenti
+
+- **Prescrittivo per dominio** → `.claude/skills/` (ade-integration, db-migrations,
+  react-patterns, security-patterns, sentry-hygiene, sonar-quality-gate,
+  stripe-webhooks, testing-patterns)
+- **Comportamento sempre-attivo** → `CLAUDE.md`
+- **Roadmap** → `PLAN.md` · **Bug/tech debt** → `REVIEW.md` · **Developer API** →
+  `DEVELOPER.md` · **Flussi HTTP AdE** → `docs/api-spec.md`

--- a/docs/architecture/config-manifest.md
+++ b/docs/architecture/config-manifest.md
@@ -1,0 +1,24 @@
+# Mappa codebase — Config manifest
+
+> Indice _puntatore_ di soglie/limiti/gate. **Non ricopia i valori** che
+> diverrebbero divergenti: indica la **fonte di verità** (il file/costante) così
+> resta un solo posto da cambiare. Quando aggiungi una soglia, aggiungi qui la
+> riga puntatore, non il valore duplicato.
+
+| Cosa                                                                     | Fonte di verità                                                                 | Note                                                       |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Soglie rate-limit per server action (emit/void/pdf/checkout/portal/auth) | `src/lib/rate-limit.ts`                                                         | Valori consolidati elencati nella skill `testing-patterns` |
+| IP del client (dietro Cloudflare)                                        | `src/lib/get-client-ip.ts`                                                      | `CF-Connecting-IP`, skill `security-patterns`              |
+| Prezzi e feature gate per piano                                          | `src/lib/plans.ts`, `src/lib/plans-shared.ts`                                   | Tabella Pricing anche in `CLAUDE.md`                       |
+| Limiti mensili Developer API                                             | `src/lib/plans-shared.ts` (`DEVELOPER_MONTHLY_LIMITS`)                          | Definiti ma non ancora applicati — vedi `REVIEW.md`        |
+| Soglia stale-pending (recovery AdE)                                      | `src/lib/services/ade-recovery.ts`                                              | Dettaglio nella skill `stripe-webhooks`                    |
+| Idempotency / request hash                                               | `src/lib/services/request-hash.ts`                                              | Riuso chiave con payload diverso → mismatch esplicito      |
+| Aritmetica monetaria (cents per-riga)                                    | `src/lib/receipts/document-lines.ts`                                            | Canonica ovunque (CLAUDE.md regola 17)                     |
+| Soglia lotteria (€1,00)                                                  | `src/lib/receipts/document-lines.ts`, `src/lib/receipts/lottery-code-schema.ts` | Calcolata sui totali per-riga                              |
+| Env d'identità (URL/hostname)                                            | `src/lib/identity-env.ts`, `src/lib/hostname-env.ts`                            | Fail-fast al boot (regola 24)                              |
+| Versione T&C corrente                                                    | `src/server/auth-actions.ts` (`CURRENT_TERMS_VERSION`)                          | Procedura aggiornamento in `CLAUDE.md`                     |
+| CSP / security headers                                                   | `src/lib/csp.ts`, `src/lib/security-headers.ts`                                 | —                                                          |
+| Chiave/secret Turnstile per ambiente                                     | `src/components/turnstile-widget.tsx`                                           | `NEXT_PUBLIC_*` baked al build (CLAUDE.md, sezione Deploy) |
+
+**Trial:** 30 giorni Starter/Pro, senza carta — gate in `src/lib/plans.ts`,
+copy/dettagli in `CLAUDE.md` (sezione Pricing).

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -1,0 +1,73 @@
+# Mappa codebase — Data flows
+
+> Deep-dive _on-demand_: leggilo quando tocchi uno di questi flussi. Ogni step
+> punta al file; le **regole di comportamento** restano in `CLAUDE.md` (non le
+> ripeto, le cito per numero). Per "dove sta X" → `docs/architecture/INDEX.md`.
+
+## Auth della richiesta
+
+1. UI/route handler chiama `getAuthenticatedUser` in `src/lib/server-auth.ts`.
+2. Risolve la sessione via `src/lib/supabase/server.ts` e **binda l'UUID** allo
+   scope Sentry (`Sentry.setUser({ id })`, CLAUDE.md regola 22).
+3. Le azioni auth (login/register/reset, versione T&C) vivono in
+   `src/server/auth-actions.ts`; il refresh sessione lato edge in
+   `src/lib/supabase/middleware.ts`.
+4. Errori d'input prevedibili (password sbagliata, P.IVA già usata) → `warn`,
+   non Sentry (regola 20).
+
+## Emissione scontrino (cassa)
+
+1. Form cassa (`src/components/cassa`) → server action
+   `src/server/receipt-actions.ts`.
+2. Validazione + calcolo totali **per-riga in cents** con
+   `src/lib/receipts/document-lines.ts` (regola 17): l'importo trasmesso ad AdE
+   e quello mostrato al cliente devono coincidere.
+3. Orchestrazione in `src/lib/services/receipt-service.ts`: idempotency
+   (`src/lib/services/request-hash.ts`), chiamata AdE, transazione DB.
+4. Client AdE risolto da `src/lib/ade/index.ts` (reale `src/lib/ade/real-client.ts`
+   vs mock `src/lib/ade/mock-client.ts` secondo `ADE_MODE`).
+5. UI optimistic: lo scontrino "sembra istantaneo" anche se AdE risponde in 2-5s
+   (priorità #1). La server action degrada, non lancia (regola 19).
+6. Fallimenti AdE classificati da `src/lib/ade/log-failure.ts` con
+   `flow: "emit-receipt"` (regole 20/23).
+
+## Annullo documento (void)
+
+Analogo all'emissione: `src/server/void-actions.ts` →
+`src/lib/services/void-service.ts` → client AdE; logging con
+`flow: "void-receipt"` via `src/lib/ade/log-failure.ts`.
+
+## Onboarding AdE (collegamento credenziali)
+
+1. Wizard `src/app/onboarding` → `src/server/onboarding-actions.ts`.
+2. Verifica credenziali Fisconline contro AdE; le credenziali sono cifrate
+   AES-256-GCM con `src/lib/crypto.ts` e salvate in `src/db/schema/ade-credentials.ts`.
+3. Logging con `flow: "onboarding-verify"` in `src/lib/ade/log-failure.ts`.
+
+## Recovery stale-pending AdE
+
+Un documento rimasto "pending" (es. crash dopo la chiamata AdE) viene
+riconciliato da `src/lib/services/ade-recovery.ts`, con la soglia temporale
+descritta nella skill `stripe-webhooks` e in `docs/architecture/config-manifest.md`.
+
+## Ciclo abbonamento Stripe
+
+1. Checkout/portal da `src/server/billing-actions.ts` (wrapper SDK in
+   `src/lib/stripe.ts`).
+2. Webhook firmato → `src/app/api/stripe`; gli eventi processati aggiornano il
+   piano su `src/db/schema/profiles.ts` (idempotenza via
+   `src/db/schema/stripe-webhook-events.ts`).
+3. API version `2026-05-27.dahlia` e gli 8 eventi obbligatori → skill
+   `stripe-webhooks` + `CLAUDE.md`.
+
+## Osservabilità ed errori
+
+1. Tutto passa da `src/lib/logger.ts` (pino). `warn` resta nei log; `error`
+   (level ≥ 50) emette anche `Sentry.captureException`.
+2. AdE: `src/lib/ade/log-failure.ts` decide il ramo — `ade_user_error`/
+   `ade_transient` → solo `warn`; `ade_failure` → Sentry con fingerprint per
+   `flow` (regole 20/23).
+3. Rumore di rete client filtrato in `src/lib/sentry-filters.ts`
+   (`sentry.client.config.ts`, `beforeSend`).
+4. Validazione drain + smoke post-deploy via `src/app/api/_debug` e
+   `src/app/api/_health` (regole 21/25, skill `sentry-hygiene`).

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:migrate": "dotenv -e .env.local -- drizzle-kit migrate",
     "db:studio": "dotenv -e .env.local -- drizzle-kit studio",
     "migrations:check": "node scripts/check-migrations.mjs",
+    "arch:check": "node scripts/check-architecture-docs.mjs",
     "seo:indexnow": "tsx scripts/indexnow-submit.ts",
     "prepare": "husky"
   },

--- a/scripts/check-architecture-docs.mjs
+++ b/scripts/check-architecture-docs.mjs
@@ -1,0 +1,130 @@
+/**
+ * Validates the codebase map under docs/architecture/: every repo path cited in
+ * those docs (as an inline code span) must still exist on disk. Catches the most
+ * damaging form of drift — a path renamed or deleted while the map kept the old
+ * reference — turning a stale map into a hard CI failure instead of silently
+ * misleading the next reader. Exits with code 1 on any dead reference.
+ *
+ * Run: node scripts/check-architecture-docs.mjs  (npm run arch:check)
+ *
+ * Validation contract (keep the docs friendly to it):
+ *  - Only INLINE code spans are scanned (`` `like/this` ``), not fenced blocks —
+ *    so directory trees and shell snippets stay illustrative.
+ *  - A span is treated as a repo path iff it starts with one of the known top
+ *    dirs (src/, supabase/, scripts/, deploy/, docs/, tests/, public/) and
+ *    contains only path characters. Write each validated path as its OWN span.
+ *  - A trailing `:NN` line-number suffix is stripped before the check.
+ *  - Tokens containing `*`, `{` or `}` (globs / brace expansion) are skipped —
+ *    they are intentionally illustrative, not literal paths.
+ *  - Route-group parens `(marketing)` and dynamic `[id]` segments are literal
+ *    directory names on disk, so they validate as-is.
+ */
+
+import { readdir, readFile, stat } from "fs/promises";
+import { join } from "path";
+
+const ARCH_DOCS_SUBDIR = ["docs", "architecture"];
+const PATH_PREFIX_RE = /^(?:src|supabase|scripts|deploy|docs|tests|public)\//;
+const PATH_BODY_RE = /^[A-Za-z0-9_./()[\]-]+$/;
+
+/**
+ * Extracts the repo paths referenced as inline code spans in a markdown string.
+ * @param {string} markdown
+ * @returns {string[]} sorted, de-duplicated path tokens
+ */
+export function extractPathTokens(markdown) {
+  const tokens = new Set();
+  const spanRe = /`([^`\n]+)`/g;
+  let match;
+  while ((match = spanRe.exec(markdown)) !== null) {
+    let token = match[1]
+      .trim()
+      .replace(/:\d+$/, "") // drop :lineNumber suffix
+      .replace(/\/+$/, ""); // drop trailing slash (dir spans normalize to bare path)
+    if (token.includes("*") || token.includes("{") || token.includes("}")) {
+      continue; // glob / brace expansion → illustrative, skip
+    }
+    if (!PATH_PREFIX_RE.test(token) || !PATH_BODY_RE.test(token)) {
+      continue; // not a repo path
+    }
+    tokens.add(token);
+  }
+  return [...tokens].sort();
+}
+
+/**
+ * @param {string} rootDir  Absolute path to the repository root
+ * @returns {Promise<{ ok: boolean; errors: string[] }>}
+ */
+export async function checkArchitectureDocs(rootDir) {
+  const errors = [];
+  const docsDir = join(rootDir, ...ARCH_DOCS_SUBDIR);
+
+  let entries;
+  try {
+    entries = await readdir(docsDir, { withFileTypes: true });
+  } catch {
+    return {
+      ok: false,
+      errors: [`Cannot read architecture docs directory: ${docsDir}`],
+    };
+  }
+
+  const mdFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith(".md"))
+    .map((e) => e.name)
+    .sort();
+
+  if (mdFiles.length === 0) {
+    return { ok: false, errors: [`No .md files found in ${docsDir}`] };
+  }
+
+  // token -> first doc that referenced it (so the error points somewhere useful)
+  const referencedBy = new Map();
+  for (const file of mdFiles) {
+    let content;
+    try {
+      content = await readFile(join(docsDir, file), "utf-8");
+    } catch {
+      errors.push(`Cannot read architecture doc: docs/architecture/${file}`);
+      continue;
+    }
+    for (const token of extractPathTokens(content)) {
+      if (!referencedBy.has(token)) referencedBy.set(token, file);
+    }
+  }
+
+  const sortedTokens = [...referencedBy.keys()].sort();
+  for (const token of sortedTokens) {
+    try {
+      await stat(join(rootDir, token));
+    } catch {
+      errors.push(
+        `Referenced path "${token}" (in docs/architecture/${referencedBy.get(token)}) does not exist`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// Run when executed directly (not when imported in tests)
+const isMain =
+  process.argv[1]?.endsWith("check-architecture-docs.mjs") === true;
+if (isMain) {
+  checkArchitectureDocs(process.cwd()).then((result) => {
+    if (!result.ok) {
+      console.error("❌ Architecture docs check failed:");
+      for (const err of result.errors) {
+        console.error(`   - ${err}`);
+      }
+      console.error(
+        "\nFix: update the stale path in docs/architecture/ (the map must point at real files).",
+      );
+      process.exit(1);
+    }
+    console.log(
+      "✅ Architecture docs check passed: all referenced paths exist.",
+    );
+  });
+}

--- a/tests/unit/scripts/check-architecture-docs.test.ts
+++ b/tests/unit/scripts/check-architecture-docs.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { checkArchitectureDocs } from "../../../scripts/check-architecture-docs.mjs";
+
+const { mockReaddir, mockReadFile, mockStat } = vi.hoisted(() => ({
+  mockReaddir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  default: { readdir: mockReaddir, readFile: mockReadFile, stat: mockStat },
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+  stat: mockStat,
+}));
+
+function makeMdDirents(names: string[]) {
+  return names.map((name) => ({
+    name,
+    isFile: () => name.endsWith(".md"),
+  }));
+}
+
+/**
+ * Wires mockReadFile to serve per-file markdown content and mockStat to resolve
+ * only for the paths listed in `existing` (relative to the fake root /repo).
+ */
+function setup(files: Record<string, string>, existing: string[]) {
+  const existingSet = new Set(existing.map((p) => `/repo/${p}`));
+  mockReaddir.mockResolvedValue(makeMdDirents(Object.keys(files)));
+  mockReadFile.mockImplementation((p: string) => {
+    const name = p.split("/").pop() as string;
+    if (name in files) return Promise.resolve(files[name]);
+    return Promise.reject(new Error(`ENOENT: ${p}`));
+  });
+  mockStat.mockImplementation((p: string) => {
+    if (existingSet.has(p)) return Promise.resolve({});
+    return Promise.reject(new Error(`ENOENT: ${p}`));
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("checkArchitectureDocs", () => {
+  it("returns ok when every referenced path exists", async () => {
+    setup(
+      {
+        "INDEX.md": "Auth lives in `src/lib/server-auth.ts` and `src/server/`.",
+      },
+      ["src/lib/server-auth.ts", "src/server"],
+    );
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("returns an error when a referenced path does not exist", async () => {
+    setup(
+      { "INDEX.md": "See `src/lib/ghost.ts` for details." },
+      [], // nothing exists
+    );
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("src/lib/ghost.ts");
+    expect(result.errors[0]).toContain("INDEX.md");
+  });
+
+  it("strips a trailing :lineNumber before checking existence", async () => {
+    setup({ "INDEX.md": "Bound at `src/lib/server-auth.ts:51`." }, [
+      "src/lib/server-auth.ts",
+    ]);
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("skips glob and brace-expansion tokens", async () => {
+    setup(
+      {
+        "INDEX.md":
+          "Handlers in `src/app/api/v1/*` and content in `src/lib/{guide,help}`.",
+      },
+      [], // neither literal path exists, but both must be skipped
+    );
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("validates route-group parens and [id] dynamic segments as literal dirs", async () => {
+    setup(
+      {
+        "INDEX.md":
+          "Pages in `src/app/(marketing)` and `src/app/api/v1/receipts/[id]`.",
+      },
+      ["src/app/(marketing)", "src/app/api/v1/receipts/[id]"],
+    );
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("ignores code spans that are not repo paths", async () => {
+    setup(
+      {
+        "INDEX.md":
+          "Call `appHref()`, run `npm run arch:check`, read `getAuthenticatedUser`.",
+      },
+      [],
+    );
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("deduplicates a path referenced in multiple docs and reports the first doc", async () => {
+    setup(
+      {
+        "INDEX.md": "`src/lib/plans.ts`",
+        "config-manifest.md": "`src/lib/plans.ts`",
+      },
+      [], // missing → exactly one error despite two references
+    );
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("INDEX.md");
+  });
+
+  it("reports multiple distinct missing paths", async () => {
+    setup({ "INDEX.md": "`src/lib/a.ts` and `src/lib/b.ts`" }, [
+      "src/lib/a.ts",
+    ]);
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("src/lib/b.ts");
+  });
+
+  it("returns an error when the architecture docs directory cannot be read", async () => {
+    mockReaddir.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain(
+      "Cannot read architecture docs directory",
+    );
+  });
+
+  it("returns an error when an individual doc cannot be read", async () => {
+    mockReaddir.mockResolvedValue(makeMdDirents(["INDEX.md"]));
+    mockReadFile.mockRejectedValue(new Error("EACCES"));
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("Cannot read architecture doc");
+    expect(result.errors[0]).toContain("INDEX.md");
+  });
+
+  it("returns an error when no markdown files are present", async () => {
+    mockReaddir.mockResolvedValue(makeMdDirents(["notes.txt"]));
+
+    const result = await checkArchitectureDocs("/repo");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("No .md files");
+  });
+});


### PR DESCRIPTION
Introduce docs/architecture/ — a descriptive map (where things live + how
data flows) that complements the prescriptive .claude/skills/. Read it before
sweeping the codebase with grep/glob, to reduce the recurring token cost of
the initial exploration on every task.

- docs/architecture/INDEX.md: src/ tree, "Dove vivo X?" table, server-actions
  index, cross-cutting modules. Read first.
- docs/architecture/data-flows.md + config-manifest.md: on-demand deep-dives.
  The manifest points to canonical source files instead of duplicating values,
  so it cannot drift out of sync.

Anti-drift: scripts/check-architecture-docs.mjs (mirrors check-migrations.mjs)
fails if any path cited in the map no longer exists on disk, with unit tests
covering line-number stripping, glob/brace skipping, route-group/[id] dirs,
dedup and read failures. Wired as `npm run arch:check`, into the Pre-PR
checklist and a dedicated CI job (triggered by docs/, the script, or src/**).

CLAUDE.md: new "Mappa codebase — leggi prima di esplorare" section, rule 26
(keep the map alive in the same PR), and references in the Pre-PR checklist
and repo-references list.