### PR TITLE
Refactor: extract AdE verification transaction logic to reduce cognitive complexity

### DIFF
--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -399,6 +399,115 @@ function checkAdeIdentityGuard(
   };
 }
 
+/**
+ * Finalizza la verifica AdE in un'unica transazione guardata dalla versione
+ * delle credenziali (optimistic locking). Estratta da `verifyAdeCredentials`
+ * per tenere il flusso principale sotto la soglia di Cognitive Complexity:
+ * tutta la logica annidata (lock miss → identità fiscale → claim P.IVA →
+ * anti-abuso trial) vive qui. Ritorna i due flag che il chiamante traduce in
+ * messaggi/email. Le violazioni del vincolo UNIQUE sulla P.IVA propagano:
+ * il chiamante le distingue con `isUniqueConstraintViolation`.
+ */
+async function finalizeAdeVerification(params: {
+  db: ReturnType<typeof getDb>;
+  businessId: string;
+  userId: string;
+  credentialVersion: Date;
+  businessSnapshot:
+    | { fiscalCode: string | null; vatNumber: string | null }
+    | undefined;
+  fiscalData: {
+    identificativiFiscali: { partitaIva: string; codiceFiscale: string };
+  } | null;
+}): Promise<{ credentialsChanged: boolean; trialAlreadyUsed: boolean }> {
+  const {
+    db,
+    businessId,
+    userId,
+    credentialVersion,
+    businessSnapshot,
+    fiscalData,
+  } = params;
+
+  let credentialsChanged = false;
+  let trialAlreadyUsed = false;
+
+  await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(adeCredentials)
+      .set({ verifiedAt: new Date() })
+      .where(
+        and(
+          eq(adeCredentials.businessId, businessId),
+          sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion.toISOString()}::timestamptz`,
+        ),
+      )
+      .returning({ id: adeCredentials.id });
+
+    if (updated.length === 0) {
+      // Optimistic-lock miss: credentials replaced during verification.
+      // Abort without writing any fiscal data from the stale session.
+      credentialsChanged = true;
+      return;
+    }
+
+    if (!fiscalData) return;
+
+    const vatNumber = fiscalData.identificativiFiscali.partitaIva;
+    const fiscalCode = fiscalData.identificativiFiscali.codiceFiscale;
+
+    await tx
+      .update(businesses)
+      .set({ vatNumber, fiscalCode })
+      .where(eq(businesses.id, businessId));
+
+    // Primo claim di questa P.IVA da parte del business, vs re-verifica
+    // dello stesso account (stessa P.IVA già registrata). `businessSnapshot`
+    // (letto prima della transazione) è in sync con `profiles.partitaIva`,
+    // scritti insieme atomicamente; l'identity guard ha già bloccato un
+    // business onboardato che arriva con una P.IVA diversa. Distinguere è
+    // essenziale: senza, ri-verificare le proprie credenziali troverebbe la
+    // P.IVA nel ledger e azzererebbe il trial attivo.
+    const wasFirstClaim = businessSnapshot?.vatNumber !== vatNumber;
+
+    // Anti-abuso trial: la P.IVA è UNIQUE su profiles per impedire trial
+    // multipli con email diverse ma stessa P.IVA (account ancora vivo). Il
+    // vincolo DB fa fallire l'UPDATE e l'intera transazione esegue rollback
+    // (verifiedAt incluso), così nessun dato resta in stato parziale.
+    await tx
+      .update(profiles)
+      .set({ partitaIva: vatNumber })
+      .where(eq(profiles.authUserId, userId));
+
+    if (!wasFirstClaim) return;
+
+    // Anti-abuso trial cross-cancellazione: il vincolo UNIQUE su
+    // profiles.partita_iva sparisce quando l'account viene cancellato,
+    // liberando la P.IVA per un secondo trial. `trial_vat_ledger`
+    // sopravvive alla cancellazione e registra ogni P.IVA che ha già
+    // consumato un trial. ON CONFLICT DO NOTHING RETURNING è race-safe:
+    // se non torna righe la P.IVA era già nel ledger da un account
+    // PRECEDENTE → trial già consumato → niente nuovo trial.
+    const inserted = await tx
+      .insert(trialVatLedger)
+      .values({ pivaHash: hashPiva(vatNumber) })
+      .onConflictDoNothing()
+      .returning({ id: trialVatLedger.id });
+
+    if (inserted.length === 0) {
+      // trialStartedAt = null → isTrialExpired() true → sola lettura
+      // immediata, riusando i gate esistenti (canEmit/canAddCatalogItem).
+      await tx
+        .update(profiles)
+        .set({ trialStartedAt: null })
+        .where(eq(profiles.authUserId, userId));
+      trialAlreadyUsed = true;
+    }
+  });
+
+  return { credentialsChanged, trialAlreadyUsed };
+}
+
 export async function verifyAdeCredentials(
   businessId: string,
 ): Promise<OnboardingActionResult> {
@@ -524,78 +633,14 @@ export async function verifyAdeCredentials(
   let credentialsChanged = false;
   let trialAlreadyUsed = false;
   try {
-    await db.transaction(async (tx) => {
-      const updated = await tx
-        .update(adeCredentials)
-        .set({ verifiedAt: new Date() })
-        .where(
-          and(
-            eq(adeCredentials.businessId, businessId),
-            sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion.toISOString()}::timestamptz`,
-          ),
-        )
-        .returning({ id: adeCredentials.id });
-
-      if (updated.length === 0) {
-        // Optimistic-lock miss: credentials replaced during verification.
-        // Abort without writing any fiscal data from the stale session.
-        credentialsChanged = true;
-        return;
-      }
-
-      if (fiscalData) {
-        const vatNumber = fiscalData.identificativiFiscali.partitaIva;
-        const fiscalCode = fiscalData.identificativiFiscali.codiceFiscale;
-
-        await tx
-          .update(businesses)
-          .set({ vatNumber, fiscalCode })
-          .where(eq(businesses.id, businessId));
-
-        // Primo claim di questa P.IVA da parte del business, vs re-verifica
-        // dello stesso account (stessa P.IVA già registrata). `businessSnapshot`
-        // (letto prima della transazione) è in sync con `profiles.partitaIva`,
-        // scritti insieme atomicamente; l'identity guard ha già bloccato un
-        // business onboardato che arriva con una P.IVA diversa. Distinguere è
-        // essenziale: senza, ri-verificare le proprie credenziali troverebbe la
-        // P.IVA nel ledger e azzererebbe il trial attivo.
-        const wasFirstClaim = businessSnapshot?.vatNumber !== vatNumber;
-
-        // Anti-abuso trial: la P.IVA è UNIQUE su profiles per impedire trial
-        // multipli con email diverse ma stessa P.IVA (account ancora vivo). Il
-        // vincolo DB fa fallire l'UPDATE e l'intera transazione esegue rollback
-        // (verifiedAt incluso), così nessun dato resta in stato parziale.
-        await tx
-          .update(profiles)
-          .set({ partitaIva: vatNumber })
-          .where(eq(profiles.authUserId, user.id));
-
-        if (wasFirstClaim) {
-          // Anti-abuso trial cross-cancellazione: il vincolo UNIQUE su
-          // profiles.partita_iva sparisce quando l'account viene cancellato,
-          // liberando la P.IVA per un secondo trial. `trial_vat_ledger`
-          // sopravvive alla cancellazione e registra ogni P.IVA che ha già
-          // consumato un trial. ON CONFLICT DO NOTHING RETURNING è race-safe:
-          // se non torna righe la P.IVA era già nel ledger da un account
-          // PRECEDENTE → trial già consumato → niente nuovo trial.
-          const inserted = await tx
-            .insert(trialVatLedger)
-            .values({ pivaHash: hashPiva(vatNumber) })
-            .onConflictDoNothing()
-            .returning({ id: trialVatLedger.id });
-
-          if (inserted.length === 0) {
-            // trialStartedAt = null → isTrialExpired() true → sola lettura
-            // immediata, riusando i gate esistenti (canEmit/canAddCatalogItem).
-            await tx
-              .update(profiles)
-              .set({ trialStartedAt: null })
-              .where(eq(profiles.authUserId, user.id));
-            trialAlreadyUsed = true;
-          }
-        }
-      }
-    });
+    ({ credentialsChanged, trialAlreadyUsed } = await finalizeAdeVerification({
+      db,
+      businessId,
+      userId: user.id,
+      credentialVersion,
+      businessSnapshot,
+      fiscalData,
+    }));
   } catch (err) {
     if (isUniqueConstraintViolation(err)) {
       logger.warn({ businessId }, "P.IVA già in uso — possibile abuso trial");


### PR DESCRIPTION
## Summary

Extracted the nested transaction logic from `verifyAdeCredentials` into a new `finalizeAdeVerification` function to reduce cognitive complexity and improve maintainability. The core verification flow remains unchanged; this is a pure refactoring for code organization.

## Key Changes

- **New function `finalizeAdeVerification`**: Encapsulates all transactional logic previously inline in `verifyAdeCredentials`:
  - Optimistic-lock check on `adeCredentials.updatedAt`
  - Fiscal data persistence (VAT number, fiscal code) to `businesses` and `profiles`
  - First-claim detection to distinguish new VAT registrations from re-verifications
  - Anti-abuse trial ledger management via `trialVatLedger` with race-safe `ON CONFLICT DO NOTHING`
  - Trial expiration logic when a VAT has already consumed a trial in a previous account

- **Caller simplification**: `verifyAdeCredentials` now delegates the entire transaction block to `finalizeAdeVerification`, receiving back two flags (`credentialsChanged`, `trialAlreadyUsed`) that drive downstream messaging/email logic

- **Comprehensive JSDoc**: Documents the function's purpose, parameters, return values, and the anti-abuse mechanisms (UNIQUE constraint propagation, trial ledger cross-deletion safety)

## Implementation Details

- **Optimistic locking preserved**: The `date_trunc('milliseconds', ...)` comparison on `credentialVersion` remains unchanged, ensuring stale verification sessions abort cleanly
- **Transaction atomicity**: All database operations remain within a single transaction; UNIQUE constraint violations on `profiles.partitaIva` still cause full rollback
- **No behavioral changes**: The extracted function is a 1:1 translation of the original nested logic; error handling and caller-side `isUniqueConstraintViolation` dispatch remain identical
- **Reduced nesting**: Moves ~80 lines of deeply nested transaction logic out of the main flow, keeping `verifyAdeCredentials` under cognitive complexity thresholds per project conventions

This refactoring aligns with the project principle of keeping main flows readable while preserving all safety guarantees (atomicity, race-safety, anti-abuse guards).

https://claude.ai/code/session_01CGZxBCavpHDbAgeW5PazfP