### PR TITLE
Recovery AdE: riduci ambiguous escludendo idtrx già collegati (follow-up #653)

### DIFF
--- a/src/lib/ade/types.ts
+++ b/src/lib/ade/types.ts
@@ -227,9 +227,10 @@ export interface AdeProduct {
 /**
  * Riepilogo documento nell'elenco risultati (GET /documenti/).
  *
- * HAR finding (annullo.har [03], [04]): campo "cfCliente" (non
- * "cfCessionarioCommittente" come nel dettaglio).
- * Date format: MM/DD/YYYY (es. "02/23/2026").
+ * HAR finding (ricerca.har, annullo.har [03], [04]): campo "cfCliente" (non
+ * "cfCessionarioCommittente" come nel dettaglio). ⚠️ Il `data` di risposta è
+ * DD/MM/YYYY HH:MM:SS (vedi campo sotto), mentre i query param dataDal/dataInvioAl
+ * usano MM/DD/YYYY — asimmetria reale, non un refuso.
  */
 export interface AdeDocumentSummary {
   idtrx: string;

--- a/src/lib/services/ade-recovery.test.ts
+++ b/src/lib/services/ade-recovery.test.ts
@@ -4,16 +4,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // vi.hoisted: i mock devono essere inizializzati PRIMA del factory vi.mock
 // (hoisted in cima) perché l'import statico di ade-recovery — che importa @/db —
 // fa girare il factory durante l'hoisting degli import.
-const { mockReturning, mockSet } = vi.hoisted(() => {
+const { mockReturning, mockSet, mockSelectWhere } = vi.hoisted(() => {
   const mockReturning = vi.fn();
   const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
   const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-  return { mockReturning, mockSet };
+  // SELECT ... FROM ... WHERE → risolve direttamente nelle righe (no .returning).
+  const mockSelectWhere = vi.fn();
+  return { mockReturning, mockSet, mockSelectWhere };
 });
 
 vi.mock("@/db", () => ({
   getDb: vi.fn().mockReturnValue({
     update: vi.fn().mockReturnValue({ set: mockSet }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: mockSelectWhere }),
+    }),
   }),
 }));
 
@@ -24,6 +29,7 @@ vi.mock("@/db/schema", () => ({
 import {
   buildAdeSearchWindow,
   claimStaleDocument,
+  findClaimedTransactionIds,
   formatAdeQueryDate,
   getStalePendingThresholdMs,
   parseAdeResultDate,
@@ -121,6 +127,108 @@ describe("claimStaleDocument", () => {
     const won = await claimStaleDocument(getDb(), "doc-1", new Date());
 
     expect(won).toBe(false);
+  });
+});
+
+describe("findClaimedTransactionIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectWhere.mockReset();
+  });
+
+  it("ritorna un set vuoto senza query quando idtrxs è vuoto", async () => {
+    const claimed = await findClaimedTransactionIds(getDb(), {
+      businessId: "biz-1",
+      excludeDocumentId: "doc-1",
+      idtrxs: [],
+    });
+    expect(claimed.size).toBe(0);
+    expect(mockSelectWhere).not.toHaveBeenCalled();
+  });
+
+  it("ritorna gli idtrx già collegati ad altre righe del business", async () => {
+    mockSelectWhere.mockResolvedValue([{ adeTransactionId: "154295136" }]);
+
+    const claimed = await findClaimedTransactionIds(getDb(), {
+      businessId: "biz-1",
+      excludeDocumentId: "doc-1",
+      idtrxs: ["154294949", "154295136"],
+    });
+
+    expect(claimed.has("154295136")).toBe(true);
+    expect(claimed.has("154294949")).toBe(false);
+  });
+
+  it("scarta gli adeTransactionId null difensivamente", async () => {
+    mockSelectWhere.mockResolvedValue([
+      { adeTransactionId: null },
+      { adeTransactionId: "154295136" },
+    ]);
+
+    const claimed = await findClaimedTransactionIds(getDb(), {
+      businessId: "biz-1",
+      excludeDocumentId: "doc-1",
+      idtrxs: ["154295136"],
+    });
+
+    expect([...claimed]).toEqual(["154295136"]);
+  });
+});
+
+describe("reconcile con esclusione claimedIdtrx", () => {
+  it("vendita: l'unico candidato è già collegato ad altra riga → none (no falso match)", () => {
+    const result = reconcileSaleDocument({
+      documents: [summary({ idtrx: "154294949" })],
+      expectedTotalCents: 170,
+      createdAt: SALE_CREATED_AT,
+      claimedIdtrx: new Set(["154294949"]),
+    });
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("vendita: due gemelle ma una già collegata → match sull'orfana residua", () => {
+    const result = reconcileSaleDocument({
+      documents: [
+        summary({ idtrx: "1", numeroProgressivo: "DCW2026/5432-1548" }),
+        summary({ idtrx: "2", numeroProgressivo: "DCW2026/5432-1549" }),
+      ],
+      expectedTotalCents: 170,
+      createdAt: SALE_CREATED_AT,
+      claimedIdtrx: new Set(["2"]),
+    });
+    expect(result).toEqual({
+      kind: "match",
+      idtrx: "1",
+      numeroProgressivo: "DCW2026/5432-1548",
+    });
+  });
+
+  it("vendita: due orfane identiche, nessuna collegata → resta ambiguous", () => {
+    const result = reconcileSaleDocument({
+      documents: [
+        summary({ idtrx: "1" }),
+        summary({ idtrx: "2", numeroProgressivo: "DCW2026/5432-1549" }),
+      ],
+      expectedTotalCents: 170,
+      createdAt: SALE_CREATED_AT,
+      claimedIdtrx: new Set(),
+    });
+    expect(result).toEqual({ kind: "ambiguous" });
+  });
+
+  it("annullo: l'unico candidato è già collegato → none", () => {
+    const result = reconcileVoidDocument({
+      documents: [
+        summary({
+          idtrx: "154295136",
+          tipoOperazione: "A",
+          annulli: "DCW2026/5432-1548",
+        }),
+      ],
+      saleProgressivo: "DCW2026/5432-1548",
+      claimedIdtrx: new Set(["154295136"]),
+    });
+    expect(result).toEqual({ kind: "none" });
   });
 });
 

--- a/src/lib/services/ade-recovery.ts
+++ b/src/lib/services/ade-recovery.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
 import type { AdeDocumentSummary } from "@/lib/ade/types";
@@ -189,6 +189,44 @@ function withinProximity(doc: AdeDocumentSummary, createdAt: Date): boolean {
   );
 }
 
+/**
+ * Fra gli `idtrx` passati, ritorna quelli già collegati come `adeTransactionId`
+ * a un ALTRO documento dello stesso business (id ≠ `excludeDocumentId`).
+ *
+ * Disambigua il lookup pre-retry: un documento AdE il cui idtrx è già
+ * rivendicato da un'altra riga è una vendita/annullo diverso e già
+ * contabilizzato → NON è il nostro orfano e va escluso dai candidati. Chiude
+ * due buchi: (1) l'`ambiguous` su vendite identiche quando la "gemella" è già
+ * andata a buon fine; (2) il falso `match` quando l'unico candidato appartiene
+ * in realtà a una vendita diversa già registrata (il nostro submit era stato
+ * rifiutato e non aveva creato nulla).
+ *
+ * `excludeDocumentId` evita di auto-escludersi in un raro TOCTOU (un retry
+ * concorrente che avesse già finalizzato la nostra stessa riga).
+ */
+export async function findClaimedTransactionIds(
+  db: ReturnType<typeof getDb>,
+  params: { businessId: string; excludeDocumentId: string; idtrxs: string[] },
+): Promise<Set<string>> {
+  const { businessId, excludeDocumentId, idtrxs } = params;
+  if (idtrxs.length === 0) return new Set();
+  const rows = await db
+    .select({ adeTransactionId: commercialDocuments.adeTransactionId })
+    .from(commercialDocuments)
+    .where(
+      and(
+        eq(commercialDocuments.businessId, businessId),
+        ne(commercialDocuments.id, excludeDocumentId),
+        inArray(commercialDocuments.adeTransactionId, idtrxs),
+      ),
+    );
+  const claimed = new Set<string>();
+  for (const row of rows) {
+    if (row.adeTransactionId) claimed.add(row.adeTransactionId);
+  }
+  return claimed;
+}
+
 /** Riduce una lista di candidati a un esito match/none/ambiguous. */
 function decide(candidates: AdeDocumentSummary[]): AdeReconcileResult {
   if (candidates.length === 0) return { kind: "none" };
@@ -208,6 +246,9 @@ function decide(candidates: AdeDocumentSummary[]): AdeReconcileResult {
  * temporale (±10 min) dal createdAt. Quando il codice lotteria è presente,
  * `cfCliente === lotteryCode` è una chiave secondaria che restringe ulteriormente.
  *
+ * `claimedIdtrx` esclude i documenti AdE già collegati ad altre righe del DB
+ * (vedi `findClaimedTransactionIds`): riduce l'ambiguous e previene i falsi match.
+ *
  * 0 candidati → none (procedi col re-submit); 1 → match (finalize-only);
  * >1 → ambiguous (conservativo: non finalizzare, resta PENDING).
  */
@@ -216,11 +257,19 @@ export function reconcileSaleDocument(params: {
   expectedTotalCents: number;
   createdAt: Date;
   lotteryCode?: string | null;
+  claimedIdtrx?: ReadonlySet<string>;
 }): AdeReconcileResult {
-  const { documents, expectedTotalCents, createdAt, lotteryCode } = params;
+  const {
+    documents,
+    expectedTotalCents,
+    createdAt,
+    lotteryCode,
+    claimedIdtrx,
+  } = params;
   const candidates = documents.filter(
     (doc) =>
       doc.tipoOperazione === "V" &&
+      !claimedIdtrx?.has(doc.idtrx) &&
       matchesAmount(doc, expectedTotalCents) &&
       withinProximity(doc, createdAt) &&
       (!lotteryCode || doc.cfCliente === lotteryCode),
@@ -234,14 +283,21 @@ export function reconcileSaleDocument(params: {
  * Chiave forte: `tipoOperazione === "A"` + `annulli === saleProgressivo` (il
  * progressivo della vendita annullata, univoco per cedente). Non serve la
  * finestra temporale: l'annullo è legato in modo univoco alla vendita.
+ *
+ * `claimedIdtrx` esclude gli annulli già collegati ad altre righe del DB (vedi
+ * `findClaimedTransactionIds`), per simmetria con la vendita.
  */
 export function reconcileVoidDocument(params: {
   documents: AdeDocumentSummary[];
   saleProgressivo: string;
+  claimedIdtrx?: ReadonlySet<string>;
 }): AdeReconcileResult {
-  const { documents, saleProgressivo } = params;
+  const { documents, saleProgressivo, claimedIdtrx } = params;
   const candidates = documents.filter(
-    (doc) => doc.tipoOperazione === "A" && doc.annulli === saleProgressivo,
+    (doc) =>
+      doc.tipoOperazione === "A" &&
+      !claimedIdtrx?.has(doc.idtrx) &&
+      doc.annulli === saleProgressivo,
   );
   return decide(candidates);
 }

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -10,7 +10,13 @@ vi.mock("@/lib/server-auth", () => ({
 }));
 
 const mockLimit = vi.fn();
-const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+// `.where()` serve due chiamanti: i lookup doc usano `.limit()`, mentre
+// findClaimedTransactionIds (REVIEW.md #4) awaita direttamente `.where()`.
+// Il thenable risolve [] (nessun idtrx già rivendicato → il match regge).
+const mockWhere = vi.fn().mockReturnValue({
+  limit: mockLimit,
+  then: (onFulfilled: (rows: unknown[]) => unknown) => onFulfilled([]),
+});
 const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
 const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -37,6 +37,7 @@ import type { AdeCedentePrestatore } from "@/lib/ade/types";
 import {
   buildAdeSearchWindow,
   claimStaleDocument,
+  findClaimedTransactionIds,
   getStalePendingThresholdMs,
   reconcileSaleDocument,
 } from "./ade-recovery";
@@ -525,6 +526,7 @@ async function reconcileSaleBeforeResubmit(
   const { documentId, businessId, createdAt, expectedTotalCents, lotteryCode } =
     ctx;
   let documents;
+  let claimedIdtrx: ReadonlySet<string>;
   try {
     const window = buildAdeSearchWindow(createdAt);
     const list = await adeClient.searchDocuments({
@@ -532,6 +534,14 @@ async function reconcileSaleBeforeResubmit(
       tipoOperazione: "V",
     });
     documents = list.elencoRisultati;
+    // Escludi i documenti AdE già collegati ad altre righe del business: un
+    // idtrx già rivendicato è una vendita diversa e già contabilizzata, non il
+    // nostro orfano (riduce ambiguous + previene falsi match).
+    claimedIdtrx = await findClaimedTransactionIds(getDb(), {
+      businessId,
+      excludeDocumentId: documentId,
+      idtrxs: documents.map((doc) => doc.idtrx),
+    });
   } catch (err) {
     // Fail-safe: non sappiamo se AdE aveva accettato → NON ri-sottomettiamo.
     logAdeFailure(
@@ -554,6 +564,7 @@ async function reconcileSaleBeforeResubmit(
     expectedTotalCents,
     createdAt,
     lotteryCode,
+    claimedIdtrx,
   });
 
   if (result.kind === "match") {

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -11,7 +11,14 @@ vi.mock("@/lib/server-auth", () => ({
 
 // DB mock
 const mockSelectLimit = vi.fn();
-const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit });
+// `.where()` serve due chiamanti: i lookup doc usano `.limit()`, mentre
+// findClaimedTransactionIds (REVIEW.md #4) awaita direttamente `.where()`.
+// Il thenable risolve [] (nessun idtrx già rivendicato → il match regge).
+const selectWhereResult = {
+  limit: mockSelectLimit,
+  then: (onFulfilled: (rows: unknown[]) => unknown) => onFulfilled([]),
+};
+const mockSelectWhere = vi.fn().mockReturnValue(selectWhereResult);
 const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
 const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
 
@@ -186,7 +193,7 @@ describe("voidReceiptForBusiness", () => {
     // select: first call returns saleDoc, subsequent calls return idempotency results
     mockSelect.mockReturnValue({ from: mockSelectFrom });
     mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
-    mockSelectWhere.mockReturnValue({ limit: mockSelectLimit });
+    mockSelectWhere.mockReturnValue(selectWhereResult);
     mockSelectLimit.mockResolvedValue([FAKE_SALE_DOC]);
 
     mockInsert.mockReturnValue({ values: mockInsertValues });

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -30,6 +30,7 @@ import type { AdeResponse } from "@/lib/ade/types";
 import {
   buildAdeSearchWindow,
   claimStaleDocument,
+  findClaimedTransactionIds,
   getStalePendingThresholdMs,
   reconcileVoidDocument,
 } from "./ade-recovery";
@@ -648,6 +649,7 @@ async function reconcileVoidBeforeResubmit(
 ): Promise<VoidReceiptResult | null> {
   const { voidDocumentId, saleDocumentId, businessId, saleProgressivo } = ctx;
   let documents;
+  let claimedIdtrx: ReadonlySet<string>;
   try {
     const window = buildAdeSearchWindow(ctx.voidCreatedAt);
     const list = await adeClient.searchDocuments({
@@ -655,6 +657,13 @@ async function reconcileVoidBeforeResubmit(
       tipoOperazione: "A",
     });
     documents = list.elencoRisultati;
+    // Escludi gli annulli AdE già collegati ad altre righe del business
+    // (simmetrico alla vendita): un idtrx già rivendicato non è il nostro orfano.
+    claimedIdtrx = await findClaimedTransactionIds(getDb(), {
+      businessId,
+      excludeDocumentId: voidDocumentId,
+      idtrxs: documents.map((doc) => doc.idtrx),
+    });
   } catch (err) {
     // Fail-safe: non sappiamo se AdE aveva registrato l'annullo → NON ri-sottomettiamo.
     logAdeFailure(
@@ -672,7 +681,11 @@ async function reconcileVoidBeforeResubmit(
     };
   }
 
-  const result = reconcileVoidDocument({ documents, saleProgressivo });
+  const result = reconcileVoidDocument({
+    documents,
+    saleProgressivo,
+    claimedIdtrx,
+  });
 
   if (result.kind === "match") {
     logger.warn(


### PR DESCRIPTION
Follow-up di [#653](https://github.com/dstmrk/scontrinozero/pull/653) (già merged), su richiesta in review.

## Contesto

Il lookup AdE pre-retry introdotto in #653 (REVIEW.md #4) classificava come `ambiguous` — quindi lasciava il documento `PENDING` — ogni volta che `searchDocuments` restituiva più candidati con stesso importo nella finestra temporale (es. due vendite identiche da €1,70 ravvicinate, senza codice lotteria).

## Cosa cambia

Tra i candidati, ora si **escludono quelli il cui `idtrx` è già collegato come `adeTransactionId` a un'ALTRA riga dello stesso business** (`findClaimedTransactionIds`). Un idtrx già rivendicato è una vendita/annullo diverso e già contabilizzato → non è il nostro orfano.

Chiude **due** casi:

1. **Ambiguous su vendite identiche** quando la "gemella" è già andata a buon fine → resta ambiguous solo se *entrambe* sono orfane (scenario rarissimo).
2. **Falso match** (bug latente di #653): se il nostro submit era stato *rifiutato* (nessun documento creato su AdE) ma esisteva una vendita identica già registrata, `searchDocuments` tornava 1 candidato → match → avremmo finalizzato la nostra riga con l'`idtrx` di **un'altra** vendita. Ora quel candidato è escluso → `none` → re-submit corretto.

`excludeDocumentId` evita l'auto-esclusione in un raro TOCTOU. Applicato anche al recovery annullo per simmetria.

**Perché non la descrizione delle voci?** Non disambigua le vendite identiche (righe identiche) e richiederebbe un `getDocument` per candidato (chiamata HTTP extra nella finestra critica). Il cross-reference col DB è una sola query indicizzata, solo nel path di recovery.

Incluso anche il fix di un commento stale su `AdeDocumentSummary` (diceva `MM/DD/YYYY`).

## Test

- `ade-recovery.test.ts`: +7 test (`findClaimedTransactionIds` con set vuoto/match/null; esclusione su vendita unica già collegata → none; due gemelle una collegata → match sull'orfana; due orfane → ancora ambiguous; annullo collegato → none).
- Suite AdE/recovery + integration verdi; type-check/eslint/prettier ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)