### PR TITLE
fix(ade): diagnostic logging on empty wizardTemplate P.IVA (SCONTRINOZERO-M)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -619,9 +619,35 @@ funzionale (l'enforcement è server-side).
    oltre la grazia + `subscriptionStatus: "active"` → stato read-only, non
    `subscribed`.
 
----
+### 32. SCONTRINOZERO-M — `wizardTemplate` ritorna `200` con lista `PIva` vuota su login Fisconline
 
-## Rischi accettati (allowlist)
+- **Categoria:** correttezza/osservabilità · **Severità:** Low — 1 evento in produzione, root cause non confermata
+- **File:** `src/lib/ade/real-client.ts` (`fetchWizardPiva`, Phase F del login Fisconline)
+
+**Problema.** `fetchWizardPiva` lancia `AdePortalError(200, "Failed to extract
+P.IVA from wizardTemplate response")` quando `data?.PIva?.[0]?.piva` è falsy su
+una response `200` valida. Status `200` ⇒ né `isTransientAdeError` né
+`isExpectedUserAdeError` ⇒ classificato `ade_failure` ⇒ Sentry (corretto: errore
+inatteso). Osservato **~5 minuti dopo** che l'utente aveva cambiato una password
+Fisconline scaduta (timeline pino: `ade:auth_failed` → `ade:password_expired`
+×2 → "Password Fisconline aggiornata con successo" → fallimento emit-receipt).
+**Ipotesi principale:** stato transient lato AdE post-cambio-password (sessione/
+entitlement non ancora propagati), **non** un cambio di shape globale (colpirebbe
+tutti i login) né un account permanentemente senza P.IVA (l'utente aveva
+onboardato correttamente via lo stesso Phase F). SPID non è attivo: il path è
+sicuramente Fisconline.
+
+**Stato.** Aggiunta diagnostica struttura-only (no PII) prima del throw —
+`logger.warn(..., "ade:wizard_piva_missing")` con `contentType` / `topLevelKeys`
+/ `pIvaIsArray` / `pIvaLength` / `firstEntryKeys` (solo nomi dei campi, mai i
+valori `piva`/`denominazione`). Stessa diagnostica sul gemello SPID
+`fetchPartitaIvaFromFiscali` (`ade:fiscali_piva_missing`).
+
+**Fix (rimandato, serve evidenza — regole 13/14).** Alla prossima occorrenza,
+leggere `ade:wizard_piva_missing` nel dataset Sentry `logs` per confermare la
+shape. Se conferma lista vuota su `200` (transient post-password-change): trattare
+`PIva` vuota come transient (retry singolo di Phase F e/o downgrade a
+`ade_transient` warn, fuori da Sentry). Non implementare prima della conferma.
 
 ### audit-ci: advisory `esbuild` dev-only (3 GHSA)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11959,9 +11959,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "overrides": {
     "typescript-eslint": "^8.58.1",
-    "hono": "^4.12.16",
+    "hono": "^4.12.25",
     "@hono/node-server": "^1.19.13",
     "undici": "^7.24.1",
     "path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -92,6 +92,21 @@ function mockLoginSequence(fetchMock: ReturnType<typeof vi.fn>): void {
 }
 
 /**
+ * Queue Phases A–E + D (everything before Phase F wizardTemplate), so a test
+ * can supply its own Phase F response to exercise fetchWizardPiva edge cases.
+ */
+function mockPhasesBeforeWizard(fetchMock: ReturnType<typeof vi.fn>): void {
+  fetchMock.mockResolvedValueOnce(mockResponse({ status: 200 })); // A
+  fetchMock.mockResolvedValueOnce(mockResponse({})); // B
+  fetchMock.mockResolvedValueOnce(mockResponse({ status: 501 })); // B2
+  fetchMock.mockResolvedValueOnce(mockResponse({})); // C
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({ headers: [["x-appl", "tok"]] }),
+  ); // E
+  fetchMock.mockResolvedValueOnce(mockResponse({})); // D
+}
+
+/**
  * Queue 7 mock responses for re-auth on 401 (Phases A-E + G, skip F).
  *
  * Phase F (wizardTemplate) è skippata perché la P.IVA è già nota.
@@ -148,7 +163,16 @@ const mockSpidCredentials: SpidCredentials = {
 //   - IdP uses SAML2 HTTP POST Binding (SimpleSAMLphp, tested with Sielte)
 //   - 2FA via push notification: poll NotifyPage until body changes
 // ---------------------------------------------------------------------------
-function mockSpidLoginSequence(fetchMock: ReturnType<typeof vi.fn>): void {
+function mockSpidLoginSequence(
+  fetchMock: ReturnType<typeof vi.fn>,
+  fiscaliBody: object = {
+    identificativiFiscali: {
+      partitaIva: "12345678901",
+      codiceFiscale: "RSSMRA80A01H501A",
+      codicePaese: "IT",
+    },
+  },
+): void {
   // S1: GET ADE_BASE_URL/dp/SPID/sielte/s4 — AdE SP returns SAML request form
   fetchMock.mockResolvedValueOnce(
     mockResponse({
@@ -259,17 +283,7 @@ function mockSpidLoginSequence(fetchMock: ReturnType<typeof vi.fn>): void {
   fetchMock.mockResolvedValueOnce(mockResponse({ status: 404 }));
 
   // S15b: GET dati/fiscali — P.IVA fallback for SPID
-  fetchMock.mockResolvedValueOnce(
-    mockResponse({
-      body: {
-        identificativiFiscali: {
-          partitaIva: "12345678901",
-          codiceFiscale: "RSSMRA80A01H501A",
-          codicePaese: "IT",
-        },
-      },
-    }),
-  );
+  fetchMock.mockResolvedValueOnce(mockResponse({ body: fiscaliBody }));
 }
 
 function makeSalePayload(): AdePayload {
@@ -587,6 +601,82 @@ describe("RealAdeClient", () => {
       );
     });
 
+    it("Phase F: logga ade:wizard_piva_missing con la struttura (no PII) su PIva vuota", async () => {
+      // SCONTRINOZERO-M: il throw arrivava su un 200 senza alcun contesto sulla
+      // response. Logghiamo la struttura (chiavi), mai i valori PII.
+      vi.mocked(logger.warn).mockClear();
+      mockPhasesBeforeWizard(fetchMock);
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          body: { PIva: [], altroCampo: "x" },
+          headers: [["content-type", "application/json"]],
+        }),
+      ); // F
+
+      await expect(client.login(mockCredentials)).rejects.toThrow(
+        AdePortalError,
+      );
+
+      const call = vi
+        .mocked(logger.warn)
+        .mock.calls.find((c) => c[1] === "ade:wizard_piva_missing");
+      expect(call).toBeDefined();
+      const ctx = call![0] as Record<string, unknown>;
+      expect(ctx).toMatchObject({
+        contentType: "application/json",
+        pIvaIsArray: true,
+        pIvaLength: 0,
+        firstEntryKeys: null,
+      });
+      expect(ctx.topLevelKeys).toEqual(
+        expect.arrayContaining(["PIva", "altroCampo"]),
+      );
+    });
+
+    it("Phase F: logga firstEntryKeys senza valore PII quando l'entry non ha piva", async () => {
+      vi.mocked(logger.warn).mockClear();
+      mockPhasesBeforeWizard(fetchMock);
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ body: { PIva: [{ denominazione: "ACME SRL" }] } }),
+      ); // F: entry presente ma senza piva
+
+      await expect(client.login(mockCredentials)).rejects.toThrow(
+        AdePortalError,
+      );
+
+      const call = vi
+        .mocked(logger.warn)
+        .mock.calls.find((c) => c[1] === "ade:wizard_piva_missing");
+      expect(call).toBeDefined();
+      const ctx = call![0] as Record<string, unknown>;
+      expect(ctx.pIvaLength).toBe(1);
+      expect(ctx.firstEntryKeys).toEqual(["denominazione"]);
+      // Nessun valore PII (denominazione) deve finire nel log.
+      expect(JSON.stringify(ctx)).not.toContain("ACME SRL");
+    });
+
+    it("Phase F: logga pIvaIsArray=false quando PIva manca del tutto", async () => {
+      vi.mocked(logger.warn).mockClear();
+      mockPhasesBeforeWizard(fetchMock);
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ body: { messaggio: "shape inattesa" } }),
+      ); // F: nessun PIva
+
+      await expect(client.login(mockCredentials)).rejects.toThrow(
+        AdePortalError,
+      );
+
+      const call = vi
+        .mocked(logger.warn)
+        .mock.calls.find((c) => c[1] === "ade:wizard_piva_missing");
+      expect(call).toBeDefined();
+      const ctx = call![0] as Record<string, unknown>;
+      expect(ctx.pIvaIsArray).toBe(false);
+      expect(ctx.pIvaLength).toBeNull();
+      expect(ctx.firstEntryKeys).toBeNull();
+      expect(ctx.topLevelKeys).toEqual(["messaggio"]);
+    });
+
     it("Phase G: POST setUserChoice con x-appl header e body corretto", async () => {
       mockLoginSequence(fetchMock);
 
@@ -874,6 +964,26 @@ describe("RealAdeClient", () => {
       expect(fiscaliCall[0]).toContain("dati/fiscali");
 
       expect(session.partitaIva).toBe("12345678901");
+    });
+
+    it("S15b: logga ade:fiscali_piva_missing (no PII) quando dati/fiscali è senza partitaIva", async () => {
+      vi.mocked(logger.warn).mockClear();
+      mockSpidLoginSequence(fetchMock, {
+        identificativiFiscali: { codiceFiscale: "RSSMRA80A01H501A" },
+      });
+
+      await expect(client.loginSpid(mockSpidCredentials)).rejects.toThrow(
+        AdePortalError,
+      );
+
+      const call = vi
+        .mocked(logger.warn)
+        .mock.calls.find((c) => c[1] === "ade:fiscali_piva_missing");
+      expect(call).toBeDefined();
+      const ctx = call![0] as Record<string, unknown>;
+      expect(ctx.topLevelKeys).toEqual(["identificativiFiscali"]);
+      expect(ctx.identificativiFiscaliKeys).toEqual(["codiceFiscale"]);
+      expect(JSON.stringify(ctx)).not.toContain("RSSMRA80A01H501A");
     });
 
     it("throws AdeSpidTimeoutError when push notification not approved within maxPolls", async () => {

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -133,7 +133,7 @@ function safeHost(url: string): string {
  */
 function objectKeysOrNull(value: unknown): string[] | null {
   return typeof value === "object" && value !== null
-    ? Object.keys(value as Record<string, unknown>)
+    ? Object.keys(value)
     : null;
 }
 

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -124,6 +124,20 @@ function safeHost(url: string): string {
 }
 
 /**
+ * Ritorna le chiavi di un oggetto, o `null` se il valore non è un oggetto
+ * (null, primitivo, undefined). Usato per loggare la **struttura** (non i
+ * valori) delle response AdE quando l'estrazione P.IVA fallisce: i payload
+ * wizardTemplate/gestori/fiscali contengono `piva` + `denominazione` (PII),
+ * quindi logghiamo solo i nomi dei campi, mai i valori (regola 22, denylist
+ * SAFE_KEYS del logger).
+ */
+function objectKeysOrNull(value: unknown): string[] | null {
+  return typeof value === "object" && value !== null
+    ? Object.keys(value as Record<string, unknown>)
+    : null;
+}
+
+/**
  * Headers required for POST document submission (api-spec.md sez. 2.4).
  *
  * Solo header effettivamente usati dal browser nelle catture HAR (vendita.har):
@@ -397,6 +411,19 @@ export class RealAdeClient implements AdeClient {
     const piva = data?.PIva?.[0]?.piva;
 
     if (!piva) {
+      // Diagnostica struttura-only (no PII): distingue "lista PIva vuota" da
+      // "entry presente senza piva" da "shape cambiata". SCONTRINOZERO-M ha
+      // visto questo throw su un 200 senza alcun contesto sulla response.
+      logger.warn(
+        {
+          contentType: response.headers.get("content-type") ?? null,
+          topLevelKeys: objectKeysOrNull(data),
+          pIvaIsArray: Array.isArray(data?.PIva),
+          pIvaLength: Array.isArray(data?.PIva) ? data.PIva.length : null,
+          firstEntryKeys: objectKeysOrNull(data?.PIva?.[0]),
+        },
+        "ade:wizard_piva_missing",
+      );
       throw new AdePortalError(
         200,
         "Failed to extract P.IVA from wizardTemplate response",
@@ -578,6 +605,16 @@ export class RealAdeClient implements AdeClient {
     const piva = data?.identificativiFiscali?.partitaIva;
 
     if (!piva) {
+      logger.warn(
+        {
+          contentType: response.headers.get("content-type") ?? null,
+          topLevelKeys: objectKeysOrNull(data),
+          identificativiFiscaliKeys: objectKeysOrNull(
+            data?.identificativiFiscali,
+          ),
+        },
+        "ade:fiscali_piva_missing",
+      );
       throw new AdePortalError(
         200,
         "Failed to extract Partita IVA from dati/fiscali response",


### PR DESCRIPTION
fetchWizardPiva throws AdePortalError(200) when the AdE wizardTemplate
response is a valid 200 JSON but PIva[0].piva is empty/missing. Status 200
means it is classified ade_failure and escalates to Sentry, but the method
logged nothing about the response, so the root cause was opaque
(SCONTRINOZERO-M, observed ~5 min after a Fisconline password change).

Add structure-only diagnostic logging before the throw (contentType,
topLevelKeys, pIvaIsArray, pIvaLength, firstEntryKeys) — field names only,
never the piva/denominazione values (PII; regola 22). Mirror the same on
the SPID sibling fetchPartitaIvaFromFiscali. No behavior change, no retry:
per regole 13/14 we gather evidence before deciding on a transient retry.

Tests cover the empty list, entry-without-piva, and missing-PIva branches
and assert no PII value reaches the log. REVIEW.md #32 tracks the pending
root-cause confirmation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETHYovF8bsFQWCx83bkB7N