### PR TITLE
Implement AdE session caching to eliminate repeated login overhead

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -97,43 +97,6 @@ creando un **documento fiscale duplicato e irreversibile** su AdE.
 
 ---
 
-### 5. Riuso sessione AdE — eliminare il re-login completo (~10 round-trip) a ogni operazione
-
-- **Categoria:** performance (latenza dominante dell'emissione) · **Severità:** High
-- **File:** `src/lib/services/receipt-service.ts:551` + logout nel `finally`; `src/lib/services/void-service.ts:612` + logout; `src/server/onboarding-actions.ts:356,614`; client: `src/lib/ade/real-client.ts`
-
-**Problema.** Ogni emissione/annullo/verifica crea un nuovo client
-(`createAdeClient`) e ripete l'intero login Fisconline (fasi A–G, ~10 round-trip
-HTTP **sequenziali** verso AdE) + `logout()`. Il login è la latenza dominante
-(principio #1, performance percepita): il `submitSale` vero è un singolo POST,
-sempre preceduto da ~10 chiamate di auth.
-
-**Fix (design già deciso, non ambiguo).**
-
-1. Cache in-process per-business: `Map<businessId, { client, expiresAt }>`
-   (assunzione single-container coerente con CLAUDE.md) che conserva
-   `RealAdeClient` (AdeSession + CookieJar) con TTL **sotto** la scadenza
-   sessione AdE (10–12 min) e cap LRU.
-2. **Lock async per businessId** (catena di Promise) che serializza le emissioni
-   concorrenti: due richieste riusano un solo login invece di gareggiare (evita
-   anche il doppio login).
-3. Il re-auth su 401 già presente in `submitDocument` resta il fallback di
-   correttezza se la sessione è scaduta lato AdE.
-4. **Sicurezza:** la cache tiene solo i cookie di sessione in memoria (mai
-   persistiti); le credenziali decifrate restano transienti per-operazione,
-   **fuori** dalla cache long-lived; invalidare la entry su cambio credenziali e
-   su `logout`.
-5. **Prerequisito:** il CookieJar deve onorare delete/expiry (item 27) — un jar
-   long-lived non può accumulare cookie cancellati.
-6. Non deve rompere l'idempotenza stale-recovery (item 4). Escludere il path
-   verify/onboarding (raro). Aggiungere metrica `loginCount` vs `emitCount` per
-   misurare l'hit-rate.
-7. **Test:** hit di cache → un solo login per due emit ravvicinate; expiry TTL →
-   nuovo login; 401 dentro submit → re-auth e retry; invalidazione su
-   `saveAdeCredentials`; LRU cap.
-
----
-
 ### 8. TTL/revoca per i link pubblici degli scontrini
 
 - **Categoria:** sicurezza · **Severità:** Medium · **Target indicativo:** v1.4.0+
@@ -615,31 +578,6 @@ non deve rivelare se l'email esiste).
    (`email_send_failed`) per l'osservabilità.
 3. **Test:** Resend KO su reset → banner di retry, nessuna differenza di
    messaggio tra email esistente e no; Resend OK → redirect invariato.
-
----
-
-### 27. `CookieJar` non onora cancellazione/scadenza dei cookie
-
-- **Categoria:** robustezza · **Severità:** Low oggi — **prerequisito dell'item 5** (riuso sessione AdE)
-- **File:** `src/lib/ade/cookie-jar.ts:14-33` (`applyResponse`)
-
-**Problema.** Il jar salva solo `name=value` dal primo segmento di `Set-Cookie`,
-ignorando `Max-Age`/`Expires` e la semantica di **cancellazione**
-(`Set-Cookie: NAME=; Max-Age=0`): memorizza `NAME=""` e continua a inviarlo.
-Impatto ~0 con i client effimeri per-operazione attuali, ma un jar long-lived
-(riuso sessione) DEVE onorare delete/expiry.
-
-**Fix (non ambiguo).**
-
-1. In `applyResponse`, parsare gli attributi `Max-Age` ed `Expires` di ogni
-   `Set-Cookie`; su delete (`Max-Age <= 0`, `Expires` nel passato, o valore
-   vuoto) eseguire `cookies.delete(name)` invece di memorizzare.
-2. _Da confermare con una cattura HAR che mostri un Set-Cookie di delete nel
-   flusso di login/SSO AdE_ (regola 14: cross-reference one-by-one).
-3. **Test:** `Max-Age=0` → cookie rimosso; `Expires` passato → rimosso; valore
-   vuoto senza attributi → rimosso; cookie normale → memorizzato come oggi;
-   attributi `Path`/`Domain` ignorati senza crash.
-4. Implementare **insieme o prima** dell'item 5.
 
 ---
 

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -25,7 +25,11 @@
 3. Orchestrazione in `src/lib/services/receipt-service.ts`: idempotency
    (`src/lib/services/request-hash.ts`), chiamata AdE, transazione DB.
 4. Client AdE risolto da `src/lib/ade/index.ts` (reale `src/lib/ade/real-client.ts`
-   vs mock `src/lib/ade/mock-client.ts` secondo `ADE_MODE`).
+   vs mock `src/lib/ade/mock-client.ts` secondo `ADE_MODE`). La sessione Fisconline
+   è riusata fra operazioni ravvicinate dello stesso business via
+   `withAdeSession` + `src/lib/ade/session-cache.ts` (cache in-process con TTL/LRU
+   e lock per-business), invalidata su cambio credenziali. Evita di ripetere il
+   login (~10 round-trip, latenza dominante) a ogni emissione.
 5. UI optimistic: lo scontrino "sembra istantaneo" anche se AdE risponde in 2-5s
    (priorità #1). La server action degrada, non lancia (regola 19).
 6. Fallimenti AdE classificati da `src/lib/ade/log-failure.ts` con

--- a/src/lib/ade/cookie-jar.test.ts
+++ b/src/lib/ade/cookie-jar.test.ts
@@ -99,6 +99,168 @@ describe("CookieJar", () => {
 
       expect(jar.size).toBe(0);
     });
+
+    it("keeps a cookie with a positive Max-Age", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/; Max-Age=3600"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(true);
+      expect(jar.toHeaderValue()).toBe("SID=val");
+    });
+
+    it("removes a cookie deleted with Max-Age=0", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/"]],
+        }),
+      );
+      expect(jar.has("SID")).toBe(true);
+
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/; Max-Age=0"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(false);
+      expect(jar.size).toBe(0);
+    });
+
+    it("removes a cookie deleted with a negative Max-Age", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/"]],
+        }),
+      );
+
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Max-Age=-1"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(false);
+    });
+
+    it("ignores Max-Age=0 for a cookie that does not exist (no crash)", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "GONE=x; Max-Age=0"]],
+        }),
+      );
+
+      expect(jar.size).toBe(0);
+    });
+
+    it("removes a cookie with Expires in the past", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/"]],
+        }),
+      );
+
+      jar.applyResponse(
+        new Response("", {
+          headers: [
+            ["Set-Cookie", "SID=val; Expires=Thu, 01 Jan 1970 00:00:00 GMT"],
+          ],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(false);
+    });
+
+    it("keeps a cookie with Expires in the future", () => {
+      const jar = new CookieJar();
+      const future = new Date(Date.now() + 86_400_000).toUTCString();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", `SID=val; Expires=${future}`]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(true);
+    });
+
+    it("ignores a malformed Expires and keeps the cookie (no false delete)", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Expires=not-a-date"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(true);
+      expect(jar.toHeaderValue()).toBe("SID=val");
+    });
+
+    it("removes a cookie set with an empty value", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/"]],
+        }),
+      );
+
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=; Path=/"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(false);
+    });
+
+    it("keeps an empty-valued cookie kept alive by a positive Max-Age", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=; Max-Age=3600"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(true);
+      expect(jar.toHeaderValue()).toBe("SID=");
+    });
+
+    it("gives Max-Age precedence over a contradictory Expires (RFC 6265)", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Path=/"]],
+        }),
+      );
+
+      // Max-Age=0 (delete) wins over a future Expires (keep).
+      const future = new Date(Date.now() + 86_400_000).toUTCString();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", `SID=val; Max-Age=0; Expires=${future}`]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(false);
+    });
+
+    it("ignores a non-numeric Max-Age and falls back to value/expires", () => {
+      const jar = new CookieJar();
+      jar.applyResponse(
+        new Response("", {
+          headers: [["Set-Cookie", "SID=val; Max-Age=abc"]],
+        }),
+      );
+
+      expect(jar.has("SID")).toBe(true);
+      expect(jar.toHeaderValue()).toBe("SID=val");
+    });
   });
 
   describe("toHeaderValue", () => {

--- a/src/lib/ade/cookie-jar.ts
+++ b/src/lib/ade/cookie-jar.ts
@@ -15,8 +15,10 @@ export class CookieJar {
     const setCookieHeaders = response.headers.getSetCookie();
 
     for (const header of setCookieHeaders) {
-      // Take only the first segment before ";" (ignore attributes)
-      const cookiePart = header.split(";")[0].trim();
+      const segments = header.split(";");
+
+      // First segment is name=value; the rest are attributes.
+      const cookiePart = segments[0].trim();
       if (!cookiePart) continue;
 
       // Split on first "=" only to handle values containing "="
@@ -25,11 +27,53 @@ export class CookieJar {
 
       const name = cookiePart.slice(0, eqIndex).trim();
       const value = cookiePart.slice(eqIndex + 1);
+      if (!name) continue;
 
-      if (name) {
-        this.cookies.set(name, value);
+      // Honor deletion/expiry semantics: a long-lived jar (session reuse) must
+      // not keep cookies the server has expired or cleared. Without this it
+      // would store NAME="" and keep sending the deleted cookie.
+      if (CookieJar.isDeletionSignal(value, segments.slice(1))) {
+        this.cookies.delete(name);
+        continue;
+      }
+
+      this.cookies.set(name, value);
+    }
+  }
+
+  /**
+   * Decide whether a Set-Cookie clears the cookie rather than storing it.
+   *
+   * Precedence per RFC 6265: Max-Age wins over Expires. A cookie is deleted on
+   * a non-positive Max-Age, an Expires in the past, or an empty value with no
+   * attribute that keeps it alive. Malformed attributes are ignored (no false
+   * delete). Path/Domain/HttpOnly/Secure/SameSite are not relevant (single
+   * origin) and are skipped without crashing.
+   */
+  private static isDeletionSignal(
+    value: string,
+    attributes: string[],
+  ): boolean {
+    let maxAge: number | undefined;
+    let expiresAt: number | undefined;
+
+    for (const attr of attributes) {
+      const eq = attr.indexOf("=");
+      if (eq === -1) continue;
+      const key = attr.slice(0, eq).trim().toLowerCase();
+      const raw = attr.slice(eq + 1).trim();
+
+      if (key === "max-age" && /^-?\d+$/.test(raw)) {
+        maxAge = Number(raw);
+      } else if (key === "expires") {
+        const t = Date.parse(raw);
+        if (!Number.isNaN(t)) expiresAt = t;
       }
     }
+
+    if (maxAge !== undefined) return maxAge <= 0;
+    if (expiresAt !== undefined) return expiresAt <= Date.now();
+    return value === "";
   }
 
   /** Return the Cookie header value for the next request. */

--- a/src/lib/ade/index.test.ts
+++ b/src/lib/ade/index.test.ts
@@ -1,8 +1,21 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { getAdeMode, createAdeClient } from "./index";
+import { getAdeMode, createAdeClient, withAdeSession } from "./index";
 import { MockAdeClient } from "./mock-client";
 import { RealAdeClient } from "./real-client";
+import { adeSessionCache } from "./session-cache";
+import type { AdeSession } from "./client";
+
+const FAKE_CREDENTIALS = {
+  codiceFiscale: "RSSMRA80A01H501U",
+  password: "secret",
+  pin: "1234567890",
+};
+const FAKE_SESSION: AdeSession = {
+  pAuth: "p",
+  partitaIva: "01234567890",
+  createdAt: 0,
+};
 
 describe("getAdeMode", () => {
   afterEach(() => {
@@ -60,5 +73,81 @@ describe("createAdeClient", () => {
 
   it("returns a RealAdeClient for mode=real", () => {
     expect(createAdeClient("real")).toBeInstanceOf(RealAdeClient);
+  });
+});
+
+describe("withAdeSession (mock mode)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("logs in, runs fn with a client, then logs out", async () => {
+    vi.stubEnv("ADE_MODE", "mock");
+    const loginSpy = vi
+      .spyOn(MockAdeClient.prototype, "login")
+      .mockResolvedValue(FAKE_SESSION);
+    const logoutSpy = vi
+      .spyOn(MockAdeClient.prototype, "logout")
+      .mockResolvedValue();
+    const fn = vi.fn().mockResolvedValue("done");
+
+    const result = await withAdeSession(
+      { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+      fn,
+    );
+
+    expect(result).toBe("done");
+    expect(loginSpy).toHaveBeenCalledWith(FAKE_CREDENTIALS);
+    expect(fn).toHaveBeenCalledOnce();
+    expect(logoutSpy).toHaveBeenCalled();
+  });
+
+  it("swallows a logout failure and still returns the fn result", async () => {
+    vi.stubEnv("ADE_MODE", "mock");
+    vi.spyOn(MockAdeClient.prototype, "login").mockResolvedValue(FAKE_SESSION);
+    vi.spyOn(MockAdeClient.prototype, "logout").mockRejectedValue(
+      new Error("logout boom"),
+    );
+
+    const result = await withAdeSession(
+      { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+      () => Promise.resolve("ok"),
+    );
+
+    expect(result).toBe("ok");
+  });
+
+  it("logs out even when fn throws (no session reuse in mock)", async () => {
+    vi.stubEnv("ADE_MODE", "mock");
+    vi.spyOn(MockAdeClient.prototype, "login").mockResolvedValue(FAKE_SESSION);
+    const logoutSpy = vi
+      .spyOn(MockAdeClient.prototype, "logout")
+      .mockResolvedValue();
+
+    await expect(
+      withAdeSession(
+        { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+        () => Promise.reject(new Error("boom")),
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(logoutSpy).toHaveBeenCalled();
+  });
+
+  it("real mode: delegates to the session cache (no per-op logout)", async () => {
+    vi.stubEnv("ADE_MODE", "real");
+    const runSpy = vi
+      .spyOn(adeSessionCache, "run")
+      .mockResolvedValue("from-cache" as never);
+    const fn = vi.fn();
+
+    const result = await withAdeSession(
+      { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+      fn,
+    );
+
+    expect(result).toBe("from-cache");
+    expect(runSpy).toHaveBeenCalledWith("biz-1", FAKE_CREDENTIALS, fn);
   });
 });

--- a/src/lib/ade/index.ts
+++ b/src/lib/ade/index.ts
@@ -5,8 +5,11 @@
  */
 
 import type { AdeClient } from "./client";
+import type { FisconlineCredentials } from "./types";
 import { MockAdeClient } from "./mock-client";
 import { RealAdeClient } from "./real-client";
+import { adeSessionCache } from "./session-cache";
+import { logger } from "@/lib/logger";
 
 export type AdeMode = "mock" | "real";
 
@@ -58,4 +61,38 @@ export function createAdeClient(mode: AdeMode): AdeClient {
     default:
       throw new Error(`Unknown ADE_MODE: ${mode}`);
   }
+}
+
+/**
+ * Esegue `fn` con un client AdE autenticato per `businessId` (REVIEW #5).
+ *
+ * - `ADE_MODE=real`: riusa la sessione via `adeSessionCache` (un solo login
+ *   Fisconline per più operazioni ravvicinate dello stesso business, serializzate
+ *   da un lock per-business). Il logout NON avviene a fine operazione: la
+ *   sessione resta in cache fino a TTL/eviction/invalidazione.
+ * - `ADE_MODE=mock`: nessuna cache. login + logout per-operazione come prima,
+ *   così il comportamento dei test mock resta invariato (login/logout no-op).
+ *
+ * Sostituisce il pattern `createAdeClient(getAdeMode())` + `login()` + `logout()`
+ * nel `finally` nei call-site di emissione/annullo.
+ */
+export async function withAdeSession<T>(
+  params: { businessId: string; credentials: FisconlineCredentials },
+  fn: (client: AdeClient) => Promise<T>,
+): Promise<T> {
+  const mode = getAdeMode();
+
+  if (mode === "mock") {
+    const client = createAdeClient("mock");
+    await client.login(params.credentials);
+    try {
+      return await fn(client);
+    } finally {
+      await client
+        .logout()
+        .catch((err) => logger.warn({ err }, "AdE logout failed"));
+    }
+  }
+
+  return adeSessionCache.run(params.businessId, params.credentials, fn);
 }

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -1035,6 +1035,38 @@ describe("RealAdeClient", () => {
       );
     });
 
+    it("clearCredentials disables 401 re-auth → AdeSessionExpiredError (REVIEW #5)", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      // La cache azzera le credenziali a fine operazione: senza credenziali un
+      // 401 non può re-autenticare e deve fallire pulito (no garbage retry).
+      client.clearCredentials();
+
+      fetchMock.mockResolvedValueOnce(mockResponse({ status: 401 }));
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdeSessionExpiredError,
+      );
+    });
+
+    it("setCredentials restores 401 re-auth without re-login (REVIEW #5)", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      // Simula il ciclo cache: scrub a fine op, re-inject prima della successiva.
+      client.clearCredentials();
+      client.setCredentials(mockCredentials);
+
+      // First attempt: 401 → re-auth (6 chiamate) → retry success
+      fetchMock.mockResolvedValueOnce(mockResponse({ status: 401 }));
+      mockReAuthSequence(fetchMock);
+      fetchMock.mockResolvedValueOnce(mockResponse({ body: successResponse }));
+
+      const result = await client.submitSale(makeSalePayload());
+      expect(result.esito).toBe(true);
+    });
+
     it("throws AdePortalError on non-401 error status", async () => {
       mockLoginSequence(fetchMock);
       await client.login(mockCredentials);

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -1117,6 +1117,27 @@ export class RealAdeClient implements AdeClient {
     return this.session;
   }
 
+  /**
+   * Re-inietta le credenziali su un client la cui sessione è già stabilita
+   * (riuso dalla cache, REVIEW #5). Necessario perché il re-auth su 401 in
+   * `submitDocument` ha bisogno delle credenziali, ma la cache long-lived non
+   * deve trattenerle tra un'operazione e l'altra (vedi `clearCredentials`).
+   * Non tocca sessione né cookie: nessun login viene rieseguito.
+   */
+  setCredentials(credentials: FisconlineCredentials): void {
+    this.credentials = credentials;
+  }
+
+  /**
+   * Azzera le credenziali decifrate dalla memoria del client mantenendo
+   * sessione e cookie. Chiamato dopo ogni operazione su un client cached così
+   * che la entry in cache conservi solo i cookie di sessione, mai le
+   * credenziali (REVIEW #5.4).
+   */
+  clearCredentials(): void {
+    this.credentials = null;
+  }
+
   async loginSpid(credentials: SpidCredentials): Promise<AdeSession> {
     // SPID sessions don't store credentials: no automatic re-auth on 401
     // (user would need to approve the push notification again)

--- a/src/lib/ade/session-cache.test.ts
+++ b/src/lib/ade/session-cache.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AdeSessionCache, type CachedAdeClient } from "./session-cache";
+import type { AdeSession } from "./client";
+import type { FisconlineCredentials } from "./types";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const CREDENTIALS: FisconlineCredentials = {
+  codiceFiscale: "RSSMRA80A01H501U",
+  password: "secret",
+  pin: "1234567890",
+};
+const SESSION: AdeSession = {
+  pAuth: "p",
+  partitaIva: "01234567890",
+  createdAt: 0,
+};
+
+/**
+ * Fake CachedAdeClient: implementa l'intera interfaccia AdeClient con stub, ma
+ * traccia login/logout/setCredentials/clearCredentials per le asserzioni.
+ */
+function makeFakeClient(): CachedAdeClient {
+  return {
+    login: vi.fn().mockResolvedValue(SESSION),
+    loginSpid: vi.fn().mockResolvedValue(SESSION),
+    submitSale: vi.fn(),
+    submitVoid: vi.fn(),
+    getFiscalData: vi.fn(),
+    getProducts: vi.fn(),
+    getDocument: vi.fn(),
+    searchDocuments: vi.fn(),
+    changePasswordFisconline: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    setCredentials: vi.fn(),
+    clearCredentials: vi.fn(),
+  };
+}
+
+describe("AdeSessionCache", () => {
+  let now: number;
+  let clients: CachedAdeClient[];
+  let createClient: () => CachedAdeClient;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    clients = [];
+    createClient = vi.fn(() => {
+      const client = makeFakeClient();
+      clients.push(client);
+      return client;
+    });
+  });
+
+  // Flush the microtask queue (login() resolves over several microtask hops).
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  function makeCache(opts: { ttlMs?: number; maxEntries?: number } = {}) {
+    return new AdeSessionCache({
+      createClient,
+      now: () => now,
+      ttlMs: opts.ttlMs ?? 10_000,
+      maxEntries: opts.maxEntries ?? 100,
+    });
+  }
+
+  it("logs in once and reuses the session for two sequential operations", async () => {
+    const cache = makeCache();
+
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve("a"));
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve("b"));
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(clients[0].login).toHaveBeenCalledTimes(1);
+    expect(cache.size).toBe(1);
+  });
+
+  it("re-injects credentials on a cache hit (for 401 re-auth)", async () => {
+    const cache = makeCache();
+
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+
+    // login already sets credentials on first op; reuse re-injects via setCredentials.
+    expect(clients[0].setCredentials).toHaveBeenCalledWith(CREDENTIALS);
+  });
+
+  it("clears credentials from the cached client after each operation", async () => {
+    const cache = makeCache();
+
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+
+    expect(clients[0].clearCredentials).toHaveBeenCalledTimes(1);
+    // The session stays cached, but credentials must not be retained.
+    expect(cache.size).toBe(1);
+  });
+
+  it("returns the value produced by fn", async () => {
+    const cache = makeCache();
+    const result = await cache.run("biz", CREDENTIALS, () =>
+      Promise.resolve({ ok: true }),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("re-logs in after TTL expiry and logs out the stale client", async () => {
+    const cache = makeCache({ ttlMs: 10_000 });
+
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+    now += 10_001; // past TTL
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(clients[0].logout).toHaveBeenCalledTimes(1); // stale one cleaned up
+    expect(clients[1].login).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the session on error and logs out, re-logging in next time", async () => {
+    const cache = makeCache();
+
+    await expect(
+      cache.run("biz", CREDENTIALS, () => Promise.reject(new Error("boom"))),
+    ).rejects.toThrow("boom");
+
+    expect(clients[0].logout).toHaveBeenCalledTimes(1);
+    expect(clients[0].clearCredentials).toHaveBeenCalledTimes(1);
+    expect(cache.size).toBe(0);
+
+    // Next operation must perform a fresh login.
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least-recently-used session past the cap and logs it out", async () => {
+    const cache = makeCache({ maxEntries: 1 });
+
+    await cache.run("biz-A", CREDENTIALS, () => Promise.resolve(null));
+    await cache.run("biz-B", CREDENTIALS, () => Promise.resolve(null));
+
+    expect(cache.size).toBe(1);
+    expect(clients[0].logout).toHaveBeenCalledTimes(1); // A evicted
+  });
+
+  it("invalidate() logs out and removes the cached session", async () => {
+    const cache = makeCache();
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+    expect(cache.size).toBe(1);
+
+    await cache.invalidate("biz");
+
+    expect(clients[0].logout).toHaveBeenCalledTimes(1);
+    expect(cache.size).toBe(0);
+
+    // Subsequent operation re-logs in.
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidate() still removes the entry when logout rejects", async () => {
+    const cache = makeCache();
+    await cache.run("biz", CREDENTIALS, () => Promise.resolve(null));
+    (clients[0].logout as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("logout boom"),
+    );
+
+    await expect(cache.invalidate("biz")).resolves.toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("invalidate() on an unknown business is a no-op", async () => {
+    const cache = makeCache();
+    await expect(cache.invalidate("nope")).resolves.toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("serializes concurrent operations on the same business (single login)", async () => {
+    const cache = makeCache();
+    const order: string[] = [];
+
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+
+    const p1 = cache.run("biz", CREDENTIALS, async () => {
+      order.push("start-1");
+      await firstGate;
+      order.push("end-1");
+    });
+    const p2 = cache.run("biz", CREDENTIALS, async () => {
+      order.push("start-2");
+      order.push("end-2");
+    });
+
+    // Let microtasks settle: op2 must NOT start while op1 holds the lock.
+    await flush();
+    expect(order).toEqual(["start-1"]);
+
+    releaseFirst();
+    await Promise.all([p1, p2]);
+
+    expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+    // Second op reused the session opened by the first.
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs operations for different businesses in parallel", async () => {
+    const cache = makeCache();
+    const order: string[] = [];
+
+    let releaseA!: () => void;
+    const gateA = new Promise<void>((r) => {
+      releaseA = r;
+    });
+
+    const pA = cache.run("biz-A", CREDENTIALS, async () => {
+      order.push("start-A");
+      await gateA;
+      order.push("end-A");
+    });
+    const pB = cache.run("biz-B", CREDENTIALS, async () => {
+      order.push("start-B");
+    });
+
+    await flush();
+    // B is not blocked by A's in-flight operation.
+    expect(order).toContain("start-B");
+
+    releaseA();
+    await Promise.all([pA, pB]);
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the lock chain working after an operation throws", async () => {
+    const cache = makeCache();
+
+    const failing = cache
+      .run("biz", CREDENTIALS, () => Promise.reject(new Error("first fails")))
+      .catch(() => "caught");
+    const following = cache.run("biz", CREDENTIALS, () =>
+      Promise.resolve("second ok"),
+    );
+
+    await expect(failing).resolves.toBe("caught");
+    await expect(following).resolves.toBe("second ok");
+  });
+});

--- a/src/lib/ade/session-cache.ts
+++ b/src/lib/ade/session-cache.ts
@@ -1,0 +1,190 @@
+/**
+ * In-process cache delle sessioni AdE per riusare un singolo login Fisconline
+ * su più operazioni ravvicinate dello stesso business (REVIEW #5).
+ *
+ * Il login Fisconline è la latenza dominante dell'emissione (~10 round-trip
+ * HTTP sequenziali verso AdE), mentre il `submitSale`/`submitVoid` vero è un
+ * singolo POST. Senza cache ogni operazione paga il login completo + logout.
+ *
+ * Assunzione single-container (coerente con CLAUDE.md): la cache vive nel
+ * processo Node. Per ogni `businessId`:
+ *  - un **lock async** (catena di Promise) serializza le operazioni concorrenti
+ *    → due emit ravvicinate riusano un solo login invece di gareggiare;
+ *  - una **entry** conserva il client autenticato (AdeSession + CookieJar) con
+ *    TTL sotto la scadenza sessione AdE e cap **LRU**.
+ *
+ * Sicurezza (REVIEW #5.4): la entry conserva solo i cookie di sessione. Le
+ * credenziali decifrate vengono re-iniettate per la singola operazione (così il
+ * re-auth su 401 in `submitDocument` funziona) e **azzerate** subito dopo —
+ * mai trattenute nella cache long-lived.
+ */
+
+import type { AdeClient } from "./client";
+import type { FisconlineCredentials } from "./types";
+import { RealAdeClient } from "./real-client";
+import { logger } from "@/lib/logger";
+
+/**
+ * Client AdE che espone la gestione esplicita delle credenziali richiesta dal
+ * riuso sessione. `RealAdeClient` la implementa.
+ */
+export interface CachedAdeClient extends AdeClient {
+  setCredentials(credentials: FisconlineCredentials): void;
+  clearCredentials(): void;
+}
+
+/** TTL di default: sotto la scadenza sessione AdE (~20 min osservati). */
+export const DEFAULT_ADE_SESSION_TTL_MS = 10 * 60 * 1000;
+
+/** Cap LRU di default sul numero di sessioni cached in memoria. */
+export const DEFAULT_ADE_SESSION_MAX_ENTRIES = 100;
+
+interface CacheEntry {
+  client: CachedAdeClient;
+  expiresAt: number;
+}
+
+export interface AdeSessionCacheOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+  /** Factory del client reale (override nei test). */
+  createClient?: () => CachedAdeClient;
+  /** Sorgente temporale (override nei test). */
+  now?: () => number;
+}
+
+export class AdeSessionCache {
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly createClient: () => CachedAdeClient;
+  private readonly now: () => number;
+
+  /** Sessioni autenticate, in ordine di accesso (insertion order = LRU). */
+  private readonly entries = new Map<string, CacheEntry>();
+  /** Lock per-business: coda di Promise che serializza le operazioni. */
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  constructor(options: AdeSessionCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_ADE_SESSION_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_ADE_SESSION_MAX_ENTRIES;
+    this.createClient = options.createClient ?? (() => new RealAdeClient());
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Esegue `fn` con un client AdE autenticato per `businessId`, riusando la
+   * sessione cached quando possibile. Le operazioni per lo stesso business sono
+   * serializzate; business diversi procedono in parallelo.
+   */
+  async run<T>(
+    businessId: string,
+    credentials: FisconlineCredentials,
+    fn: (client: AdeClient) => Promise<T>,
+  ): Promise<T> {
+    const prev = this.chains.get(businessId) ?? Promise.resolve();
+    // `prev` è sempre un guard già protetto da `.catch` (vedi sotto), quindi non
+    // rifiuta mai: basta il ramo fulfilled per accodarsi dopo l'op precedente.
+    const task = prev.then(() => this.execute(businessId, credentials, fn));
+    const guard = task.catch(() => {});
+    this.chains.set(businessId, guard);
+    try {
+      return await task;
+    } finally {
+      // Pulizia del lock quando nessun'altra operazione si è accodata.
+      if (this.chains.get(businessId) === guard) {
+        this.chains.delete(businessId);
+      }
+    }
+  }
+
+  /**
+   * Invalida la sessione cached di un business (chiamato su cambio credenziali).
+   * Esegue il logout best-effort e rimuove la entry.
+   */
+  async invalidate(businessId: string): Promise<void> {
+    const entry = this.entries.get(businessId);
+    if (!entry) return;
+    this.entries.delete(businessId);
+    await entry.client.logout().catch((err) => {
+      logger.warn({ err, businessId }, "AdE session invalidate logout failed");
+    });
+  }
+
+  private async execute<T>(
+    businessId: string,
+    credentials: FisconlineCredentials,
+    fn: (client: AdeClient) => Promise<T>,
+  ): Promise<T> {
+    const entry = await this.acquireEntry(businessId, credentials);
+
+    try {
+      return await fn(entry.client);
+    } catch (err) {
+      // La sessione potrebbe essere compromessa: invalida così la prossima
+      // operazione ri-effettua il login pulito invece di riusare uno stato rotto.
+      this.entries.delete(businessId);
+      await entry.client.logout().catch(() => {});
+      throw err;
+    } finally {
+      // Mai trattenere le credenziali decifrate nella cache long-lived.
+      entry.client.clearCredentials();
+    }
+  }
+
+  private async acquireEntry(
+    businessId: string,
+    credentials: FisconlineCredentials,
+  ): Promise<CacheEntry> {
+    const existing = this.entries.get(businessId);
+
+    if (existing && existing.expiresAt > this.now()) {
+      // Cache hit: riusa la sessione, re-inietta le credenziali per il 401
+      // re-auth, e sposta la entry in coda (most-recently-used).
+      this.entries.delete(businessId);
+      this.entries.set(businessId, existing);
+      existing.client.setCredentials(credentials);
+      logger.info(
+        { businessId, event: "ade_session_reuse" },
+        "AdE session reused",
+      );
+      return existing;
+    }
+
+    if (existing) {
+      // Scaduta: logout best-effort e rimozione prima del nuovo login.
+      this.entries.delete(businessId);
+      await existing.client.logout().catch(() => {});
+    }
+
+    const client = this.createClient();
+    await client.login(credentials);
+    const entry: CacheEntry = { client, expiresAt: this.now() + this.ttlMs };
+    this.entries.set(businessId, entry);
+    this.evictIfNeeded();
+    logger.info(
+      { businessId, event: "ade_session_login" },
+      "AdE session login",
+    );
+    return entry;
+  }
+
+  private evictIfNeeded(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = this.entries.get(oldestKey);
+      this.entries.delete(oldestKey);
+      if (oldest) {
+        void oldest.client.logout().catch(() => {});
+      }
+    }
+  }
+
+  /** Numero di sessioni attualmente cached (test/diagnostica). */
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+/** Cache singleton usata in produzione. */
+export const adeSessionCache = new AdeSessionCache();

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -62,13 +62,27 @@ vi.mock("@/db/schema", () => ({
 const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockSubmitSale = vi.fn();
+const mockAdeClient = {
+  login: mockLogin,
+  logout: mockLogout,
+  submitSale: mockSubmitSale,
+};
+// withAdeSession (REVIEW #5) sostituisce createAdeClient + login/logout manuali.
+// Il mock riproduce il ciclo mock-mode: login → fn(client) → logout nel finally,
+// così le asserzioni su mockLogin/mockLogout/mockSubmitSale restano valide.
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
-  createAdeClient: vi.fn().mockReturnValue({
-    login: mockLogin,
-    logout: mockLogout,
-    submitSale: mockSubmitSale,
-  }),
+  withAdeSession: async (
+    params: { credentials: unknown },
+    fn: (client: typeof mockAdeClient) => unknown,
+  ) => {
+    await mockAdeClient.login(params.credentials);
+    try {
+      return await fn(mockAdeClient);
+    } finally {
+      await mockAdeClient.logout();
+    }
+  },
 }));
 
 const mockMapSaleToAdePayload = vi.fn().mockReturnValue({ mapped: true });

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -11,7 +11,8 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
-import { createAdeClient, getAdeMode } from "@/lib/ade";
+import { withAdeSession } from "@/lib/ade";
+import type { AdeClient } from "@/lib/ade/client";
 import { AdePasswordExpiredError } from "@/lib/ade/errors";
 import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
 import { logAdeFailure } from "@/lib/ade/log-failure";
@@ -544,84 +545,22 @@ async function submitSaleToAde(
     deductibleAmount: 0,
   };
 
-  const adeClient = createAdeClient(getAdeMode());
-  let loggedIn = false;
-
   try {
-    await adeClient.login({ codiceFiscale, password, pin });
-    loggedIn = true;
-    const payload = mapSaleToAdePayload(saleDocRequest, cedentePrestatore);
-    const adeResponse = await adeClient.submitSale(payload);
-
-    if (!adeResponse.esito) {
-      const errorCodes = adeResponse.errori?.map((e) => e.codice) ?? [];
-      const errorDescriptions =
-        adeResponse.errori?.map((e) => e.descrizione) ?? [];
-      // warn (level 40) — sotto la soglia Sentry: un rifiuto business AdE
-      // (esito:false) non è un errore applicativo, quindi non apre issue
-      // Sentry. Resta nei log Docker per indagine.
-      logger.warn(
-        {
-          documentId,
-          adeIdtrx: adeResponse.idtrx,
-          adeProgressivo: adeResponse.progressivo,
-          adeErrorCodes: errorCodes,
-          adeErrorDescriptions: errorDescriptions,
-          recovery: options.recovery,
-        },
-        "AdE rejected sale",
-      );
-      // Retry on timeout. La submitSale è già successa (esito:false è una
-      // risposta valida AdE, non un errore di rete) — il DB deve riflettere
-      // REJECTED altrimenti la stale recovery ritenterà invano una sale già
-      // rifiutata.
-      await retryOnStatementTimeout("emit-update-rejected", () =>
-        db
-          .update(commercialDocuments)
-          .set({
-            status: "REJECTED",
-            adeResponse: adeResponse as unknown as Record<string, unknown>,
-          })
-          .where(eq(commercialDocuments.id, documentId)),
-      );
-      return {
-        error:
-          "Il portale Agenzia delle Entrate Fatture e Corrispettivi ha rifiutato l'emissione dello scontrino. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
-      };
-    }
-
-    // Retry su timeout. La submitSale ha avuto esito true: AdE ha accettato
-    // lo scontrino. Se la UPDATE finale fallisce, la riga resta PENDING e la
-    // stale recovery la recupera; ma il retry qui evita la maggior parte dei
-    // casi di disallineamento DB↔AdE.
-    await retryOnStatementTimeout("emit-update-accepted", () =>
-      db
-        .update(commercialDocuments)
-        .set({
-          status: "ACCEPTED",
-          adeTransactionId: adeResponse.idtrx ?? null,
-          adeProgressive: adeResponse.progressivo ?? null,
-          adeResponse: adeResponse as unknown as Record<string, unknown>,
-        })
-        .where(eq(commercialDocuments.id, documentId)),
-    );
-
-    logger.info(
+    return await withAdeSession(
       {
-        documentId,
         businessId: input.businessId,
-        adeTransactionId: adeResponse.idtrx,
-        apiKeyId: apiKeyId ?? undefined,
-        recovery: options.recovery,
+        credentials: { codiceFiscale, password, pin },
       },
-      "Receipt emitted successfully",
+      (adeClient) =>
+        runSubmitSale(adeClient, {
+          documentId,
+          input,
+          saleDocRequest,
+          cedentePrestatore,
+          apiKeyId,
+          recovery: options.recovery,
+        }),
     );
-
-    return {
-      documentId,
-      adeTransactionId: adeResponse.idtrx ?? undefined,
-      adeProgressive: adeResponse.progressivo ?? undefined,
-    };
   } catch (err) {
     logAdeFailure(
       err,
@@ -657,11 +596,105 @@ async function submitSaleToAde(
     }
 
     return formatEmitError(err);
-  } finally {
-    if (loggedIn) {
-      await adeClient
-        .logout()
-        .catch((err) => logger.warn({ err }, "AdE logout failed"));
-    }
   }
+}
+
+/**
+ * Esegue la submitSale su un client AdE già autenticato e persiste il risultato.
+ * Separata da `submitSaleToAde` perché gira dentro `withAdeSession` (REVIEW #5):
+ * la gestione errori/logout vive nel chiamante, qui solo la logica di emissione.
+ */
+async function runSubmitSale(
+  adeClient: AdeClient,
+  ctx: {
+    documentId: string;
+    input: SubmitReceiptInput;
+    saleDocRequest: SaleDocumentRequest;
+    cedentePrestatore: AdeCedentePrestatore;
+    apiKeyId: string | null | undefined;
+    recovery: boolean;
+  },
+): Promise<SubmitReceiptResult> {
+  const db = getDb();
+  const {
+    documentId,
+    input,
+    saleDocRequest,
+    cedentePrestatore,
+    apiKeyId,
+    recovery,
+  } = ctx;
+
+  const payload = mapSaleToAdePayload(saleDocRequest, cedentePrestatore);
+  const adeResponse = await adeClient.submitSale(payload);
+
+  if (!adeResponse.esito) {
+    const errorCodes = adeResponse.errori?.map((e) => e.codice) ?? [];
+    const errorDescriptions =
+      adeResponse.errori?.map((e) => e.descrizione) ?? [];
+    // warn (level 40) — sotto la soglia Sentry: un rifiuto business AdE
+    // (esito:false) non è un errore applicativo, quindi non apre issue
+    // Sentry. Resta nei log Docker per indagine.
+    logger.warn(
+      {
+        documentId,
+        adeIdtrx: adeResponse.idtrx,
+        adeProgressivo: adeResponse.progressivo,
+        adeErrorCodes: errorCodes,
+        adeErrorDescriptions: errorDescriptions,
+        recovery,
+      },
+      "AdE rejected sale",
+    );
+    // Retry on timeout. La submitSale è già successa (esito:false è una
+    // risposta valida AdE, non un errore di rete) — il DB deve riflettere
+    // REJECTED altrimenti la stale recovery ritenterà invano una sale già
+    // rifiutata.
+    await retryOnStatementTimeout("emit-update-rejected", () =>
+      db
+        .update(commercialDocuments)
+        .set({
+          status: "REJECTED",
+          adeResponse: adeResponse as unknown as Record<string, unknown>,
+        })
+        .where(eq(commercialDocuments.id, documentId)),
+    );
+    return {
+      error:
+        "Il portale Agenzia delle Entrate Fatture e Corrispettivi ha rifiutato l'emissione dello scontrino. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
+    };
+  }
+
+  // Retry su timeout. La submitSale ha avuto esito true: AdE ha accettato
+  // lo scontrino. Se la UPDATE finale fallisce, la riga resta PENDING e la
+  // stale recovery la recupera; ma il retry qui evita la maggior parte dei
+  // casi di disallineamento DB↔AdE.
+  await retryOnStatementTimeout("emit-update-accepted", () =>
+    db
+      .update(commercialDocuments)
+      .set({
+        status: "ACCEPTED",
+        adeTransactionId: adeResponse.idtrx ?? null,
+        adeProgressive: adeResponse.progressivo ?? null,
+        adeResponse: adeResponse as unknown as Record<string, unknown>,
+      })
+      .where(eq(commercialDocuments.id, documentId)),
+  );
+
+  logger.info(
+    {
+      documentId,
+      businessId: input.businessId,
+      adeTransactionId: adeResponse.idtrx,
+      apiKeyId: apiKeyId ?? undefined,
+      recovery,
+    },
+    "Receipt emitted successfully",
+  );
+
+  return {
+    documentId,
+    adeTransactionId: adeResponse.idtrx ?? undefined,
+    adeProgressive: adeResponse.progressivo ?? undefined,
+  };
 }

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -62,14 +62,28 @@ const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockGetDocument = vi.fn();
 const mockSubmitVoid = vi.fn();
+const mockAdeClient = {
+  login: mockLogin,
+  logout: mockLogout,
+  getDocument: mockGetDocument,
+  submitVoid: mockSubmitVoid,
+};
+// withAdeSession (REVIEW #5) sostituisce createAdeClient + login/logout manuali.
+// Il mock riproduce il ciclo mock-mode: login → fn(client) → logout nel finally,
+// così le asserzioni su mockLogin/mockLogout/mockSubmitVoid restano valide.
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
-  createAdeClient: vi.fn().mockReturnValue({
-    login: mockLogin,
-    logout: mockLogout,
-    getDocument: mockGetDocument,
-    submitVoid: mockSubmitVoid,
-  }),
+  withAdeSession: async (
+    params: { credentials: unknown },
+    fn: (client: typeof mockAdeClient) => unknown,
+  ) => {
+    await mockAdeClient.login(params.credentials);
+    try {
+      return await fn(mockAdeClient);
+    } finally {
+      await mockAdeClient.logout();
+    }
+  },
 }));
 
 const mockMapVoidToAdePayload = vi.fn().mockReturnValue({ mapped: true });

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -11,7 +11,7 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
-import { createAdeClient, getAdeMode } from "@/lib/ade";
+import { withAdeSession } from "@/lib/ade";
 import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
 import { logAdeFailure } from "@/lib/ade/log-failure";
 import { mapVoidToAdePayload } from "@/lib/ade/mapper";
@@ -609,38 +609,41 @@ export async function voidReceiptForBusiness(
   const { codiceFiscale, password, pin, cedentePrestatore } =
     prep.prerequisites;
 
-  const adeClient = createAdeClient(getAdeMode());
-  let loggedIn = false;
-
   try {
-    await adeClient.login({ codiceFiscale, password, pin });
-    loggedIn = true;
-
-    // Fetch original document from AdE to get real idElementoContabile values
-    const originalAdeDoc = await adeClient.getDocument(saleAdeTransactionId);
-
-    const voidReq: VoidRequest = {
-      idempotencyKey: input.idempotencyKey,
-      originalDocument: {
-        transactionId: saleAdeTransactionId,
-        documentProgressive: saleAdeProgressive,
-        date: getFiscalDate(saleCreatedAt),
+    return await withAdeSession(
+      {
+        businessId: input.businessId,
+        credentials: { codiceFiscale, password, pin },
       },
-    };
+      async (adeClient) => {
+        // Fetch original document from AdE to get real idElementoContabile values
+        const originalAdeDoc =
+          await adeClient.getDocument(saleAdeTransactionId);
 
-    const payload = mapVoidToAdePayload(
-      voidReq,
-      cedentePrestatore,
-      originalAdeDoc,
+        const voidReq: VoidRequest = {
+          idempotencyKey: input.idempotencyKey,
+          originalDocument: {
+            transactionId: saleAdeTransactionId,
+            documentProgressive: saleAdeProgressive,
+            date: getFiscalDate(saleCreatedAt),
+          },
+        };
+
+        const payload = mapVoidToAdePayload(
+          voidReq,
+          cedentePrestatore,
+          originalAdeDoc,
+        );
+        const adeResponse = await adeClient.submitVoid(payload);
+        return await processVoidAdeResponse({
+          adeResponse,
+          voidDocumentId,
+          saleDocumentId: input.documentId,
+          businessId: input.businessId,
+          apiKeyId,
+        });
+      },
     );
-    const adeResponse = await adeClient.submitVoid(payload);
-    return await processVoidAdeResponse({
-      adeResponse,
-      voidDocumentId,
-      saleDocumentId: input.documentId,
-      businessId: input.businessId,
-      apiKeyId,
-    });
   } catch (err) {
     logAdeFailure(
       err,
@@ -686,11 +689,5 @@ export async function voidReceiptForBusiness(
       "Errore durante l'annullo dello scontrino. Riprova più tardi.",
     );
     return { error: userFacing.message };
-  } finally {
-    if (loggedIn) {
-      await adeClient
-        .logout()
-        .catch((err) => logger.warn({ err }, "AdE logout failed"));
-    }
   }
 }

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -12,6 +12,7 @@ import {
   getKeyVersion,
 } from "@/lib/crypto";
 import { createAdeClient, getAdeMode } from "@/lib/ade";
+import { adeSessionCache } from "@/lib/ade/session-cache";
 import {
   AdeAuthError,
   AdeError,
@@ -306,6 +307,10 @@ export async function saveAdeCredentials(
     });
 
   logger.info({ businessId }, "ADE credentials updated");
+
+  // Invalida la sessione AdE cached (REVIEW #5): le credenziali sono cambiate,
+  // la prossima emissione/annullo deve rieffettuare il login con le nuove.
+  await adeSessionCache.invalidate(businessId);
 
   // Invalida la Router Cache client-side del dashboard: dopo aver salvato le
   // credenziali l'utente è eleggibile ad accedere al dashboard, ma il redirect

--- a/src/server/receipt-actions.test.ts
+++ b/src/server/receipt-actions.test.ts
@@ -73,13 +73,25 @@ vi.mock("@/db/schema", () => ({
 const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockSubmitSale = vi.fn();
+const mockAdeClient = {
+  login: mockLogin,
+  logout: mockLogout,
+  submitSale: mockSubmitSale,
+};
+// withAdeSession (REVIEW #5) replica il ciclo mock-mode: login → fn → logout.
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
-  createAdeClient: vi.fn().mockReturnValue({
-    login: mockLogin,
-    logout: mockLogout,
-    submitSale: mockSubmitSale,
-  }),
+  withAdeSession: async (
+    params: { credentials: unknown },
+    fn: (client: typeof mockAdeClient) => unknown,
+  ) => {
+    await mockAdeClient.login(params.credentials);
+    try {
+      return await fn(mockAdeClient);
+    } finally {
+      await mockAdeClient.logout();
+    }
+  },
 }));
 
 const mockMapSaleToAdePayload = vi.fn().mockReturnValue({ mapped: true });

--- a/src/server/void-actions.test.ts
+++ b/src/server/void-actions.test.ts
@@ -53,14 +53,26 @@ const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockGetDocument = vi.fn();
 const mockSubmitVoid = vi.fn();
+const mockAdeClient = {
+  login: mockLogin,
+  logout: mockLogout,
+  getDocument: mockGetDocument,
+  submitVoid: mockSubmitVoid,
+};
+// withAdeSession (REVIEW #5) replica il ciclo mock-mode: login → fn → logout.
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
-  createAdeClient: vi.fn().mockReturnValue({
-    login: mockLogin,
-    logout: mockLogout,
-    getDocument: mockGetDocument,
-    submitVoid: mockSubmitVoid,
-  }),
+  withAdeSession: async (
+    params: { credentials: unknown },
+    fn: (client: typeof mockAdeClient) => unknown,
+  ) => {
+    await mockAdeClient.login(params.credentials);
+    try {
+      return await fn(mockAdeClient);
+    } finally {
+      await mockAdeClient.logout();
+    }
+  },
 }));
 
 const mockMapVoidToAdePayload = vi.fn().mockReturnValue({ mapped: true });

--- a/tests/unit/receipt-service-password-expired.test.ts
+++ b/tests/unit/receipt-service-password-expired.test.ts
@@ -55,6 +55,21 @@ vi.mock("@/lib/server-auth", () => ({
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
   createAdeClient: mockCreateAdeClient,
+  // withAdeSession (REVIEW #5): replica il ciclo mock-mode usando il client di
+  // mockCreateAdeClient → login/fn/logout (login fuori dal try, come nel codice:
+  // un login fallito non chiama logout).
+  withAdeSession: async (
+    params: { credentials: unknown },
+    fn: (client: ReturnType<typeof mockCreateAdeClient>) => unknown,
+  ) => {
+    const client = mockCreateAdeClient();
+    await client.login(params.credentials);
+    try {
+      return await fn(client);
+    } finally {
+      await client.logout();
+    }
+  },
 }));
 vi.mock("@/lib/ade/mapper", () => ({
   mapSaleToAdePayload: mockMapSaleToAdePayload,

--- a/tests/unit/void-service.test.ts
+++ b/tests/unit/void-service.test.ts
@@ -57,6 +57,21 @@ vi.mock("@/lib/server-auth", () => ({
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
   createAdeClient: mockCreateAdeClient,
+  // withAdeSession (REVIEW #5): replica il ciclo mock-mode usando il client
+  // costruito da mockCreateAdeClient → login/fn/logout, così le asserzioni
+  // esistenti su mockAdeLogin/mockAdeSubmitVoid/mockAdeLogout restano valide.
+  withAdeSession: async (
+    params: { credentials: unknown },
+    fn: (client: ReturnType<typeof mockCreateAdeClient>) => unknown,
+  ) => {
+    const client = mockCreateAdeClient();
+    await client.login(params.credentials);
+    try {
+      return await fn(client);
+    } finally {
+      await client.logout();
+    }
+  },
 }));
 vi.mock("@/lib/ade/mapper", () => ({
   mapVoidToAdePayload: mockMapVoidToAdePayload,


### PR DESCRIPTION
## Summary

Implements in-process session caching for AdE (Agenzia delle Entrate) to reuse authenticated sessions across multiple operations on the same business, eliminating the ~10 sequential HTTP round-trips of the Fisconline login on every emit/void operation.

**Resolves REVIEW.md item #5** (performance: session reuse).

## Key Changes

### New Session Cache Infrastructure
- **`src/lib/ade/session-cache.ts`** — `AdeSessionCache` class with:
  - Per-business LRU cache (`Map<businessId, { client, expiresAt }>`) storing authenticated `RealAdeClient` instances (session + cookie jar)
  - Async lock per business (Promise chain) serializing concurrent operations → two rapid emits reuse one login instead of racing
  - TTL-based expiry (default 10 min, below observed AdE session timeout ~20 min)
  - LRU eviction cap (default 100 entries) with best-effort logout on eviction
  - Singleton instance `adeSessionCache` exported for production use
  - Comprehensive test suite (`session-cache.test.ts`) covering cache hits, TTL expiry, error invalidation, LRU eviction, concurrency serialization, and parallel execution across businesses

### Client Credential Management (REVIEW #5.4 — Security)
- **`src/lib/ade/real-client.ts`** — Added `setCredentials()` and `clearCredentials()` methods:
  - `setCredentials()` re-injects credentials on cache hit (required for 401 re-auth in `submitDocument`)
  - `clearCredentials()` scrubs decrypted credentials after each operation → credentials never retained in long-lived cache
  - Credentials remain transient per-operation; only session cookies persist
- **`src/lib/ade/session-cache.ts` interface `CachedAdeClient`** — Extends `AdeClient` with credential management methods
- **Tests in `real-client.test.ts`** — Verify `clearCredentials` disables 401 re-auth (throws `AdeSessionExpiredError`), and `setCredentials` restores it without re-login

### Cookie Jar Deletion/Expiry Semantics (Prerequisite for Long-Lived Cache)
- **`src/lib/ade/cookie-jar.ts`** — Honors RFC 6265 deletion signals:
  - Deletes cookies on `Max-Age=0`, `Max-Age<0`, `Expires` in past, or empty value with no keep-alive attribute
  - `Max-Age` takes precedence over `Expires` per spec
  - Malformed attributes ignored (no false deletes)
  - Prevents long-lived jar from accumulating deleted cookies
- **Tests in `cookie-jar.test.ts`** — 10 new test cases covering all deletion/expiry scenarios

### High-Level API: `withAdeSession()`
- **`src/lib/ade/index.ts`** — New `withAdeSession()` function:
  - `ADE_MODE=real`: delegates to `adeSessionCache.run()` (session reuse, no per-op logout)
  - `ADE_MODE=mock`: login + fn + logout per-operation (preserves test behavior)
  - Replaces manual `createAdeClient()` + `login()` + `logout()` pattern
- **Tests in `index.test.ts`** — Verify both modes and cache delegation

### Service Layer Refactoring
- **`src/lib/services/receipt-service.ts`**:
  - Replaced manual login/logout with `withAdeSession()` call
  - Extracted `runSubmitSale()` helper (runs inside session, handles AdE response + DB persistence)
  - Simplified error handling (logout/invalidation now in cache)
  
- **`src/lib/services/void-service.ts`**:
  - Replaced manual login/logout with `withAdeSession()` call
  - Async callback wraps `getDocument()` + `submitVoid()` +

https://claude.ai/code/session_012r237FYEkFovgqG3a7uHgs