### PR TITLE
feat(marketing): add /strumenti hub page for SEO link consolidation

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -53,6 +53,7 @@ sonar.coverage.exclusions=\
   src/components/marketing/footer.tsx,\
   src/components/marketing/faq-items.ts,\
   src/components/marketing/faq-section.tsx,\
+  src/components/marketing/breadcrumbs.tsx,\
   src/components/marketing/marketing-hero.tsx,\
   src/components/marketing/pricing-section.tsx,\
   src/components/marketing/waitlist-form.tsx,\
@@ -110,12 +111,14 @@ sonar.coverage.exclusions=\
   src/app/(marketing)/per/[slug]/opengraph-image.tsx,\
   src/app/(marketing)/confronto/opengraph-image.tsx,\
   src/app/(marketing)/strumenti/[slug]/opengraph-image.tsx,\
+  src/app/(marketing)/strumenti/opengraph-image.tsx,\
   src/app/(marketing)/per/page.tsx,\
   src/app/(marketing)/per/[slug]/page.tsx,\
   src/lib/per/categories.ts,\
   src/app/(marketing)/confronto/page.tsx,\
   src/components/marketing/comparison-table.tsx,\
   src/app/(marketing)/strumenti/[slug]/page.tsx,\
+  src/app/(marketing)/strumenti/page.tsx,\
   src/components/marketing/tools/scorporo-iva-tool.tsx,\
   src/components/marketing/tools/verifica-lotteria-tool.tsx,\
   src/components/marketing/tools/calcolatore-risparmio-tool.tsx,\

--- a/src/app/(marketing)/confronto/page.tsx
+++ b/src/app/(marketing)/confronto/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight, Check, X } from "lucide-react";
+import { ArrowRight, Check, X } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Button } from "@/components/ui/button";
 import {
@@ -8,6 +8,7 @@ import {
   breadcrumbListJsonLd,
   faqPageJsonLd,
 } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { confrontoContent } from "@/lib/confronto/comparisons";
 import { helpArticles } from "@/lib/help/articles";
 
@@ -32,26 +33,19 @@ export default function ConfrontoPage() {
   const relatedArticles = c.relatedHelp
     .map((helpSlug) => helpArticles[helpSlug])
     .filter((a) => a !== undefined);
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Confronto", url: PAGE_URL },
+  ];
 
   return (
     <>
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: SITE_URL },
-          { name: "Confronto", url: PAGE_URL },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
       {c.faq.length > 0 && <JsonLd data={faqPageJsonLd(c.faq)} />}
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Torna alla home"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {c.title}

--- a/src/app/(marketing)/guide/[slug]/page.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, ArrowRight, Clock } from "lucide-react";
+import { ArrowRight, Clock } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Button } from "@/components/ui/button";
 import {
   JsonLd,
   articleJsonLd,
+  breadcrumbListJsonLd,
   faqPageJsonLd,
-  guideArticleBreadcrumb,
+  guideArticleBreadcrumbItems,
 } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import {
   getGuide,
   guideArticles,
@@ -71,10 +73,11 @@ export default async function GuidePage({ params }: PageParams) {
     .map((helpSlug) => helpArticles[helpSlug])
     .filter((a) => a !== undefined);
   const relatedGuides = g.relatedGuides.map((s) => guideArticles[s]);
+  const crumbs = guideArticleBreadcrumbItems(g.slug, g.title);
 
   return (
     <>
-      <JsonLd data={guideArticleBreadcrumb(g.slug, g.title)} />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
       <JsonLd
         data={articleJsonLd({
           headline: g.title,
@@ -88,13 +91,7 @@ export default async function GuidePage({ params }: PageParams) {
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/guide"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Tutte le guide"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {g.title}

--- a/src/app/(marketing)/guide/page.tsx
+++ b/src/app/(marketing)/guide/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight, Clock } from "lucide-react";
+import { ArrowRight, Clock } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Button } from "@/components/ui/button";
 import { JsonLd, breadcrumbListJsonLd } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { guideArticles, guideSlugs } from "@/lib/guide/articles";
 
 const SITE_URL = "https://scontrinozero.it";
@@ -24,24 +25,17 @@ export const metadata: Metadata = {
 };
 
 export default function GuideIndexPage() {
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Guide", url: `${SITE_URL}/guide` },
+  ];
   return (
     <>
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: SITE_URL },
-          { name: "Guide", url: `${SITE_URL}/guide` },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Torna alla home"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {"Guide e approfondimenti"}

--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function AliquoteIvaPage() {
       />
       <HelpArticleJsonLd slug="aliquote-iva" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "aliquote-iva",
+            "Aliquote IVA, catalogo e pagamenti",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function AnnullareScontrinoPage() {
       />
       <HelpArticleJsonLd slug="annullare-scontrino" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "annullare-scontrino",
+            "Annullare uno scontrino",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -14,13 +17,9 @@ export default function ApiDocsPage() {
       <JsonLd data={helpArticleBreadcrumb("api", "API per sviluppatori")} />
       <HelpArticleJsonLd slug="api" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems("api", "API per sviluppatori")}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function CambioPianoPage() {
       />
       <HelpArticleJsonLd slug="cambio-piano" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "cambio-piano",
+            "Cambio piano: mensile ad annuale",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -16,13 +20,12 @@ export default function CassettoFiscalePage() {
       />
       <HelpArticleJsonLd slug="cassetto-fiscale" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "cassetto-fiscale",
+            "Cassetto fiscale",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
+++ b/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function ChiusuraGiornalieraPage() {
       />
       <HelpArticleJsonLd slug="chiusura-giornaliera" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "chiusura-giornaliera",
+            "Chiusura giornaliera",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/come-collegare-ade/page.tsx
+++ b/src/app/(marketing)/help/come-collegare-ade/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function ComeCollegareAde() {
       />
       <HelpArticleJsonLd slug="come-collegare-ade" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "come-collegare-ade",
+            "Collegare l'Agenzia delle Entrate",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/contatto-assistenza/page.tsx
+++ b/src/app/(marketing)/help/contatto-assistenza/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function ContattoAssistenzaPage() {
       />
       <HelpArticleJsonLd slug="contatto-assistenza" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "contatto-assistenza",
+            "Contattare l'assistenza",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/credenziali-fisconline/page.tsx
+++ b/src/app/(marketing)/help/credenziali-fisconline/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function CredenzialiPage() {
       />
       <HelpArticleJsonLd slug="credenziali-fisconline" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "credenziali-fisconline",
+            "Credenziali Fisconline",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/errori-ade/page.tsx
+++ b/src/app/(marketing)/help/errori-ade/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -16,13 +20,12 @@ export default function ErroriAdePage() {
       />
       <HelpArticleJsonLd slug="errori-ade" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "errori-ade",
+            "Errori di accesso AdE",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/fatture-e-ricevute/page.tsx
+++ b/src/app/(marketing)/help/fatture-e-ricevute/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -16,13 +19,12 @@ export default function FattureERicevutePage() {
       />
       <HelpArticleJsonLd slug="fatture-e-ricevute" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "fatture-e-ricevute",
+            "Fatture e ricevute",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/installare-app/page.tsx
+++ b/src/app/(marketing)/help/installare-app/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -16,13 +19,12 @@ export default function InstallareAppPage() {
       />
       <HelpArticleJsonLd slug="installare-app" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "installare-app",
+            "Installare l'app",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/intestazione-scontrino/page.tsx
+++ b/src/app/(marketing)/help/intestazione-scontrino/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function IntestazioneScontrinoPage() {
       />
       <HelpArticleJsonLd slug="intestazione-scontrino" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "intestazione-scontrino",
+            "Intestazione scontrino",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/normativa-pos-2026/page.tsx
+++ b/src/app/(marketing)/help/normativa-pos-2026/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function NormativaPos2026Page() {
       />
       <HelpArticleJsonLd slug="normativa-pos-2026" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "normativa-pos-2026",
+            "Collegamento POS-cassa 2026",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChevronRight } from "lucide-react";
 import { JsonLd, breadcrumbListJsonLd } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 
 const SITE_URL = "https://scontrinozero.it";
 const PAGE_URL = `${SITE_URL}/help`;
@@ -215,15 +216,16 @@ const helpCategories: HelpCategory[] = [
 ];
 
 export default function HelpHomePage() {
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Help Center", url: PAGE_URL },
+  ];
   return (
     <section className="px-4 py-16 md:py-24">
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: "https://scontrinozero.it" },
-          { name: "Help Center", url: "https://scontrinozero.it/help" },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
       <div className="mx-auto max-w-6xl space-y-12">
+        <Breadcrumbs items={crumbs} />
+
         {/* ─── Intestazione ─── */}
         <div className="space-y-3">
           <p className="text-primary text-sm font-semibold tracking-wide uppercase">

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -16,13 +19,9 @@ export default function PianiEPrezziPage() {
       />
       <HelpArticleJsonLd slug="piani-e-prezzi" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems("piani-e-prezzi", "Piani e prezzi")}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
+++ b/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function PosRtObbligoPage() {
       />
       <HelpArticleJsonLd slug="pos-rt-obbligo" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "pos-rt-obbligo",
+            "POS-RT: obbligo e scadenze 2026",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/prima-configurazione/page.tsx
+++ b/src/app/(marketing)/help/prima-configurazione/page.tsx
@@ -1,8 +1,12 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -20,13 +24,12 @@ export default function PrimaConfigurazioneePage() {
       />
       <HelpArticleJsonLd slug="prima-configurazione" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "prima-configurazione",
+            "Prima configurazione",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/primo-scontrino/page.tsx
+++ b/src/app/(marketing)/help/primo-scontrino/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function PrimoScontrinoPage() {
       />
       <HelpArticleJsonLd slug="primo-scontrino" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "primo-scontrino",
+            "Primo scontrino elettronico",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/regime-forfettario/page.tsx
+++ b/src/app/(marketing)/help/regime-forfettario/page.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   JsonLd,
   faqPageJsonLd,
   helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
   type FaqItem,
 } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -61,13 +62,12 @@ export default function RegimeForfettarioPage() {
       <HelpArticleJsonLd slug="regime-forfettario" />
       <JsonLd data={faqPageJsonLd(faqItems)} />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "regime-forfettario",
+            "Regime forfettario",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/registrare-pos-portale-ade/page.tsx
+++ b/src/app/(marketing)/help/registrare-pos-portale-ade/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function RegistrarePosPortaleAdePage() {
       />
       <HelpArticleJsonLd slug="registrare-pos-portale-ade" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "registrare-pos-portale-ade",
+            "Registrare un POS nel portale Fatture e Corrispettivi",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
+++ b/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
@@ -1,7 +1,10 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +22,12 @@ export default function SicurezzaCredenzialiPage() {
       />
       <HelpArticleJsonLd slug="sicurezza-credenziali" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "sicurezza-credenziali",
+            "Sicurezza e privacy delle credenziali",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
+++ b/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function StampareScontrinoTermicaPage() {
       />
       <HelpArticleJsonLd slug="stampare-scontrino-termica" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "stampare-scontrino-termica",
+            "Stampare lo scontrino su carta termica",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { JsonLd, helpArticleBreadcrumb } from "@/components/json-ld";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
@@ -19,13 +23,12 @@ export default function StoricoEdEsportazionePage() {
       />
       <HelpArticleJsonLd slug="storico-ed-esportazione" />
       <article className="mx-auto max-w-3xl">
-        <Link
-          href="/help"
-          className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Help Center
-        </Link>
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "storico-ed-esportazione",
+            "Storico ed esportazione",
+          )}
+        />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(marketing)/per/[slug]/page.tsx
+++ b/src/app/(marketing)/per/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { appHref } from "@/lib/marketing-to-app-href";
-import { ArrowLeft, ArrowRight, Check } from "lucide-react";
+import { ArrowRight, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   JsonLd,
@@ -10,6 +10,7 @@ import {
   faqPageJsonLd,
   serviceJsonLd,
 } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import {
   categories,
   categorySlugs,
@@ -60,16 +61,15 @@ export default async function CategoryLandingPage({ params }: PageParams) {
   const relatedArticles = category.relatedHelp
     .map((helpSlug) => helpArticles[helpSlug])
     .filter((a) => a !== undefined);
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Soluzioni per categoria", url: `${SITE_URL}/per` },
+    { name: category.title, url: pageUrl },
+  ];
 
   return (
     <>
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: SITE_URL },
-          { name: "Soluzioni per categoria", url: `${SITE_URL}/per` },
-          { name: category.title, url: pageUrl },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
       <JsonLd
         data={serviceJsonLd({
           name: category.title,
@@ -82,13 +82,7 @@ export default async function CategoryLandingPage({ params }: PageParams) {
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/per"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Tutte le categorie"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {category.title}

--- a/src/app/(marketing)/per/page.tsx
+++ b/src/app/(marketing)/per/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { JsonLd, breadcrumbListJsonLd } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { categories, categorySlugs } from "@/lib/per/categories";
 
 const SITE_URL = "https://scontrinozero.it";
@@ -24,24 +25,17 @@ export const metadata: Metadata = {
 };
 
 export default function PerIndexPage() {
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Soluzioni per categoria", url: PAGE_URL },
+  ];
   return (
     <>
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: SITE_URL },
-          { name: "Soluzioni per categoria", url: PAGE_URL },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Torna alla home"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {"Soluzioni per categoria"}

--- a/src/app/(marketing)/strumenti/[slug]/page.tsx
+++ b/src/app/(marketing)/strumenti/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,6 +9,7 @@ import {
   breadcrumbListJsonLd,
   webApplicationJsonLd,
 } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { ScorporoIvaTool } from "@/components/marketing/tools/scorporo-iva-tool";
 import { VerificaLotteriaTool } from "@/components/marketing/tools/verifica-lotteria-tool";
 import { CalcolatoreRisparmioTool } from "@/components/marketing/tools/calcolatore-risparmio-tool";
@@ -74,6 +75,11 @@ export default async function ToolPage({ params }: PageParams) {
     .map((helpSlug) => helpArticles[helpSlug])
     .filter((a) => a !== undefined);
   const otherTools = toolSlugs.filter((s) => s !== t.slug);
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Strumenti", url: `${SITE_URL}/strumenti` },
+    { name: t.title, url: pageUrl },
+  ];
 
   return (
     <>
@@ -84,23 +90,11 @@ export default async function ToolPage({ params }: PageParams) {
           url: pageUrl,
         })}
       />
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: SITE_URL },
-          { name: "Strumenti", url: `${SITE_URL}/strumenti` },
-          { name: t.title, url: pageUrl },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/strumenti"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Tutti gli strumenti"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {t.title}

--- a/src/app/(marketing)/strumenti/[slug]/page.tsx
+++ b/src/app/(marketing)/strumenti/[slug]/page.tsx
@@ -87,7 +87,7 @@ export default async function ToolPage({ params }: PageParams) {
       <JsonLd
         data={breadcrumbListJsonLd([
           { name: "Home", url: SITE_URL },
-          { name: "Strumenti", url: `${SITE_URL}/strumenti/scorporo-iva` },
+          { name: "Strumenti", url: `${SITE_URL}/strumenti` },
           { name: t.title, url: pageUrl },
         ])}
       />
@@ -95,7 +95,7 @@ export default async function ToolPage({ params }: PageParams) {
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
           <Link
-            href="/"
+            href="/strumenti"
             className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
           >
             <ArrowLeft className="h-4 w-4" />

--- a/src/app/(marketing)/strumenti/opengraph-image.tsx
+++ b/src/app/(marketing)/strumenti/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { ImageResponse } from "next/og";
+import { OgImageTemplate, OG_SIZE } from "@/components/og-image-template";
+
+export { OG_SIZE as size } from "@/components/og-image-template";
+
+export const alt = "Strumenti gratuiti — ScontrinoZero";
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    <OgImageTemplate
+      title="Strumenti gratuiti"
+      subtitle="Scorporo IVA, verifica codice Lotteria e calcolatore di risparmio."
+    />,
+    OG_SIZE,
+  );
+}

--- a/src/app/(marketing)/strumenti/page.tsx
+++ b/src/app/(marketing)/strumenti/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Button } from "@/components/ui/button";
 import { JsonLd, breadcrumbListJsonLd } from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { tools, toolSlugs } from "@/lib/strumenti/tools";
 
 const SITE_URL = "https://scontrinozero.it";
@@ -25,24 +26,17 @@ export const metadata: Metadata = {
 };
 
 export default function StrumentiIndexPage() {
+  const crumbs = [
+    { name: "Home", url: SITE_URL },
+    { name: "Strumenti", url: PAGE_URL },
+  ];
   return (
     <>
-      <JsonLd
-        data={breadcrumbListJsonLd([
-          { name: "Home", url: SITE_URL },
-          { name: "Strumenti", url: PAGE_URL },
-        ])}
-      />
+      <JsonLd data={breadcrumbListJsonLd(crumbs)} />
 
       <section className="px-4 py-16">
         <article className="mx-auto max-w-3xl">
-          <Link
-            href="/"
-            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {"Torna alla home"}
-          </Link>
+          <Breadcrumbs items={crumbs} />
 
           <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
             {"Strumenti gratuiti"}

--- a/src/app/(marketing)/strumenti/page.tsx
+++ b/src/app/(marketing)/strumenti/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { appHref } from "@/lib/marketing-to-app-href";
+import { Button } from "@/components/ui/button";
+import { JsonLd, breadcrumbListJsonLd } from "@/components/json-ld";
+import { tools, toolSlugs } from "@/lib/strumenti/tools";
+
+const SITE_URL = "https://scontrinozero.it";
+const PAGE_URL = `${SITE_URL}/strumenti`;
+
+export const metadata: Metadata = {
+  title: "Strumenti gratuiti",
+  description:
+    "Calcolatori e verifiche gratuite per partite IVA: scorporo IVA, codice Lotteria degli Scontrini e risparmio rispetto al registratore telematico. Senza registrazione.",
+  openGraph: {
+    title: "Strumenti gratuiti | ScontrinoZero",
+    description:
+      "Scorporo IVA, verifica codice Lotteria degli Scontrini e calcolatore di risparmio: strumenti gratuiti, nessuna registrazione.",
+    url: PAGE_URL,
+  },
+  alternates: {
+    canonical: PAGE_URL,
+  },
+};
+
+export default function StrumentiIndexPage() {
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbListJsonLd([
+          { name: "Home", url: SITE_URL },
+          { name: "Strumenti", url: PAGE_URL },
+        ])}
+      />
+
+      <section className="px-4 py-16">
+        <article className="mx-auto max-w-3xl">
+          <Link
+            href="/"
+            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            {"Torna alla home"}
+          </Link>
+
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
+            {"Strumenti gratuiti"}
+          </h1>
+          <p className="text-muted-foreground mt-4 text-lg leading-relaxed">
+            {
+              "Calcolatori e verifiche pensati per chi emette scontrini elettronici. Sono gratuiti, non richiedono registrazione e funzionano direttamente nel browser."
+            }
+          </p>
+
+          <div className="mt-10 space-y-4">
+            {toolSlugs.map((slug) => {
+              const t = tools[slug];
+              return (
+                <Link
+                  key={slug}
+                  href={`/strumenti/${slug}`}
+                  className="bg-card hover:border-primary/40 block rounded-lg border p-5 transition-colors"
+                >
+                  <h2 className="text-lg font-semibold">{t.title}</h2>
+                  <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+                    {t.heroIntro}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+
+          <div className="bg-muted/40 border-border mt-12 rounded-lg border p-5 text-center">
+            <p className="text-sm font-semibold">
+              {"Vuoi emettere scontrini con ScontrinoZero?"}
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              {"30 giorni di prova gratuita, senza carta di credito."}
+            </p>
+            <Button asChild className="mt-3">
+              <a href={appHref("/register")}>
+                {"Crea l'account "}
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </a>
+            </Button>
+          </div>
+        </article>
+      </section>
+    </>
+  );
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(57);
+    expect(result).toHaveLength(58);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -67,6 +67,16 @@ describe("sitemap", () => {
       "https://scontrinozero.it/confronto/fatture-in-cloud",
     );
 
+    // Strumenti hub (inserted before the individual tool pages)
+    expect(allUrls).toContain("https://scontrinozero.it/strumenti");
+    const strumentiHubEntry = result.find(
+      (e) => e.url === "https://scontrinozero.it/strumenti",
+    );
+    expect(strumentiHubEntry).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.6,
+    });
+
     // Tool pages
     const expectedToolUrls = [
       "https://scontrinozero.it/strumenti/scorporo-iva",
@@ -106,39 +116,39 @@ describe("sitemap", () => {
     }
 
     // Legal
-    expect(result[25]).toMatchObject({
+    expect(result[26]).toMatchObject({
       url: "https://scontrinozero.it/privacy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[26]).toMatchObject({
+    expect(result[27]).toMatchObject({
       url: "https://scontrinozero.it/privacy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[27]).toMatchObject({
+    expect(result[28]).toMatchObject({
       url: "https://scontrinozero.it/termini",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[28]).toMatchObject({
+    expect(result[29]).toMatchObject({
       url: "https://scontrinozero.it/termini/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[29]).toMatchObject({
+    expect(result[30]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[30]).toMatchObject({
+    expect(result[31]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
 
     // Help center hub
-    expect(result[31]).toMatchObject({
+    expect(result[32]).toMatchObject({
       url: "https://scontrinozero.it/help",
       changeFrequency: "monthly",
       priority: 0.6,
@@ -165,12 +175,12 @@ describe("sitemap", () => {
     });
 
     // Auth pages (last two)
-    expect(result[55]).toMatchObject({
+    expect(result[56]).toMatchObject({
       url: "https://scontrinozero.it/login",
       changeFrequency: "yearly",
       priority: 0.5,
     });
-    expect(result[56]).toMatchObject({
+    expect(result[57]).toMatchObject({
       url: "https://scontrinozero.it/register",
       changeFrequency: "yearly",
       priority: 0.5,
@@ -190,15 +200,16 @@ describe("sitemap", () => {
     expect(result[3].url).toBe("https://test.scontrinozero.it/per");
     expect(result[4].url).toBe("https://test.scontrinozero.it/per/ambulanti");
     expect(result[10].url).toBe("https://test.scontrinozero.it/confronto");
-    expect(result[11].url).toBe(
+    expect(result[11].url).toBe("https://test.scontrinozero.it/strumenti");
+    expect(result[12].url).toBe(
       "https://test.scontrinozero.it/strumenti/scorporo-iva",
     );
-    expect(result[14].url).toBe("https://test.scontrinozero.it/guide");
-    expect(result[15].url).toBe(
+    expect(result[15].url).toBe("https://test.scontrinozero.it/guide");
+    expect(result[16].url).toBe(
       "https://test.scontrinozero.it/guide/documento-commerciale-online",
     );
-    expect(result[25].url).toBe("https://test.scontrinozero.it/privacy");
-    expect(result[31].url).toBe("https://test.scontrinozero.it/help");
+    expect(result[26].url).toBe("https://test.scontrinozero.it/privacy");
+    expect(result[32].url).toBe("https://test.scontrinozero.it/help");
 
     vi.unstubAllEnvs();
   });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -66,6 +66,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/strumenti`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
     ...toolPages,
     {
       url: `${baseUrl}/guide`,

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -132,14 +132,21 @@ export function breadcrumbListJsonLd(items: readonly BreadcrumbItem[]) {
   } as const;
 }
 
-export function helpArticleBreadcrumb(slug: string, name: string) {
-  if (!slug) throw new Error("helpArticleBreadcrumb: slug is required");
-  if (!name) throw new Error("helpArticleBreadcrumb: name is required");
-  return breadcrumbListJsonLd([
+export function helpArticleBreadcrumbItems(
+  slug: string,
+  name: string,
+): readonly BreadcrumbItem[] {
+  if (!slug) throw new Error("helpArticleBreadcrumbItems: slug is required");
+  if (!name) throw new Error("helpArticleBreadcrumbItems: name is required");
+  return [
     { name: "Home", url: SITE_URL },
     { name: "Help Center", url: `${SITE_URL}/help` },
     { name, url: `${SITE_URL}/help/${slug}` },
-  ]);
+  ];
+}
+
+export function helpArticleBreadcrumb(slug: string, name: string) {
+  return breadcrumbListJsonLd(helpArticleBreadcrumbItems(slug, name));
 }
 
 export interface ServiceJsonLdInput {
@@ -204,14 +211,21 @@ export function webApplicationJsonLd(input: WebApplicationJsonLdInput) {
   } as const;
 }
 
-export function guideArticleBreadcrumb(slug: string, name: string) {
-  if (!slug) throw new Error("guideArticleBreadcrumb: slug is required");
-  if (!name) throw new Error("guideArticleBreadcrumb: name is required");
-  return breadcrumbListJsonLd([
+export function guideArticleBreadcrumbItems(
+  slug: string,
+  name: string,
+): readonly BreadcrumbItem[] {
+  if (!slug) throw new Error("guideArticleBreadcrumbItems: slug is required");
+  if (!name) throw new Error("guideArticleBreadcrumbItems: name is required");
+  return [
     { name: "Home", url: SITE_URL },
     { name: "Guide", url: `${SITE_URL}/guide` },
     { name, url: `${SITE_URL}/guide/${slug}` },
-  ]);
+  ];
+}
+
+export function guideArticleBreadcrumb(slug: string, name: string) {
+  return breadcrumbListJsonLd(guideArticleBreadcrumbItems(slug, name));
 }
 
 export interface ArticleJsonLdInput {

--- a/src/components/marketing/breadcrumbs.test.tsx
+++ b/src/components/marketing/breadcrumbs.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Breadcrumbs } from "./breadcrumbs";
+
+const ITEMS = [
+  { name: "Home", url: "https://scontrinozero.it" },
+  { name: "Guide", url: "https://scontrinozero.it/guide" },
+  {
+    name: "Documento commerciale online",
+    url: "https://scontrinozero.it/guide/documento-commerciale-online",
+  },
+];
+
+describe("Breadcrumbs", () => {
+  it("renders a nav landmark labelled 'breadcrumb'", () => {
+    render(<Breadcrumbs items={ITEMS} />);
+    expect(
+      screen.getByRole("navigation", { name: /breadcrumb/i }),
+    ).toBeTruthy();
+  });
+
+  it("renders intermediate items as links with relative pathnames (intra-marketing soft routing)", () => {
+    render(<Breadcrumbs items={ITEMS} />);
+    const home = screen.getByRole("link", { name: "Home" });
+    const guide = screen.getByRole("link", { name: "Guide" });
+    expect(home.getAttribute("href")).toBe("/");
+    expect(guide.getAttribute("href")).toBe("/guide");
+  });
+
+  it("renders the last item as current page, not a link", () => {
+    render(<Breadcrumbs items={ITEMS} />);
+    const last = screen.getByText("Documento commerciale online");
+    expect(last.getAttribute("aria-current")).toBe("page");
+    expect(
+      screen.queryByRole("link", { name: "Documento commerciale online" }),
+    ).toBeNull();
+  });
+
+  it("preserves item order", () => {
+    render(<Breadcrumbs items={ITEMS} />);
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems.map((li) => li.textContent)).toEqual([
+      "Home",
+      "Guide",
+      "Documento commerciale online",
+    ]);
+  });
+
+  it("renders a single item (only Home) as current page", () => {
+    render(
+      <Breadcrumbs
+        items={[{ name: "Home", url: "https://scontrinozero.it" }]}
+      />,
+    );
+    const home = screen.getByText("Home");
+    expect(home.getAttribute("aria-current")).toBe("page");
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders nothing for an empty list", () => {
+    const { container } = render(<Breadcrumbs items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/marketing/breadcrumbs.tsx
+++ b/src/components/marketing/breadcrumbs.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import type { BreadcrumbItem } from "@/components/json-ld";
+
+/**
+ * Breadcrumb HTML visibile per le pagine marketing. Riceve lo stesso array di
+ * `BreadcrumbItem` passato a `breadcrumbListJsonLd()`, così la navigazione a
+ * video e lo structured data restano un'unica fonte (nessuna divergenza di
+ * nomi/ordine tra ciò che vede l'utente e ciò che legge il crawler).
+ *
+ * Gli `url` degli item sono assoluti (richiesti dallo schema BreadcrumbList):
+ * qui ne ricaviamo il path relativo così che `<Link>` faccia soft routing
+ * intra-marketing. I link puntano sempre a pagine del gruppo marketing, mai a
+ * `/login`/`/register`/`/reset-password`, quindi non serve `appHref` (regola 15).
+ */
+function toPathname(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+export function Breadcrumbs({
+  items,
+}: {
+  readonly items: readonly BreadcrumbItem[];
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <nav aria-label="breadcrumb" className="mb-8">
+      <ol className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <li key={item.url} className="flex items-center gap-1.5">
+              {index > 0 && (
+                <ChevronRight
+                  className="h-3.5 w-3.5 shrink-0"
+                  aria-hidden="true"
+                />
+              )}
+              {isLast ? (
+                <span
+                  aria-current="page"
+                  className="text-foreground font-medium"
+                >
+                  {item.name}
+                </span>
+              ) : (
+                <Link
+                  href={toPathname(item.url)}
+                  className="hover:text-foreground transition-colors"
+                >
+                  {item.name}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/marketing/footer.tsx
+++ b/src/components/marketing/footer.tsx
@@ -90,7 +90,7 @@ export function Footer() {
               </li>
               <li>
                 <Link
-                  href="/strumenti/scorporo-iva"
+                  href="/strumenti"
                   className="hover:text-foreground transition-colors"
                 >
                   Strumenti gratis

--- a/src/lib/confronto/comparisons.ts
+++ b/src/lib/confronto/comparisons.ts
@@ -49,7 +49,7 @@ export const confrontoContent: ConfrontoContent = {
   title: "ScontrinoZero a confronto con le alternative",
   metaTitle: "Alternative a ScontrinoZero: confronto onesto",
   metaDescription:
-    "Panoramica onesta delle alternative a ScontrinoZero: registratore telematico, gestionali di fatturazione, altri software per scontrini elettronici (Scontrinare, Scontrina, ScontrinoSenzaCassa, CassaDigitale). Quando ha senso scegliere noi, quando no.",
+    "Le alternative a ScontrinoZero a confronto: registratore telematico, gestionali di fatturazione e software scontrini come Scontrinare e Scontrina. Quando conviene e quando no.",
   heroIntro:
     "Esistono diverse strade per emettere documenti fiscali in Italia: registratore telematico fisico, gestionali di fatturazione B2B, oppure software online che usano la procedura Documento Commerciale Online dell'Agenzia delle Entrate. Questa pagina riassume le opzioni e indica in modo trasparente quando ScontrinoZero è la scelta giusta e quando non lo è. I dati sui competitor sono presi dai loro siti pubblici alla data riportata in fondo: per informazioni aggiornate ti consigliamo di controllare direttamente i loro listini.",
   categories: [

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -104,7 +104,7 @@ export const helpArticles: Record<string, HelpArticle> = {
     title: "Errori comuni di accesso AdE e come risolverli",
     metaTitle: "Errori comuni di accesso AdE e come risolverli",
     description:
-      "Guida alla risoluzione degli errori più frequenti nel collegamento con l'Agenzia delle Entrate: password scaduta, credenziali errate, password bloccata, portale non disponibile e scontrino rifiutato in fase di emissione.",
+      "Risolvi gli errori più comuni di accesso all'Agenzia delle Entrate: password scaduta o bloccata, credenziali errate, portale non disponibile e scontrino rifiutato.",
     related: [
       "come-collegare-ade",
       "credenziali-fisconline",
@@ -138,8 +138,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "normativa-pos-2026": {
     slug: "normativa-pos-2026",
     title: "Collegamento POS-cassa 2026: cosa cambia",
-    metaTitle:
-      "Normativa POS 2026: obbligo, scadenze e sanzioni del collegamento POS-cassa",
+    metaTitle: "Normativa POS 2026: obbligo, scadenze e sanzioni POS-cassa",
     description:
       "Normativa POS 2026 (Legge 207/2024): chi è obbligato a collegare il POS al sistema di cassa, scadenze, sanzioni e come metterti in regola con il Documento Commerciale Online.",
     related: ["pos-rt-obbligo", "chiusura-giornaliera", "regime-forfettario"],
@@ -157,7 +156,7 @@ export const helpArticles: Record<string, HelpArticle> = {
     title: "Collegamento POS-RT: obbligo e scadenze 2026",
     metaTitle: "Collegamento POS-RT: chi è obbligato e scadenze 2026",
     description:
-      "Tutto sull'obbligo di collegare il POS al registratore telematico dal 2026: fonte normativa, scadenze, sanzioni e come si effettua l'associazione POS-DCO sul portale Fatture e Corrispettivi dell'Agenzia delle Entrate.",
+      "Obbligo di collegare il POS al registratore telematico dal 2026: fonte normativa, scadenze, sanzioni e come fare l'associazione POS-DCO sul portale AdE.",
     related: ["normativa-pos-2026", "come-collegare-ade", "primo-scontrino"],
   },
   "prima-configurazione": {
@@ -183,8 +182,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "regime-forfettario": {
     slug: "regime-forfettario",
     title: "Regime forfettario: configurazione IVA corretta",
-    metaTitle:
-      "Codice e natura IVA del regime forfettario (N2/N2.2) sullo scontrino",
+    metaTitle: "Codice e natura IVA del forfettario (N2/N2.2) sullo scontrino",
     description:
       "Qual è il codice IVA del regime forfettario sullo scontrino: natura N2 sul documento commerciale (N2.2 in fattura), dicitura di esenzione e come configurarlo in ScontrinoZero senza errori.",
     related: ["aliquote-iva", "primo-scontrino", "annullare-scontrino"],

--- a/src/lib/marketing/meta-length.test.ts
+++ b/src/lib/marketing/meta-length.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { guideArticles } from "@/lib/guide/articles";
+import { categories } from "@/lib/per/categories";
+import { tools } from "@/lib/strumenti/tools";
+import { helpArticles } from "@/lib/help/articles";
+import { confrontoContent } from "@/lib/confronto/comparisons";
+
+/**
+ * Guard anti-regressione sulla lunghezza dei metadati SEO delle pagine
+ * marketing: titoli e description troppo lunghi vengono troncati nella SERP.
+ *
+ * Non sono i limiti di display "ottimali" di Google (~60 char titolo, ~155
+ * description) — il corpus attuale, già passato da review umana, front-carica
+ * le keyword e accetta titoli più lunghi. Sono soffitti che impediscono di
+ * peggiorare: nuovi contenuti (o modifiche) che sforano vengono bloccati in CI.
+ *
+ * Titolo: il root layout applica il template "%s | ScontrinoZero", quindi la
+ * lunghezza che conta è quella *effettiva* renderizzata (titolo + suffisso).
+ * Alcuni registry (es. /per) bakano già il suffisso nel valore: lo
+ * normalizziamo togliendolo e riaggiungendone uno solo, così tutti i registry
+ * si misurano sulla stessa base a prescindere dalla convenzione locale.
+ */
+const BRAND_SUFFIX = " | ScontrinoZero";
+const TITLE_MAX_EFFECTIVE = 81; // ≈ 65 char di titolo + suffisso brand
+const DESCRIPTION_MAX = 200;
+
+function effectiveTitleLength(title: string): number {
+  const bare = title.replace(/\s*\|\s*ScontrinoZero\s*$/, "");
+  return bare.length + BRAND_SUFFIX.length;
+}
+
+interface MetaRow {
+  readonly registry: string;
+  readonly slug: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+const rows: readonly MetaRow[] = [
+  ...Object.values(guideArticles).map((a) => ({
+    registry: "guide",
+    slug: a.slug,
+    title: a.metaTitle,
+    description: a.metaDescription,
+  })),
+  ...Object.values(categories).map((c) => ({
+    registry: "per",
+    slug: c.slug,
+    title: c.metaTitle,
+    description: c.metaDescription,
+  })),
+  ...Object.values(tools).map((t) => ({
+    registry: "strumenti",
+    slug: t.slug,
+    title: t.metaTitle,
+    description: t.metaDescription,
+  })),
+  ...Object.values(helpArticles).map((h) => ({
+    registry: "help",
+    slug: h.slug,
+    title: h.metaTitle,
+    description: h.description,
+  })),
+  {
+    registry: "confronto",
+    slug: "confronto",
+    title: confrontoContent.metaTitle,
+    description: confrontoContent.metaDescription,
+  },
+];
+
+describe("marketing metadata length", () => {
+  it("covers every editorial registry", () => {
+    // Sanity: se un registry sparisce o si svuota il guard non protegge nulla.
+    expect(rows.length).toBeGreaterThanOrEqual(40);
+    for (const registry of ["guide", "per", "strumenti", "help", "confronto"]) {
+      expect(rows.some((r) => r.registry === registry)).toBe(true);
+    }
+  });
+
+  it(`keeps effective titles within ${TITLE_MAX_EFFECTIVE} chars (brand suffix included)`, () => {
+    const offenders = rows
+      .filter((r) => effectiveTitleLength(r.title) > TITLE_MAX_EFFECTIVE)
+      .map((r) => `${r.registry}/${r.slug}=${effectiveTitleLength(r.title)}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it(`keeps meta descriptions within ${DESCRIPTION_MAX} chars`, () => {
+    const offenders = rows
+      .filter((r) => r.description.length > DESCRIPTION_MAX)
+      .map((r) => `${r.registry}/${r.slug}=${r.description.length}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("has a non-empty title and description for every entry", () => {
+    const empty = rows
+      .filter((r) => r.title.trim() === "" || r.description.trim() === "")
+      .map((r) => `${r.registry}/${r.slug}`);
+    expect(empty).toEqual([]);
+  });
+});

--- a/src/lib/marketing/meta-length.test.ts
+++ b/src/lib/marketing/meta-length.test.ts
@@ -98,4 +98,15 @@ describe("marketing metadata length", () => {
       .map((r) => `${r.registry}/${r.slug}`);
     expect(empty).toEqual([]);
   });
+
+  it("does not bake the brand suffix into metaTitle (the root template adds it once)", () => {
+    // Le metaTitle sono passate come `title:` e il template root
+    // "%s | ScontrinoZero" aggiunge il brand: se il valore lo contiene già si
+    // ottiene il doppio suffisso "… | ScontrinoZero | ScontrinoZero" (era il
+    // caso delle pagine /per).
+    const doubled = rows
+      .filter((r) => / \| ScontrinoZero$/.test(r.title))
+      .map((r) => `${r.registry}/${r.slug}`);
+    expect(doubled).toEqual([]);
+  });
 });

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -38,7 +38,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   ambulanti: {
     slug: "ambulanti",
     title: "Registratore di cassa per ambulanti e mercati",
-    metaTitle: "Registratore di cassa per ambulanti | ScontrinoZero",
+    metaTitle: "Registratore di cassa per ambulanti e mercati",
     metaDescription:
       "Emetti scontrini elettronici al mercato direttamente dallo smartphone. Nessun registratore fisico, nessun canone. Da €2,50/mese, 30 giorni di prova gratuita.",
     heroSubtitle:
@@ -80,8 +80,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   "parrucchieri-estetisti": {
     slug: "parrucchieri-estetisti",
     title: "Scontrino elettronico per parrucchieri, estetisti e tatuatori",
-    metaTitle:
-      "Scontrino elettronico per parrucchieri ed estetisti | ScontrinoZero",
+    metaTitle: "Scontrino elettronico per parrucchieri ed estetisti",
     metaDescription:
       "Gestisci scontrini e incassi del salone da tablet o smartphone. Senza registratore sul banco, senza canoni. Da €2,50/mese, prova 30 giorni gratis.",
     heroSubtitle:
@@ -125,7 +124,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   artigiani: {
     slug: "artigiani",
     title: "Scontrino elettronico per artigiani e installatori",
-    metaTitle: "Scontrino elettronico per artigiani | ScontrinoZero",
+    metaTitle: "Scontrino elettronico per artigiani e installatori",
     metaDescription:
       "Idraulici, elettricisti, meccanici: emetti lo scontrino direttamente dal cantiere o dal furgone, con lo smartphone. Da €2,50/mese, 30 giorni gratis.",
     heroSubtitle:
@@ -170,7 +169,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   "b-and-b": {
     slug: "b-and-b",
     title: "Scontrino elettronico per B&B e strutture ricettive",
-    metaTitle: "Scontrino elettronico per B&B e affittacamere | ScontrinoZero",
+    metaTitle: "Scontrino elettronico per B&B e affittacamere",
     metaDescription:
       "Gestisci scontrini per B&B, affittacamere e strutture stagionali senza registratore fisico. Ideale per attività che aprono pochi mesi all'anno. Da €2,50/mese.",
     heroSubtitle:
@@ -214,7 +213,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   "regime-forfettario": {
     slug: "regime-forfettario",
     title: "Scontrino elettronico in regime forfettario",
-    metaTitle: "Scontrino elettronico in regime forfettario | ScontrinoZero",
+    metaTitle: "Scontrino elettronico in regime forfettario",
     metaDescription:
       "Sei in regime forfettario? Emetti scontrini verso privati senza IVA e senza registratore fisico. Soluzione più economica del mercato, da €2,50/mese.",
     heroSubtitle:
@@ -257,8 +256,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   professionisti: {
     slug: "professionisti",
     title: "Scontrino elettronico per liberi professionisti",
-    metaTitle:
-      "Scontrino elettronico per liberi professionisti | ScontrinoZero",
+    metaTitle: "Scontrino elettronico per liberi professionisti",
     metaDescription:
       "Quando un professionista deve emettere scontrino e quando fattura? Guida pratica e soluzione mobile per chi incassa al momento. Da €2,50/mese.",
     heroSubtitle:


### PR DESCRIPTION
Le pagine /strumenti/[slug] esistevano senza una pagina hub di listing.
Aggiunge /strumenti come hub che consolida link equity sui tool gratuiti
(backlink-magnet, regola 8), con entry in sitemap (priority 0.6), OG image
dedicata e breadcrumb JSON-LD reale.

Effetti collaterali corretti: la breadcrumb JSON-LD delle pagine tool puntava
a .../strumenti/scorporo-iva come nodo "Strumenti" (workaround perche' l'hub
non esisteva), ora punta a /strumenti; il link "Tutti gli strumenti" andava a
/ ora va a /strumenti; il footer "Strumenti gratis" punta all'hub invece del
singolo scorporo-iva.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018iX6h8gYSvnTUfLmQuPsqk