### PR TITLE
Extract shared SALE schema to receipt-schema.ts

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -210,31 +210,29 @@ zero-downtime è impossibile nello stato attuale dei caller.
 
 ---
 
-### 18. Error envelope uniforme API + schema Zod SALE condiviso
+### 18. Error envelope uniforme API
 
 - **Categoria:** architettura/manutenibilità · **Severità:** Low
-- **File:** schema duplicati: `src/server/receipt-actions.ts:14-43` (`lineSchema`/`submitReceiptSchema`) vs `src/app/api/v1/receipts/route.ts:26-73` (`receiptBodySchema`) — già condividono `refineLotteryCode`; envelope: tutti gli endpoint `src/app/api/**`
+- **File:** envelope: tutti gli endpoint `src/app/api/**`
 
-**Problema.** Due copie quasi identiche dello schema SALE (la server action
-aggiunge solo `id` UI-only e `businessId`): un bump di `max()` in una copia e non
-nell'altra fa divergere API e UI silenziosamente. Inoltre le risposte d'errore API
-non hanno una shape uniforme (`{error}` vs `{error, code}` vs status diversi per
-lo stesso caso).
+> **Schema Zod SALE condiviso: RISOLTO.** Lo schema linea + base SALE è stato
+> estratto in `src/lib/receipts/receipt-schema.ts` (`saleLineSchema`,
+> `saleBodySchema` + field schema riusabili): la route API lo usa diretto, la
+> server action ricompone aggiungendo solo `id` (UI) e `businessId`. Resta
+> aperta la sola standardizzazione dell'envelope d'errore.
+
+**Problema.** Le risposte d'errore API non hanno una shape uniforme (`{error}`
+vs `{error, code}` vs status diversi per lo stesso caso).
 
 **Fix (non ambiguo).**
 
-1. Estrarre lo schema linea + base SALE in `src/lib/receipts/receipt-schema.ts`:
-   `export const saleLineSchema = ...; export const saleBodySchema = ...`; la
-   server action lo estende con `.extend({ id: z.string() })` sulla linea e
-   `businessId`; la route API lo usa diretto.
-2. Standardizzare l'envelope: `{ code, message, requestId }` su tutti gli endpoint
+1. Standardizzare l'envelope: `{ code, message, requestId }` su tutti gli endpoint
    `/api/v1/*` (e progressivamente gli altri), con classificazione
    transient/permanent per gli errori delle integrazioni esterne (coerente con
    regola 10). `requestId` = correlazione log (già presente nel logger o da
    generare per-request).
-3. Aggiornare `docs/api-spec.md` con l'envelope.
-4. **Test:** uno schema, due consumer — un cambiamento al limite si riflette in
-   entrambi; snapshot dell'envelope per gli error path principali (400, 401, 404,
+2. Aggiornare `docs/api-spec.md` con l'envelope.
+3. **Test:** snapshot dell'envelope per gli error path principali (400, 401, 404,
    409, 429, 503).
 
 ---

--- a/src/app/api/v1/receipts/route.ts
+++ b/src/app/api/v1/receipts/route.ts
@@ -1,4 +1,3 @@
-import { z } from "zod/v4";
 import { and, count, desc, eq, gte, inArray, lt } from "drizzle-orm";
 import { commercialDocuments } from "@/db/schema";
 import {
@@ -6,7 +5,7 @@ import {
   groupLinesByDocId,
   calcDocTotal,
 } from "@/lib/receipts/document-lines";
-import { refineLotteryCode } from "@/lib/receipts/lottery-code-schema";
+import { saleBodySchema } from "@/lib/receipts/receipt-schema";
 import { parseStrictIsoDateUtc } from "@/lib/date-utils";
 import { dbTimeoutResponse, isStatementTimeoutError } from "@/lib/api-errors";
 import { withStatementTimeout } from "@/lib/db-timeout";
@@ -23,54 +22,9 @@ import {
 } from "@/lib/api-v1-helpers";
 import type { SubmitReceiptInput } from "@/types/cassa";
 
-const receiptBodySchema = z
-  .object({
-    lines: z
-      .array(
-        z.object({
-          description: z.string().min(1).max(200),
-          // max 3 decimal places — matches DB column numeric(10,3).
-          // parseFloat(toFixed(3)) === v: roundtrips cleanly through string
-          // representation and handles IEEE-754 FP edge cases correctly.
-          quantity: z
-            .number()
-            .positive()
-            .max(9999)
-            .refine(
-              (v) => Number.parseFloat(v.toFixed(3)) === v,
-              "max 3 decimali",
-            ),
-          // max 2 decimal places — matches DB column numeric(10,2).
-          grossUnitPrice: z
-            .number()
-            .nonnegative()
-            .max(999_999.99)
-            .refine(
-              (v) => Number.parseFloat(v.toFixed(2)) === v,
-              "max 2 decimali",
-            ),
-          vatCode: z.enum([
-            "4",
-            "5",
-            "10",
-            "22",
-            "N1",
-            "N2",
-            "N3",
-            "N4",
-            "N5",
-            "N6",
-          ]),
-        }),
-      )
-      .min(1)
-      .max(100),
-    paymentMethod: z.enum(["PC", "PE"]),
-    idempotencyKey: z.string().uuid(),
-    // Format-validated only when paymentMethod === "PE" — see refineLotteryCode.
-    lotteryCode: z.string().nullable().optional(),
-  })
-  .superRefine(refineLotteryCode);
+// Schema corpo SALE: condiviso con la server action `emitReceipt` via
+// `saleBodySchema` (src/lib/receipts/receipt-schema.ts). Unica fonte di verità
+// dei limiti di precisione fiscale e dei vincoli del corpo scontrino.
 
 // Rate limit: 120 receipts per hour per API key
 const receiptApiLimiter = new RateLimiter({
@@ -118,7 +72,7 @@ export async function POST(request: Request): Promise<Response> {
   // payloads before JSON.parse to prevent memory/CPU pressure (DoS guard).
   const bodyResult = await parseAndValidateBody(
     request,
-    receiptBodySchema,
+    saleBodySchema,
     32 * 1024,
   );
   if ("error" in bodyResult) return bodyResult.error;

--- a/src/lib/receipts/receipt-schema.test.ts
+++ b/src/lib/receipts/receipt-schema.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  SALE_LINES_MAX,
+  SALE_LINES_MIN,
+  saleBodySchema,
+  saleLineSchema,
+} from "./receipt-schema";
+
+const validLine = {
+  description: "Caffè",
+  quantity: 2,
+  grossUnitPrice: 1.5,
+  vatCode: "22" as const,
+};
+
+const validBody = {
+  lines: [validLine],
+  paymentMethod: "PC" as const,
+  idempotencyKey: "550e8400-e29b-41d4-a716-446655440000",
+  lotteryCode: null,
+};
+
+describe("saleLineSchema", () => {
+  it("accetta una riga valida", () => {
+    expect(saleLineSchema.safeParse(validLine).success).toBe(true);
+  });
+
+  it("accetta ogni vatCode ammesso", () => {
+    const codes = ["4", "5", "10", "22", "N1", "N2", "N3", "N4", "N5", "N6"];
+    for (const vatCode of codes) {
+      expect(saleLineSchema.safeParse({ ...validLine, vatCode }).success).toBe(
+        true,
+      );
+    }
+  });
+
+  it("rifiuta description vuota", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, description: "" }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta description oltre 200 caratteri", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, description: "x".repeat(201) })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rifiuta quantity non positiva", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, quantity: 0 }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta quantity con più di 3 decimali", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, quantity: 1.2345 }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta quantity oltre il massimo", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, quantity: 10000 }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta grossUnitPrice negativo", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, grossUnitPrice: -1 }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta grossUnitPrice con più di 2 decimali", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, grossUnitPrice: 1.234 }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta grossUnitPrice oltre il massimo", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, grossUnitPrice: 1_000_000 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rifiuta vatCode fuori enum", () => {
+    expect(
+      saleLineSchema.safeParse({ ...validLine, vatCode: "99" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("saleBodySchema", () => {
+  it("accetta un body valido", () => {
+    expect(saleBodySchema.safeParse(validBody).success).toBe(true);
+  });
+
+  it("rifiuta lines vuoto (sotto SALE_LINES_MIN)", () => {
+    expect(saleBodySchema.safeParse({ ...validBody, lines: [] }).success).toBe(
+      false,
+    );
+  });
+
+  it("rifiuta più di SALE_LINES_MAX righe", () => {
+    const lines = Array.from({ length: SALE_LINES_MAX + 1 }, () => validLine);
+    expect(saleBodySchema.safeParse({ ...validBody, lines }).success).toBe(
+      false,
+    );
+  });
+
+  it("rifiuta paymentMethod invalido", () => {
+    expect(
+      saleBodySchema.safeParse({ ...validBody, paymentMethod: "XX" }).success,
+    ).toBe(false);
+  });
+
+  it("rifiuta idempotencyKey non-uuid", () => {
+    expect(
+      saleBodySchema.safeParse({ ...validBody, idempotencyKey: "not-a-uuid" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rifiuta lotteryCode malformato su PE", () => {
+    const r = saleBodySchema.safeParse({
+      ...validBody,
+      paymentMethod: "PE",
+      lotteryCode: "garbage",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accetta lotteryCode malformato su PC (refine permissivo)", () => {
+    const r = saleBodySchema.safeParse({
+      ...validBody,
+      paymentMethod: "PC",
+      lotteryCode: "garbage-value",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accetta lotteryCode null/omesso", () => {
+    expect(
+      saleBodySchema.safeParse({ ...validBody, lotteryCode: null }).success,
+    ).toBe(true);
+    const { lotteryCode: _omitted, ...withoutCode } = validBody;
+    expect(saleBodySchema.safeParse(withoutCode).success).toBe(true);
+  });
+
+  it("espone SALE_LINES_MIN/MAX coerenti", () => {
+    expect(SALE_LINES_MIN).toBe(1);
+    expect(SALE_LINES_MAX).toBe(100);
+  });
+});

--- a/src/lib/receipts/receipt-schema.ts
+++ b/src/lib/receipts/receipt-schema.ts
@@ -1,0 +1,64 @@
+import { z } from "zod/v4";
+import { refineLotteryCode } from "@/lib/receipts/lottery-code-schema";
+
+/**
+ * Schema di validazione condiviso per un documento commerciale di vendita (SALE).
+ *
+ * Fonte di verità **unica** dei limiti di precisione fiscale e dei vincoli del
+ * corpo scontrino, consumata sia dalla server action `emitReceipt`
+ * (`src/server/receipt-actions.ts`, canale cassa/UI) sia dalla Developer API
+ * `POST /api/v1/receipts` (`src/app/api/v1/receipts/route.ts`). Prima esistevano
+ * due copie quasi identiche: un bump di un `max()` (o un nuovo `vatCode`) su una
+ * sola le faceva divergere silenziosamente. Stesso razionale per cui
+ * `refineLotteryCode` era già stato estratto (`lottery-code-schema.ts`).
+ *
+ * Gli unici bit consumer-specifici NON vivono qui: la server action aggiunge
+ * `id` (chiave React UI-only) sulla riga e `businessId` sul corpo; la route API
+ * ricava il `businessId` dall'auth. La server action ricompone il proprio
+ * oggetto riusando questi schema (vedi nota su `saleBodySchema`).
+ */
+
+/** Singola riga SALE — regole di precisione allineate alle colonne DB. */
+export const saleLineSchema = z.object({
+  description: z.string().min(1).max(200),
+  // max 3 decimali — colonna DB numeric(10,3). parseFloat(toFixed(3)) === v:
+  // roundtrip pulito via stringa, gestisce gli edge case IEEE-754.
+  quantity: z
+    .number()
+    .positive()
+    .max(9999)
+    .refine((v) => Number.parseFloat(v.toFixed(3)) === v, "max 3 decimali"),
+  // max 2 decimali — colonna DB numeric(10,2).
+  grossUnitPrice: z
+    .number()
+    .nonnegative()
+    .max(999_999.99)
+    .refine((v) => Number.parseFloat(v.toFixed(2)) === v, "max 2 decimali"),
+  vatCode: z.enum(["4", "5", "10", "22", "N1", "N2", "N3", "N4", "N5", "N6"]),
+});
+
+/** Numero minimo/massimo di righe per scontrino, condiviso tra i consumer. */
+export const SALE_LINES_MIN = 1;
+export const SALE_LINES_MAX = 100;
+
+/** Field schema riusabili dal corpo SALE. */
+export const paymentMethodSchema = z.enum(["PC", "PE"]);
+export const idempotencyKeySchema = z.string().uuid();
+// Format-validated solo quando paymentMethod === "PE" — vedi refineLotteryCode.
+export const lotteryCodeSchema = z.string().nullable().optional();
+
+/**
+ * Corpo SALE usato **direttamente** da `POST /api/v1/receipts`.
+ *
+ * È un `ZodEffects` (per via di `.superRefine`) → **non** estendibile con
+ * `.extend`. La server action non lo estende: ricompone il proprio oggetto
+ * riusando `saleLineSchema.extend({ id })` + i field schema esportati sopra.
+ */
+export const saleBodySchema = z
+  .object({
+    lines: z.array(saleLineSchema).min(SALE_LINES_MIN).max(SALE_LINES_MAX),
+    paymentMethod: paymentMethodSchema,
+    idempotencyKey: idempotencyKeySchema,
+    lotteryCode: lotteryCodeSchema,
+  })
+  .superRefine(refineLotteryCode);

--- a/src/server/receipt-actions.ts
+++ b/src/server/receipt-actions.ts
@@ -6,39 +6,33 @@ import { getPlan, canEmit, TRIAL_EXPIRED_MESSAGE } from "@/lib/plans";
 import { RateLimiter } from "@/lib/rate-limit";
 import { refineLotteryCode } from "@/lib/receipts/lottery-code-schema";
 import {
+  SALE_LINES_MAX,
+  SALE_LINES_MIN,
+  idempotencyKeySchema,
+  lotteryCodeSchema,
+  paymentMethodSchema,
+  saleLineSchema,
+} from "@/lib/receipts/receipt-schema";
+import {
   getAuthenticatedUser,
   checkBusinessOwnership,
 } from "@/lib/server-auth";
 import { emitReceiptForBusiness } from "@/lib/services/receipt-service";
 import type { SubmitReceiptInput, SubmitReceiptResult } from "@/types/cassa";
 
-// Runtime validation schema — mirrors the API v1 receiptBodySchema but includes
-// the UI-only `id` field present in CartLine. Enforces the same fiscal precision
-// rules server-side so a tampered client cannot bypass API-level validation.
-const lineSchema = z.object({
-  id: z.string(),
-  description: z.string().min(1).max(200),
-  quantity: z
-    .number()
-    .positive()
-    .max(9999)
-    .refine((v) => Number.parseFloat(v.toFixed(3)) === v, "max 3 decimali"),
-  grossUnitPrice: z
-    .number()
-    .nonnegative()
-    .max(999_999.99)
-    .refine((v) => Number.parseFloat(v.toFixed(2)) === v, "max 2 decimali"),
-  vatCode: z.enum(["4", "5", "10", "22", "N1", "N2", "N3", "N4", "N5", "N6"]),
-});
+// Runtime validation schema — riusa lo schema SALE condiviso (receipt-schema.ts)
+// e aggiunge solo i bit consumer-specifici: `id` (chiave React UI-only sulla
+// riga) e `businessId`. Enforce le stesse regole fiscali della API v1 anche sul
+// canale server action, così un client manomesso non può bypassarle.
+const submitLineSchema = saleLineSchema.extend({ id: z.string() });
 
 const submitReceiptSchema = z
   .object({
     businessId: z.string().uuid("Business ID non valido."),
-    lines: z.array(lineSchema).min(1).max(100),
-    paymentMethod: z.enum(["PC", "PE"]),
-    idempotencyKey: z.string().uuid(),
-    // Format-validated only when paymentMethod === "PE" — see refineLotteryCode.
-    lotteryCode: z.string().nullable().optional(),
+    lines: z.array(submitLineSchema).min(SALE_LINES_MIN).max(SALE_LINES_MAX),
+    paymentMethod: paymentMethodSchema,
+    idempotencyKey: idempotencyKeySchema,
+    lotteryCode: lotteryCodeSchema,
   })
   .superRefine(refineLotteryCode);
 


### PR DESCRIPTION
## Summary

Consolidates duplicated receipt validation schemas into a single source of truth (`src/lib/receipts/receipt-schema.ts`), eliminating schema drift between the API v1 endpoint and the server action. Both consumers now reuse the same line and body schemas, with only consumer-specific fields added where needed.

## Changes

- **New file:** `src/lib/receipts/receipt-schema.ts`
  - Exports `saleLineSchema` with fiscal precision rules (description, quantity, grossUnitPrice, vatCode)
  - Exports `saleBodySchema` with body-level validation (lines array, paymentMethod, idempotencyKey, lotteryCode)
  - Exports constants `SALE_LINES_MIN` (1) and `SALE_LINES_MAX` (100)
  - Exports reusable field schemas: `paymentMethodSchema`, `idempotencyKeySchema`, `lotteryCodeSchema`
  - Integrates `refineLotteryCode` for conditional lottery code validation based on payment method

- **New file:** `src/lib/receipts/receipt-schema.test.ts`
  - Comprehensive test suite covering all validation rules for both schemas
  - Tests decimal precision (3 decimals for quantity, 2 for price)
  - Tests enum constraints (vatCode, paymentMethod)
  - Tests array bounds (SALE_LINES_MIN/MAX)
  - Tests conditional lotteryCode validation (strict on PE, permissive on PC)

- **Modified:** `src/app/api/v1/receipts/route.ts`
  - Removes inline `receiptBodySchema` definition (54 lines)
  - Imports and uses `saleBodySchema` directly
  - Adds clarifying comment about shared schema source of truth

- **Modified:** `src/server/receipt-actions.ts`
  - Removes duplicate line and body schema definitions
  - Reuses `saleLineSchema.extend({ id: z.string() })` for UI-specific `id` field
  - Reuses field schemas (`paymentMethodSchema`, `idempotencyKeySchema`, `lotteryCodeSchema`)
  - Reuses constants (`SALE_LINES_MIN`, `SALE_LINES_MAX`)
  - Maintains `refineLotteryCode` integration for conditional validation

- **Modified:** `REVIEW.md`
  - Marks issue #18 (schema duplication) as resolved
  - Narrows remaining work to API error envelope standardization only

## Implementation Details

- **Precision rules:** Enforced via `.refine()` with `toFixed()` roundtrip to handle IEEE-754 edge cases correctly
- **Conditional validation:** `superRefine(refineLotteryCode)` validates lotteryCode format only when `paymentMethod === "PE"`
- **Reusability:** Field schemas exported separately so server action can compose its own schema without extending `ZodEffects` (which would break `.extend()`)
- **Test coverage:** 156 lines of tests covering happy path, all enum values, boundary conditions, and conditional logic

This eliminates the risk of silent schema divergence (e.g., bumping `max()` in one place but not the other) and establishes a single source of truth for fiscal precision limits across both channels.

https://claude.ai/code/session_01RHk4Src9CMyzEKQ3DJ1pDX