### PR TITLE
Bump version to 1.3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Patch version bump to 1.3.13 in preparation for a new release.

## Changes
- Updated `package.json` version from 1.3.12 to 1.3.13
- Lockfile updated with transitive dependency resolution

## Notes
This is a routine version bump. The actual feature/fix changes should be documented in the git tag `v1.3.13` and release notes.

https://claude.ai/code/session_01X57q6CyvSWdjp1SAfp2Lfq