### PR TITLE
feat(trial): backfill automatico del ledger P.IVA al primo avvio

### DIFF
--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -29,6 +29,16 @@ vi.mock("@/lib/identity-env", () => ({
   assertIdentityEnv: mockAssertIdentityEnv,
 }));
 
+const mockBackfill = vi.fn();
+vi.mock("@/lib/backfill-trial-vat-ledger", () => ({
+  backfillTrialVatLedgerIfEmpty: mockBackfill,
+}));
+
+const mockLoggerError = vi.fn();
+vi.mock("@/lib/logger", () => ({
+  logger: { error: mockLoggerError, warn: vi.fn(), info: vi.fn() },
+}));
+
 describe("instrumentation register()", () => {
   let originalNextRuntime: string | undefined;
   let originalDbUrl: string | undefined;
@@ -127,6 +137,36 @@ describe("instrumentation register()", () => {
     await register();
 
     expect(mockClientEnd).toHaveBeenCalled();
+  });
+
+  it("esegue il backfill del ledger anti-frode dopo migrate e prima di chiudere la connessione", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.DATABASE_URL = "postgres://test";
+    const { register } = await import("./instrumentation");
+
+    await register();
+
+    expect(mockBackfill).toHaveBeenCalledWith(mockDb);
+    const migrateOrder = mockMigrate.mock.invocationCallOrder[0]!;
+    const backfillOrder = mockBackfill.mock.invocationCallOrder[0]!;
+    const endOrder = mockClientEnd.mock.invocationCallOrder[0]!;
+    expect(migrateOrder).toBeLessThan(backfillOrder);
+    expect(backfillOrder).toBeLessThan(endOrder);
+  });
+
+  it("non blocca l'avvio se il backfill fallisce (degrada, regola 19)", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.DATABASE_URL = "postgres://test";
+    mockBackfill.mockRejectedValueOnce(new Error("backfill boom"));
+    const { register } = await import("./instrumentation");
+
+    await expect(register()).resolves.toBeUndefined();
+    // La connessione viene comunque chiusa e l'errore è loggato.
+    expect(mockClientEnd).toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ critical: true }),
+      expect.stringContaining("backfill trial_vat_ledger fallito"),
+    );
   });
 
   it("R24: chiama assertIdentityEnv come prima istruzione nel runtime nodejs", async () => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -37,6 +37,24 @@ export async function register() {
     const db = drizzle({ client });
 
     await migrate(db, { migrationsFolder: "./supabase/migrations" });
+
+    // Backfill una-tantum del registro anti-frode `trial_vat_ledger` dalle
+    // P.IVA già su `profiles` (account creati prima del ledger). Self-gated:
+    // no-op se il ledger non è vuoto, quindi gira a ogni boot senza effetti.
+    // Degradare, non crashare (regola 19): un errore qui non deve impedire
+    // l'avvio — gli onboarding futuri popolano comunque il ledger.
+    try {
+      const { backfillTrialVatLedgerIfEmpty } =
+        await import("@/lib/backfill-trial-vat-ledger");
+      await backfillTrialVatLedgerIfEmpty(db);
+    } catch (err) {
+      const { logger } = await import("@/lib/logger");
+      logger.error(
+        { err, critical: true },
+        "backfill trial_vat_ledger fallito al boot (ignorato, riprova al prossimo avvio)",
+      );
+    }
+
     await client.end();
   }
 

--- a/src/lib/backfill-trial-vat-ledger.test.ts
+++ b/src/lib/backfill-trial-vat-ledger.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { backfillTrialVatLedgerIfEmpty } from "./backfill-trial-vat-ledger";
+
+vi.mock("@/db/schema", () => ({
+  profiles: { partitaIva: "profiles.partita_iva" },
+  trialVatLedger: { id: "trial_vat_ledger.id" },
+}));
+
+vi.mock("@/lib/piva-hash", () => ({
+  hashPiva: (piva: string) => `hash-${piva}`,
+}));
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// drizzle-orm operators: identità sufficiente per i test (non eseguiamo SQL).
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  isNotNull: (col: unknown) => ({ isNotNull: col }),
+  ne: (col: unknown, val: unknown) => ({ ne: [col, val] }),
+}));
+
+type DbMock = ReturnType<typeof makeDb>;
+
+function makeDb(opts: {
+  ledgerRows: { id: string }[];
+  profileRows: { partitaIva: string | null }[];
+}) {
+  const ledgerLimit = vi.fn().mockResolvedValue(opts.ledgerRows);
+  const profilesWhere = vi.fn().mockResolvedValue(opts.profileRows);
+  const from = vi.fn().mockReturnValue({
+    limit: ledgerLimit,
+    where: profilesWhere,
+  });
+  const select = vi.fn().mockReturnValue({ from });
+
+  const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoNothing });
+  const insert = vi.fn().mockReturnValue({ values });
+
+  return {
+    select,
+    insert,
+    // exposed mocks for assertions
+    _ledgerLimit: ledgerLimit,
+    _profilesWhere: profilesWhere,
+    _values: values,
+    _onConflictDoNothing: onConflictDoNothing,
+  };
+}
+
+// Cast helper: la firma richiede un PostgresJsDatabase, ma nei test passiamo il
+// mock strutturale.
+function asDb(db: DbMock) {
+  return db as unknown as Parameters<typeof backfillTrialVatLedgerIfEmpty>[0];
+}
+
+describe("backfillTrialVatLedgerIfEmpty", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("no-op se il ledger ha già righe (non legge profiles, non inserisce)", async () => {
+    const db = makeDb({
+      ledgerRows: [{ id: "existing" }],
+      profileRows: [{ partitaIva: "12345678901" }],
+    });
+
+    const result = await backfillTrialVatLedgerIfEmpty(asDb(db));
+
+    expect(result).toEqual({ skipped: true, inserted: 0 });
+    expect(db._profilesWhere).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("inserisce gli hash delle P.IVA pregresse quando il ledger è vuoto", async () => {
+    const db = makeDb({
+      ledgerRows: [],
+      profileRows: [
+        { partitaIva: "12345678901" },
+        { partitaIva: "10987654321" },
+      ],
+    });
+
+    const result = await backfillTrialVatLedgerIfEmpty(asDb(db));
+
+    expect(result).toEqual({ skipped: false, inserted: 2 });
+    expect(db._values).toHaveBeenCalledWith([
+      { pivaHash: "hash-12345678901" },
+      { pivaHash: "hash-10987654321" },
+    ]);
+    expect(db._onConflictDoNothing).toHaveBeenCalled();
+  });
+
+  it("deduplica gli hash quando profiles contiene la stessa P.IVA più volte", async () => {
+    const db = makeDb({
+      ledgerRows: [],
+      profileRows: [
+        { partitaIva: "12345678901" },
+        { partitaIva: "12345678901" },
+      ],
+    });
+
+    const result = await backfillTrialVatLedgerIfEmpty(asDb(db));
+
+    expect(result.inserted).toBe(1);
+    expect(db._values).toHaveBeenCalledWith([{ pivaHash: "hash-12345678901" }]);
+  });
+
+  it("non inserisce nulla se non ci sono P.IVA pregresse", async () => {
+    const db = makeDb({ ledgerRows: [], profileRows: [] });
+
+    const result = await backfillTrialVatLedgerIfEmpty(asDb(db));
+
+    expect(result).toEqual({ skipped: false, inserted: 0 });
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining("nessuna P.IVA pregressa"),
+    );
+  });
+});

--- a/src/lib/backfill-trial-vat-ledger.ts
+++ b/src/lib/backfill-trial-vat-ledger.ts
@@ -1,0 +1,56 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { and, isNotNull, ne } from "drizzle-orm";
+import { profiles, trialVatLedger } from "@/db/schema";
+import { hashPiva } from "@/lib/piva-hash";
+import { logger } from "@/lib/logger";
+
+export type BackfillResult = { skipped: boolean; inserted: number };
+
+/**
+ * Backfill una-tantum del registro anti-frode `trial_vat_ledger` a partire
+ * dalle P.IVA già presenti su `profiles` (account creati prima dell'introduzione
+ * del ledger). Riusa `hashPiva` così l'HMAC è garantito identico a quello che
+ * genererà ogni onboarding futuro.
+ *
+ * **Self-gated e idempotente:** esegue il backfill SOLO se il ledger è vuoto
+ * (prima esecuzione dopo la migrazione `0018`). Può quindi girare a ogni boot
+ * senza effetti collaterali: appena il ledger ha almeno una riga è un no-op
+ * (un solo `SELECT ... LIMIT 1`). Gli onboarding successivi popolano il ledger
+ * in modo incrementale in `verifyAdeCredentials`.
+ */
+export async function backfillTrialVatLedgerIfEmpty(
+  db: PostgresJsDatabase,
+): Promise<BackfillResult> {
+  const existing = await db
+    .select({ id: trialVatLedger.id })
+    .from(trialVatLedger)
+    .limit(1);
+  if (existing.length > 0) {
+    return { skipped: true, inserted: 0 };
+  }
+
+  const rows = await db
+    .select({ partitaIva: profiles.partitaIva })
+    .from(profiles)
+    .where(and(isNotNull(profiles.partitaIva), ne(profiles.partitaIva, "")));
+
+  // Dedup sugli hash: P.IVA distinte normalizzano sempre a hash distinti, ma
+  // la dedup ci protegge anche da eventuali duplicati storici su profiles.
+  const pivas = rows
+    .map((r) => r.partitaIva)
+    .filter((v): v is string => v !== null && v !== "");
+  const hashes = [...new Set(pivas.map((piva) => hashPiva(piva)))];
+
+  if (hashes.length === 0) {
+    logger.info("backfill trial_vat_ledger: nessuna P.IVA pregressa");
+    return { skipped: false, inserted: 0 };
+  }
+
+  await db
+    .insert(trialVatLedger)
+    .values(hashes.map((pivaHash) => ({ pivaHash })))
+    .onConflictDoNothing();
+
+  logger.info({ count: hashes.length }, "backfill trial_vat_ledger completato");
+  return { skipped: false, inserted: hashes.length };
+}


### PR DESCRIPTION
Aggiunge backfillTrialVatLedgerIfEmpty: popola trial_vat_ledger dalle P.IVA già presenti su profiles (account creati prima del ledger), riusando hashPiva così l'HMAC è identico a quello degli onboarding futuri.

Self-gated e idempotente: esegue solo se il ledger è vuoto (un SELECT ... LIMIT 1), quindi può girare a ogni boot senza effetti. Invocato da instrumentation.ts subito dopo migrate() (la tabella esiste già) e in modo resiliente: un errore viene loggato ma non blocca l'avvio (regola 19), si ritenta al boot successivo.

Scelto il boot applicativo invece della migration SQL perché l'HMAC richiede PIVA_HASH_SECRET (per-ambiente, non committabile) e una migration dev'essere deterministica/env-agnostica.


Claude-Session: https://claude.ai/code/session_01YEqNY3iYmR9koNK3ZHtVNv