### PR TITLE
Refactor AdE login verification & standardize test assertions

### DIFF
--- a/src/components/json-ld.test.tsx
+++ b/src/components/json-ld.test.tsx
@@ -36,7 +36,7 @@ describe("JsonLd component", () => {
     };
     const html = renderToStaticMarkup(createElement(JsonLd, { data }));
     const closings = html.match(/<\/script>/g) ?? [];
-    expect(closings.length).toBe(1);
+    expect(closings).toHaveLength(1);
     expect(html).toContain("\\u003c/script\\u003e");
   });
 
@@ -193,11 +193,11 @@ describe("faqPageJsonLd", () => {
       { question: "Q2?", answer: "A2" },
     ];
     const result = faqPageJsonLd(items);
-    expect(result.mainEntity.length).toBe(items.length);
+    expect(result.mainEntity).toHaveLength(items.length);
   });
 
   it("includes all FAQ entries from faqItems", () => {
-    expect(faqPageJsonLd(faqItems).mainEntity.length).toBe(faqItems.length);
+    expect(faqPageJsonLd(faqItems).mainEntity).toHaveLength(faqItems.length);
   });
 
   it("each entry has @type Question", () => {

--- a/src/lib/ade/cookie-jar.test.ts
+++ b/src/lib/ade/cookie-jar.test.ts
@@ -280,7 +280,7 @@ describe("CookieJar", () => {
       expect(value).toContain("A=1");
       expect(value).toContain("B=2");
       expect(value).toContain("C=3");
-      expect(value.split("; ").length).toBe(3);
+      expect(value.split("; ")).toHaveLength(3);
     });
 
     it("returns empty string when jar is empty", () => {

--- a/src/lib/ade/mock-client.test.ts
+++ b/src/lib/ade/mock-client.test.ts
@@ -228,7 +228,7 @@ describe("MockAdeClient", () => {
       const session = await client.loginSpid(spidCreds);
 
       expect(session.pAuth).toMatch(/^mock_p_auth_spid_/);
-      expect(session.partitaIva.length).toBe(11);
+      expect(session.partitaIva).toHaveLength(11);
       expect(session.createdAt).toBeGreaterThan(0);
     });
 

--- a/src/lib/crypto.test.ts
+++ b/src/lib/crypto.test.ts
@@ -130,7 +130,7 @@ describe("getEncryptionKey", () => {
     process.env.ENCRYPTION_KEY = "ab".repeat(32);
     const key = getEncryptionKey();
     expect(key).toBeInstanceOf(Buffer);
-    expect(key.length).toBe(32);
+    expect(key).toHaveLength(32);
   });
 
   it("throws when ENCRYPTION_KEY is missing", () => {

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -508,6 +508,47 @@ async function finalizeAdeVerification(params: {
   return { credentialsChanged, trialAlreadyUsed };
 }
 
+/**
+ * Esegue il login AdE per la verifica credenziali e traduce gli errori in un
+ * OnboardingActionResult pronto da restituire al client. Ritorna `null` quando
+ * il login ha successo. Estratto da verifyAdeCredentials per tenerne sotto
+ * controllo la Cognitive Complexity (SonarCloud).
+ */
+async function attemptAdeLoginForVerification(
+  adeClient: ReturnType<typeof createAdeClient>,
+  credentials: { codiceFiscale: string; password: string; pin: string },
+  businessId: string,
+): Promise<OnboardingActionResult | null> {
+  try {
+    await adeClient.login(credentials);
+    return null;
+  } catch (err) {
+    if (err instanceof AdePasswordExpiredError) {
+      logger.warn({ businessId }, "AdE password scaduta durante verifica");
+      return {
+        error: "La password Fisconline è scaduta.",
+        passwordExpired: true,
+      };
+    }
+    logAdeFailure(
+      err,
+      { businessId, flow: "onboarding-verify" },
+      {
+        transient: "AdE credential verification: transient failure",
+        failure: "AdE credential verification failed",
+      },
+    );
+    const userFacing = getUserFacingAdeErrorMessage(
+      err,
+      "Verifica fallita. Controlla le credenziali Fisconline.",
+    );
+    return {
+      error: userFacing.message,
+      ...(userFacing.passwordExpired ? { passwordExpired: true } : {}),
+    };
+  }
+}
+
 export async function verifyAdeCredentials(
   businessId: string,
 ): Promise<OnboardingActionResult> {
@@ -559,33 +600,12 @@ export async function verifyAdeCredentials(
 
   const adeClient = createAdeClient(getAdeMode());
 
-  try {
-    await adeClient.login({ codiceFiscale, password, pin });
-  } catch (err) {
-    if (err instanceof AdePasswordExpiredError) {
-      logger.warn({ businessId }, "AdE password scaduta durante verifica");
-      return {
-        error: "La password Fisconline è scaduta.",
-        passwordExpired: true,
-      };
-    }
-    logAdeFailure(
-      err,
-      { businessId, flow: "onboarding-verify" },
-      {
-        transient: "AdE credential verification: transient failure",
-        failure: "AdE credential verification failed",
-      },
-    );
-    const userFacing = getUserFacingAdeErrorMessage(
-      err,
-      "Verifica fallita. Controlla le credenziali Fisconline.",
-    );
-    return {
-      error: userFacing.message,
-      ...(userFacing.passwordExpired ? { passwordExpired: true } : {}),
-    };
-  }
+  const loginError = await attemptAdeLoginForVerification(
+    adeClient,
+    { codiceFiscale, password, pin },
+    businessId,
+  );
+  if (loginError) return loginError;
 
   // Fetch fiscal data from AdE while the session is still active. Best-effort:
   // verification still succeeds (verifiedAt set) even if AdE doesn't return it;

--- a/tests/unit/lib-generate-pdf-response.test.ts
+++ b/tests/unit/lib-generate-pdf-response.test.ts
@@ -28,7 +28,7 @@ describe("sanitizePdfFilename", () => {
 
   it("truncates to 100 characters max", () => {
     const long = "a".repeat(200);
-    expect(sanitizePdfFilename(long).length).toBe(100);
+    expect(sanitizePdfFilename(long)).toHaveLength(100);
   });
 
   it("resists path traversal attempts (removes slashes)", () => {


### PR DESCRIPTION
## Summary

This PR extracts AdE login logic into a dedicated helper function to reduce cognitive complexity in `verifyAdeCredentials`, and standardizes test assertions across the codebase to use `toHaveLength()` instead of `.length` property checks.

## Key Changes

- **Extract `attemptAdeLoginForVerification()` helper** (`src/server/onboarding-actions.ts`)
  - Moves AdE login attempt and error handling from `verifyAdeCredentials` into a separate function
  - Handles `AdePasswordExpiredError`, logs failures with context, and translates errors to user-facing messages
  - Returns `null` on success or an `OnboardingActionResult` error object on failure
  - Reduces cognitive complexity in the parent function (SonarCloud compliance)

- **Standardize test assertions** across multiple test files
  - Replace `.length` property checks with Jest's `toHaveLength()` matcher:
    - `src/components/json-ld.test.tsx` (2 occurrences)
    - `src/lib/ade/cookie-jar.test.ts` (1 occurrence)
    - `src/lib/ade/mock-client.test.ts` (1 occurrence)
    - `src/lib/crypto.test.ts` (1 occurrence)
    - `tests/unit/lib-generate-pdf-response.test.ts` (1 occurrence)
  - Improves test readability and follows Jest best practices

## Implementation Details

- The extracted `attemptAdeLoginForVerification()` function maintains the exact same error handling logic and user-facing messages as the original inline code
- Function signature includes `adeClient`, credentials object, and `businessId` for logging context
- All error paths (password expired, transient failures, general failures) are preserved with identical behavior
- Test assertion changes are purely stylistic with no functional impact

https://claude.ai/code/session_01JyiZaCSfuoQhfJk5VbUcBR