### PR TITLE
Allinea contenuti forfettario: niente selettore, N2 sul DCO (N2.2 solo in fattura)

### DIFF
--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -266,14 +266,15 @@ export default function AliquoteIvaPage() {
               Sono in regime forfettario ma vedo le opzioni IVA
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              Verifica che la P.IVA inserita in onboarding sia stata
-              riconosciuta come forfettaria: in <em>Impostazioni → Attività</em>{" "}
-              il campo IVA prevalente deve essere impostato di conseguenza.
-              Quando il regime è forfettario, le righe dello scontrino vanno
-              emesse con il codice natura <strong>N2</strong> (operazioni non
-              soggette). Per il dettaglio del flusso e delle differenze fra N2
-              sul documento commerciale e N2.2 sulla fattura elettronica vedi la
-              guida{" "}
+              ScontrinoZero non rileva il regime dalla P.IVA: sei tu a impostare
+              il campo <em>IVA prevalente</em> su «0% – Non soggette» (natura
+              N2), in onboarding oppure in <em>Impostazioni → Attività</em>.
+              Finché l&apos;aliquota prevalente non è N2 continui a vedere le
+              opzioni IVA ordinarie. Quando il regime è forfettario, le righe
+              dello scontrino vanno emesse con il codice natura{" "}
+              <strong>N2</strong> (operazioni non soggette). Per il dettaglio
+              del flusso e delle differenze fra N2 sul documento commerciale e
+              N2.2 sulla fattura elettronica vedi la guida{" "}
               <Link
                 href="/help/regime-forfettario"
                 className="text-primary hover:underline"

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -92,7 +92,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Posso emettere DCO anche in regime forfettario?",
         answer:
-          "Sì. Il regime forfettario non esonera dall'obbligo di emettere il documento commerciale per le vendite B2C. Sul documento va indicata la natura N2.2 (operazione non soggetta IVA, art. 1 c. 54-89 L. 190/2014) al posto dell'aliquota, ma lo scontrino va comunque emesso e trasmesso.",
+          "Sì. Il regime forfettario non esonera dall'obbligo di emettere il documento commerciale per le vendite B2C. Sul documento va indicata la natura N2 (operazione non soggetta IVA, art. 1 c. 54-89 L. 190/2014) al posto dell'aliquota — il codice granulare N2.2 vale solo per la fattura elettronica — ma lo scontrino va comunque emesso e trasmesso.",
       },
     ],
     relatedHelp: [
@@ -315,7 +315,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Come configurare l'IVA",
-        body: "Sui documenti emessi da un forfettario l'operazione è non soggetta a IVA ai sensi dell'art. 1 c. 54-89 L. 190/2014. Sul DCO va indicato il codice natura N2.2 (operazione non soggetta IVA) al posto dell'aliquota, con la dicitura normativa di esenzione. In ScontrinoZero, in fase di onboarding indichi che sei in regime forfettario e l'app applica automaticamente la configurazione corretta.",
+        body: "Sui documenti emessi da un forfettario l'operazione è non soggetta a IVA ai sensi dell'art. 1 c. 54-89 L. 190/2014. Sullo scontrino (documento commerciale) si indica la natura N2 al posto dell'aliquota; il codice granulare N2.2 riguarda invece la fattura elettronica. In ScontrinoZero non esiste un selettore «regime forfettario» dedicato: durante l'onboarding imposti l'aliquota IVA prevalente su «0% – Non soggette» (natura N2) e, se usi il catalogo rapido, fai lo stesso sui singoli prodotti. La dicitura di esenzione non è richiesta sullo scontrino (basta la natura N2): resta obbligatoria solo sulle fatture.",
       },
       {
         heading: "Lotteria degli Scontrini e altri aspetti",
@@ -334,7 +334,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Posso usare ScontrinoZero se sono in regime forfettario?",
         answer:
-          "Sì, ScontrinoZero è progettato anche per i forfettari. In fase di configurazione iniziale indichi il regime e l'app imposta automaticamente le aliquote IVA a 0% e la dicitura normativa di esenzione su tutti gli scontrini emessi.",
+          "Sì, ScontrinoZero è progettato anche per i forfettari. Non c'è un selettore di regime dedicato: durante la configurazione iniziale imposti l'aliquota IVA prevalente su «0% – Non soggette» (natura N2) e, se usi il catalogo, sui singoli prodotti; da lì gli scontrini escono senza IVA, con la natura N2.",
       },
       {
         question:
@@ -591,7 +591,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
         question:
           "Sono in regime forfettario: devo gestire la lotteria degli scontrini?",
         answer:
-          "Sì, anche in regime forfettario puoi (e in pratica conviene) accettare il codice lotteria del cliente: la lotteria si applica al consumatore finale, non al regime fiscale dell'esercente. Il DCO emesso da un forfettario include normalmente il campo lotteria, con la natura N2.2 (operazione non soggetta IVA art. 1 c. 54-89 L. 190/2014) al posto dell'aliquota.",
+          "Sì, anche in regime forfettario puoi (e in pratica conviene) accettare il codice lotteria del cliente: la lotteria si applica al consumatore finale, non al regime fiscale dell'esercente. Il DCO emesso da un forfettario include normalmente il campo lotteria, con la natura N2 (operazione non soggetta IVA art. 1 c. 54-89 L. 190/2014) al posto dell'aliquota.",
       },
       {
         question:

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -67,7 +67,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       {
         question: "Va bene anche per chi è in regime forfettario?",
         answer:
-          "Sì. Il regime forfettario non esonera dall'emissione del documento commerciale verso privati. ScontrinoZero gestisce correttamente la natura N2.2 e l'assenza di IVA tipica del forfettario.",
+          "Sì. Il regime forfettario non esonera dall'emissione del documento commerciale verso privati. Con ScontrinoZero imposti la natura N2 (operazioni non soggette) come aliquota prevalente e gli scontrini escono senza IVA, come previsto per il forfettario.",
       },
       {
         question: "Quanto costa al mese?",
@@ -222,15 +222,15 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     audience:
       "partite IVA in regime forfettario (L. 190/2014) con vendite o servizi B2C",
     useCase:
-      "Il regime forfettario non ti esonera dall'emissione del documento commerciale quando vendi a privati. Ma non ha senso pagare centinaia di euro per un registratore di cassa telematico se il tuo volume di scontrini è modesto. ScontrinoZero applica automaticamente il codice natura N2.2 (il codice IVA che identifica chi è in regime forfettario, da indicare al posto dell'aliquota) e ti fa risparmiare sull'hardware.",
+      "Il regime forfettario non ti esonera dall'emissione del documento commerciale quando vendi a privati. Ma non ha senso pagare centinaia di euro per un registratore di cassa telematico se il tuo volume di scontrini è modesto. Con ScontrinoZero imposti come aliquota prevalente la natura N2 (il codice IVA delle operazioni non soggette del forfettario, da indicare al posto dell'aliquota) e risparmi sull'hardware.",
     obligations: [
       "Emissione del Documento Commerciale Online verso privati anche in regime forfettario.",
-      "Indicazione della natura N2.2 sullo scontrino (operazione non soggetta IVA, art. 1 c. 54-89 L. 190/2014).",
+      "Indicazione della natura N2 sullo scontrino (operazione non soggetta IVA, art. 1 c. 54-89 L. 190/2014).",
       "Trasmissione corrispettivi all'Agenzia delle Entrate entro 12 giorni.",
       "Limite di ricavi €85.000/anno per restare nel regime forfettario.",
     ],
     benefits: [
-      "Selezione guidata della natura N2.2 in fase di onboarding, pre-configurata sugli scontrini.",
+      "Natura N2 impostabile come aliquota prevalente in onboarding, così è già pre-compilata sugli scontrini.",
       "Costo mensile più basso del mercato: a partire da €2,50/mese (annuale).",
       "Zero hardware da acquistare: solo lo smartphone che già hai.",
       "Storico ordinato e ricercabile; export CSV sul piano Pro.",
@@ -239,7 +239,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       {
         question: "In forfettario devo davvero emettere scontrino?",
         answer:
-          "Sì, se vendi beni o servizi a privati e non emetti fattura. Il regime forfettario riguarda la fiscalità (IVA, IRPEF), non l'obbligo di documentare la transazione. Lo scontrino senza IVA, con natura N2.2, è la forma corretta.",
+          "Sì, se vendi beni o servizi a privati e non emetti fattura. Il regime forfettario riguarda la fiscalità (IVA, IRPEF), non l'obbligo di documentare la transazione. Lo scontrino senza IVA, con natura N2, è la forma corretta.",
       },
       {
         question: "Cosa cambia se supero gli €85.000 di ricavi?",


### PR DESCRIPTION
## Contesto

La pagina help `regime-forfettario` è accurata, ma altri contenuti marketing promettevano un comportamento del prodotto inesistente e usavano il codice natura sbagliato sullo scontrino. Allineati alla realtà del prodotto e alla pagina help.

Due punti di fatto confermati dall'utente:
- **Non esiste un selettore "regime forfettario"** né un auto-riconoscimento dalla P.IVA: si imposta l'**aliquota IVA prevalente su «0% – Non soggette» (natura N2)** in onboarding e, se serve, sui prodotti del catalogo.
- **Sullo scontrino (documento commerciale) il codice natura è N2**; **N2.2 vale solo per la fattura elettronica**.

## Modifiche

- **`src/lib/guide/articles.ts`** — guide `scontrino-regime-forfettario`, `documento-commerciale-online`, `lotteria-scontrini-commerciante`: rimosso il claim del selettore/configurazione automatica e della dicitura inserita in automatico; codice natura sullo scontrino corretto da N2.2 a N2.
- **`src/lib/per/categories.ts`** — categoria `/per/regime-forfettario` (+ FAQ ambulanti): stessi claim corretti, 5 occorrenze di N2.2→N2, rimosso "applica automaticamente"/"selezione guidata".
- **`src/app/(marketing)/help/aliquote-iva/page.tsx`** — rimosso il claim di "P.IVA riconosciuta come forfettaria" (nessun rilevamento del regime): è l'utente a impostare l'aliquota prevalente su N2.

`N2.2` resta solo nei riferimenti corretti alla fattura elettronica.

## Verifica

- `npm run lint` · `npm run type-check` · `prettier --check` puliti
- Test verdi (`src/lib/guide`, `src/lib/per`: 208; suite completa precedentemente verde)

## Fuori scope (come concordato)

La questione se la **dicitura di esenzione** vada citata anche sullo scontrino (oggi i contenuti dicono: solo natura N2 sul DCO, dicitura obbligatoria solo su fattura) è rinviata su richiesta dell'utente.

https://claude.ai/code/session_01MhZsHkkwLHKg4WRTRrhYD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhZsHkkwLHKg4WRTRrhYD4)_