### PR TITLE
Bump version to 1.3.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.3.11",
+      "version": "1.3.12",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Routine version bump to 1.3.12 in preparation for release.

## Changes
- Updated `package.json` version from `1.3.11` to `1.3.12`
- Lockfile updated with transitive dependency resolution

## Notes
No functional code changes. This is a version increment only.

https://claude.ai/code/session_01XhSQGyH8yVEUvapAzNCeJP