### PR TITLE
fix(boot): skip backfill DB work when SKIP_MIGRATIONS=true

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,12 +126,6 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
       SUPABASE_SECRET_KEY: ${{ secrets.TEST_SUPABASE_SECRET_KEY }}
-      # Override del DSN bakato nell'immagine: lo smoke gira senza DB raggiungibile,
-      # quindi gli errori di boot (es. backfill che non connette) NON devono finire
-      # sul progetto Sentry di prod taggati environment=production (SCONTRINOZERO-N
-      # era esattamente questo: rumore CI, non un incidente prod). enabled: !!dsn in
-      # sentry.server.config.ts → stringa vuota disabilita Sentry nel container CI.
-      NEXT_PUBLIC_SENTRY_DSN: ""
       DATABASE_URL: "postgresql://smoke:smoke@localhost:5432/smoke"
       ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY }}
       ENCRYPTION_KEY_VERSION: "1"
@@ -157,7 +151,6 @@ jobs:
             -e NEXT_PUBLIC_SUPABASE_URL \
             -e NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
             -e SUPABASE_SECRET_KEY \
-            -e NEXT_PUBLIC_SENTRY_DSN \
             -e DATABASE_URL \
             -e ENCRYPTION_KEY \
             -e ENCRYPTION_KEY_VERSION \

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -49,11 +49,16 @@ describe("instrumentation register()", () => {
   let originalNextRuntime: string | undefined;
   let originalDbUrl: string | undefined;
   let originalDbUrlDirect: string | undefined;
+  let originalSkipMigrations: string | undefined;
 
   beforeEach(() => {
     originalNextRuntime = process.env.NEXT_RUNTIME;
     originalDbUrl = process.env.DATABASE_URL;
     originalDbUrlDirect = process.env.DATABASE_URL_DIRECT;
+    originalSkipMigrations = process.env.SKIP_MIGRATIONS;
+    // Default deterministico: il blocco DB di boot gira a meno che un test non
+    // setti esplicitamente SKIP_MIGRATIONS=true (evita leakage dall'env del runner).
+    delete process.env.SKIP_MIGRATIONS;
     // resetModules: il keep-alive ha una guardia di idempotenza module-level
     // (keepAliveStarted) — senza reset, dopo il primo register() nodejs gli
     // altri test non vedrebbero più setInterval chiamato.
@@ -81,6 +86,11 @@ describe("instrumentation register()", () => {
       delete process.env.DATABASE_URL_DIRECT;
     } else {
       process.env.DATABASE_URL_DIRECT = originalDbUrlDirect;
+    }
+    if (originalSkipMigrations === undefined) {
+      delete process.env.SKIP_MIGRATIONS;
+    } else {
+      process.env.SKIP_MIGRATIONS = originalSkipMigrations;
     }
   });
 
@@ -182,6 +192,25 @@ describe("instrumentation register()", () => {
       expect.objectContaining({ critical: true }),
       expect.stringContaining("backfill trial_vat_ledger fallito"),
     );
+  });
+
+  it("salta il blocco DB di boot quando SKIP_MIGRATIONS=true (no connessione, no backfill)", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.DATABASE_URL = "postgres://test";
+    process.env.SKIP_MIGRATIONS = "true";
+    const { register } = await import("./instrumentation");
+
+    await register();
+
+    // Nessun lavoro DB al boot: nello smoke-test CI (immagine prod senza DB
+    // raggiungibile) il backfill faceva ECONNREFUSED → Sentry "production"
+    // (SCONTRINOZERO-P). Coerente con migrate.js che onora lo stesso flag.
+    expect(mockPostgresDefault).not.toHaveBeenCalled();
+    expect(mockBackfill).not.toHaveBeenCalled();
+    expect(mockClientEnd).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    // Il keep-alive Supabase parte comunque (fuori dal gate).
+    expect(global.setInterval).toHaveBeenCalledOnce();
   });
 
   it("R24: chiama assertIdentityEnv come prima istruzione nel runtime nodejs", async () => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -45,59 +45,72 @@ export async function register() {
 
     await import("../sentry.server.config");
 
-    // ⚠️ Le migrazioni NON girano qui. Il sistema canonico è il runner
-    // handwritten `scripts/migrate.ts` (compilato in `migrate.js`), eseguito
-    // come processo separato dal CMD del Dockerfile PRIMA di `server.js`:
-    // traccia in `__applied_migrations` con checksum e ha la logica di
-    // bootstrap su DB pre-esistente (regola 11 + skill db-migrations).
-    // Chiamare qui il migrator NATIVO di drizzle (`drizzle-orm/.../migrator`)
-    // era un residuo del consolidamento dei due register() (PR #582): traccia
-    // in una tabella DIVERSA (`drizzle.__drizzle_migrations`), senza bootstrap,
-    // quindi su un DB già inizializzato dal runner handwritten ritentava da
-    // `0000_initial.sql` e crashava al boot con `type "document_kind" already
-    // exists`. Qui apriamo una connessione solo per il backfill una-tantum.
-    const postgres = (await import("postgres")).default;
-    const { drizzle } = await import("drizzle-orm/postgres-js");
+    // `SKIP_MIGRATIONS=true` ⇒ in questo ambiente non c'è un DB di boot da
+    // toccare: lo stesso flag con cui `migrate.js` (`scripts/migrate.ts`) salta
+    // le migrazioni SENZA connettersi. Lo onoriamo anche qui, altrimenti il
+    // backfill apre comunque una connessione e fallisce: nello smoke-test CI
+    // (immagine prod, `DATABASE_URL` su un Postgres inesistente, nessun
+    // `services:`) la `SELECT ... LIMIT 1` faceva `ECONNREFUSED` →
+    // `logger.error({critical})` → Sentry, taggato `environment:production`,
+    // pur essendo un container CI usa-e-getta (SCONTRINOZERO-P, e prima -N via
+    // `migrate()` rimosso in PR #645). Regola 20: condizioni attese ≠ errori.
+    // Prod NON setta `SKIP_MIGRATIONS` (il CMD esegue `migrate.js` a ogni boot),
+    // quindi il backfill continua a girare normalmente in produzione.
+    if (process.env.SKIP_MIGRATIONS !== "true") {
+      // Apriamo una connessione solo per il backfill una-tantum. Le migrazioni
+      // NON girano qui: il sistema canonico è il runner handwritten
+      // `scripts/migrate.ts` (compilato in `migrate.js`), eseguito come processo
+      // separato dal CMD del Dockerfile PRIMA di `server.js` (traccia in
+      // `__applied_migrations` con checksum + bootstrap su DB pre-esistente,
+      // regola 11 + skill db-migrations). Il migrator NATIVO di drizzle qui era
+      // un residuo del consolidamento dei due register() (PR #582): tracciava in
+      // una tabella DIVERSA (`drizzle.__drizzle_migrations`), senza bootstrap, e
+      // su un DB già inizializzato ritentava da `0000_initial.sql` crashando con
+      // `type "document_kind" already exists` (rimosso in PR #645).
+      const postgres = (await import("postgres")).default;
+      const { drizzle } = await import("drizzle-orm/postgres-js");
 
-    const rawUrl = process.env.DATABASE_URL_DIRECT ?? process.env.DATABASE_URL;
-    if (!rawUrl) {
-      throw new Error(
-        "DATABASE_URL_DIRECT or DATABASE_URL is required for the boot-time backfill",
-      );
+      const rawUrl =
+        process.env.DATABASE_URL_DIRECT ?? process.env.DATABASE_URL;
+      if (!rawUrl) {
+        throw new Error(
+          "DATABASE_URL_DIRECT or DATABASE_URL is required for the boot-time backfill",
+        );
+      }
+
+      // postgres.js v3 tries ALL resolved addresses (IPv4 + IPv6) in order.
+      // On VPSes without IPv6 routing, AAAA records cause ENETUNREACH before
+      // the IPv4 attempt. We resolve to IPv4 explicitly to skip that.
+      const { resolve4 } = await import("node:dns/promises");
+      const parsed = new URL(rawUrl);
+      const [ipv4] = await resolve4(parsed.hostname);
+      parsed.hostname = ipv4;
+      const url = parsed.toString();
+
+      // max: 1 — dedicated connection just for the boot-time backfill
+      // prepare: false — required for Supabase transaction pooler (harmless for direct)
+      const client = postgres(url, { max: 1, prepare: false });
+      const db = drizzle({ client });
+
+      // Backfill una-tantum del registro anti-frode `trial_vat_ledger` dalle
+      // P.IVA già su `profiles` (account creati prima del ledger). Self-gated:
+      // no-op se il ledger non è vuoto, quindi gira a ogni boot senza effetti.
+      // Degradare, non crashare (regola 19): un errore qui non deve impedire
+      // l'avvio — gli onboarding futuri popolano comunque il ledger.
+      try {
+        const { backfillTrialVatLedgerIfEmpty } =
+          await import("@/lib/backfill-trial-vat-ledger");
+        await backfillTrialVatLedgerIfEmpty(db);
+      } catch (err) {
+        const { logger } = await import("@/lib/logger");
+        logger.error(
+          { err, critical: true },
+          "backfill trial_vat_ledger fallito al boot (ignorato, riprova al prossimo avvio)",
+        );
+      }
+
+      await client.end();
     }
-
-    // postgres.js v3 tries ALL resolved addresses (IPv4 + IPv6) in order.
-    // On VPSes without IPv6 routing, AAAA records cause ENETUNREACH before
-    // the IPv4 attempt. We resolve to IPv4 explicitly to skip that.
-    const { resolve4 } = await import("node:dns/promises");
-    const parsed = new URL(rawUrl);
-    const [ipv4] = await resolve4(parsed.hostname);
-    parsed.hostname = ipv4;
-    const url = parsed.toString();
-
-    // max: 1 — dedicated connection just for the boot-time backfill
-    // prepare: false — required for Supabase transaction pooler (harmless for direct)
-    const client = postgres(url, { max: 1, prepare: false });
-    const db = drizzle({ client });
-
-    // Backfill una-tantum del registro anti-frode `trial_vat_ledger` dalle
-    // P.IVA già su `profiles` (account creati prima del ledger). Self-gated:
-    // no-op se il ledger non è vuoto, quindi gira a ogni boot senza effetti.
-    // Degradare, non crashare (regola 19): un errore qui non deve impedire
-    // l'avvio — gli onboarding futuri popolano comunque il ledger.
-    try {
-      const { backfillTrialVatLedgerIfEmpty } =
-        await import("@/lib/backfill-trial-vat-ledger");
-      await backfillTrialVatLedgerIfEmpty(db);
-    } catch (err) {
-      const { logger } = await import("@/lib/logger");
-      logger.error(
-        { err, critical: true },
-        "backfill trial_vat_ledger fallito al boot (ignorato, riprova al prossimo avvio)",
-      );
-    }
-
-    await client.end();
 
     // Keep-alive Supabase in coda al boot nodejs (dopo migrazioni e backfill):
     // la guardia di idempotenza dentro startSupabaseKeepAlive() evita timer


### PR DESCRIPTION
The boot hook (register) opened a DB connection and ran the trial_vat_ledger backfill unconditionally. In the CI smoke-test the prod image runs with no reachable DB (SKIP_MIGRATIONS=true, no postgres service), so the backfill's SELECT failed with ECONNREFUSED → logger.error({critical}) → Sentry, tagged environment=production from a throwaway CI container (SCONTRINOZERO-P; -N was the same class via migrate(), removed in #645).

Gate the boot-time DB block on SKIP_MIGRATIONS, mirroring migrate.js which already honors the same flag without connecting. Expected/environmental condition, not an error (CLAUDE.md rule 20). Prod does not set SKIP_MIGRATIONS (the CMD runs migrate.js every boot), so the backfill keeps running there.

Also revert the ineffective #646 smoke change: NEXT_PUBLIC_* DSN is inlined into the bundle at build time, so the runtime -e override was a no-op (proven by SCONTRINOZERO-P firing despite it).


Claude-Session: https://claude.ai/code/session_01XXK9TZpyXokkkr2LiVqrza