### PR TITLE
fix(instrumentation): guardia idempotenza su keep-alive Supabase

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -474,10 +474,11 @@ effettivamente girando in produzione, o se è codice morto.
 
 **Fix (non ambiguo).**
 
-1. **Idempotenza keep-alive:** guardia module-level in `startSupabaseKeepAlive()`
+1. ✅ **RISOLTO** (branch `claude/review-md-bug-m60ys2`). **Idempotenza keep-alive:**
+   guardia module-level in `startSupabaseKeepAlive()`
    (`let keepAliveStarted = false; if (keepAliveStarted) return; keepAliveStarted = true;`)
    così invocazioni multiple di `register()` non accumulano timer. Test: due chiamate
-   consecutive → un solo `setInterval`.
+   consecutive → un solo `setInterval` (in `tests/unit/instrumentation-keep-alive.test.ts`).
 2. **Consolidare i due file in uno solo:** unire keep-alive + `assertIdentityEnv` +
    migrazioni in un unico `register()` (preferibile `src/instrumentation.ts`, già
    citato dalla regola 24/skill `db-migrations`), eliminando l'altro file. Ordine

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -6,7 +6,15 @@ import { logger } from "@/lib/logger";
 // TODO: rimuovere quando si passa a Supabase Pro.
 export const KEEP_ALIVE_INTERVAL_MS = 5 * 24 * 60 * 60 * 1000; // 5 giorni
 
+// Guardia di idempotenza: register() può essere invocata più volte per lo stesso
+// deploy (osservati due ping reali a ~13s di distanza in prod, REVIEW.md #29).
+// Senza questa guardia ogni invocazione impilerebbe un nuovo setInterval.
+let keepAliveStarted = false;
+
 export function startSupabaseKeepAlive() {
+  if (keepAliveStarted) return;
+  keepAliveStarted = true;
+
   const interval: ReturnType<typeof setInterval> = setInterval(async () => {
     try {
       const { createAdminSupabaseClient } =

--- a/tests/unit/instrumentation-keep-alive.test.ts
+++ b/tests/unit/instrumentation-keep-alive.test.ts
@@ -1,10 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  KEEP_ALIVE_INTERVAL_MS,
-  startSupabaseKeepAlive,
-  register,
-} from "../../instrumentation";
+import { KEEP_ALIVE_INTERVAL_MS } from "../../instrumentation";
 
 const { mockCreateAdminSupabaseClient, mockLoggerInfo, mockLoggerWarn } =
   vi.hoisted(() => ({
@@ -40,8 +36,14 @@ describe("startSupabaseKeepAlive()", () => {
   let mockLimit: ReturnType<typeof vi.fn>;
   let mockSelect: ReturnType<typeof vi.fn>;
   let mockFrom: ReturnType<typeof vi.fn>;
+  let startSupabaseKeepAlive: () => void;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Reset dello stato module-level (guardia di idempotenza) tra i test:
+    // senza questo, dal secondo test in poi la guardia farebbe early-return.
+    vi.resetModules();
+    ({ startSupabaseKeepAlive } = await import("../../instrumentation"));
+
     mockUnref = vi.fn();
     const mockTimer = { unref: mockUnref } as unknown as ReturnType<
       typeof setInterval
@@ -122,13 +124,25 @@ describe("startSupabaseKeepAlive()", () => {
 
     expect(mockCreateAdminSupabaseClient).toHaveBeenCalledTimes(2);
   });
+
+  it("due chiamate consecutive avviano un solo setInterval (idempotenza)", () => {
+    startSupabaseKeepAlive();
+    startSupabaseKeepAlive();
+
+    expect(global.setInterval).toHaveBeenCalledOnce();
+  });
 });
 
 describe("register()", () => {
   let originalNextRuntime: string | undefined;
   let mockUnref: ReturnType<typeof vi.fn>;
+  let register: () => Promise<void>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Reset dello stato module-level (guardia di idempotenza) tra i test.
+    vi.resetModules();
+    ({ register } = await import("../../instrumentation"));
+
     originalNextRuntime = process.env.NEXT_RUNTIME;
     mockUnref = vi.fn();
     const mockTimer = { unref: mockUnref } as unknown as ReturnType<
@@ -164,5 +178,14 @@ describe("register()", () => {
     await register();
 
     expect(global.setInterval).not.toHaveBeenCalled();
+  });
+
+  it("due register() consecutive (nodejs) avviano un solo setInterval (idempotenza)", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+
+    await register();
+    await register();
+
+    expect(global.setInterval).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
register() può essere invocata più volte per lo stesso deploy e
startSupabaseKeepAlive() impilava un nuovo setInterval a ogni chiamata
(osservati due ping reali a ~13s in produzione, REVIEW.md #29 punto 1).

Aggiunta una guardia module-level (keepAliveStarted) che fa early-return
dopo il primo avvio. Test di idempotenza: N chiamate → un solo setInterval,
con reset dello stato module-level via vi.resetModules() tra i test.

Punti 2-3 del finding #29 (consolidamento dei due instrumentation.ts,
indagine dead-code migrazioni) restano aperti: richiedono conferma prod.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AXYvJEbNiN6omtkzwoNFp