### PR TITLE
Fix REVIEW findings #15, #16, #31: observability, DST robustness, plan expiry

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -207,31 +207,6 @@ silenziosi: nessun segnale nei log per rilevare l'enumerazione in corso.
 
 ---
 
-### 16. `formatIsoInRome`: offset calcolato con trick "fake UTC", fragile sui bordi DST
-
-- **Categoria:** robustezza · **Severità:** Low
-- **File:** `src/lib/date-utils.ts:64-75`
-
-**Problema.** L'offset Europe/Rome è derivato ri-parsando il wall-clock come UTC
-(`new Date(isoWall + "Z") - date`). Funziona nei casi normali, ma è un antipattern:
-nell'ora di transizione DST (ultima domenica di marzo 02:00→03:00, ultima domenica
-di ottobre 03:00→02:00) il wall-clock è ambiguo o inesistente e il diff può
-produrre un offset sbagliato di un'ora sul timestamp fiscale esportato.
-
-**Fix (non ambiguo).**
-
-1. **Prima i test** (TDD): casi al bordo — `2026-03-29T00:59:59Z` (ancora +01:00),
-   `2026-03-29T01:00:00Z` (diventa +02:00), `2026-10-25T00:59:59Z` (+02:00),
-   `2026-10-25T01:00:00Z` (+01:00) — assert sull'offset nell'output.
-2. Se i test passano già, chiudere il finding aggiungendo solo i test come
-   regression guard (il trick resta documentato dal commento esistente).
-3. Se falliscono: ricavare l'offset con un secondo formatter
-   `new Intl.DateTimeFormat("en-US", { timeZone: "Europe/Rome", timeZoneName: "longOffset" })`
-   e parsing della parte `GMT+02:00` da `formatToParts()`, eliminando il re-parse
-   fake-UTC. Nessun nuovo package (vincolo "dipendenze minime").
-
----
-
 ### 17. Key rotation zero-downtime: i caller passano sempre una sola chiave
 
 - **Categoria:** sicurezza/operatività · **Severità:** Low (finché non serve ruotare)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -180,33 +180,6 @@ fatto che i payload sono statici, ma è un single point of failure.
 
 ## P3 — Bassa priorità
 
-### 15. Nessun log dei tentativi di accesso cross-tenant sull'API v1
-
-- **Categoria:** osservabilità/sicurezza · **Severità:** Low
-- **File:** `src/app/api/v1/receipts/[id]/void/route.ts` e gli altri endpoint v1 che accettano un UUID nel path (`grep -rn "params" src/app/api/v1 --include="route.ts" -l`); servizi: `src/lib/services/void-service.ts` (branch "documento non trovato")
-
-**Problema.** L'enforcement dell'ownership è corretto (il service filtra per
-`businessId` della API key e risponde 404 generico — niente IDOR, niente oracle).
-Ma un attaccante che enumera UUID altrui con la propria key produce solo 404
-silenziosi: nessun segnale nei log per rilevare l'enumerazione in corso.
-
-**Fix (non ambiguo).**
-
-1. Nel branch not-found dei servizi chiamati dagli endpoint v1 con UUID nel path,
-   distinguere "documento inesistente" da "documento esistente ma di altro
-   business" richiederebbe una query in più — **non** farla. Loggare invece un
-   `logger.warn` unico sul not-found: `{ documentId, businessId, apiKeyId, errorClass: "v1_document_not_found" }`.
-   Il rate di questi warn per `apiKeyId` è il segnale di enumerazione (query
-   canonica `errorClass:v1_document_not_found` in Sentry Logs, coerente con la
-   skill `sentry-hygiene`).
-2. `warn`, non `error`: condizione prevedibile dall'input (regola 20), non deve
-   aprire issue Sentry.
-3. La risposta HTTP resta invariata (404 generico).
-4. **Test:** void di UUID inesistente → 404 + warn con i 3 campi; void del proprio
-   documento → nessun warn.
-
----
-
 ### 17. Key rotation zero-downtime: i caller passano sempre una sola chiave
 
 - **Categoria:** sicurezza/operatività · **Severità:** Low (finché non serve ruotare)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -568,32 +568,6 @@ business_id, created_at`) poi disegnare l'euristica del salto.
 
 ---
 
-### 31. Card "Abbonamento" mostra "attivo" se il fallback `planExpiresAt` ha già degradato l'utente
-
-- **Categoria:** UX coerenza · **Severità:** Low
-- **File:** `src/app/dashboard/settings/page.tsx:105-114` (`cardState`); `src/server/billing-actions.ts` (`getProfilePlan`)
-
-**Problema.** I gate feature ora degradano a sola-lettura quando un piano a
-pagamento è scaduto oltre la grazia (`isPaidPlanExpired`, safety-net per webhook
-`customer.subscription.deleted` persi — vedi `plans-shared.ts`). Ma `cardState`
-in settings deriva ancora lo stato da `subscriptionStatus` (stantio nello stesso
-scenario di webhook perso): se la subscription row è rimasta `active` mostra
-"Pro attivo" mentre cassa/catalogo/API rispondono sola-lettura. Incoerenza solo
-visiva, nello scenario raro (renewal mancato **e** webhook perso); nessun impatto
-funzionale (l'enforcement è server-side).
-
-**Fix (non ambiguo).**
-
-1. `getProfilePlan` espone già/aggiunge `planExpiresAt` nel `ProfilePlanResult`.
-2. In `cardState`, prima del ramo `subscribed`, aggiungere:
-   `if (isPaidPlanExpired(planData.plan, planData.planExpiresAt)) return "trial-expired";`
-   (riusa lo stato read-only esistente; eventualmente introdurre un nuovo stato
-   `"expired"` con copy dedicato "Abbonamento scaduto — riattiva" se si vuole
-   distinguere dal trial).
-3. **Test:** `settings-page-card-state.test.ts` — piano `pro` con `planExpiresAt`
-   oltre la grazia + `subscriptionStatus: "active"` → stato read-only, non
-   `subscribed`.
-
 ### 32. SCONTRINOZERO-M — `wizardTemplate` ritorna `200` con lista `PIva` vuota su login Fisconline
 
 - **Categoria:** correttezza/osservabilità · **Severità:** Low — 1 evento in produzione, root cause non confermata

--- a/package-lock.json
+++ b/package-lock.json
@@ -17682,9 +17682,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typescript-eslint": "^8.58.1",
     "hono": "^4.12.25",
     "@hono/node-server": "^1.19.13",
-    "undici": "^7.24.1",
+    "undici": "^7.28.0",
     "path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",
     "vite": "^8.0.5",
     "yaml": ">=2.8.3",

--- a/src/app/api/v1/receipts/[id]/route.test.ts
+++ b/src/app/api/v1/receipts/[id]/route.test.ts
@@ -255,11 +255,20 @@ describe("GET /api/v1/receipts/[id]", () => {
     mockTxExecute.mockResolvedValue(undefined);
     setupDocMock(null);
 
-    const res = await GET(
-      makeRequest(),
-      makeParams("00000000-0000-0000-0000-000000000000"),
-    );
+    const missingId = "00000000-0000-0000-0000-000000000000";
+    const res = await GET(makeRequest(), makeParams(missingId));
     expect(res.status).toBe(404);
+
+    // REVIEW #15: un warn unico sul not-found dà visibilità sull'enumerazione
+    // cross-tenant. Risposta HTTP invariata (404 generico, niente oracle).
+    expect(mockLoggerWarn).toHaveBeenCalledOnce();
+    const [ctx] = mockLoggerWarn.mock.calls[0];
+    expect(ctx).toMatchObject({
+      documentId: missingId,
+      businessId: FAKE_AUTH.businessId,
+      apiKeyId: FAKE_AUTH.apiKey.id,
+      errorClass: "v1_document_not_found",
+    });
   });
 
   it("ritorna 503 con Retry-After su statement timeout DB (Postgres 57014)", async () => {

--- a/src/app/api/v1/receipts/[id]/route.ts
+++ b/src/app/api/v1/receipts/[id]/route.ts
@@ -84,6 +84,20 @@ export async function GET(
   }
 
   if (!result) {
+    // Not-found cross-tenant: la query filtra per businessId della API key e
+    // risponde 404 generico (no IDOR/oracle). Loggare un warn unico (REVIEW
+    // #15) dà visibilità sull'enumerazione di UUID altrui — il rate per
+    // apiKeyId è il segnale. warn, non error (input prevedibile, regola 20):
+    // niente issue Sentry, query canonica `errorClass:v1_document_not_found`.
+    logger.warn(
+      {
+        documentId: id,
+        businessId: auth.businessId,
+        apiKeyId: auth.apiKey.id,
+        errorClass: "v1_document_not_found",
+      },
+      "v1 document not found",
+    );
     return withCors(
       Response.json({ error: "Documento non trovato." }, { status: 404 }),
     );

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -15,7 +15,12 @@ import { EditProfileSection } from "@/components/settings/edit-profile-section";
 import { EditBusinessSection } from "@/components/settings/edit-business-section";
 import { ChangePasswordSection } from "@/components/settings/change-password-section";
 import { getProfilePlan } from "@/server/billing-actions";
-import { canUseApi, isTrialExpired, TRIAL_DAYS } from "@/lib/plans";
+import {
+  canUseApi,
+  isPaidPlanExpired,
+  isTrialExpired,
+  TRIAL_DAYS,
+} from "@/lib/plans";
 import { PRICE_IDS } from "@/lib/stripe";
 import { ApiKeySection } from "@/components/settings/api-key-section";
 import { PlanBadge } from "@/components/billing/plan-badge";
@@ -107,6 +112,14 @@ export default async function SettingsPage({
     if (planData.plan === "unlimited") return "unlimited";
     if (planData.hasSubscription && planData.subscriptionStatus === "past_due")
       return "past-due";
+    // Safety-net per webhook `customer.subscription.deleted` persi (REVIEW #31):
+    // se il piano pagato e' scaduto oltre la grazia i gate sono gia' read-only
+    // (isPaidPlanExpired). La subscription row puo' essere rimasta `active`:
+    // senza questo check la card mostrerebbe "Pro attivo" mentre cassa/catalogo/
+    // API rispondono sola-lettura. Riusa lo stato read-only "trial-expired".
+    // Va DOPO il ramo past_due per non oscurare il dunning legittimo.
+    if (isPaidPlanExpired(planData.plan, planData.planExpiresAt))
+      return "trial-expired";
     if (planData.hasSubscription && planData.subscriptionStatus === "active")
       return "subscribed";
     if (isTrialExpired(planData.trialStartedAt)) return "trial-expired";

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -136,6 +136,39 @@ describe("formatIsoInRome", () => {
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/,
     );
   });
+
+  // Regression guard sui bordi DST (REVIEW #16): la transizione CET↔CEST in
+  // Europe/Rome avviene alle 01:00 UTC (ultima domenica di marzo/ottobre).
+  // Asseriamo l'offset esatto agli istanti immediatamente prima/dopo lo switch.
+  describe("DST transition boundaries", () => {
+    it("keeps +01:00 one second before spring-forward (2026-03-29 01:00 UTC)", () => {
+      // 2026-03-29T00:59:59Z = 01:59:59 CET, ancora UTC+1
+      expect(formatIsoInRome(new Date("2026-03-29T00:59:59Z"))).toBe(
+        "2026-03-29T01:59:59+01:00",
+      );
+    });
+
+    it("switches to +02:00 at spring-forward (2026-03-29 01:00 UTC)", () => {
+      // 2026-03-29T01:00:00Z: l'orologio salta 02:00→03:00 CEST, ora UTC+2
+      expect(formatIsoInRome(new Date("2026-03-29T01:00:00Z"))).toBe(
+        "2026-03-29T03:00:00+02:00",
+      );
+    });
+
+    it("keeps +02:00 one second before fall-back (2026-10-25 00:59:59 UTC)", () => {
+      // 2026-10-25T00:59:59Z = 02:59:59 CEST, ancora UTC+2
+      expect(formatIsoInRome(new Date("2026-10-25T00:59:59Z"))).toBe(
+        "2026-10-25T02:59:59+02:00",
+      );
+    });
+
+    it("switches to +01:00 at fall-back (2026-10-25 01:00 UTC)", () => {
+      // 2026-10-25T01:00:00Z: l'orologio torna 03:00→02:00 CET, ora UTC+1
+      expect(formatIsoInRome(new Date("2026-10-25T01:00:00Z"))).toBe(
+        "2026-10-25T02:00:00+01:00",
+      );
+    });
+  });
 });
 
 describe("parseStrictIsoDateUtc", () => {

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -251,6 +251,41 @@ describe("voidReceiptForBusiness", () => {
     expect(mockLogin).not.toHaveBeenCalled();
   });
 
+  it("REVIEW #15: logga warn v1_document_not_found sul not-found via API key", async () => {
+    mockSelectLimit.mockResolvedValue([]);
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    const { logger } = await import("@/lib/logger");
+    const result = await voidReceiptForBusiness(
+      VALID_INPUT,
+      "api-key-uuid-123",
+    );
+
+    expect(result.error).toMatch(/non trovato/i);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: VALID_INPUT.documentId,
+        businessId: VALID_INPUT.businessId,
+        apiKeyId: "api-key-uuid-123",
+        errorClass: "v1_document_not_found",
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("REVIEW #15: NON logga il warn v1 sul not-found da UI session (apiKeyId assente)", async () => {
+    mockSelectLimit.mockResolvedValue([]);
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    const { logger } = await import("@/lib/logger");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.objectContaining({ errorClass: "v1_document_not_found" }),
+      expect.any(String),
+    );
+  });
+
   it("ritorna errore se il documento non è di tipo SALE", async () => {
     mockSelectLimit.mockResolvedValue([{ ...FAKE_SALE_DOC, kind: "VOID" }]);
 

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -444,6 +444,23 @@ async function prepareVoidDocument(
   }
 
   if (!saleDoc) {
+    // Solo per il path API v1 (apiKeyId presente): loggare un warn unico sul
+    // not-found cross-tenant (REVIEW #15) per dare visibilità sull'enumerazione
+    // di UUID altrui — il rate per apiKeyId è il segnale. Gate su apiKeyId: la
+    // stessa funzione serve le UI session (apiKeyId null), dove l'errorClass v1
+    // sarebbe fuorviante e l'enumerazione non è applicabile. warn, non error
+    // (input prevedibile, regola 20): niente issue Sentry.
+    if (apiKeyId) {
+      logger.warn(
+        {
+          documentId: input.documentId,
+          businessId: input.businessId,
+          apiKeyId,
+          errorClass: "v1_document_not_found",
+        },
+        "v1 document not found",
+      );
+    }
     return { kind: "done", result: { error: "Scontrino non trovato." } };
   }
   if (saleDoc.kind !== "SALE") {

--- a/tests/unit/api-v1-receipt-get.test.ts
+++ b/tests/unit/api-v1-receipt-get.test.ts
@@ -81,6 +81,7 @@ describe("GET /api/v1/receipts/[id]", () => {
     mockAuthenticateApiKey.mockResolvedValue({
       plan: "pro",
       businessId: "biz-123",
+      apiKey: { id: "key-uuid-123" },
     });
     mockCanUseApi.mockReturnValue(true);
 

--- a/tests/unit/settings-page-card-state.test.ts
+++ b/tests/unit/settings-page-card-state.test.ts
@@ -9,6 +9,7 @@ const {
   mockGetProfilePlan,
   mockCanUseApi,
   mockIsTrialExpired,
+  mockIsPaidPlanExpired,
   mockGetDb,
   mockSelect,
   mockFrom,
@@ -20,6 +21,7 @@ const {
   mockGetProfilePlan: vi.fn(),
   mockCanUseApi: vi.fn(),
   mockIsTrialExpired: vi.fn(),
+  mockIsPaidPlanExpired: vi.fn(),
   mockGetDb: vi.fn(),
   mockSelect: vi.fn(),
   mockFrom: vi.fn(),
@@ -42,6 +44,7 @@ vi.mock("@/server/billing-actions", () => ({
 vi.mock("@/lib/plans", () => ({
   canUseApi: mockCanUseApi,
   isTrialExpired: mockIsTrialExpired,
+  isPaidPlanExpired: mockIsPaidPlanExpired,
   TRIAL_DAYS: 30,
 }));
 
@@ -204,6 +207,7 @@ describe("SettingsPage — cardState state machine", () => {
     // Default: authenticated user with profile, business, no credentials
     mockGetUser.mockResolvedValue({ data: { user: FAKE_USER } });
     mockIsTrialExpired.mockReturnValue(false);
+    mockIsPaidPlanExpired.mockReturnValue(false);
     mockCanUseApi.mockReturnValue(false);
 
     // DB mock: 3 sequential limit() calls (profiles, businesses, adeCredentials)
@@ -307,6 +311,45 @@ describe("SettingsPage — cardState state machine", () => {
       const jsx = await SettingsPage({ searchParams: Promise.resolve({}) });
 
       // Portal link is present in past-due state (to update payment method)
+      expect(hasLink(jsx, "/api/stripe/portal")).toBe(true);
+      expect(hasComponent(jsx, PlanSelection)).toBe(false);
+    });
+  });
+
+  describe("expired paid plan fallback (REVIEW #31)", () => {
+    it("shows PlanSelection (not portal link) when paid plan is expired despite active subscription row", async () => {
+      // Webhook customer.subscription.deleted perso: la row e' rimasta active
+      // ma il piano e' scaduto oltre la grazia → gate read-only.
+      mockGetProfilePlan.mockResolvedValue(makeActivePlanData("pro", "year"));
+      mockIsPaidPlanExpired.mockReturnValue(true);
+
+      const jsx = await SettingsPage({ searchParams: Promise.resolve({}) });
+
+      expect(hasComponent(jsx, PlanSelection)).toBe(true);
+      expect(hasLink(jsx, "/api/stripe/portal")).toBe(false);
+    });
+
+    it("keeps subscribed state (portal link) when paid plan is NOT expired", async () => {
+      mockGetProfilePlan.mockResolvedValue(makeActivePlanData("pro", "year"));
+      mockIsPaidPlanExpired.mockReturnValue(false);
+
+      const jsx = await SettingsPage({ searchParams: Promise.resolve({}) });
+
+      expect(hasLink(jsx, "/api/stripe/portal")).toBe(true);
+      expect(hasComponent(jsx, PlanSelection)).toBe(false);
+    });
+
+    it("keeps past-due state even if paid plan is expired (dunning precedes the fallback)", async () => {
+      mockGetProfilePlan.mockResolvedValue({
+        ...makeActivePlanData("pro"),
+        subscriptionStatus: "past_due",
+      });
+      mockIsPaidPlanExpired.mockReturnValue(true);
+
+      const jsx = await SettingsPage({ searchParams: Promise.resolve({}) });
+
+      // Il ramo past_due precede il check isPaidPlanExpired: l'utente in
+      // dunning vede ancora il portale per aggiornare il pagamento.
       expect(hasLink(jsx, "/api/stripe/portal")).toBe(true);
       expect(hasComponent(jsx, PlanSelection)).toBe(false);
     });


### PR DESCRIPTION
## Summary

Resolves three low-priority findings from REVIEW.md:
- **#15** (observability): Add structured logging for cross-tenant UUID enumeration attempts on v1 API endpoints
- **#16** (robustness): Add DST boundary regression tests for `formatIsoInRome` to guard against offset calculation errors
- **31** (UX coherence): Fix settings card state to reflect expired paid plans despite active subscription rows (webhook loss safety-net)

## Key Changes

### REVIEW #15: v1 API enumeration logging
- Added `logger.warn()` in `void-service.ts` and `GET /api/v1/receipts/[id]` when document not found via API key
- Logs structured context: `{ documentId, businessId, apiKeyId, errorClass: "v1_document_not_found" }`
- Only logs for API key requests (not UI sessions); HTTP response remains 404 (no oracle)
- Rate of these warns per `apiKeyId` signals enumeration attempts (Sentry query: `errorClass:v1_document_not_found`)
- Added tests verifying warn is logged on v1 not-found and NOT logged on UI session not-found

### REVIEW #16: DST transition regression guard
- Added four test cases in `date-utils.test.ts` covering Europe/Rome DST boundaries:
  - Spring-forward: `2026-03-29T00:59:59Z` (+01:00) → `2026-03-29T01:00:00Z` (+02:00)
  - Fall-back: `2026-10-25T00:59:59Z` (+02:00) → `2026-10-25T01:00:00Z` (+01:00)
- Tests assert exact offset in output; existing implementation passes (no code change needed to `formatIsoInRome`)
- Regression guard prevents future refactors from breaking DST handling

### REVIEW #31: Expired paid plan fallback
- Added `isPaidPlanExpired()` check in `SettingsPage` cardState logic (after `past_due`, before `subscribed`)
- When paid plan is expired beyond grace period, card shows read-only state even if subscription row is `active`
- Handles webhook loss scenario: renewal failed + `customer.subscription.deleted` webhook lost → row stays active but gates are read-only
- Reuses existing "trial-expired" state for consistency
- Added three test cases: expired plan with active row, non-expired plan, and past_due precedence

## Implementation Details

- **No new dependencies:** uses existing `isPaidPlanExpired()` from `@/lib/plans`
- **Logging level:** `warn` (not `error`) per rule 20 — input is predictable, no Sentry issue
- **Test coverage:** all three findings have dedicated test suites with edge cases
- **Removed from REVIEW.md:** findings #15, #16, #31 (resolved)

https://claude.ai/code/session_01EAnwcbW1zt91Az69NBn7yz