### PR TITLE
Disable Sentry in smoke test CI environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,12 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
       SUPABASE_SECRET_KEY: ${{ secrets.TEST_SUPABASE_SECRET_KEY }}
+      # Override del DSN bakato nell'immagine: lo smoke gira senza DB raggiungibile,
+      # quindi gli errori di boot (es. backfill che non connette) NON devono finire
+      # sul progetto Sentry di prod taggati environment=production (SCONTRINOZERO-N
+      # era esattamente questo: rumore CI, non un incidente prod). enabled: !!dsn in
+      # sentry.server.config.ts → stringa vuota disabilita Sentry nel container CI.
+      NEXT_PUBLIC_SENTRY_DSN: ""
       DATABASE_URL: "postgresql://smoke:smoke@localhost:5432/smoke"
       ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY }}
       ENCRYPTION_KEY_VERSION: "1"
@@ -151,6 +157,7 @@ jobs:
             -e NEXT_PUBLIC_SUPABASE_URL \
             -e NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
             -e SUPABASE_SECRET_KEY \
+            -e NEXT_PUBLIC_SENTRY_DSN \
             -e DATABASE_URL \
             -e ENCRYPTION_KEY \
             -e ENCRYPTION_KEY_VERSION \


### PR DESCRIPTION
## Summary

Disables Sentry error reporting during smoke test CI runs to prevent boot errors (e.g., database connection failures during backfill) from being reported to the production Sentry project and creating noise.

## Changes

- Set `NEXT_PUBLIC_SENTRY_DSN` to an empty string in the smoke test job environment variables
- Added the environment variable to the Docker container invocation so it's properly passed through
- Added explanatory comment documenting why this is necessary: smoke tests run without a reachable database, so boot errors should not be tagged as production incidents

## Implementation Details

The empty DSN string disables Sentry in the container via the existing `enabled: !!dsn` check in `sentry.server.config.ts`. This prevents CI noise from being reported as production incidents (addressing the issue that was originally tracked as SCONTRINOZERO-N).

The change applies only to the smoke test environment and does not affect production, sandbox, or dev deployments.

https://claude.ai/code/session_01XXK9TZpyXokkkr2LiVqrza