### PR TITLE
Bump version to 1.3.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Routine version bump to 1.3.15 in preparation for release.

## Changes
- Updated `package.json` version from `1.3.14` to `1.3.15`

## Notes
This is a standard version increment. The lockfile has been automatically updated with transitive dependency resolution.

https://claude.ai/code/session_01XaGDUPsGBipY3ydE3r1zMP