### PR TITLE
Remove native drizzle migrator from instrumentation hook

### DIFF
--- a/.claude/skills/db-migrations/SKILL.md
+++ b/.claude/skills/db-migrations/SKILL.md
@@ -41,7 +41,20 @@ finché non diventa pain).
 
 **Runtime runner:** `scripts/migrate.ts` legge i `.sql` ordinati per nome, traccia
 i file applicati in `__applied_migrations`, wrappa ogni migrazione in transazione.
-Non legge il journal — quello è solo per il check CI di completezza.
+Non legge il journal — quello è solo per il check CI di completezza. In container
+gira come processo separato (`migrate.js`, compilato via esbuild) dal `CMD` del
+`Dockerfile` PRIMA di `server.js`: `node migrate.js && node server.js`.
+
+🚫 **MAI chiamare il migrator NATIVO di drizzle** (`migrate` da
+`drizzle-orm/postgres-js/migrator`) in `src/instrumentation.ts` o altrove. Traccia
+in una tabella DIVERSA (`drizzle.__drizzle_migrations`), si aspetta migrazioni
+generate da drizzle-kit, e **non ha la logica di bootstrap** su DB pre-esistente.
+Affiancato al runner handwritten su un DB già inizializzato ritenta da
+`0000_initial.sql` e crasha al boot con `type "document_kind" already exists`
+(crash loop dell'instrumentation hook). È esattamente la regressione di PR #582:
+il consolidamento dei due `register()` aveva portato dietro una chiamata
+`migrate()` nativa che prima era codice morto (l'hook attivo era il root
+`/instrumentation.ts`). Le migrazioni hanno UN solo owner: `migrate.js`.
 
 ### Pattern `ALTER TABLE ADD COLUMN`
 
@@ -91,7 +104,7 @@ Esempi nel codice: `void-service.ts`, `receipt-service.ts`.
 
 ---
 
-## Drizzle raw `sql\`\`` templates: `Date` va pre-serializzato
+## Drizzle raw `sql\`\``templates:`Date` va pre-serializzato
 
 Dentro `db.update().set({...})` e `eq(col, value)` Drizzle conosce il tipo della
 colonna e converte JS value nel formato Postgres corretto. Dentro `` sql`...${value}...` ``
@@ -107,7 +120,7 @@ Buffer or ArrayBuffer. Received an instance of Date
 (Regressione `SCONTRINOZERO-TEST-7`, 14 giorni nascosta nel flow "Verifica
 connessione" AdE.)
 
-**Pattern obbligato per `Date` in `` sql`` ``:**
+**Pattern obbligato per `Date` in ` sql` ``:**
 
 ```typescript
 sql`date_trunc('milliseconds', ${col}) = ${date.toISOString()}::timestamptz`;
@@ -149,5 +162,6 @@ diversi che usano accidentalmente la stessa UUID ed espone metadati cross-tenant
 I fallback di lookup devono filtrare per `businessId` in aggiunta alla key.
 
 ## Supabase official Skills
+
 https://raw.githubusercontent.com/supabase/agent-skills/refs/heads/main/skills/supabase/SKILL.md
 https://raw.githubusercontent.com/supabase/agent-skills/refs/heads/main/skills/supabase-postgres-best-practices/SKILL.md

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -1,15 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockMigrate = vi.fn();
 const mockClientEnd = vi.fn();
 const mockClient = { end: mockClientEnd };
 const mockPostgresDefault = vi.fn(() => mockClient);
 const mockDb = {};
 const mockDrizzleFn = vi.fn(() => mockDb);
 
-vi.mock("drizzle-orm/postgres-js/migrator", () => ({
-  migrate: mockMigrate,
-}));
+// NB: le migrazioni NON girano in register() (le applica `migrate.js`, processo
+// separato del Dockerfile). Niente mock del migrator nativo di drizzle: era il
+// residuo di PR #582 che crashava al boot su DB pre-esistente (document_kind).
 
 vi.mock("postgres", () => ({
   default: mockPostgresDefault,
@@ -91,7 +90,7 @@ describe("instrumentation register()", () => {
 
     await register();
 
-    expect(mockMigrate).not.toHaveBeenCalled();
+    expect(mockPostgresDefault).not.toHaveBeenCalled();
   });
 
   it("throws when neither DATABASE_URL_DIRECT nor DATABASE_URL is set", async () => {
@@ -101,7 +100,7 @@ describe("instrumentation register()", () => {
     const { register } = await import("./instrumentation");
 
     await expect(register()).rejects.toThrow(
-      "DATABASE_URL_DIRECT or DATABASE_URL is required to run migrations",
+      "DATABASE_URL_DIRECT or DATABASE_URL is required for the boot-time backfill",
     );
   });
 
@@ -133,19 +132,19 @@ describe("instrumentation register()", () => {
     );
   });
 
-  it("calls migrate with the correct migrations folder", async () => {
+  it("non chiama il migrator nativo di drizzle (le migrazioni girano in migrate.js)", async () => {
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.DATABASE_URL = "postgres://test";
     const { register } = await import("./instrumentation");
 
     await register();
 
-    expect(mockMigrate).toHaveBeenCalledWith(mockDb, {
-      migrationsFolder: "./supabase/migrations",
-    });
+    // Il modulo del migrator nativo non deve nemmeno essere importato: il
+    // backfill apre la connessione, ma nessun migrate() gira qui (PR #582).
+    expect(mockBackfill).toHaveBeenCalledOnce();
   });
 
-  it("closes the DB connection after migration completes", async () => {
+  it("closes the DB connection after the backfill completes", async () => {
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.DATABASE_URL = "postgres://test";
     const { register } = await import("./instrumentation");
@@ -155,7 +154,7 @@ describe("instrumentation register()", () => {
     expect(mockClientEnd).toHaveBeenCalled();
   });
 
-  it("esegue il backfill del ledger anti-frode dopo migrate e prima di chiudere la connessione", async () => {
+  it("esegue il backfill del ledger anti-frode dopo aver aperto la connessione e prima di chiuderla", async () => {
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.DATABASE_URL = "postgres://test";
     const { register } = await import("./instrumentation");
@@ -163,10 +162,10 @@ describe("instrumentation register()", () => {
     await register();
 
     expect(mockBackfill).toHaveBeenCalledWith(mockDb);
-    const migrateOrder = mockMigrate.mock.invocationCallOrder[0]!;
+    const connOrder = mockPostgresDefault.mock.invocationCallOrder[0]!;
     const backfillOrder = mockBackfill.mock.invocationCallOrder[0]!;
     const endOrder = mockClientEnd.mock.invocationCallOrder[0]!;
-    expect(migrateOrder).toBeLessThan(backfillOrder);
+    expect(connOrder).toBeLessThan(backfillOrder);
     expect(backfillOrder).toBeLessThan(endOrder);
   });
 
@@ -211,8 +210,7 @@ describe("instrumentation register()", () => {
     await expect(register()).rejects.toThrow(
       /identity env validation failed at boot/,
     );
-    // Migrate non deve essere eseguito quando l'identita' e' rotta.
-    expect(mockMigrate).not.toHaveBeenCalled();
+    // Il pool DB non deve essere aperto quando l'identita' e' rotta.
     expect(mockPostgresDefault).not.toHaveBeenCalled();
   });
 
@@ -233,7 +231,7 @@ describe("instrumentation register()", () => {
     await register();
 
     expect(global.setInterval).toHaveBeenCalledOnce();
-    // Keep-alive in coda: dopo il backfill (che a sua volta è dopo migrate).
+    // Keep-alive in coda: dopo il backfill.
     const backfillOrder = mockBackfill.mock.invocationCallOrder[0]!;
     const setIntervalOrder = vi.mocked(global.setInterval).mock
       .invocationCallOrder[0]!;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -45,14 +45,24 @@ export async function register() {
 
     await import("../sentry.server.config");
 
-    const { migrate } = await import("drizzle-orm/postgres-js/migrator");
+    // ⚠️ Le migrazioni NON girano qui. Il sistema canonico è il runner
+    // handwritten `scripts/migrate.ts` (compilato in `migrate.js`), eseguito
+    // come processo separato dal CMD del Dockerfile PRIMA di `server.js`:
+    // traccia in `__applied_migrations` con checksum e ha la logica di
+    // bootstrap su DB pre-esistente (regola 11 + skill db-migrations).
+    // Chiamare qui il migrator NATIVO di drizzle (`drizzle-orm/.../migrator`)
+    // era un residuo del consolidamento dei due register() (PR #582): traccia
+    // in una tabella DIVERSA (`drizzle.__drizzle_migrations`), senza bootstrap,
+    // quindi su un DB già inizializzato dal runner handwritten ritentava da
+    // `0000_initial.sql` e crashava al boot con `type "document_kind" already
+    // exists`. Qui apriamo una connessione solo per il backfill una-tantum.
     const postgres = (await import("postgres")).default;
     const { drizzle } = await import("drizzle-orm/postgres-js");
 
     const rawUrl = process.env.DATABASE_URL_DIRECT ?? process.env.DATABASE_URL;
     if (!rawUrl) {
       throw new Error(
-        "DATABASE_URL_DIRECT or DATABASE_URL is required to run migrations",
+        "DATABASE_URL_DIRECT or DATABASE_URL is required for the boot-time backfill",
       );
     }
 
@@ -65,12 +75,10 @@ export async function register() {
     parsed.hostname = ipv4;
     const url = parsed.toString();
 
-    // max: 1 — dedicated connection just for migrations
+    // max: 1 — dedicated connection just for the boot-time backfill
     // prepare: false — required for Supabase transaction pooler (harmless for direct)
     const client = postgres(url, { max: 1, prepare: false });
     const db = drizzle({ client });
-
-    await migrate(db, { migrationsFolder: "./supabase/migrations" });
 
     // Backfill una-tantum del registro anti-frode `trial_vat_ledger` dalle
     // P.IVA già su `profiles` (account creati prima del ledger). Self-gated:


### PR DESCRIPTION
## Summary

Removes the native drizzle migrator (`drizzle-orm/postgres-js/migrator`) from the `register()` instrumentation hook. Migrations are now exclusively handled by the handwritten runner (`scripts/migrate.ts` → `migrate.js`), executed as a separate process in the Dockerfile before `server.js`.

## Changes

- **Removed drizzle native migrator mock and calls** from `src/instrumentation.ts`:
  - Deleted `import { migrate }` from `drizzle-orm/postgres-js/migrator`
  - Removed `await migrate(db, { migrationsFolder: "./supabase/migrations" })` call
  - Kept the postgres connection open only for the one-time anti-fraud ledger backfill

- **Updated test suite** (`src/instrumentation.test.ts`):
  - Removed mock for `drizzle-orm/postgres-js/migrator`
  - Changed assertions from checking `mockMigrate` calls to checking `mockPostgresDefault` (connection opening)
  - Updated test descriptions to reflect that migrations run in `migrate.js`, not in the boot hook
  - Updated error message test: "required to run migrations" → "required for the boot-time backfill"
  - Fixed test ordering assertions to verify connection → backfill → close sequence

- **Updated skill documentation** (`.claude/skills/db-migrations/SKILL.md`):
  - Added explicit warning against calling native drizzle migrator
  - Documented the crash regression from PR #582 (duplicate migration tracking table, bootstrap logic missing)
  - Clarified that migrations have a single owner: `migrate.js`
  - Noted the Dockerfile execution order: `node migrate.js && node server.js`

## Implementation Details

The native drizzle migrator was a residual from PR #582's consolidation of two `register()` functions. It caused boot crashes on pre-existing databases because:
1. It tracks migrations in `drizzle.__drizzle_migrations` (different table than the handwritten runner's `__applied_migrations`)
2. It lacks bootstrap logic for existing databases
3. When run after the handwritten runner on an initialized DB, it would retry from `0000_initial.sql` and crash with `type "document_kind" already exists`

The instrumentation hook now only opens a connection for the one-time backfill of the anti-fraud ledger (`trial_vat_ledger`), which is self-gated and idempotent.

https://claude.ai/code/session_012Yn8PZDP1qUHbQgkDdVa8V