### PR TITLE
feat(settings): aggiungi card "Aspetto" per il tema chiaro/scuro/sistema

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { redirect } from "next/navigation";
+import { ThemeProvider } from "next-themes";
 import { LogOut, Settings } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getOnboardingStatus } from "@/server/onboarding-actions";
@@ -35,59 +36,71 @@ export default async function DashboardLayout({
   const announcement = getAnnouncement();
 
   return (
-    <div className="flex min-h-screen flex-col">
-      {announcement && <AnnouncementBanner {...announcement} />}
-      <header className="bg-background border-b">
-        <div className="container mx-auto flex items-center justify-between px-4 py-3">
-          <Link
-            href="/dashboard"
-            className="text-primary flex items-center gap-2 text-lg font-bold"
-          >
-            <Image src="/logo.png" alt="ScontrinoZero" width={20} height={20} />
-            ScontrinoZero
-          </Link>
-
-          <div className="flex items-center md:hidden">
-            <Button
-              variant="ghost"
-              size="icon"
-              asChild
-              aria-label="Impostazioni"
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <div className="flex min-h-screen flex-col">
+        {announcement && <AnnouncementBanner {...announcement} />}
+        <header className="bg-background border-b">
+          <div className="container mx-auto flex items-center justify-between px-4 py-3">
+            <Link
+              href="/dashboard"
+              className="text-primary flex items-center gap-2 text-lg font-bold"
             >
-              <Link href="/dashboard/settings">
-                <Settings className="h-5 w-5" />
-              </Link>
-            </Button>
-            <form action={signOut}>
+              <Image
+                src="/logo.png"
+                alt="ScontrinoZero"
+                width={20}
+                height={20}
+              />
+              ScontrinoZero
+            </Link>
+
+            <div className="flex items-center md:hidden">
               <Button
                 variant="ghost"
                 size="icon"
-                type="submit"
-                aria-label="Esci"
+                asChild
+                aria-label="Impostazioni"
               >
-                <LogOut className="h-5 w-5" />
+                <Link href="/dashboard/settings">
+                  <Settings className="h-5 w-5" />
+                </Link>
               </Button>
-            </form>
+              <form action={signOut}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  type="submit"
+                  aria-label="Esci"
+                >
+                  <LogOut className="h-5 w-5" />
+                </Button>
+              </form>
+            </div>
+
+            <nav className="hidden items-center gap-4 md:flex">
+              <HeaderNav />
+
+              <form action={signOut}>
+                <Button variant="ghost" size="sm" type="submit">
+                  Esci
+                </Button>
+              </form>
+            </nav>
           </div>
+        </header>
 
-          <nav className="hidden items-center gap-4 md:flex">
-            <HeaderNav />
+        <main className="container mx-auto flex-1 px-4 py-6 pb-20 md:pb-6">
+          {children}
+        </main>
 
-            <form action={signOut}>
-              <Button variant="ghost" size="sm" type="submit">
-                Esci
-              </Button>
-            </form>
-          </nav>
-        </div>
-      </header>
-
-      <main className="container mx-auto flex-1 px-4 py-6 pb-20 md:pb-6">
-        {children}
-      </main>
-
-      <BottomNav />
-      <PwaInstallPrompt />
-    </div>
+        <BottomNav />
+        <PwaInstallPrompt />
+      </div>
+    </ThemeProvider>
   );
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -14,6 +14,7 @@ import { EditAdeCredentialsSection } from "@/components/settings/edit-ade-creden
 import { EditProfileSection } from "@/components/settings/edit-profile-section";
 import { EditBusinessSection } from "@/components/settings/edit-business-section";
 import { ChangePasswordSection } from "@/components/settings/change-password-section";
+import { ThemeSection } from "@/components/settings/theme-section";
 import { getProfilePlan } from "@/server/billing-actions";
 import {
   canUseApi,
@@ -363,6 +364,15 @@ export default async function SettingsPage({
           </CardContent>
         </Card>
       )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Aspetto</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ThemeSection />
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -75,7 +75,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="it">
+    <html lang="it" suppressHydrationWarning>
       <body
         className={`${nunitoSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/components/settings/theme-section.test.tsx
+++ b/src/components/settings/theme-section.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ThemeSection } from "./theme-section";
+
+// --- Mocks ---
+// Firma reale di setTheme (string) per evitare TS2556 (regola 16).
+const mockSetTheme = vi.fn<(theme: string) => void>();
+let mockTheme: string | undefined = "system";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: mockTheme, setTheme: mockSetTheme }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTheme = "system";
+});
+
+// --- Tests ---
+
+describe("ThemeSection", () => {
+  it("mostra le tre opzioni di tema", () => {
+    render(<ThemeSection />);
+
+    expect(screen.getByRole("button", { name: "Chiaro" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Scuro" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sistema" })).toBeInTheDocument();
+  });
+
+  it("evidenzia l'opzione attiva in base al tema corrente", () => {
+    mockTheme = "dark";
+    render(<ThemeSection />);
+
+    expect(screen.getByRole("button", { name: "Scuro" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Chiaro" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Sistema" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("imposta il tema chiaro al click su 'Chiaro'", () => {
+    render(<ThemeSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Chiaro" }));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("imposta il tema scuro al click su 'Scuro'", () => {
+    render(<ThemeSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Scuro" }));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("imposta il tema di sistema al click su 'Sistema'", () => {
+    render(<ThemeSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Sistema" }));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
+  });
+
+  it("non evidenzia alcuna opzione quando il tema non è ancora risolto", () => {
+    mockTheme = undefined;
+    render(<ThemeSection />);
+
+    for (const name of ["Chiaro", "Scuro", "Sistema"]) {
+      expect(screen.getByRole("button", { name })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    }
+  });
+});

--- a/src/components/settings/theme-section.test.tsx
+++ b/src/components/settings/theme-section.test.tsx
@@ -27,6 +27,14 @@ describe("ThemeSection", () => {
     expect(screen.getByRole("button", { name: "Sistema" })).toBeInTheDocument();
   });
 
+  it("espone il gruppo con un nome accessibile", () => {
+    render(<ThemeSection />);
+
+    expect(
+      screen.getByRole("group", { name: "Tema dell'interfaccia" }),
+    ).toBeInTheDocument();
+  });
+
   it("evidenzia l'opzione attiva in base al tema corrente", () => {
     mockTheme = "dark";
     render(<ThemeSection />);

--- a/src/components/settings/theme-section.tsx
+++ b/src/components/settings/theme-section.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Chiaro", Icon: Sun },
+  { value: "dark", label: "Scuro", Icon: Moon },
+  { value: "system", label: "Sistema", Icon: Monitor },
+] as const;
+
+export function ThemeSection() {
+  const { theme, setTheme } = useTheme();
+  // Il tema reale è noto solo lato client (localStorage / preferenza OS):
+  // finché non siamo montati nessuna opzione è "attiva", così il primo render
+  // client combacia con l'HTML del server ed evita hydration mismatch.
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- flag post-mount per evitare SSR/client mismatch sul tema risolto da localStorage
+    setMounted(true);
+  }, []);
+
+  return (
+    <div>
+      <p className="text-muted-foreground mb-4 text-sm">
+        Scegli l&apos;aspetto dell&apos;app. &laquo;Sistema&raquo; segue le
+        impostazioni del tuo dispositivo.
+      </p>
+      <div
+        className="grid grid-cols-3 gap-2"
+        role="group"
+        aria-label="Tema dell'interfaccia"
+      >
+        {THEME_OPTIONS.map(({ value, label, Icon }) => {
+          const isActive = mounted && theme === value;
+          return (
+            <Button
+              key={value}
+              type="button"
+              variant={isActive ? "default" : "outline"}
+              aria-pressed={isActive}
+              aria-label={label}
+              onClick={() => setTheme(value)}
+              className="flex h-auto flex-col gap-1.5 py-3"
+            >
+              <Icon className="size-5" aria-hidden="true" />
+              <span className="text-xs font-normal">{label}</span>
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/theme-section.tsx
+++ b/src/components/settings/theme-section.tsx
@@ -29,11 +29,8 @@ export function ThemeSection() {
         Scegli l&apos;aspetto dell&apos;app. &laquo;Sistema&raquo; segue le
         impostazioni del tuo dispositivo.
       </p>
-      <div
-        className="grid grid-cols-3 gap-2"
-        role="group"
-        aria-label="Tema dell'interfaccia"
-      >
+      <fieldset className="m-0 grid grid-cols-3 gap-2 border-0 p-0">
+        <legend className="sr-only">Tema dell&apos;interfaccia</legend>
         {THEME_OPTIONS.map(({ value, label, Icon }) => {
           const isActive = mounted && theme === value;
           return (
@@ -51,7 +48,7 @@ export function ThemeSection() {
             </Button>
           );
         })}
-      </div>
+      </fieldset>
     </div>
   );
 }


### PR DESCRIPTION
Cabla next-themes (gia in dipendenze ma mai configurato) e aggiunge una
card nelle impostazioni per scegliere il tema dell'interfaccia:
chiaro / scuro / sistema (default sistema, persistito in localStorage).

Scope limitato all'app autenticata: il ThemeProvider avvolge solo il
layout dashboard/, quindi marketing, auth, onboarding, la pagina pubblica
dello scontrino (/r/[documentId]) e /offline restano sempre light. Il PDF
e generato server-side da pdfkit ed e immune al tema.

- ThemeProvider in src/app/dashboard/layout.tsx (attribute=class,
  defaultTheme=system, enableSystem, disableTransitionOnChange)
- suppressHydrationWarning su <html> nel root layout
- nuovo ThemeSection (picker a 3 segmenti con Button + icone lucide),
  guard mounted per evitare hydration mismatch sul tema da localStorage
- card "Aspetto" in dashboard/settings + test del componente

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LuGhqCDpXUU41HTE3XRpXr