### PR TITLE
Type-safe AdeResponse persistence in commercial documents

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -124,34 +124,6 @@ nessuna traccia di accesso.
 
 ---
 
-### 9. Doppio cast `as unknown as Record<string, unknown>` su `adeResponse` (type safety bypassata su dominio fiscale)
-
-- **Categoria:** bad practice/type safety · **Severità:** Medium
-- **File:** `src/lib/services/receipt-service.ts:587,608` · `src/lib/services/void-service.ts:297,320` · `src/db/schema/commercial-documents.ts:53`
-
-**Problema.** La risposta AdE viene persistita nel JSONB con un doppio cast che
-azzera il type-checking: se la shape della response AdE cambia (o un refactor passa
-l'oggetto sbagliato), il compilatore non se ne accorge e il dato salvato diverge
-silenziosamente da ciò che i consumer futuri si aspettano.
-
-**Fix (non ambiguo).**
-
-1. In `src/db/schema/commercial-documents.ts`, tipizzare la colonna:
-   `adeResponse: jsonb("ade_response").$type<AdeSubmitResponse>()` — dove
-   `AdeSubmitResponse` è il tipo (o union dei tipi) già usato come return di
-   `submitSale`/`submitVoid` nei client AdE (`src/lib/ade/*-client.ts`; individuarlo
-   con `grep -n "esito" src/lib/ade/types.ts` o file equivalente). Se sale e void
-   hanno tipi diversi, usare la union.
-2. Rimuovere i 4 cast: l'assegnazione diventa `adeResponse: adeResponse` e il
-   compilatore la verifica.
-3. Verificare i punti di **lettura** della colonna (`grep -rn "adeResponse" src --include="*.ts" -l`):
-   con `$type` il select è tipato — eventuali consumer che la trattavano come
-   `Record<string, unknown>` vanno adeguati.
-4. Nessun cambiamento runtime: basta `npm run type-check` + test esistenti verdi.
-   Niente migration (il tipo Drizzle `$type` è solo compile-time).
-
----
-
 ### 10. Catalogo: refetch completo dopo ogni mutazione, senza optimistic update
 
 - **Categoria:** UX/performance percepita · **Severità:** Medium

--- a/src/db/schema/commercial-documents.test.ts
+++ b/src/db/schema/commercial-documents.test.ts
@@ -1,10 +1,13 @@
 import { getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
+import type { AdeResponse } from "@/lib/ade/types";
+
 import {
   commercialDocuments,
   documentKindEnum,
   documentStatusEnum,
+  type SelectCommercialDocument,
 } from "./commercial-documents";
 
 describe("commercial_documents schema", () => {
@@ -25,6 +28,14 @@ describe("commercial_documents schema", () => {
     expect(cols).toContain("status");
     expect(cols).toContain("createdAt");
     expect(cols).toContain("updatedAt");
+  });
+
+  it("expone adeResponse tipato come AdeResponse, non unknown", () => {
+    const value = {} as SelectCommercialDocument["adeResponse"];
+    // Se la colonna regredisse a jsonb non tipizzato (unknown), questa
+    // assegnazione fallirebbe `npm run type-check`.
+    const typed: AdeResponse | null = value;
+    expect(typed).toBeDefined();
   });
 
   it("document kind enum has correct values", () => {

--- a/src/db/schema/commercial-documents.ts
+++ b/src/db/schema/commercial-documents.ts
@@ -11,6 +11,8 @@ import {
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
+import type { AdeResponse } from "@/lib/ade/types";
+
 import { businesses } from "./businesses";
 import { apiKeys } from "./api-keys";
 
@@ -50,7 +52,7 @@ export const commercialDocuments = pgTable(
      */
     requestHash: text("request_hash"),
     /** Risposta raw dell'AdE */
-    adeResponse: jsonb("ade_response"),
+    adeResponse: jsonb("ade_response").$type<AdeResponse>(),
     /** idtrx AdE — identificativo transazione */
     adeTransactionId: text("ade_transaction_id"),
     /** progressivo AdE — numero documento */

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -655,7 +655,7 @@ async function runSubmitSale(
         .update(commercialDocuments)
         .set({
           status: "REJECTED",
-          adeResponse: adeResponse as unknown as Record<string, unknown>,
+          adeResponse,
         })
         .where(eq(commercialDocuments.id, documentId)),
     );
@@ -676,7 +676,7 @@ async function runSubmitSale(
         status: "ACCEPTED",
         adeTransactionId: adeResponse.idtrx ?? null,
         adeProgressive: adeResponse.progressivo ?? null,
-        adeResponse: adeResponse as unknown as Record<string, unknown>,
+        adeResponse,
       })
       .where(eq(commercialDocuments.id, documentId)),
   );

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -294,7 +294,7 @@ async function processVoidAdeResponse(args: {
         .update(commercialDocuments)
         .set({
           status: "REJECTED",
-          adeResponse: adeResponse as unknown as Record<string, unknown>,
+          adeResponse,
         })
         .where(eq(commercialDocuments.id, voidDocumentId)),
     );
@@ -317,7 +317,7 @@ async function processVoidAdeResponse(args: {
             status: "VOID_ACCEPTED",
             adeTransactionId: adeResponse.idtrx ?? null,
             adeProgressive: adeResponse.progressivo ?? null,
-            adeResponse: adeResponse as unknown as Record<string, unknown>,
+            adeResponse,
           })
           .where(eq(commercialDocuments.id, voidDocumentId));
 


### PR DESCRIPTION
## Summary

Resolves issue #9 from `REVIEW.md` by adding compile-time type safety to the `adeResponse` JSONB column in the `commercial_documents` table. Removes unsafe double-cast patterns that bypassed TypeScript checking on AdE response data.

## Changes

- **Schema typing:** Added `$type<AdeResponse>()` to the `adeResponse` column definition in `src/db/schema/commercial-documents.ts`, ensuring the column is typed as `AdeResponse | null` at compile time rather than `unknown`.

- **Import AdeResponse type:** Imported `AdeResponse` from `@/lib/ade/types` in both the schema and test files to establish the canonical type for AdE responses.

- **Removed unsafe casts:** Eliminated four instances of `as unknown as Record<string, unknown>` in:
  - `src/lib/services/receipt-service.ts` (lines 658, 679)
  - `src/lib/services/void-service.ts` (lines 297, 320)
  
  Assignments now use direct `adeResponse` without casting, allowing TypeScript to verify type correctness.

- **Added regression test:** New test in `src/db/schema/commercial-documents.test.ts` that verifies `adeResponse` is typed as `AdeResponse | null` and will fail `npm run type-check` if the column regresses to untyped `jsonb`.

## Implementation Details

- **No runtime changes:** The Drizzle `$type` modifier is compile-time only; no database migration required.
- **Type verification:** All existing tests pass; `npm run type-check` confirms type safety.
- **Consumer compatibility:** The select query is now properly typed, so any code reading `adeResponse` from the database receives `AdeResponse | null` instead of `unknown`, enabling proper type narrowing downstream.

Closes #9 in `REVIEW.md`.

https://claude.ai/code/session_01PGMSeGFtDw1C3FWyAP9jRh