### PR TITLE
fix(auth): downgrade reset-password generateLink failure to warn

### DIFF
--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -1387,10 +1387,11 @@ describe("auth-actions", () => {
     it("still redirects when generateLink returns an error (no email sent)", async () => {
       mockGenerateLink.mockResolvedValue({
         data: { properties: {} },
-        error: { message: "User not found" },
+        error: { message: "User not found", status: 422 },
       });
 
       const { resetPassword } = await import("./auth-actions");
+      const { logger } = await import("@/lib/logger");
 
       try {
         await resetPassword(
@@ -1406,6 +1407,14 @@ describe("auth-actions", () => {
 
       await Promise.resolve();
       expect(mockSendEmail).not.toHaveBeenCalled();
+      // Regola 20 / SCONTRINOZERO-Q: "User not found" è input utente
+      // prevedibile → warn (con errorClass) e MAI error (che risalirebbe a
+      // Sentry come issue). Allineato a resendConfirmationEmail.
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ errorClass: expect.any(String) }),
+        "Reset password generateLink failed",
+      );
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("still redirects when action_link is missing (no email sent)", async () => {
@@ -1459,6 +1468,7 @@ describe("auth-actions", () => {
       });
 
       const { resetPassword } = await import("./auth-actions");
+      const { logger } = await import("@/lib/logger");
 
       try {
         await resetPassword(
@@ -1474,6 +1484,14 @@ describe("auth-actions", () => {
 
       await Promise.resolve();
       expect(mockSendEmail).not.toHaveBeenCalled();
+      // A differenza del fallimento generateLink (input utente → warn), il
+      // mismatch di hostname segnala una vera misconfigurazione/anomalia di
+      // sicurezza (cfr. SCONTRINOZERO-D) e DEVE restare a livello error →
+      // Sentry. Protegge la distinzione voluta tra i due branch.
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ actionLinkHostname: "evil.example.com" }),
+        "Reset password: action_link hostname mismatch or invalid URL — email not sent",
+      );
     });
 
     it("does not send email when redirect_to host is not the app host", async () => {

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -579,8 +579,14 @@ export async function resetPassword(
   });
 
   if (error || !data.properties?.action_link) {
-    logger.error(
-      { error: error?.message },
+    // Causa di gran lunga più comune: email non registrata → GoTrue risponde
+    // "User not found". È input utente prevedibile, non un bug nostro: warn
+    // (osservabilità in pino → Sentry Logs) ma NON un'issue Sentry. Allinea
+    // questo branch al flow gemello resendConfirmationEmail (CLAUDE.md regola
+    // 20, SCONTRINOZERO-Q). Il logger.error resta riservato al mismatch di
+    // hostname sotto, che segnala una vera misconfigurazione/anomalia.
+    logger.warn(
+      { errorClass: classifySupabaseAuthError(error ?? {}) },
       "Reset password generateLink failed",
     );
     // Always redirect to avoid email enumeration


### PR DESCRIPTION
La causa di gran lunga più comune del fallimento di
supabaseAdmin.auth.admin.generateLink in resetPassword è l'email non
registrata: GoTrue risponde "User not found". È input utente prevedibile,
non un bug nostro, ma veniva loggato con logger.error → Sentry
(SCONTRINOZERO-Q), violando la regola 20 di CLAUDE.md.

Allinea il branch al flow gemello resendConfirmationEmail: logger.warn con
errorClass via classifySupabaseAuthError. Osservabilità preservata in pino
→ Sentry Logs senza generare un'issue. Il redirect anti-enumeration a
/verify-email resta invariato; il logger.error sul mismatch di hostname
(vera misconfigurazione, cfr. SCONTRINOZERO-D) resta intatto.

Test: il caso generateLink-error ora asserisce warn + nessun error; nuovo
assert protegge che il branch hostname-mismatch resti a error.

Fixes SCONTRINOZERO-Q

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jqwxb1YHeG4bMTNyXe2Sfy