### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.15",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.3.15",
+      "version": "1.4.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.3.15",
+  "version": "1.4.0",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Release version 1.4.0 of ScontrinoZero.

## Changes
- Updated `package.json` version from `1.3.15` to `1.4.0`

## Notes
This is a minor version bump. Ensure that:
- All features intended for 1.4.0 are complete and tested
- Release notes/changelog have been prepared (if applicable)
- Deployment to production is coordinated with the version tag

https://claude.ai/code/session_01QL2JmrZ5wLLN2pRkeioAGn