### PR TITLE
feat(trial): blocca re-trial con stessa P.IVA via ledger persistente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,14 @@ ENCRYPTION_KEY=your-64-char-hex-key-here
 ENCRYPTION_KEY_VERSION=1
 
 # =============================================================================
+# Anti-frode trial: pepper per l'HMAC-SHA256 della P.IVA nel registro
+# `trial_vat_ledger` (impedisce un secondo trial cancellando l'account e
+# ri-registrandosi con la stessa P.IVA). Server-side, runtime (NON NEXT_PUBLIC,
+# NON build-arg). Obbligatorio in produzione (fail-fast al primo hash se vuoto).
+# Generate with: openssl rand -hex 32
+PIVA_HASH_SECRET=your-piva-hash-secret-here
+
+# =============================================================================
 # Logging
 # =============================================================================
 LOG_LEVEL=debug

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -62,6 +62,10 @@ NEW_SIGNUP_NOTIFICATION_EMAIL=
 ENCRYPTION_KEY=your-64-char-hex-key-here
 ENCRYPTION_KEY_VERSION=1
 
+# Anti-frode trial: pepper HMAC della P.IVA (registro trial_vat_ledger).
+# Server-side runtime. Generate with: openssl rand -hex 32
+PIVA_HASH_SECRET=your-piva-hash-secret-here
+
 # ---- Logging ----------------------------------------------------------------
 LOG_LEVEL=debug
 

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -47,6 +47,11 @@ Analogo all'emissione: `src/server/void-actions.ts` →
 2. Verifica credenziali Fisconline contro AdE; le credenziali sono cifrate
    AES-256-GCM con `src/lib/crypto.ts` e salvate in `src/db/schema/ade-credentials.ts`.
 3. Logging con `flow: "onboarding-verify"` in `src/lib/ade/log-failure.ts`.
+4. Anti-frode trial: al primo claim della P.IVA si registra il suo HMAC
+   (`src/lib/piva-hash.ts`) in `src/db/schema/trial-vat-ledger.ts` (registro che
+   sopravvive alla cancellazione dell'account). Se la P.IVA è già presente →
+   `trialStartedAt = null` → sola lettura immediata via i gate esistenti in
+   `src/lib/plans-shared.ts`.
 
 ## Recovery stale-pending AdE
 

--- a/src/app/onboarding/onboarding-form.tsx
+++ b/src/app/onboarding/onboarding-form.tsx
@@ -33,6 +33,7 @@ import {
   verifyAdeCredentials,
 } from "@/server/onboarding-actions";
 import { VAT_CODES, VAT_DESCRIPTIONS } from "@/types/cassa";
+import { BILLING_SETTINGS_HREF } from "@/lib/plans-shared";
 
 const STEPS = ["Dati attivita", "Credenziali AdE", "Verifica"];
 
@@ -108,6 +109,7 @@ export function OnboardingForm({
   );
   const [verifyError, setVerifyError] = useState<string | null>(null);
   const [verifyPivaConflict, setVerifyPivaConflict] = useState(false);
+  const [trialAlreadyUsed, setTrialAlreadyUsed] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const step1Form = useForm<Step1Data>({
@@ -161,6 +163,7 @@ export function OnboardingForm({
   function handleVerify() {
     setVerifyError(null);
     setVerifyPivaConflict(false);
+    setTrialAlreadyUsed(false);
     if (!businessId) return;
     const id = businessId;
     startTransition(async () => {
@@ -168,6 +171,13 @@ export function OnboardingForm({
       if (result.error) {
         setVerifyError(result.error);
         setVerifyPivaConflict(!!result.pivaConflict);
+        return;
+      }
+      if (result.trialAlreadyUsed) {
+        // Onboarding completato ma trial già consumato per questa P.IVA:
+        // niente redirect automatico, mostriamo il motivo e l'invito ad
+        // attivare un piano prima di entrare (già in sola lettura).
+        setTrialAlreadyUsed(true);
         return;
       }
       router.push("/dashboard");
@@ -394,27 +404,52 @@ export function OnboardingForm({
                 </div>
               )}
 
-              <div className="flex flex-col gap-2">
-                <Button onClick={handleVerify} disabled={isPending}>
-                  {isPending ? "Verifica in corso…" : "Verifica connessione"}
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={handleSkipVerify}
-                  disabled={isPending}
-                >
-                  Salta per ora
-                </Button>
-              </div>
+              {trialAlreadyUsed ? (
+                <div className="space-y-3">
+                  <p className="text-sm" role="alert">
+                    Hai già utilizzato il periodo di prova con questa P.IVA.
+                    L&apos;account è attivo in sola lettura: attiva un piano per
+                    tornare a emettere scontrini.
+                  </p>
+                  <div className="flex flex-col gap-2">
+                    <Button onClick={() => router.push(BILLING_SETTINGS_HREF)}>
+                      Attiva un piano
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={() => router.push("/dashboard")}
+                    >
+                      Vai al pannello
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="flex flex-col gap-2">
+                    <Button onClick={handleVerify} disabled={isPending}>
+                      {isPending
+                        ? "Verifica in corso…"
+                        : "Verifica connessione"}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={handleSkipVerify}
+                      disabled={isPending}
+                    >
+                      Salta per ora
+                    </Button>
+                  </div>
 
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setStep(1)}
-                className="mt-2"
-              >
-                Modifica credenziali
-              </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setStep(1)}
+                    className="mt-2"
+                  >
+                    Modifica credenziali
+                  </Button>
+                </>
+              )}
             </div>
           )}
         </CardContent>

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -7,4 +7,5 @@ export * from "./catalog-items";
 export * from "./subscriptions";
 export * from "./api-keys";
 export * from "./stripe-webhook-events";
+export * from "./trial-vat-ledger";
 export * from "./relations";

--- a/src/db/schema/trial-vat-ledger.ts
+++ b/src/db/schema/trial-vat-ledger.ts
@@ -1,0 +1,23 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * Registro delle P.IVA che hanno già consumato un trial. Anti-abuso
+ * cross-cancellazione: `profiles.partita_iva` è UNIQUE ma `deleteAccount`
+ * elimina la riga e libera il vincolo, permettendo un secondo trial con email
+ * diversa e stessa P.IVA. Questa tabella **sopravvive alla cancellazione**
+ * (nessuna FK a `profiles`) e non viene mai svuotata in automatico.
+ *
+ * `pivaHash` è un HMAC-SHA256 con secret server-side (`PIVA_HASH_SECRET`, vedi
+ * `src/lib/piva-hash.ts`): nessuna P.IVA in chiaro persiste oltre la
+ * cancellazione dell'account (pseudonimizzazione GDPR-friendly).
+ */
+export const trialVatLedger = pgTable("trial_vat_ledger", {
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  pivaHash: text("piva_hash").notNull().unique(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});

--- a/src/lib/piva-hash.test.ts
+++ b/src/lib/piva-hash.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hashPiva } from "./piva-hash";
+
+const SECRET = "test-piva-hash-secret-0123456789abcdef";
+
+describe("hashPiva", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("è deterministico: stessa P.IVA + stesso secret → stesso hash", () => {
+    vi.stubEnv("PIVA_HASH_SECRET", SECRET);
+    expect(hashPiva("12345678901")).toBe(hashPiva("12345678901"));
+  });
+
+  it("produce un digest esadecimale SHA-256 (64 caratteri hex)", () => {
+    vi.stubEnv("PIVA_HASH_SECRET", SECRET);
+    expect(hashPiva("12345678901")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("P.IVA diverse producono hash diversi", () => {
+    vi.stubEnv("PIVA_HASH_SECRET", SECRET);
+    expect(hashPiva("12345678901")).not.toBe(hashPiva("10987654321"));
+  });
+
+  it("normalizza spazi interni e di contorno (stesso hash)", () => {
+    vi.stubEnv("PIVA_HASH_SECRET", SECRET);
+    expect(hashPiva("  123 456 78901 ")).toBe(hashPiva("12345678901"));
+  });
+
+  it("normalizza il case (uppercase) per P.IVA con lettere", () => {
+    vi.stubEnv("PIVA_HASH_SECRET", SECRET);
+    expect(hashPiva("it12345678901")).toBe(hashPiva("IT12345678901"));
+  });
+
+  it("il secret influenza l'output: secret diverso → hash diverso", () => {
+    vi.stubEnv("PIVA_HASH_SECRET", SECRET);
+    const a = hashPiva("12345678901");
+    vi.stubEnv("PIVA_HASH_SECRET", "un-secret-completamente-diverso");
+    const b = hashPiva("12345678901");
+    expect(a).not.toBe(b);
+  });
+
+  it("in produzione lancia se il secret è assente", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PIVA_HASH_SECRET", "");
+    expect(() => hashPiva("12345678901")).toThrow(/PIVA_HASH_SECRET/);
+  });
+
+  it("in produzione lancia se il secret è solo whitespace (present-but-empty)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PIVA_HASH_SECRET", "   ");
+    expect(() => hashPiva("12345678901")).toThrow(/PIVA_HASH_SECRET/);
+  });
+
+  it("fuori produzione usa un fallback e non lancia se il secret è assente", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("PIVA_HASH_SECRET", "");
+    expect(hashPiva("12345678901")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/lib/piva-hash.ts
+++ b/src/lib/piva-hash.ts
@@ -1,0 +1,62 @@
+import { createHmac } from "node:crypto";
+import { logger } from "@/lib/logger";
+
+/**
+ * Fallback usato SOLO fuori produzione quando `PIVA_HASH_SECRET` non è
+ * impostato, così il dev loop e i test non richiedono il secret reale. In
+ * produzione la sua assenza è fail-fast (vedi `getPivaHashSecret`).
+ */
+const DEV_FALLBACK_SECRET = "dev-only-piva-hash-secret-not-for-production";
+
+let warnedMissingSecret = false;
+
+/**
+ * Carica il secret per l'HMAC della P.IVA dal env `PIVA_HASH_SECRET`.
+ *
+ * - In produzione: fail-fast se assente o vuoto/whitespace (regola 18,
+ *   `?? default` non scatta su `""`). Un ledger anti-frode con secret vuoto
+ *   sarebbe forzabile (P.IVA = 11 cifre, ~37 bit).
+ * - Fuori produzione: `logger.warn` (una volta) e fallback deterministico, per
+ *   non bloccare dev/test.
+ */
+function getPivaHashSecret(): string {
+  const raw = process.env.PIVA_HASH_SECRET;
+  if (raw && raw.trim() !== "") return raw;
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "PIVA_HASH_SECRET must be set (non-empty) in production — anti-fraud trial ledger",
+    );
+  }
+
+  if (!warnedMissingSecret) {
+    warnedMissingSecret = true;
+    logger.warn(
+      { errorClass: "piva_hash_secret_missing" },
+      "PIVA_HASH_SECRET non impostato: uso il fallback dev (NON valido in produzione)",
+    );
+  }
+  return DEV_FALLBACK_SECRET;
+}
+
+/**
+ * Normalizza una P.IVA prima dell'hashing: rimuove tutto ciò che non è
+ * alfanumerico (spazi, punti, trattini) e porta in uppercase. La P.IVA AdE è
+ * già pulita (11 cifre), ma normalizzare evita che varianti tipografiche dello
+ * stesso numero producano hash diversi → falle nel ledger anti-frode.
+ */
+function normalizePiva(piva: string): string {
+  return piva.replace(/[^a-zA-Z0-9]/g, "").toUpperCase();
+}
+
+/**
+ * HMAC-SHA256 (hex) della P.IVA normalizzata, con pepper server-side. Token a
+ * senso unico, non reversibile né enumerabile senza `PIVA_HASH_SECRET`: usato
+ * come chiave del registro anti-frode `trial_vat_ledger`, che sopravvive alla
+ * cancellazione dell'account senza conservare la P.IVA in chiaro.
+ */
+export function hashPiva(piva: string): string {
+  return createHmac("sha256", getPivaHashSecret())
+    .update(normalizePiva(piva))
+    .digest("hex");
+}

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -38,9 +38,20 @@ const mockFrom = vi.fn().mockReturnValue({
 const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 const mockReturning = vi.fn();
 const mockOnConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+// trial_vat_ledger anti-frode: insert ... onConflictDoNothing().returning().
+// Default [{ id }] = riga inserita (prima volta → trial concesso). Override con
+// mockLedgerReturning.mockResolvedValueOnce([]) per simulare conflict (P.IVA già
+// nel ledger → trial negato).
+const mockLedgerReturning = vi
+  .fn()
+  .mockResolvedValue([{ id: "ledger-row-id" }]);
+const mockOnConflictDoNothing = vi
+  .fn()
+  .mockReturnValue({ returning: mockLedgerReturning });
 const mockInsertValues = vi.fn().mockReturnValue({
   returning: mockReturning,
   onConflictDoUpdate: mockOnConflictDoUpdate,
+  onConflictDoNothing: mockOnConflictDoNothing,
 });
 const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
 // The returning mock defaults to 1 row (success). Override per-test with
@@ -66,6 +77,7 @@ vi.mock("@/db/schema", () => ({
   profiles: "profiles-table",
   businesses: "businesses-table",
   adeCredentials: "ade-credentials-table",
+  trialVatLedger: "trial-vat-ledger-table",
 }));
 
 const mockEncrypt = vi.fn().mockReturnValue("encrypted-data");
@@ -135,6 +147,9 @@ describe("onboarding-actions", () => {
     mockLimit.mockReset();
     mockReturning.mockReset();
     mockOnConflictDoUpdate.mockReset().mockResolvedValue(undefined);
+    mockLedgerReturning
+      .mockReset()
+      .mockResolvedValue([{ id: "ledger-row-id" }]);
     mockGetUser.mockResolvedValue({ data: { user: FAKE_USER } });
     mockRevalidatePath.mockReset();
     process.env.ENCRYPTION_KEY = "a".repeat(64);
@@ -1248,6 +1263,131 @@ describe("onboarding-actions", () => {
       // dell'intera transazione, verifiedAt incluso.
       expect(mockUpdate).toHaveBeenCalledTimes(3);
       expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("concede il trial e registra la P.IVA nel ledger alla prima verifica", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+          verifiedAt: null,
+        },
+      ]);
+      // businessSnapshot default [{ fiscalCode: null }] → vatNumber undefined →
+      // primo claim della P.IVA.
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+      // Default mockLedgerReturning [{ id }] = riga inserita (P.IVA mai vista).
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      expect(result.error).toBeUndefined();
+      expect(result.businessId).toBe("biz-789");
+      expect(result.trialAlreadyUsed).toBeUndefined();
+      // Inserisce nel ledger con ON CONFLICT DO NOTHING e un HMAC esadecimale.
+      expect(mockOnConflictDoNothing).toHaveBeenCalled();
+      expect(mockInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pivaHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        }),
+      );
+      // Solo 3 update: verifiedAt + businesses + profiles.partitaIva. Nessun
+      // azzeramento di trialStartedAt (trial concesso).
+      expect(mockUpdate).toHaveBeenCalledTimes(3);
+      expect(mockUpdateSet).not.toHaveBeenCalledWith({ trialStartedAt: null });
+    });
+
+    it("nega il trial e mette in sola lettura se la P.IVA ha già consumato un trial (ledger conflict)", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+          verifiedAt: null,
+        },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+      // Conflict: la P.IVA è già nel ledger da un account precedente (cancellato).
+      mockLedgerReturning.mockResolvedValueOnce([]);
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      expect(result.error).toBeUndefined();
+      expect(result.businessId).toBe("biz-789");
+      expect(result.trialAlreadyUsed).toBe(true);
+      // 4 update: verifiedAt + businesses + profiles.partitaIva +
+      // profiles.trialStartedAt=null (sola lettura immediata).
+      expect(mockUpdate).toHaveBeenCalledTimes(4);
+      expect(mockUpdateSet).toHaveBeenCalledWith({ trialStartedAt: null });
+      const { logger } = await import("@/lib/logger");
+      expect(logger.warn).toHaveBeenCalledWith(
+        { businessId: "biz-789" },
+        expect.stringContaining("Trial già usato"),
+      );
+    });
+
+    it("non azzera il trial e non tocca il ledger se lo stesso account ri-verifica la propria P.IVA", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+          verifiedAt: new Date("2026-01-01"),
+        },
+      ]);
+      // businessSnapshot: già onboardato con la STESSA P.IVA → wasFirstClaim false.
+      mockLimit.mockResolvedValueOnce([
+        { fiscalCode: "RSSMRA80A01H501U", vatNumber: "12345678901" },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      expect(result.error).toBeUndefined();
+      expect(result.trialAlreadyUsed).toBeUndefined();
+      // Nessun insert nel ledger e nessun azzeramento di trialStartedAt.
+      expect(mockOnConflictDoNothing).not.toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledTimes(3);
+      expect(mockUpdateSet).not.toHaveBeenCalledWith({ trialStartedAt: null });
     });
 
     // P1.1 (code review): se le credenziali vengono sostituite mentre AdE

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -4,7 +4,13 @@ import { cache, createElement } from "react";
 import { revalidatePath } from "next/cache";
 import { and, eq, sql } from "drizzle-orm";
 import { getDb } from "@/db";
-import { businesses, adeCredentials, profiles } from "@/db/schema";
+import {
+  businesses,
+  adeCredentials,
+  profiles,
+  trialVatLedger,
+} from "@/db/schema";
+import { hashPiva } from "@/lib/piva-hash";
 import {
   encrypt,
   decrypt,
@@ -64,6 +70,15 @@ export type OnboardingActionResult = {
    * P.IVA, distinguendolo dal generico "credenziali errate".
    */
   pivaMismatch?: boolean;
+  /**
+   * La P.IVA ha già consumato un trial in passato (registrata in
+   * `trial_vat_ledger`, sopravvissuta alla cancellazione del vecchio account):
+   * l'onboarding viene completato ma il trial è negato (`trialStartedAt` =
+   * null → sola lettura immediata). La UI usa questo flag per spiegare il
+   * motivo e spingere all'attivazione di un piano, distinguendolo dal generico
+   * "trial scaduto".
+   */
+  trialAlreadyUsed?: boolean;
 };
 
 const changePasswordLimiter = new RateLimiter({
@@ -507,6 +522,7 @@ export async function verifyAdeCredentials(
   // raw `sql` template Drizzle has no column-type context to bind a JS Date and
   // would crash `Buffer.byteLength(<Date>)` in postgres-js.
   let credentialsChanged = false;
+  let trialAlreadyUsed = false;
   try {
     await db.transaction(async (tx) => {
       const updated = await tx
@@ -536,14 +552,48 @@ export async function verifyAdeCredentials(
           .set({ vatNumber, fiscalCode })
           .where(eq(businesses.id, businessId));
 
+        // Primo claim di questa P.IVA da parte del business, vs re-verifica
+        // dello stesso account (stessa P.IVA già registrata). `businessSnapshot`
+        // (letto prima della transazione) è in sync con `profiles.partitaIva`,
+        // scritti insieme atomicamente; l'identity guard ha già bloccato un
+        // business onboardato che arriva con una P.IVA diversa. Distinguere è
+        // essenziale: senza, ri-verificare le proprie credenziali troverebbe la
+        // P.IVA nel ledger e azzererebbe il trial attivo.
+        const wasFirstClaim = businessSnapshot?.vatNumber !== vatNumber;
+
         // Anti-abuso trial: la P.IVA è UNIQUE su profiles per impedire trial
-        // multipli con email diverse ma stessa P.IVA. Il vincolo DB fa fallire
-        // l'INSERT/UPDATE e l'intera transazione esegue rollback (verifiedAt
-        // incluso), così nessun dato resta in stato parziale.
+        // multipli con email diverse ma stessa P.IVA (account ancora vivo). Il
+        // vincolo DB fa fallire l'UPDATE e l'intera transazione esegue rollback
+        // (verifiedAt incluso), così nessun dato resta in stato parziale.
         await tx
           .update(profiles)
           .set({ partitaIva: vatNumber })
           .where(eq(profiles.authUserId, user.id));
+
+        if (wasFirstClaim) {
+          // Anti-abuso trial cross-cancellazione: il vincolo UNIQUE su
+          // profiles.partita_iva sparisce quando l'account viene cancellato,
+          // liberando la P.IVA per un secondo trial. `trial_vat_ledger`
+          // sopravvive alla cancellazione e registra ogni P.IVA che ha già
+          // consumato un trial. ON CONFLICT DO NOTHING RETURNING è race-safe:
+          // se non torna righe la P.IVA era già nel ledger da un account
+          // PRECEDENTE → trial già consumato → niente nuovo trial.
+          const inserted = await tx
+            .insert(trialVatLedger)
+            .values({ pivaHash: hashPiva(vatNumber) })
+            .onConflictDoNothing()
+            .returning({ id: trialVatLedger.id });
+
+          if (inserted.length === 0) {
+            // trialStartedAt = null → isTrialExpired() true → sola lettura
+            // immediata, riusando i gate esistenti (canEmit/canAddCatalogItem).
+            await tx
+              .update(profiles)
+              .set({ trialStartedAt: null })
+              .where(eq(profiles.authUserId, user.id));
+            trialAlreadyUsed = true;
+          }
+        }
       }
     });
   } catch (err) {
@@ -591,9 +641,21 @@ export async function verifyAdeCredentials(
     );
   }
 
+  if (trialAlreadyUsed) {
+    // Input prevedibile (utente che ha già usato il trial con questa P.IVA),
+    // non un bug nostro: warn → osservabilità senza issue Sentry (regola 20).
+    logger.warn(
+      { businessId },
+      "Trial già usato per questa P.IVA — onboarding completato in sola lettura",
+    );
+  }
+
   revalidatePath("/dashboard", "layout");
 
-  return { businessId };
+  return {
+    businessId,
+    ...(trialAlreadyUsed ? { trialAlreadyUsed: true } : {}),
+  };
 }
 
 /**

--- a/supabase/migrations/0018_trial_vat_ledger.sql
+++ b/supabase/migrations/0018_trial_vat_ledger.sql
@@ -1,0 +1,32 @@
+-- Migration: 0018_trial_vat_ledger
+-- Anti-abuso trial cross-cancellazione. La P.IVA è UNIQUE su `profiles`
+-- (anti-abuso trial), ma `deleteAccount` elimina la riga `profiles` e quindi
+-- LIBERA quel vincolo: un utente poteva cancellare l'account a trial scaduto e
+-- ri-registrarsi con la stessa P.IVA (email nuova) per un secondo trial.
+--
+-- Questo registro tiene traccia delle P.IVA che hanno GIÀ consumato un trial e
+-- **sopravvive alla cancellazione dell'account** (nessuna FK a `profiles`, nessun
+-- cascade). Una P.IVA presente qui → niente nuovo trial (l'utente entra subito in
+-- sola lettura). Riga inserita la prima volta che le credenziali Fisconline
+-- verificano e restituiscono la P.IVA (vedi `verifyAdeCredentials`).
+--
+-- Privacy/GDPR: NON memorizziamo la P.IVA in chiaro (sarebbe un dato personale
+-- per le ditte individuali, conservato a tempo indeterminato oltre la
+-- cancellazione). Salviamo solo un HMAC-SHA256 con secret server-side
+-- (`PIVA_HASH_SECRET`): la P.IVA italiana è 11 cifre (~37 bit), un hash nudo
+-- sarebbe forzabile per brute-force — l'HMAC con pepper è irreversibile/non
+-- enumerabile senza il secret. Token a senso unico per sola anti-frode.
+--
+-- Idempotente: CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS "trial_vat_ledger" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "piva_hash" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "trial_vat_ledger_piva_hash_unique" UNIQUE ("piva_hash")
+);
+
+-- RLS: nessun accesso dal client. La tabella è manipolata solo server-side via
+-- service role (come le altre tabelle non esposte). Abilitiamo RLS senza alcuna
+-- policy → ogni richiesta con la anon/authenticated key viene negata di default.
+ALTER TABLE "trial_vat_ledger" ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1780099201000,
       "tag": "0017_add_request_hash_to_commercial_documents",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1780099202000,
+      "tag": "0018_trial_vat_ledger",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/server-onboarding-actions.test.ts
+++ b/tests/unit/server-onboarding-actions.test.ts
@@ -64,6 +64,7 @@ vi.mock("@/db/schema", () => ({
   adeCredentials: "ade-credentials-table",
   businesses: "businesses-table",
   profiles: "profiles-table",
+  trialVatLedger: "trial-vat-ledger-table",
 }));
 
 vi.mock("@/lib/crypto", () => ({
@@ -204,15 +205,31 @@ describe("verifyAdeCredentials", () => {
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
 
+    // Anti-frode trial: insert nel ledger (onConflictDoNothing().returning()).
+    // Default [{ id }] = riga inserita (prima volta → trial concesso, nessun
+    // azzeramento di trialStartedAt).
+    const mockLedgerInsert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "ledger-row-id" }]),
+        }),
+      }),
+    });
+
     // Transaction passthrough
     mockTransaction.mockImplementation(
       async (fn: (tx: unknown) => Promise<void>) =>
-        fn({ update: mockUpdate, select: mockSelect }),
+        fn({
+          update: mockUpdate,
+          select: mockSelect,
+          insert: mockLedgerInsert,
+        }),
     );
 
     mockGetDb.mockReturnValue({
       select: mockSelect,
       update: mockUpdate,
+      insert: mockLedgerInsert,
       transaction: mockTransaction,
     });
 


### PR DESCRIPTION
Un utente poteva ottenere trial multipli cancellando l'account a fine
prova e ri-registrandosi con la stessa P.IVA: deleteAccount elimina la
riga profiles e libera il vincolo UNIQUE su partita_iva.

Aggiunge trial_vat_ledger, un registro che sopravvive alla cancellazione
(nessuna FK a profiles) e tiene un HMAC-SHA256 della P.IVA (PIVA_HASH_SECRET
come pepper: la P.IVA è 11 cifre, un hash nudo sarebbe forzabile; nessun
dato personale in chiaro persiste oltre la cancellazione).

In verifyAdeCredentials, al primo claim della P.IVA si inserisce l'hash con
ON CONFLICT DO NOTHING RETURNING (race-safe): se la riga esisteva già da un
account precedente, il trial è negato impostando trialStartedAt = null →
sola lettura immediata riusando i gate esistenti (canEmit/canAddCatalogItem).
La re-verifica dello stesso account (P.IVA già registrata) è distinta via
businessSnapshot.vatNumber e non azzera il trial attivo.

La UI di onboarding mostra un messaggio dedicato (flag trialAlreadyUsed) con
invito ad attivare un piano. La policy "un trial per P.IVA" è già nei Termini
v01 (clausola anti-abuso), nessun bump necessario.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YEqNY3iYmR9koNK3ZHtVNv