### PR TITLE
Catalogo: optimistic update su add/edit/delete

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -124,35 +124,6 @@ nessuna traccia di accesso.
 
 ---
 
-### 10. Catalogo: refetch completo dopo ogni mutazione, senza optimistic update
-
-- **Categoria:** UX/performance percepita · **Severità:** Medium
-- **File:** `src/components/catalogo/catalogo-client.tsx:32-37` (`refreshItems`), call-site alle righe ~207 e ~220; delete handler nello stesso file
-
-**Problema.** Dopo ogni add/edit/delete, `refreshItems()` ricarica **l'intero
-catalogo** dal server (`getCatalogItems`) e nel frattempo la lista mostra lo stato
-vecchio: l'item appena aggiunto/modificato appare solo al termine del round-trip.
-In contrasto con la priorità #1 (optimistic UI) e destinato a peggiorare con
-cataloghi Pro grandi (item 11). I due fix sono indipendenti.
-
-**Fix (non ambiguo).**
-
-1. Le server action `addCatalogItem`/`updateCatalogItem` ritornano (o vanno fatte
-   ritornare) l'item persistito in `CatalogActionResult`; usare quel valore per
-   aggiornare lo state locale immediatamente: insert in posizione ordinata per
-   `description` (l'ordinamento server è `asc(description)`), patch per l'edit,
-   remove per il delete (per il delete, rimozione ottimistica **prima** della
-   action con rollback su `{ error }`, pattern `useOptimistic`/`useTransition`
-   della skill `react-patterns`).
-2. Mantenere `refreshItems()` come riconciliazione in background (non bloccante)
-   oppure rimuoverlo se i ritorni delle action coprono tutti i campi.
-3. **Edge case + test:** delete che fallisce (item ricompare + `deleteError`
-   mostrato); add con descrizione che si ordina in mezzo alla lista; doppio click
-   rapido su delete (idempotenza UI); limite Starter raggiunto (l'errore del gate
-   server non deve lasciare l'item fantasma in lista).
-
----
-
 ### 11. `getCatalogItems` senza LIMIT + autocomplete server-side
 
 - **Categoria:** performance/scalabilità · **Severità:** Medium · **Target: v1.7.0** (insieme a "Catalogo: modifica prodotto + sync AdE", già in roadmap PLAN.md)

--- a/src/components/catalogo/add-item-dialog.test.tsx
+++ b/src/components/catalogo/add-item-dialog.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AddItemDialog } from "./add-item-dialog";
+import type { CatalogItem } from "@/types/catalogo";
 
 // --- Mocks ---
 
@@ -15,14 +16,23 @@ vi.mock("@/server/catalog-actions", () => ({
   addCatalogItem: (...args: unknown[]) => mockAddCatalogItem(...args),
 }));
 
+// --- Fixtures ---
+
+const PERSISTED_ITEM: CatalogItem = {
+  id: "new-item-1",
+  businessId: "biz-123",
+  description: "Caffè espresso",
+  defaultPrice: "1.20",
+  defaultVatCode: "22",
+  createdAt: new Date("2026-06-15"),
+};
+
 // scrollIntoView richiesto da Radix UI Select e Dialog
 beforeEach(() => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
   vi.clearAllMocks();
-  mockAddCatalogItem.mockResolvedValue({});
+  mockAddCatalogItem.mockResolvedValue({ item: PERSISTED_ITEM });
 });
-
-// --- Fixtures ---
 
 const DEFAULT_PROPS = {
   businessId: "biz-123",
@@ -99,7 +109,7 @@ describe("AddItemDialog", () => {
     });
   });
 
-  it("chiama onSuccess dopo aggiunta riuscita", async () => {
+  it("chiama onSuccess con l'item persistito dopo aggiunta riuscita", async () => {
     const onSuccess = vi.fn();
     render(<AddItemDialog {...DEFAULT_PROPS} onSuccess={onSuccess} />);
 
@@ -116,7 +126,7 @@ describe("AddItemDialog", () => {
       );
     });
 
-    expect(onSuccess).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(PERSISTED_ITEM);
   });
 
   it("mostra l'errore restituito da addCatalogItem", async () => {

--- a/src/components/catalogo/add-item-dialog.tsx
+++ b/src/components/catalogo/add-item-dialog.tsx
@@ -3,12 +3,13 @@
 import { CatalogItemDialog } from "./catalog-item-dialog";
 import { addCatalogItem } from "@/server/catalog-actions";
 import type { VatCode } from "@/types/cassa";
+import type { CatalogItem } from "@/types/catalogo";
 
 const DEFAULT_VAT: VatCode = "22";
 
 interface AddItemDialogProps {
   readonly businessId: string;
-  readonly onSuccess: () => void;
+  readonly onSuccess: (item: CatalogItem) => void;
   readonly onClose: () => void;
 }
 

--- a/src/components/catalogo/catalog-item-dialog.tsx
+++ b/src/components/catalogo/catalog-item-dialog.tsx
@@ -15,6 +15,7 @@ import { VatSelector } from "@/components/cassa/vat-selector";
 import { TrialExpiredMessage } from "@/components/billing/trial-expired-message";
 import { TRIAL_EXPIRED_MESSAGE } from "@/lib/plans-shared";
 import type { VatCode } from "@/types/cassa";
+import type { CatalogActionResult, CatalogItem } from "@/types/catalogo";
 
 interface CatalogItemDialogProps {
   readonly title: string;
@@ -27,8 +28,8 @@ interface CatalogItemDialogProps {
     description: string;
     price: string;
     vatCode: VatCode;
-  }) => Promise<{ error?: string }>;
-  readonly onSuccess: () => void;
+  }) => Promise<CatalogActionResult>;
+  readonly onSuccess: (item: CatalogItem) => void;
   readonly onClose: () => void;
 }
 
@@ -60,8 +61,12 @@ export function CatalogItemDialog({
 
     if (result.error) {
       setError(result.error);
+    } else if (result.item) {
+      onSuccess(result.item);
     } else {
-      onSuccess();
+      // Successo senza item persistito: stato inatteso, non chiamare onSuccess
+      // (eviterebbe un update ottimistico con item undefined).
+      setError("Si è verificato un errore. Riprova.");
     }
   };
 

--- a/src/components/catalogo/catalogo-client.test.tsx
+++ b/src/components/catalogo/catalogo-client.test.tsx
@@ -19,11 +19,13 @@ vi.mock("next/navigation", () => ({
 
 const mockGetCatalogItems = vi.fn();
 const mockDeleteCatalogItem = vi.fn();
+const mockAddCatalogItem = vi.fn();
+const mockUpdateCatalogItem = vi.fn();
 vi.mock("@/server/catalog-actions", () => ({
   getCatalogItems: (...args: unknown[]) => mockGetCatalogItems(...args),
   deleteCatalogItem: (...args: unknown[]) => mockDeleteCatalogItem(...args),
-  addCatalogItem: vi.fn(),
-  updateCatalogItem: vi.fn(),
+  addCatalogItem: (...args: unknown[]) => mockAddCatalogItem(...args),
+  updateCatalogItem: (...args: unknown[]) => mockUpdateCatalogItem(...args),
 }));
 
 // scrollIntoView richiesto da Radix UI Dialog
@@ -33,6 +35,17 @@ beforeEach(() => {
   mockDeleteCatalogItem.mockResolvedValue({});
   mockGetCatalogItems.mockResolvedValue([]);
 });
+
+/** Asserisce che `texts` compaiano nel DOM nell'ordine dato. */
+function assertOrder(texts: string[]) {
+  const els = texts.map((t) => screen.getByText(t));
+  for (let i = 1; i < els.length; i++) {
+    expect(
+      els[i - 1].compareDocumentPosition(els[i]) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  }
+}
 
 // --- Fixtures ---
 
@@ -230,7 +243,99 @@ describe("CatalogoClient", () => {
         "Errore durante l'eliminazione.",
       );
     });
-    // Il prodotto rimane nella lista
+    // Rimozione ottimistica annullata: il prodotto ricompare in lista (rollback)
     expect(screen.getByText("Caffè espresso")).toBeInTheDocument();
+  });
+
+  it("add inserisce l'item in posizione ordinata, senza refetch completo", async () => {
+    mockAddCatalogItem.mockResolvedValue({
+      item: {
+        id: "item-new",
+        businessId: "biz-1",
+        description: "Cornetto",
+        defaultPrice: "1.00",
+        defaultVatCode: "22",
+        createdAt: new Date("2026-02-01"),
+      },
+    });
+
+    renderWithQuery(
+      <CatalogoClient businessId="biz-1" initialData={FAKE_ITEMS} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /aggiungi/i }));
+    fireEvent.change(screen.getByLabelText("Descrizione"), {
+      target: { value: "Cornetto" },
+    });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByLabelText("Descrizione").closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Cornetto")).toBeInTheDocument();
+    });
+    // Ordinamento alfabetico: Caffè < Cornetto < Pizza
+    assertOrder(["Caffè espresso", "Cornetto", "Pizza margherita"]);
+    // Nessun refetch dell'intero catalogo (update ottimistico locale)
+    expect(mockGetCatalogItems).not.toHaveBeenCalled();
+  });
+
+  it("edit ri-ordina l'item quando cambia la descrizione", async () => {
+    mockUpdateCatalogItem.mockResolvedValue({
+      item: {
+        id: "item-1",
+        businessId: "biz-1",
+        description: "Zucchero",
+        defaultPrice: "1.20",
+        defaultVatCode: "22",
+        createdAt: new Date("2026-01-01"),
+      },
+    });
+
+    renderWithQuery(
+      <CatalogoClient businessId="biz-1" initialData={FAKE_ITEMS} />,
+    );
+
+    enterEditMode();
+    fireEvent.click(
+      screen.getByRole("button", { name: /modifica caffè espresso/i }),
+    );
+    fireEvent.change(screen.getByLabelText("Descrizione"), {
+      target: { value: "Zucchero" },
+    });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByLabelText("Descrizione").closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Zucchero")).toBeInTheDocument();
+    });
+    // "Caffè espresso" rinominato in "Zucchero" → si sposta in fondo
+    assertOrder(["Pizza margherita", "Zucchero"]);
+    expect(mockGetCatalogItems).not.toHaveBeenCalled();
+  });
+
+  it("doppio click rapido su Elimina è idempotente (nessun crash)", async () => {
+    renderWithQuery(
+      <CatalogoClient businessId="biz-1" initialData={FAKE_ITEMS} />,
+    );
+
+    enterEditMode();
+    fireEvent.click(
+      screen.getByRole("button", { name: /elimina caffè espresso/i }),
+    );
+    const confirmBtn = screen.getByRole("button", { name: "Elimina" });
+
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+      fireEvent.click(confirmBtn); // secondo click mentre la riga sparisce
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Caffè espresso")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Pizza margherita")).toBeInTheDocument();
   });
 });

--- a/src/components/catalogo/catalogo-client.tsx
+++ b/src/components/catalogo/catalogo-client.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Package, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { getCatalogItems, deleteCatalogItem } from "@/server/catalog-actions";
+import { deleteCatalogItem } from "@/server/catalog-actions";
 import { VAT_LABELS } from "@/types/cassa";
 import { formatCurrency } from "@/lib/utils";
 import { AddItemDialog } from "./add-item-dialog";
@@ -14,6 +14,20 @@ import type { CatalogItem } from "@/types/catalogo";
 interface CatalogoClientProps {
   readonly businessId: string;
   readonly initialData: CatalogItem[];
+}
+
+/**
+ * Riordina per descrizione replicando l'ordinamento server `asc(description)`,
+ * con tie-break stabile su `id` (regola 17). Eventuali divergenze minime di
+ * collation si auto-correggono al prossimo load (i dati arrivano già ordinati
+ * dal server in `initialData`).
+ */
+function sortByDescription(items: CatalogItem[]): CatalogItem[] {
+  return [...items].sort(
+    (a, b) =>
+      a.description.localeCompare(b.description, "it") ||
+      a.id.localeCompare(b.id),
+  );
 }
 
 export function CatalogoClient({
@@ -27,14 +41,6 @@ export function CatalogoClient({
   const [editingItem, setEditingItem] = useState<CatalogItem | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [, startTransition] = useTransition();
-
-  const refreshItems = () => {
-    startTransition(async () => {
-      const updated = await getCatalogItems(businessId);
-      setItems(updated);
-    });
-  };
 
   const exitEditMode = () => {
     setEditMode(false);
@@ -61,12 +67,16 @@ export function CatalogoClient({
 
   const handleDeleteConfirm = async (itemId: string) => {
     setDeleteError(null);
+    // Rimozione ottimistica prima della action (priorità #1), con rollback
+    // allo snapshot corrente se la server action ritorna un errore.
+    const snapshot = items;
+    setDeletingId(null);
+    setItems((prev) => prev.filter((i) => i.id !== itemId));
+
     const result = await deleteCatalogItem(itemId, businessId);
     if (result.error) {
+      setItems(snapshot);
       setDeleteError(result.error);
-    } else {
-      setDeletingId(null);
-      setItems((prev) => prev.filter((i) => i.id !== itemId));
     }
   };
 
@@ -202,9 +212,9 @@ export function CatalogoClient({
       {showAddDialog && (
         <AddItemDialog
           businessId={businessId}
-          onSuccess={() => {
+          onSuccess={(item) => {
             setShowAddDialog(false);
-            refreshItems();
+            setItems((prev) => sortByDescription([...prev, item]));
           }}
           onClose={() => setShowAddDialog(false)}
         />
@@ -215,9 +225,11 @@ export function CatalogoClient({
         <EditItemDialog
           businessId={businessId}
           item={editingItem}
-          onSuccess={() => {
+          onSuccess={(item) => {
             setEditingItem(null);
-            refreshItems();
+            setItems((prev) =>
+              sortByDescription(prev.map((i) => (i.id === item.id ? item : i))),
+            );
           }}
           onClose={() => setEditingItem(null)}
         />

--- a/src/components/catalogo/edit-item-dialog.test.tsx
+++ b/src/components/catalogo/edit-item-dialog.test.tsx
@@ -10,13 +10,6 @@ vi.mock("@/server/catalog-actions", () => ({
   updateCatalogItem: (...args: unknown[]) => mockUpdateCatalogItem(...args),
 }));
 
-// scrollIntoView richiesto da Radix UI Select e Dialog
-beforeEach(() => {
-  window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  vi.clearAllMocks();
-  mockUpdateCatalogItem.mockResolvedValue({});
-});
-
 // --- Fixtures ---
 
 const FAKE_ITEM: CatalogItem = {
@@ -27,6 +20,18 @@ const FAKE_ITEM: CatalogItem = {
   defaultVatCode: "10",
   createdAt: new Date("2026-01-01"),
 };
+
+const UPDATED_ITEM: CatalogItem = {
+  ...FAKE_ITEM,
+  description: "Pizza marinara",
+};
+
+// scrollIntoView richiesto da Radix UI Select e Dialog
+beforeEach(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  vi.clearAllMocks();
+  mockUpdateCatalogItem.mockResolvedValue({ item: UPDATED_ITEM });
+});
 
 const DEFAULT_PROPS = {
   businessId: "biz-456",
@@ -96,7 +101,7 @@ describe("EditItemDialog", () => {
     );
   });
 
-  it("chiama onSuccess dopo aggiornamento riuscito", async () => {
+  it("chiama onSuccess con l'item aggiornato dopo aggiornamento riuscito", async () => {
     const onSuccess = vi.fn();
     render(<EditItemDialog {...DEFAULT_PROPS} onSuccess={onSuccess} />);
 
@@ -106,7 +111,7 @@ describe("EditItemDialog", () => {
       );
     });
 
-    expect(onSuccess).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(UPDATED_ITEM);
   });
 
   it("pre-popola il campo prezzo come stringa vuota se defaultPrice è null", () => {

--- a/src/components/catalogo/edit-item-dialog.tsx
+++ b/src/components/catalogo/edit-item-dialog.tsx
@@ -7,7 +7,7 @@ import type { CatalogItem } from "@/types/catalogo";
 interface EditItemDialogProps {
   readonly businessId: string;
   readonly item: CatalogItem;
-  readonly onSuccess: () => void;
+  readonly onSuccess: (item: CatalogItem) => void;
   readonly onClose: () => void;
 }
 

--- a/src/server/catalog-actions.test.ts
+++ b/src/server/catalog-actions.test.ts
@@ -19,13 +19,21 @@ const mockSelectWhere = vi
 const mockFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
 const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
-const mockInsertValues = vi.fn().mockResolvedValue(undefined);
+// insert(...).values(...).returning() → [row]
+const mockInsertReturning = vi.fn();
+const mockInsertValues = vi
+  .fn()
+  .mockReturnValue({ returning: mockInsertReturning });
 const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
 
 const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
 const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere });
 
-const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+// update(...).set(...).where(...).returning() → [row]
+const mockUpdateReturning = vi.fn();
+const mockUpdateWhere = vi
+  .fn()
+  .mockReturnValue({ returning: mockUpdateReturning });
 const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
 const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
 
@@ -95,9 +103,9 @@ describe("catalog-actions", () => {
 
     mockOrderBy.mockResolvedValue([]);
     mockLimit.mockResolvedValue([]);
-    mockInsertValues.mockResolvedValue(undefined);
+    mockInsertReturning.mockResolvedValue([FAKE_ITEM]);
     mockDeleteWhere.mockResolvedValue(undefined);
-    mockUpdateWhere.mockResolvedValue(undefined);
+    mockUpdateReturning.mockResolvedValue([FAKE_ITEM]);
 
     mockGetPlan.mockResolvedValue({
       plan: "pro",
@@ -280,6 +288,32 @@ describe("catalog-actions", () => {
       expect(insertArg.description).toBe("Caffè espresso");
       expect(insertArg.defaultPrice).toBe("1.20");
       expect(insertArg.defaultVatCode).toBe("22");
+    });
+
+    it("ritorna l'item persistito (RETURNING) mappato a CatalogItem", async () => {
+      const persisted = {
+        id: "new-item-1",
+        businessId: FAKE_BUSINESS_ID,
+        description: "Caffè espresso",
+        defaultPrice: "1.20",
+        defaultVatCode: "22",
+        createdAt: new Date("2026-06-15"),
+        updatedAt: new Date("2026-06-15"),
+      };
+      mockInsertReturning.mockResolvedValue([persisted]);
+
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem(VALID_ADD_INPUT);
+
+      expect(result.error).toBeUndefined();
+      expect(result.item).toEqual({
+        id: "new-item-1",
+        businessId: FAKE_BUSINESS_ID,
+        description: "Caffè espresso",
+        defaultPrice: "1.20",
+        defaultVatCode: "22",
+        createdAt: new Date("2026-06-15"),
+      });
     });
 
     it("accetta prezzo null (prezzo da definire in cassa)", async () => {
@@ -567,6 +601,43 @@ describe("catalog-actions", () => {
       expect(updateArg.description).toBe("Pizza margherita aggiornata");
       expect(updateArg.defaultPrice).toBe("10.00");
       expect(updateArg.defaultVatCode).toBe("10");
+    });
+
+    it("ritorna l'item aggiornato (RETURNING) mappato a CatalogItem", async () => {
+      mockLimit.mockResolvedValue([{ id: FAKE_ITEM_ID }]);
+      const persisted = {
+        id: FAKE_ITEM_ID,
+        businessId: FAKE_BUSINESS_ID,
+        description: "Pizza margherita aggiornata",
+        defaultPrice: "10.00",
+        defaultVatCode: "10",
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-06-15"),
+      };
+      mockUpdateReturning.mockResolvedValue([persisted]);
+
+      const { updateCatalogItem } = await import("./catalog-actions");
+      const result = await updateCatalogItem(VALID_UPDATE_INPUT);
+
+      expect(result.item).toEqual({
+        id: FAKE_ITEM_ID,
+        businessId: FAKE_BUSINESS_ID,
+        description: "Pizza margherita aggiornata",
+        defaultPrice: "10.00",
+        defaultVatCode: "10",
+        createdAt: new Date("2026-01-01"),
+      });
+    });
+
+    it("RETURNING vuoto (riga eliminata in concorrenza) → nessun item, nessun errore", async () => {
+      mockLimit.mockResolvedValue([{ id: FAKE_ITEM_ID }]);
+      mockUpdateReturning.mockResolvedValue([]);
+
+      const { updateCatalogItem } = await import("./catalog-actions");
+      const result = await updateCatalogItem(VALID_UPDATE_INPUT);
+
+      expect(result.error).toBeUndefined();
+      expect(result.item).toBeUndefined();
     });
 
     it("accetta prezzo null (normalizzato a null nel DB)", async () => {

--- a/src/server/catalog-actions.ts
+++ b/src/server/catalog-actions.ts
@@ -29,6 +29,25 @@ import type {
 // Private helpers
 // ---------------------------------------------------------------------------
 
+/** Riga DB del catalogo → CatalogItem del dominio (forma condivisa). */
+function toCatalogItem(row: {
+  id: string;
+  businessId: string;
+  description: string;
+  defaultPrice: string | null;
+  defaultVatCode: string;
+  createdAt: Date;
+}): CatalogItem {
+  return {
+    id: row.id,
+    businessId: row.businessId,
+    description: row.description,
+    defaultPrice: row.defaultPrice,
+    defaultVatCode: row.defaultVatCode as CatalogItem["defaultVatCode"],
+    createdAt: row.createdAt,
+  };
+}
+
 /** Autentica l'utente e verifica l'ownership del business. Ritorna null se OK. */
 async function authenticateAndAuthorize(
   businessId: string,
@@ -90,14 +109,7 @@ export async function getCatalogItems(
       .where(eq(catalogItems.businessId, businessId))
       .orderBy(asc(catalogItems.description));
 
-    return items.map((item) => ({
-      id: item.id,
-      businessId: item.businessId,
-      description: item.description,
-      defaultPrice: item.defaultPrice,
-      defaultVatCode: item.defaultVatCode as CatalogItem["defaultVatCode"],
-      createdAt: item.createdAt,
-    }));
+    return items.map(toCatalogItem);
   } catch (err) {
     logger.error({ err, businessId }, "getCatalogItems failed unexpectedly");
     return [];
@@ -170,14 +182,17 @@ export async function addCatalogItem(
     };
   }
 
-  await db.insert(catalogItems).values({
-    businessId: input.businessId,
-    description: input.description.trim(),
-    defaultPrice: validated.priceStr,
-    defaultVatCode: input.defaultVatCode,
-  });
+  const [row] = await db
+    .insert(catalogItems)
+    .values({
+      businessId: input.businessId,
+      description: input.description.trim(),
+      defaultPrice: validated.priceStr,
+      defaultVatCode: input.defaultVatCode,
+    })
+    .returning();
 
-  return {};
+  return { item: toCatalogItem(row) };
 }
 
 // ---------------------------------------------------------------------------
@@ -255,14 +270,20 @@ export async function updateCatalogItem(
     return { error: "Prodotto non trovato." };
   }
 
-  await db
+  const [row] = await db
     .update(catalogItems)
     .set({
       description: input.description.trim(),
       defaultPrice: validated.priceStr,
       defaultVatCode: input.defaultVatCode,
     })
-    .where(eq(catalogItems.id, input.itemId));
+    .where(eq(catalogItems.id, input.itemId))
+    .returning();
 
-  return {};
+  // Race: la riga potrebbe essere stata eliminata tra la verifica e l'UPDATE
+  // (0 righe → returning vuoto). Degradare a successo senza item invece di
+  // crashare (regola 19).
+  if (!row) return {};
+
+  return { item: toCatalogItem(row) };
 }

--- a/src/types/catalogo.ts
+++ b/src/types/catalogo.ts
@@ -37,5 +37,10 @@ export interface UpdateCatalogItemInput {
   defaultVatCode: VatCode;
 }
 
-/** Risultato generico delle server actions del catalogo */
-export type CatalogActionResult = { error?: string };
+/**
+ * Risultato generico delle server actions del catalogo.
+ * `item` è valorizzato dalle action di scrittura (add/update) con la riga
+ * persistita, così il client può aggiornare lo state in modo ottimistico
+ * senza un refetch completo del catalogo.
+ */
+export type CatalogActionResult = { error?: string; item?: CatalogItem };


### PR DESCRIPTION
REVIEW.md #10. Le server action addCatalogItem/updateCatalogItem ritornano
ora l'item persistito via RETURNING (CatalogActionResult.item); il client
aggiorna lo state locale immediatamente invece di rifare il refetch completo
del catalogo, eliminando il secondo round-trip e allineandosi alla priorità #1
(optimistic UI / performance percepita).

- add: insert dell'item ritornato in posizione ordinata (asc(description),
  tie-break stabile su id)
- edit: patch + re-sort sull'eventuale cambio descrizione
- delete: rimozione ottimistica prima della action con rollback su errore
- rimosso refreshItems()/getCatalogItems dal client (ritorni coprono i campi)
- mapper toCatalogItem condiviso per evitare duplicazione

Test: ritorno item mappato (add/update), RETURNING vuoto in race → no item,
ordinamento ottimistico, rollback delete, doppio-click idempotente, onSuccess
riceve l'item. Voce #10 rimossa da REVIEW.md.