### PR TITLE
Implement member-get-member referral program (v1.4.0)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -58,30 +58,31 @@ middleware), `src/lib/pdf`, `src/lib/pwa`, e i data file marketing
 
 ## Dove vivo X? (i punti che oggi costringono a grep)
 
-| Cerchi…                                           | Vai a                                                                                                                     |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Auth della richiesta (user UUID, bind Sentry)     | `src/lib/server-auth.ts` (`getAuthenticatedUser`)                                                                         |
-| Client Supabase (browser/server/admin/middleware) | `src/lib/supabase/server.ts`, `src/lib/supabase/client.ts`, `src/lib/supabase/admin.ts`, `src/lib/supabase/middleware.ts` |
-| Azioni auth (login/register/reset, T&C version)   | `src/server/auth-actions.ts`                                                                                              |
-| Plan gate / feature flag per piano                | `src/lib/plans.ts` + `src/lib/plans-shared.ts`                                                                            |
-| Totali scontrino (cents per-riga, canonico)       | `src/lib/receipts/document-lines.ts` (`calcInputLinesTotalCents`, `calcDocTotal`)                                         |
-| Orchestrazione emissione / annullo                | `src/lib/services/receipt-service.ts`, `src/lib/services/void-service.ts`                                                 |
-| Recovery stale-pending AdE                        | `src/lib/services/ade-recovery.ts`, `src/lib/services/request-hash.ts`                                                    |
-| Integrazione AdE (client reale/mock, adapter)     | `src/lib/ade/index.ts`, `src/lib/ade/real-client.ts`, `src/lib/ade/mock-client.ts`                                        |
-| Classi errore AdE + logging tipato                | `src/lib/ade/errors.ts`, `src/lib/ade/log-failure.ts`                                                                     |
-| Logger pino → Sentry (hook level≥50)              | `src/lib/logger.ts`                                                                                                       |
-| Filtri Sentry client (network noise)              | `src/lib/sentry-filters.ts`, `sentry.client.config.ts`                                                                    |
-| Env d'identità (URL/hostname, fail-fast)          | `src/lib/identity-env.ts`, `src/lib/hostname-env.ts`, `src/lib/trusted-app-url.ts`                                        |
-| Link marketing → app (cross-origin)               | `src/lib/marketing-to-app-href.ts` (`appHref`)                                                                            |
-| Rate limit                                        | `src/lib/rate-limit.ts`; client IP → `src/lib/get-client-ip.ts`                                                           |
-| Validazione boundary (UUID/email/body)            | `src/lib/validation.ts`, `src/lib/uuid.ts`, `src/lib/request-utils.ts`, `src/lib/api-errors.ts`                           |
-| Crittografia credenziali AdE (AES-256-GCM)        | `src/lib/crypto.ts`                                                                                                       |
-| CSP / security headers                            | `src/lib/csp.ts`, `src/lib/security-headers.ts`                                                                           |
-| Developer API (auth Bearer + handler)             | `src/app/api/v1/receipts`, `src/lib/api-auth.ts`, `src/lib/api-keys.ts`                                                   |
-| Stripe (SDK wrapper + webhook)                    | `src/lib/stripe.ts`, `src/app/api/stripe`                                                                                 |
-| Schema DB (una tabella per file)                  | `src/db/schema` (es. `src/db/schema/profiles.ts`, `src/db/schema/commercial-documents.ts`)                                |
-| Contenuti marketing/SEO (data file)               | `src/lib/guide`, `src/lib/help`, `src/lib/per`, `src/lib/confronto`, `src/lib/strumenti`                                  |
-| Health/diagnostica post-deploy                    | `src/app/api/health`, `src/app/api/_health`, `src/app/api/_debug`                                                         |
+| Cerchi…                                           | Vai a                                                                                                                                                                                             |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Auth della richiesta (user UUID, bind Sentry)     | `src/lib/server-auth.ts` (`getAuthenticatedUser`)                                                                                                                                                 |
+| Client Supabase (browser/server/admin/middleware) | `src/lib/supabase/server.ts`, `src/lib/supabase/client.ts`, `src/lib/supabase/admin.ts`, `src/lib/supabase/middleware.ts`                                                                         |
+| Azioni auth (login/register/reset, T&C version)   | `src/server/auth-actions.ts`                                                                                                                                                                      |
+| Plan gate / feature flag per piano                | `src/lib/plans.ts` + `src/lib/plans-shared.ts`                                                                                                                                                    |
+| Referral program (codice, redemption, reward)     | `src/lib/referral-code.ts`, `src/db/schema/referral-redemptions.ts`, cattura in `src/server/auth-actions.ts` (`signUp`), reward in `src/server/onboarding-actions.ts` (`finalizeAdeVerification`) |
+| Totali scontrino (cents per-riga, canonico)       | `src/lib/receipts/document-lines.ts` (`calcInputLinesTotalCents`, `calcDocTotal`)                                                                                                                 |
+| Orchestrazione emissione / annullo                | `src/lib/services/receipt-service.ts`, `src/lib/services/void-service.ts`                                                                                                                         |
+| Recovery stale-pending AdE                        | `src/lib/services/ade-recovery.ts`, `src/lib/services/request-hash.ts`                                                                                                                            |
+| Integrazione AdE (client reale/mock, adapter)     | `src/lib/ade/index.ts`, `src/lib/ade/real-client.ts`, `src/lib/ade/mock-client.ts`                                                                                                                |
+| Classi errore AdE + logging tipato                | `src/lib/ade/errors.ts`, `src/lib/ade/log-failure.ts`                                                                                                                                             |
+| Logger pino → Sentry (hook level≥50)              | `src/lib/logger.ts`                                                                                                                                                                               |
+| Filtri Sentry client (network noise)              | `src/lib/sentry-filters.ts`, `sentry.client.config.ts`                                                                                                                                            |
+| Env d'identità (URL/hostname, fail-fast)          | `src/lib/identity-env.ts`, `src/lib/hostname-env.ts`, `src/lib/trusted-app-url.ts`                                                                                                                |
+| Link marketing → app (cross-origin)               | `src/lib/marketing-to-app-href.ts` (`appHref`)                                                                                                                                                    |
+| Rate limit                                        | `src/lib/rate-limit.ts`; client IP → `src/lib/get-client-ip.ts`                                                                                                                                   |
+| Validazione boundary (UUID/email/body)            | `src/lib/validation.ts`, `src/lib/uuid.ts`, `src/lib/request-utils.ts`, `src/lib/api-errors.ts`                                                                                                   |
+| Crittografia credenziali AdE (AES-256-GCM)        | `src/lib/crypto.ts`                                                                                                                                                                               |
+| CSP / security headers                            | `src/lib/csp.ts`, `src/lib/security-headers.ts`                                                                                                                                                   |
+| Developer API (auth Bearer + handler)             | `src/app/api/v1/receipts`, `src/lib/api-auth.ts`, `src/lib/api-keys.ts`                                                                                                                           |
+| Stripe (SDK wrapper + webhook)                    | `src/lib/stripe.ts`, `src/app/api/stripe`                                                                                                                                                         |
+| Schema DB (una tabella per file)                  | `src/db/schema` (es. `src/db/schema/profiles.ts`, `src/db/schema/commercial-documents.ts`)                                                                                                        |
+| Contenuti marketing/SEO (data file)               | `src/lib/guide`, `src/lib/help`, `src/lib/per`, `src/lib/confronto`, `src/lib/strumenti`                                                                                                          |
+| Health/diagnostica post-deploy                    | `src/app/api/health`, `src/app/api/_health`, `src/app/api/_debug`                                                                                                                                 |
 
 ## Indice Server Actions (`src/server/*-actions.ts`)
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -63,6 +63,12 @@ function RegisterForm() {
   // un codice invalido blocca la registrazione — l'utente deve poterlo
   // correggere o cancellare dal form per procedere senza referral.
   const rcodeParam = useSearchParams().get("rcode");
+  // Nascosto dietro un toggle per non appesantire il form per chi non ha un
+  // codice (la maggioranza); già aperto se l'utente arriva da un link
+  // ?rcode= così non perde un click per vedere il valore precompilato.
+  const [showReferralField, setShowReferralField] = useState(
+    Boolean(rcodeParam),
+  );
 
   const form = useForm<RegisterData>({
     resolver: zodResolver(registerSchema),
@@ -222,28 +228,39 @@ function RegisterForm() {
               )}
             />
 
-            <FormField
-              control={form.control}
-              name="referralCode"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Codice referral (opzionale)</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="es. AB2CDEFG"
-                      autoComplete="off"
-                      spellCheck={false}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Hai un codice da un amico? Inseriscilo per ottenere 1 mese
-                    di trial extra. Lascia vuoto per registrarti senza.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            {showReferralField ? (
+              <FormField
+                control={form.control}
+                name="referralCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Codice referral (opzionale)</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="es. AB2CDEFG"
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Hai un codice da un amico? Inseriscilo per ottenere 1 mese
+                      di trial extra. Lascia vuoto per registrarti senza.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <button
+                type="button"
+                aria-expanded={false}
+                onClick={() => setShowReferralField(true)}
+                className="text-muted-foreground hover:text-foreground text-sm underline"
+              >
+                Hai un codice invito?
+              </button>
+            )}
 
             <TurnstileWidget
               ref={turnstileRef}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -10,6 +10,7 @@ import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { signUp } from "@/server/auth-actions";
 import { passwordFieldSchema } from "@/lib/validation";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -40,6 +41,7 @@ const registerSchema = z
     specificClausesAccepted: z
       .boolean()
       .refine((v) => v, "Devi accettare specificamente le clausole indicate."),
+    referralCode: z.string().optional(),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Le password non coincidono.",
@@ -57,6 +59,10 @@ function RegisterForm() {
   // Suspense boundary in RegisterPage required by Next.js for useSearchParams
   // during SSG prerender (CSR bailout).
   const refParam = useSearchParams().get("ref");
+  // Codice referral: visibile e modificabile (a differenza di `ref`) perché
+  // un codice invalido blocca la registrazione — l'utente deve poterlo
+  // correggere o cancellare dal form per procedere senza referral.
+  const rcodeParam = useSearchParams().get("rcode");
 
   const form = useForm<RegisterData>({
     resolver: zodResolver(registerSchema),
@@ -66,6 +72,7 @@ function RegisterForm() {
       confirmPassword: "",
       termsAccepted: false,
       specificClausesAccepted: false,
+      referralCode: rcodeParam ?? "",
     },
   });
 
@@ -78,6 +85,7 @@ function RegisterForm() {
     formData.set("specificClausesAccepted", "true");
     if (captchaToken) formData.set("captchaToken", captchaToken);
     if (refParam) formData.set("ref", refParam);
+    if (data.referralCode) formData.set("rcode", data.referralCode);
 
     startTransition(async () => {
       const result = await signUp(formData);
@@ -209,6 +217,29 @@ function RegisterForm() {
                       di Torino per controversie B2B).
                     </label>
                   </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="referralCode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Codice referral (opzionale)</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="es. AB2CDEFG"
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Hai un codice da un amico? Inseriscilo per ottenere 1 mese
+                    di trial extra. Lascia vuoto per registrarti senza.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,8 +1,14 @@
 import { redirect } from "next/navigation";
-import { eq } from "drizzle-orm";
+import { and, count, eq, isNotNull } from "drizzle-orm";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getDb } from "@/db";
-import { profiles, businesses, adeCredentials } from "@/db/schema";
+import {
+  profiles,
+  businesses,
+  adeCredentials,
+  referralRedemptions,
+} from "@/db/schema";
+import { ReferralSection } from "@/components/settings/referral-section";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { VAT_DESCRIPTIONS, type VatCode, VAT_CODES } from "@/types/cassa";
@@ -87,6 +93,20 @@ export default async function SettingsPage({
     VAT_CODES.includes(business.preferredVatCode as VatCode)
       ? VAT_DESCRIPTIONS[business.preferredVatCode as VatCode]
       : null;
+
+  const completedReferrals = profile
+    ? ((
+        await db
+          .select({ value: count() })
+          .from(referralRedemptions)
+          .where(
+            and(
+              eq(referralRedemptions.referrerId, profile.id),
+              isNotNull(referralRedemptions.rewardedAt),
+            ),
+          )
+      )[0]?.value ?? 0)
+    : 0;
 
   const planResult = await getProfilePlan();
   const planData =
@@ -242,6 +262,20 @@ export default async function SettingsPage({
           />
         </CardContent>
       </Card>
+
+      {profile && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Referral</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ReferralSection
+              referralCode={profile.referralCode}
+              completedReferrals={completedReferrals}
+            />
+          </CardContent>
+        </Card>
+      )}
 
       {planData && (
         // id="billing" → ancora del deep-link BILLING_SETTINGS_HREF

--- a/src/app/r/[documentId]/share-button.test.tsx
+++ b/src/app/r/[documentId]/share-button.test.tsx
@@ -23,6 +23,30 @@ describe("ShareButton", () => {
     expect(screen.getByText("Condividi ricevuta")).toBeInTheDocument();
   });
 
+  it("usa label e copiedLabel custom quando forniti", async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      share: undefined,
+      clipboard: { writeText: mockWriteText },
+    });
+
+    render(
+      <ShareButton
+        url="/register?rcode=AB2CDEFG"
+        title="Test"
+        label="Condividi codice referral"
+        copiedLabel="Codice copiato!"
+      />,
+    );
+    expect(screen.getByText("Condividi codice referral")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Codice copiato!")).toBeInTheDocument();
+    });
+  });
+
   it("chiama navigator.share con l'URL completo quando disponibile", async () => {
     const mockShare = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { share: mockShare });

--- a/src/app/r/[documentId]/share-button.tsx
+++ b/src/app/r/[documentId]/share-button.tsx
@@ -6,9 +6,16 @@ import { Share2, Check, Copy } from "lucide-react";
 interface ShareButtonProps {
   readonly url: string;
   readonly title: string;
+  readonly label?: string;
+  readonly copiedLabel?: string;
 }
 
-export function ShareButton({ url, title }: ShareButtonProps) {
+export function ShareButton({
+  url,
+  title,
+  label = "Condividi ricevuta",
+  copiedLabel = "Link copiato!",
+}: ShareButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleShare = async () => {
@@ -44,12 +51,12 @@ export function ShareButton({ url, title }: ShareButtonProps) {
       {copied ? (
         <>
           <Check className="h-4 w-4 text-green-600" />
-          <span className="text-green-600">Link copiato!</span>
+          <span className="text-green-600">{copiedLabel}</span>
         </>
       ) : (
         <>
           <Share2 className="h-4 w-4" />
-          Condividi ricevuta
+          {label}
         </>
       )}
       {!copied && <Copy className="ml-auto h-3.5 w-3.5 text-gray-400" />}

--- a/src/components/settings/referral-section.test.tsx
+++ b/src/components/settings/referral-section.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReferralSection } from "./referral-section";
+
+describe("ReferralSection", () => {
+  it("mostra il codice referral dell'utente", () => {
+    render(<ReferralSection referralCode="AB2CDEFG" completedReferrals={0} />);
+    expect(screen.getByText("AB2CDEFG")).toBeInTheDocument();
+  });
+
+  it("mostra il bottone di condivisione con label custom per il referral", () => {
+    render(<ReferralSection referralCode="AB2CDEFG" completedReferrals={0} />);
+    expect(screen.getByText("Condividi codice referral")).toBeInTheDocument();
+  });
+
+  it("non mostra il contatore referral completati quando è zero", () => {
+    render(<ReferralSection referralCode="AB2CDEFG" completedReferrals={0} />);
+    expect(screen.queryByText(/Referral completati/)).not.toBeInTheDocument();
+  });
+
+  it("mostra il contatore referral completati quando maggiore di zero", () => {
+    render(<ReferralSection referralCode="AB2CDEFG" completedReferrals={3} />);
+    expect(screen.getByText("Referral completati: 3")).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/referral-section.tsx
+++ b/src/components/settings/referral-section.tsx
@@ -1,0 +1,35 @@
+import { ShareButton } from "@/app/r/[documentId]/share-button";
+
+interface ReferralSectionProps {
+  readonly referralCode: string;
+  readonly completedReferrals: number;
+}
+
+export function ReferralSection({
+  referralCode,
+  completedReferrals,
+}: ReferralSectionProps) {
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-sm">
+        Invita un amico: chi si registra con il tuo codice ottiene 1 mese di
+        trial extra, e tu ricevi 1 mese in più sul tuo piano quando completa la
+        verifica della P.IVA.
+      </p>
+      <div className="bg-muted flex items-center justify-between rounded-md border px-3 py-2">
+        <span className="font-mono text-sm tracking-wider">{referralCode}</span>
+      </div>
+      <ShareButton
+        url={`/register?rcode=${referralCode}`}
+        title="Unisciti a ScontrinoZero"
+        label="Condividi codice referral"
+        copiedLabel="Link copiato!"
+      />
+      {completedReferrals > 0 && (
+        <p className="text-muted-foreground text-xs">
+          Referral completati: {completedReferrals}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -8,4 +8,5 @@ export * from "./subscriptions";
 export * from "./api-keys";
 export * from "./stripe-webhook-events";
 export * from "./trial-vat-ledger";
+export * from "./referral-redemptions";
 export * from "./relations";

--- a/src/db/schema/profiles.ts
+++ b/src/db/schema/profiles.ts
@@ -1,4 +1,11 @@
-import { check, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import {
+  check,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
 export const profiles = pgTable(
@@ -33,6 +40,23 @@ export const profiles = pgTable(
     // Attribution: provenance from ?ref= query string at signup time.
     // Validated against allowlist in src/lib/signup-source.ts before insert.
     signupSource: text("signup_source"),
+    // Referral program (member-get-member). Codice personale riusabile,
+    // derivato deterministicamente dall'authUserId all'INSERT
+    // (src/lib/referral-code.ts). Distinto dal futuro `referred_by` del
+    // programma Partner (NDS, monouso, B2B). NOT NULL: i profili
+    // pre-esistenti alla migration 0021 sono stati backfillati in SQL nella
+    // migration stessa (replica esatta dell'algoritmo JS), nessun intervento
+    // manuale richiesto.
+    referralCode: text("referral_code").notNull().unique(),
+    // Codice referral usato da QUESTO utente in fase di signup (audit, NULL
+    // se nessun referral). Nome distinto da `referred_by` per non confondersi
+    // con l'attribution partner futura.
+    referredByReferralCode: text("referred_by_referral_code"),
+    // Giorni bonus accumulati via referral (proprio +1 mese da nuovo utente +
+    // reward come referrer). Additivo, mai scritto dal webhook Stripe — vedi
+    // src/lib/plans.ts fetchPlan(). Per `unlimited` è ininfluente: i gate non
+    // leggono planExpiresAt/trialStartedAt per quel piano.
+    referralBonusDays: integer("referral_bonus_days").notNull().default(0),
   },
   (table) => [
     // Defense-in-depth (migration 0019): 254 = RFC 5321 max address length.

--- a/src/db/schema/referral-redemptions.ts
+++ b/src/db/schema/referral-redemptions.ts
@@ -1,0 +1,36 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { profiles } from "./profiles";
+
+/**
+ * Audit + idempotenza del reward referral. Una riga per ogni signup avvenuto
+ * con un `?rcode=` valido. `rewardedAt` resta NULL finché il referee non
+ * completa la verifica P.IVA (stesso checkpoint anti-abuso del
+ * `trial_vat_ledger`) — solo a quel punto il referrer riceve +30 giorni su
+ * `profiles.referral_bonus_days` (src/server/onboarding-actions.ts
+ * finalizeAdeVerification).
+ *
+ * `refereeId` è UNIQUE: ogni referee può far guadagnare il reward al
+ * referrer una sola volta, anche sotto race (claim via
+ * `UPDATE ... WHERE rewarded_at IS NULL`).
+ */
+export const referralRedemptions = pgTable("referral_redemptions", {
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  referrerId: uuid("referrer_id")
+    .notNull()
+    .references(() => profiles.id),
+  refereeId: uuid("referee_id")
+    .notNull()
+    .unique()
+    .references(() => profiles.id),
+  referralCode: text("referral_code").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  rewardedAt: timestamp("rewarded_at", { withTimezone: true }),
+});
+
+export type InsertReferralRedemption = typeof referralRedemptions.$inferInsert;
+export type SelectReferralRedemption = typeof referralRedemptions.$inferSelect;

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -494,6 +494,65 @@ describe("getPlan", () => {
     });
   });
 
+  it("trasla trialStartedAt indietro di referralBonusDays (trial più lungo)", async () => {
+    const trialStartedAt = new Date("2026-01-15T00:00:00Z");
+    mockLimit.mockResolvedValue([
+      {
+        plan: "trial",
+        trialStartedAt,
+        planExpiresAt: null,
+        referralBonusDays: 30,
+      },
+    ]);
+
+    const result = await getPlan("user-bonus-trial");
+
+    expect(result.trialStartedAt).toEqual(new Date("2025-12-16T00:00:00Z"));
+  });
+
+  it("trasla planExpiresAt avanti di referralBonusDays (scadenza più lontana)", async () => {
+    const planExpiresAt = new Date("2026-06-01T00:00:00Z");
+    mockLimit.mockResolvedValue([
+      {
+        plan: "pro",
+        trialStartedAt: null,
+        planExpiresAt,
+        referralBonusDays: 30,
+      },
+    ]);
+
+    const result = await getPlan("user-bonus-pro");
+
+    expect(result.planExpiresAt).toEqual(new Date("2026-07-01T00:00:00Z"));
+  });
+
+  it("referralBonusDays = 0 lascia le date inalterate (regression guard)", async () => {
+    const trialStartedAt = new Date("2026-01-01T00:00:00Z");
+    mockLimit.mockResolvedValue([
+      {
+        plan: "trial",
+        trialStartedAt,
+        planExpiresAt: null,
+        referralBonusDays: 0,
+      },
+    ]);
+
+    const result = await getPlan("user-no-bonus");
+
+    expect(result.trialStartedAt).toEqual(trialStartedAt);
+  });
+
+  it("referralBonusDays mancante nella riga DB non rompe il calcolo (default 0)", async () => {
+    const trialStartedAt = new Date("2026-01-01T00:00:00Z");
+    mockLimit.mockResolvedValue([
+      { plan: "trial", trialStartedAt, planExpiresAt: null },
+    ]);
+
+    const result = await getPlan("user-undefined-bonus");
+
+    expect(result.trialStartedAt).toEqual(trialStartedAt);
+  });
+
   it("throws ProfileNotFoundError when profile is not found", async () => {
     mockLimit.mockResolvedValue([]);
 

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -71,6 +71,7 @@ async function fetchPlan(authUserId: string): Promise<PlanInfo> {
       plan: profiles.plan,
       trialStartedAt: profiles.trialStartedAt,
       planExpiresAt: profiles.planExpiresAt,
+      referralBonusDays: profiles.referralBonusDays,
     })
     .from(profiles)
     .where(eq(profiles.authUserId, authUserId))
@@ -92,10 +93,23 @@ async function fetchPlan(authUserId: string): Promise<PlanInfo> {
     throw new ProfileNotFoundError(authUserId);
   }
 
+  // Bonus referral (member-get-member): trasla le date PRIMA di ritornarle,
+  // così isTrialExpired/isPaidPlanExpired e i 14 call site esistenti non
+  // cambiano firma. `referral_bonus_days` è additivo e indipendente dal sync
+  // Stripe (che sovrascrive solo planExpiresAt in toto) — vive qui, nell'unico
+  // punto che produce PlanInfo.
+  const bonusMs = (profile.referralBonusDays ?? 0) * 24 * 60 * 60 * 1000;
+  const trialStartedAt = profile.trialStartedAt
+    ? new Date(profile.trialStartedAt.getTime() - bonusMs)
+    : null;
+  const planExpiresAt = profile.planExpiresAt
+    ? new Date(profile.planExpiresAt.getTime() + bonusMs)
+    : null;
+
   return {
     plan: profile.plan,
-    trialStartedAt: profile.trialStartedAt ?? null,
-    planExpiresAt: profile.planExpiresAt ?? null,
+    trialStartedAt,
+    planExpiresAt,
   };
 }
 

--- a/src/lib/referral-code.test.ts
+++ b/src/lib/referral-code.test.ts
@@ -1,16 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { generateReferralCode, normalizeReferralCode } from "./referral-code";
 
+const ALPHABET_RE = /^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{8}$/;
+
 describe("generateReferralCode", () => {
-  it("genera un codice di 8 caratteri nell'alfabeto senza ambigui", () => {
+  it("genera un codice di 8 caratteri nell'alfabeto Crockford base32", () => {
     const code = generateReferralCode("user-1");
-    expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{8}$/);
+    expect(code).toMatch(ALPHABET_RE);
   });
 
-  it("non genera caratteri ambigui (0, O, 1, I, L)", () => {
+  it("genera SEMPRE 8 caratteri validi, mai 'undefined' o simboli fuori alfabeto (regression: alfabeto a 32 simboli, indice 5-bit 0–31 sempre mappato)", () => {
+    // Con un alfabeto a 31 simboli ~22% dei seed produceva la stringa
+    // letterale "undefined" (indice 31 → ALPHABET[31] === undefined). Copre
+    // abbastanza seed da incontrare con certezza un indice 31 in ogni posizione.
+    for (let i = 0; i < 2000; i++) {
+      const code = generateReferralCode(`seed-${i}`);
+      expect(code).toMatch(ALPHABET_RE);
+      expect(code).not.toContain("undefined");
+    }
+  });
+
+  it("non genera caratteri ambigui (O, I, L, U)", () => {
     for (let i = 0; i < 200; i++) {
       const code = generateReferralCode(`seed-${i}`);
-      expect(code).not.toMatch(/[01OIL]/);
+      expect(code).not.toMatch(/[OILU]/);
     }
   });
 
@@ -32,6 +45,10 @@ describe("normalizeReferralCode", () => {
     expect(normalizeReferralCode("ab2cdefg")).toBe("AB2CDEFG");
   });
 
+  it("accetta cifre 0 e 1 (non ambigue: O e I non sono nell'alfabeto)", () => {
+    expect(normalizeReferralCode("01234567")).toBe("01234567");
+  });
+
   it("ignora spazi superflui", () => {
     expect(normalizeReferralCode("  AB2CDEFG  ")).toBe("AB2CDEFG");
   });
@@ -50,9 +67,11 @@ describe("normalizeReferralCode", () => {
     expect(normalizeReferralCode("AB2CDEFGH")).toBeNull();
   });
 
-  it("rifiuta caratteri ambigui (0, O, 1, I, L)", () => {
-    expect(normalizeReferralCode("AB2CDEF0")).toBeNull();
+  it("rifiuta caratteri ambigui esclusi dall'alfabeto (O, I, L, U)", () => {
+    expect(normalizeReferralCode("AB2CDEFO")).toBeNull();
     expect(normalizeReferralCode("AB2CDEFI")).toBeNull();
+    expect(normalizeReferralCode("AB2CDEFL")).toBeNull();
+    expect(normalizeReferralCode("AB2CDEFU")).toBeNull();
   });
 
   it("rifiuta caratteri non alfanumerici", () => {

--- a/src/lib/referral-code.test.ts
+++ b/src/lib/referral-code.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { generateReferralCode, normalizeReferralCode } from "./referral-code";
+
+describe("generateReferralCode", () => {
+  it("genera un codice di 8 caratteri nell'alfabeto senza ambigui", () => {
+    const code = generateReferralCode("user-1");
+    expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{8}$/);
+  });
+
+  it("non genera caratteri ambigui (0, O, 1, I, L)", () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateReferralCode(`seed-${i}`);
+      expect(code).not.toMatch(/[01OIL]/);
+    }
+  });
+
+  it("è deterministico: lo stesso seed produce sempre lo stesso codice", () => {
+    const seed = "11111111-1111-1111-1111-111111111111";
+    expect(generateReferralCode(seed)).toBe(generateReferralCode(seed));
+  });
+
+  it("seed diversi producono codici diversi", () => {
+    const codes = new Set(
+      Array.from({ length: 50 }, (_, i) => generateReferralCode(`seed-${i}`)),
+    );
+    expect(codes.size).toBe(50);
+  });
+});
+
+describe("normalizeReferralCode", () => {
+  it("accetta un codice valido e lo normalizza in maiuscolo", () => {
+    expect(normalizeReferralCode("ab2cdefg")).toBe("AB2CDEFG");
+  });
+
+  it("ignora spazi superflui", () => {
+    expect(normalizeReferralCode("  AB2CDEFG  ")).toBe("AB2CDEFG");
+  });
+
+  it("rifiuta input non stringa", () => {
+    expect(normalizeReferralCode(null)).toBeNull();
+    expect(normalizeReferralCode(undefined)).toBeNull();
+  });
+
+  it("rifiuta stringa vuota", () => {
+    expect(normalizeReferralCode("")).toBeNull();
+  });
+
+  it("rifiuta lunghezza errata", () => {
+    expect(normalizeReferralCode("AB2CDEF")).toBeNull();
+    expect(normalizeReferralCode("AB2CDEFGH")).toBeNull();
+  });
+
+  it("rifiuta caratteri ambigui (0, O, 1, I, L)", () => {
+    expect(normalizeReferralCode("AB2CDEF0")).toBeNull();
+    expect(normalizeReferralCode("AB2CDEFI")).toBeNull();
+  });
+
+  it("rifiuta caratteri non alfanumerici", () => {
+    expect(normalizeReferralCode("AB2CDEF!")).toBeNull();
+  });
+});

--- a/src/lib/referral-code.ts
+++ b/src/lib/referral-code.ts
@@ -14,13 +14,18 @@
  * non-ambiguo, rischio di collisione trascurabile per le dimensioni di
  * questo prodotto).
  *
- * Alfabeto base32 senza caratteri ambigui (niente 0/O, 1/I/L), 32 simboli =
- * esattamente 5 bit/carattere: i primi 5 byte del digest (40 bit) si
- * suddividono in 8 simboli senza bias né bit di scarto.
+ * Alfabeto Crockford base32 (`0123456789ABCDEFGHJKMNPQRSTVWXYZ`): 32 simboli
+ * = esattamente 5 bit/carattere, così i primi 5 byte del digest (40 bit) si
+ * suddividono in 8 simboli senza bias né bit di scarto, e ogni indice a 5 bit
+ * (0–31) ha un simbolo corrispondente. Esclude I/L/O/U (ambigui con 1/0 e tra
+ * loro): tenere 0 e 1 è sicuro proprio perché O e I non esistono nell'alfabeto.
+ * ⚠️ Deve restare identico, carattere per carattere, alla replica SQL in
+ * `supabase/migrations/0021_referral_program.sql` (backfill via pgcrypto):
+ * qualunque divergenza genera codici diversi tra app e backfill.
  */
 import { createHash } from "node:crypto";
 
-const ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const CODE_LENGTH = 8;
 const CODE_RE = new RegExp(`^[${ALPHABET}]{${CODE_LENGTH}}$`);
 

--- a/src/lib/referral-code.ts
+++ b/src/lib/referral-code.ts
@@ -1,0 +1,53 @@
+/**
+ * Codice referral personale: condivisibile via link
+ * (`/register?rcode=<code>`), riusabile da più nuovi utenti (a differenza dei
+ * partner code monouso). Non è un segreto — non protegge nulla, identifica
+ * solo il referrer — quindi nessun hash separato, salvato in chiaro su
+ * `profiles.referral_code`.
+ *
+ * **Deterministico, non casuale**: derivato dall'`authUserId` via SHA-256
+ * troncato, non da `crypto.randomInt`. Due motivi: (1) ripetibile — lo stesso
+ * authUserId produce sempre lo stesso codice, utile per il backfill dei
+ * profili pre-esistenti (replicato in SQL nella migration 0021, via
+ * `digest()`/pgcrypto, stesso algoritmo bit-per-bit); (2) nessun retry su
+ * collisione necessario in pratica (40 bit di entropia su un alfabeto
+ * non-ambiguo, rischio di collisione trascurabile per le dimensioni di
+ * questo prodotto).
+ *
+ * Alfabeto base32 senza caratteri ambigui (niente 0/O, 1/I/L), 32 simboli =
+ * esattamente 5 bit/carattere: i primi 5 byte del digest (40 bit) si
+ * suddividono in 8 simboli senza bias né bit di scarto.
+ */
+import { createHash } from "node:crypto";
+
+const ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const CODE_LENGTH = 8;
+const CODE_RE = new RegExp(`^[${ALPHABET}]{${CODE_LENGTH}}$`);
+
+/** Genera il codice referral per `seed` (tipicamente `authUserId`). Deterministico. */
+export function generateReferralCode(seed: string): string {
+  const digest = createHash("sha256").update(seed).digest();
+  let bits = BigInt(0);
+  for (let i = 0; i < 5; i++) {
+    bits = (bits << BigInt(8)) | BigInt(digest[i]);
+  }
+  let code = "";
+  for (let i = CODE_LENGTH - 1; i >= 0; i--) {
+    const index = Number((bits >> BigInt(i * 5)) & BigInt(31));
+    code += ALPHABET[index];
+  }
+  return code;
+}
+
+/**
+ * Valida solo il formato del codice letto da `?rcode=`/form — nessun accesso
+ * DB (boundary API, stesso pattern di `normalizeSignupSource`). Il lookup in
+ * `profiles` avviene a parte, nel chiamante.
+ */
+export function normalizeReferralCode(
+  raw: string | null | undefined,
+): string | null {
+  if (typeof raw !== "string") return null;
+  const normalised = raw.trim().toUpperCase();
+  return CODE_RE.test(normalised) ? normalised : null;
+}

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -38,7 +38,8 @@ vi.mock("@/lib/supabase/admin", () => ({
   }),
 }));
 
-const mockValues = vi.fn().mockResolvedValue(undefined);
+const mockReturning = vi.fn().mockResolvedValue([{ id: "profile-id" }]);
+const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
 const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
 const mockLimit = vi.fn().mockResolvedValue([]);
 const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
@@ -537,6 +538,131 @@ describe("auth-actions", () => {
       expect(result).toEqual({ error: "Registrazione fallita. Riprova." });
       expect(logger.error).toHaveBeenCalled();
       expect(mockSignUp).not.toHaveBeenCalled();
+    });
+
+    it("blocca la registrazione con un codice referral malformato (hard-block, non enumeration)", async () => {
+      const { signUp } = await import("./auth-actions");
+      const result = await signUp(
+        formData({
+          email: "test@example.com",
+          password: "Secure#99x",
+          confirmPassword: "Secure#99x",
+          termsAccepted: "true",
+          specificClausesAccepted: "true",
+          captchaToken: "valid-token",
+          rcode: "not-valid!!",
+        }),
+      );
+
+      expect(result).toEqual({
+        error:
+          "Codice referral non valido. Correggilo o rimuovilo per continuare.",
+      });
+      expect(mockSignUp).not.toHaveBeenCalled();
+    });
+
+    it("blocca la registrazione con un codice referral ben formato ma inesistente", async () => {
+      // 1a mockLimit: email pre-check (non esiste) → []. 2a: lookup referral → [].
+      mockLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const { signUp } = await import("./auth-actions");
+      const result = await signUp(
+        formData({
+          email: "test@example.com",
+          password: "Secure#99x",
+          confirmPassword: "Secure#99x",
+          termsAccepted: "true",
+          specificClausesAccepted: "true",
+          captchaToken: "valid-token",
+          rcode: "AB2CDEFG",
+        }),
+      );
+
+      expect(result).toEqual({
+        error:
+          "Codice referral non valido. Correggilo o rimuovilo per continuare.",
+      });
+      expect(mockSignUp).not.toHaveBeenCalled();
+    });
+
+    it("registra referredByReferralCode e crea la redemption row con un codice referral valido", async () => {
+      mockLimit
+        .mockResolvedValueOnce([]) // email pre-check
+        .mockResolvedValueOnce([
+          { id: "referrer-profile-id", referralCode: "AB2CDEFG" },
+        ]); // referral lookup
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+            rcode: "AB2CDEFG",
+          }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+      }
+
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referredByReferralCode: "AB2CDEFG",
+          referralBonusDays: 30,
+        }),
+      );
+      // Seconda insert: la redemption row su referral_redemptions.
+      expect(mockInsert).toHaveBeenCalledTimes(2);
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referrerId: "referrer-profile-id",
+          refereeId: "profile-id",
+          referralCode: "AB2CDEFG",
+        }),
+      );
+    });
+
+    it("registra signup senza bonus quando rcode è assente (comportamento di default)", async () => {
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+      }
+
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referredByReferralCode: null,
+          referralBonusDays: 0,
+        }),
+      );
+      expect(mockInsert).toHaveBeenCalledTimes(1);
     });
 
     it("returns error when profile insert fails (terms acceptance is mandatory)", async () => {

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -46,7 +46,14 @@ const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
 const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
 const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 vi.mock("@/db", () => ({
-  getDb: vi.fn().mockReturnValue({ insert: mockInsert, select: mockSelect }),
+  getDb: vi.fn().mockReturnValue({
+    insert: mockInsert,
+    select: mockSelect,
+    // insertProfileOrRollback avvolge profilo + redemption in una transazione;
+    // il tx riusa lo stesso mock insert (catena values().returning() invariata).
+    transaction: async (cb: (tx: unknown) => unknown) =>
+      cb({ insert: mockInsert }),
+  }),
 }));
 
 vi.mock("@/db/schema", () => ({

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -330,6 +330,44 @@ async function insertProfileOrRollback(
   }
 }
 
+type ReferrerRow = { id: string; referralCode: string };
+
+/**
+ * Risolve il codice referral grezzo dal form in un referrer DB row, oppure
+ * in un errore utente. Estratto da `signUp` per tenerne sotto controllo la
+ * complessità cognitiva (SonarCloud S3776).
+ */
+async function resolveReferrer(
+  rawReferralCode: string,
+): Promise<{ referrer: ReferrerRow | null } | { error: string }> {
+  if (rawReferralCode.trim().length === 0) return { referrer: null };
+
+  // Codice referral: a differenza di `ref` (signup source, soft) un codice
+  // presente ma invalido blocca la registrazione — l'utente deve correggerlo
+  // o rimuoverlo dal form per procedere. Non è un problema di enumeration
+  // (il codice non è un segreto, identifica solo il referrer) quindi l'errore
+  // può essere esplicito.
+  const normalizedReferralCode = normalizeReferralCode(rawReferralCode);
+  const invalidCodeError = {
+    error: "Codice referral non valido. Correggilo o rimuovilo per continuare.",
+  };
+  if (!normalizedReferralCode) return invalidCodeError;
+
+  try {
+    const db = getDb();
+    const [referrerRow] = await db
+      .select({ id: profiles.id, referralCode: profiles.referralCode })
+      .from(profiles)
+      .where(sql`${profiles.referralCode} = ${normalizedReferralCode}`)
+      .limit(1);
+    if (!referrerRow) return invalidCodeError;
+    return { referrer: referrerRow };
+  } catch (err) {
+    logger.error({ err }, "Referral code lookup failed");
+    return { error: "Registrazione fallita. Riprova." };
+  }
+}
+
 export async function signUp(formData: FormData): Promise<AuthActionResult> {
   // Centralised email normalisation — consistent across signUp / signIn /
   // magicLink / resetPassword (CLAUDE.md regola 22).
@@ -394,39 +432,9 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
     redirect("/verify-email");
   }
 
-  // Codice referral: a differenza di `ref` (signup source, soft) un codice
-  // presente ma invalido blocca la registrazione — l'utente deve correggerlo
-  // o rimuoverlo dal form per procedere. Non è un problema di enumeration
-  // (il codice non è un segreto, identifica solo il referrer) quindi l'errore
-  // può essere esplicito.
-  let referrer: { id: string; referralCode: string } | null = null;
-  if (rawReferralCode.trim().length > 0) {
-    const normalizedReferralCode = normalizeReferralCode(rawReferralCode);
-    if (!normalizedReferralCode) {
-      return {
-        error:
-          "Codice referral non valido. Correggilo o rimuovilo per continuare.",
-      };
-    }
-    try {
-      const db = getDb();
-      const [referrerRow] = await db
-        .select({ id: profiles.id, referralCode: profiles.referralCode })
-        .from(profiles)
-        .where(sql`${profiles.referralCode} = ${normalizedReferralCode}`)
-        .limit(1);
-      if (!referrerRow) {
-        return {
-          error:
-            "Codice referral non valido. Correggilo o rimuovilo per continuare.",
-        };
-      }
-      referrer = referrerRow;
-    } catch (err) {
-      logger.error({ err }, "Referral code lookup failed");
-      return { error: "Registrazione fallita. Riprova." };
-    }
-  }
+  const referralResult = await resolveReferrer(rawReferralCode);
+  if ("error" in referralResult) return { error: referralResult.error };
+  const { referrer } = referralResult;
 
   const supabase = await createServerSupabaseClient();
   const hostname =

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -285,27 +285,34 @@ async function insertProfileOrRollback(
   try {
     const db = getDb();
     const referralCode = generateReferralCode(authUserId);
-    const [profile] = await db
-      .insert(profiles)
-      .values({
-        authUserId,
-        email,
-        termsAcceptedAt: new Date(),
-        termsVersion: CURRENT_TERMS_VERSION,
-        signupSource,
-        referralCode,
-        referredByReferralCode: referrer?.referralCode ?? null,
-        referralBonusDays: referrer ? REFERRAL_SIGNUP_BONUS_DAYS : 0,
-      })
-      .returning({ id: profiles.id });
+    // Profilo + eventuale redemption in UNA transazione: se l'insert della
+    // redemption fallisce (referrer sparito tra lookup e insert, hiccup DB)
+    // il rollback rimuove anche il profilo, così il catch sotto cancella
+    // l'auth user senza lasciare un profilo orfano che punta a un auth user
+    // inesistente.
+    await db.transaction(async (tx) => {
+      const [profile] = await tx
+        .insert(profiles)
+        .values({
+          authUserId,
+          email,
+          termsAcceptedAt: new Date(),
+          termsVersion: CURRENT_TERMS_VERSION,
+          signupSource,
+          referralCode,
+          referredByReferralCode: referrer?.referralCode ?? null,
+          referralBonusDays: referrer ? REFERRAL_SIGNUP_BONUS_DAYS : 0,
+        })
+        .returning({ id: profiles.id });
 
-    if (referrer) {
-      await db.insert(referralRedemptions).values({
-        referrerId: referrer.id,
-        refereeId: profile.id,
-        referralCode: referrer.referralCode,
-      });
-    }
+      if (referrer) {
+        await tx.insert(referralRedemptions).values({
+          referrerId: referrer.id,
+          refereeId: profile.id,
+          referralCode: referrer.referralCode,
+        });
+      }
+    });
     return null;
   } catch (err) {
     // Any insert failure means the auth user just created has no matching

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -22,6 +22,14 @@ import { ERROR_MESSAGES } from "@/lib/error-messages";
 import { getFormString, getFormStringRaw } from "@/lib/form-utils";
 import { isUniqueConstraintViolation } from "@/lib/db-errors";
 import { normalizeSignupSource } from "@/lib/signup-source";
+import {
+  generateReferralCode,
+  normalizeReferralCode,
+} from "@/lib/referral-code";
+import { referralRedemptions } from "@/db/schema/referral-redemptions";
+
+/** Giorni di trial bonus concessi al nuovo utente che si registra con un referral valido (+1 mese). */
+const REFERRAL_SIGNUP_BONUS_DAYS = 30;
 
 const CURRENT_TERMS_VERSION = "v01";
 
@@ -272,16 +280,32 @@ async function insertProfileOrRollback(
   authUserId: string,
   email: string,
   signupSource: string | null,
+  referrer: { id: string; referralCode: string } | null,
 ): Promise<AuthActionResult | null> {
   try {
     const db = getDb();
-    await db.insert(profiles).values({
-      authUserId,
-      email,
-      termsAcceptedAt: new Date(),
-      termsVersion: CURRENT_TERMS_VERSION,
-      signupSource,
-    });
+    const referralCode = generateReferralCode(authUserId);
+    const [profile] = await db
+      .insert(profiles)
+      .values({
+        authUserId,
+        email,
+        termsAcceptedAt: new Date(),
+        termsVersion: CURRENT_TERMS_VERSION,
+        signupSource,
+        referralCode,
+        referredByReferralCode: referrer?.referralCode ?? null,
+        referralBonusDays: referrer ? REFERRAL_SIGNUP_BONUS_DAYS : 0,
+      })
+      .returning({ id: profiles.id });
+
+    if (referrer) {
+      await db.insert(referralRedemptions).values({
+        referrerId: referrer.id,
+        refereeId: profile.id,
+        referralCode: referrer.referralCode,
+      });
+    }
     return null;
   } catch (err) {
     // Any insert failure means the auth user just created has no matching
@@ -312,6 +336,7 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
   const specificClausesAccepted = formData.get("specificClausesAccepted");
   const captchaToken = getFormString(formData, "captchaToken");
   const signupSource = normalizeSignupSource(getFormString(formData, "ref"));
+  const rawReferralCode = getFormString(formData, "rcode");
 
   const validationError = validateSignUpInput(
     email,
@@ -362,6 +387,40 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
     redirect("/verify-email");
   }
 
+  // Codice referral: a differenza di `ref` (signup source, soft) un codice
+  // presente ma invalido blocca la registrazione — l'utente deve correggerlo
+  // o rimuoverlo dal form per procedere. Non è un problema di enumeration
+  // (il codice non è un segreto, identifica solo il referrer) quindi l'errore
+  // può essere esplicito.
+  let referrer: { id: string; referralCode: string } | null = null;
+  if (rawReferralCode.trim().length > 0) {
+    const normalizedReferralCode = normalizeReferralCode(rawReferralCode);
+    if (!normalizedReferralCode) {
+      return {
+        error:
+          "Codice referral non valido. Correggilo o rimuovilo per continuare.",
+      };
+    }
+    try {
+      const db = getDb();
+      const [referrerRow] = await db
+        .select({ id: profiles.id, referralCode: profiles.referralCode })
+        .from(profiles)
+        .where(sql`${profiles.referralCode} = ${normalizedReferralCode}`)
+        .limit(1);
+      if (!referrerRow) {
+        return {
+          error:
+            "Codice referral non valido. Correggilo o rimuovilo per continuare.",
+        };
+      }
+      referrer = referrerRow;
+    } catch (err) {
+      logger.error({ err }, "Referral code lookup failed");
+      return { error: "Registrazione fallita. Riprova." };
+    }
+  }
+
   const supabase = await createServerSupabaseClient();
   const hostname =
     process.env.APP_HOSTNAME ??
@@ -384,6 +443,7 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
       data.user.id,
       email,
       signupSource,
+      referrer,
     );
     if (profileError) return profileError;
   }

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/db/schema", () => ({
   businesses: "businesses-table",
   adeCredentials: "ade-credentials-table",
   trialVatLedger: "trial-vat-ledger-table",
+  referralRedemptions: "referral-redemptions-table",
 }));
 
 const mockEncrypt = vi.fn().mockReturnValue("encrypted-data");
@@ -663,7 +664,12 @@ describe("onboarding-actions", () => {
       expect(mockLogin).toHaveBeenCalled();
       expect(mockLogout).toHaveBeenCalled();
       expect(mockGetFiscalData).toHaveBeenCalled();
-      expect(mockUpdate).toHaveBeenCalledTimes(3); // businesses vatNumber/fiscalCode + profiles partitaIva + adeCredentials verifiedAt
+      // 3 update "core" (adeCredentials verifiedAt + businesses vatNumber/
+      // fiscalCode + profiles partitaIva) + 2 update del claim referral
+      // (referral_redemptions.rewardedAt + profiles.referralBonusDays) che
+      // scattano sempre sotto i mock generici condivisi (returning() risolve
+      // sempre a una riga non-vuota di default).
+      expect(mockUpdate).toHaveBeenCalledTimes(5);
       expect(mockRevalidatePath).toHaveBeenCalledWith("/dashboard", "layout");
     });
 
@@ -1304,9 +1310,12 @@ describe("onboarding-actions", () => {
           pivaHash: expect.stringMatching(/^[0-9a-f]{64}$/),
         }),
       );
-      // Solo 3 update: verifiedAt + businesses + profiles.partitaIva. Nessun
-      // azzeramento di trialStartedAt (trial concesso).
-      expect(mockUpdate).toHaveBeenCalledTimes(3);
+      // 3 update "core" (verifiedAt + businesses + profiles.partitaIva,
+      // nessun azzeramento di trialStartedAt: trial concesso) + 2 update del
+      // claim referral (referral_redemptions.rewardedAt +
+      // profiles.referralBonusDays) che scattano sempre sotto i mock generici
+      // condivisi (returning() risolve sempre a una riga non-vuota).
+      expect(mockUpdate).toHaveBeenCalledTimes(5);
       expect(mockUpdateSet).not.toHaveBeenCalledWith({ trialStartedAt: null });
     });
 
@@ -1341,9 +1350,12 @@ describe("onboarding-actions", () => {
       expect(result.error).toBeUndefined();
       expect(result.businessId).toBe("biz-789");
       expect(result.trialAlreadyUsed).toBe(true);
-      // 4 update: verifiedAt + businesses + profiles.partitaIva +
-      // profiles.trialStartedAt=null (sola lettura immediata).
-      expect(mockUpdate).toHaveBeenCalledTimes(4);
+      // 4 update "core" (verifiedAt + businesses + profiles.partitaIva +
+      // profiles.trialStartedAt=null, sola lettura immediata) + 2 update del
+      // claim referral (referral_redemptions.rewardedAt +
+      // profiles.referralBonusDays) che scattano sempre sotto i mock generici
+      // condivisi (returning() risolve sempre a una riga non-vuota).
+      expect(mockUpdate).toHaveBeenCalledTimes(6);
       expect(mockUpdateSet).toHaveBeenCalledWith({ trialStartedAt: null });
       const { logger } = await import("@/lib/logger");
       expect(logger.warn).toHaveBeenCalledWith(

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -1350,12 +1350,12 @@ describe("onboarding-actions", () => {
       expect(result.error).toBeUndefined();
       expect(result.businessId).toBe("biz-789");
       expect(result.trialAlreadyUsed).toBe(true);
-      // 4 update "core" (verifiedAt + businesses + profiles.partitaIva +
-      // profiles.trialStartedAt=null, sola lettura immediata) + 2 update del
-      // claim referral (referral_redemptions.rewardedAt +
-      // profiles.referralBonusDays) che scattano sempre sotto i mock generici
-      // condivisi (returning() risolve sempre a una riga non-vuota).
-      expect(mockUpdate).toHaveBeenCalledTimes(6);
+      // Solo 4 update "core": verifiedAt + businesses + profiles.partitaIva +
+      // profiles.trialStartedAt=null (sola lettura immediata). Il claim
+      // referral NON scatta: la P.IVA era già nel ledger → trial negato →
+      // niente reward al referrer (il blocco reward è gatato sul trial
+      // effettivamente concesso, esce prima via early-return).
+      expect(mockUpdate).toHaveBeenCalledTimes(4);
       expect(mockUpdateSet).toHaveBeenCalledWith({ trialStartedAt: null });
       const { logger } = await import("@/lib/logger");
       expect(logger.warn).toHaveBeenCalledWith(

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -9,6 +9,7 @@ import {
   adeCredentials,
   profiles,
   trialVatLedger,
+  referralRedemptions,
 } from "@/db/schema";
 import { hashPiva } from "@/lib/piva-hash";
 import {
@@ -480,6 +481,38 @@ async function finalizeAdeVerification(params: {
       .where(eq(profiles.authUserId, userId));
 
     if (!wasFirstClaim) return;
+
+    // Reward referral: trigger = verifica P.IVA completata (stesso
+    // checkpoint anti-abuso del trial_vat_ledger sotto). Claim atomico via
+    // UPDATE ... WHERE rewarded_at IS NULL: idempotente sotto retry della
+    // stessa finalizeAdeVerification, niente doppio reward.
+    const [refereeProfile] = await tx
+      .select({ id: profiles.id })
+      .from(profiles)
+      .where(eq(profiles.authUserId, userId))
+      .limit(1);
+
+    if (refereeProfile) {
+      const claimed = await tx
+        .update(referralRedemptions)
+        .set({ rewardedAt: new Date() })
+        .where(
+          and(
+            eq(referralRedemptions.refereeId, refereeProfile.id),
+            sql`${referralRedemptions.rewardedAt} IS NULL`,
+          ),
+        )
+        .returning({ referrerId: referralRedemptions.referrerId });
+
+      if (claimed.length > 0) {
+        await tx
+          .update(profiles)
+          .set({
+            referralBonusDays: sql`${profiles.referralBonusDays} + 30`,
+          })
+          .where(eq(profiles.id, claimed[0].referrerId));
+      }
+    }
 
     // Anti-abuso trial cross-cancellazione: il vincolo UNIQUE su
     // profiles.partita_iva sparisce quando l'account viene cancellato,

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -482,8 +482,37 @@ async function finalizeAdeVerification(params: {
 
     if (!wasFirstClaim) return;
 
-    // Reward referral: trigger = verifica P.IVA completata (stesso
-    // checkpoint anti-abuso del trial_vat_ledger sotto). Claim atomico via
+    // Anti-abuso trial cross-cancellazione: il vincolo UNIQUE su
+    // profiles.partita_iva sparisce quando l'account viene cancellato,
+    // liberando la P.IVA per un secondo trial. `trial_vat_ledger`
+    // sopravvive alla cancellazione e registra ogni P.IVA che ha già
+    // consumato un trial. ON CONFLICT DO NOTHING RETURNING è race-safe:
+    // se non torna righe la P.IVA era già nel ledger da un account
+    // PRECEDENTE → trial già consumato → niente nuovo trial.
+    const inserted = await tx
+      .insert(trialVatLedger)
+      .values({ pivaHash: hashPiva(vatNumber) })
+      .onConflictDoNothing()
+      .returning({ id: trialVatLedger.id });
+
+    if (inserted.length === 0) {
+      // trialStartedAt = null → isTrialExpired() true → sola lettura
+      // immediata, riusando i gate esistenti (canEmit/canAddCatalogItem).
+      // La P.IVA era già nel ledger → NON è un nuovo cliente vero: niente
+      // reward al referrer (sotto). Esce dalla transazione qui.
+      await tx
+        .update(profiles)
+        .set({ trialStartedAt: null })
+        .where(eq(profiles.authUserId, userId));
+      trialAlreadyUsed = true;
+      return;
+    }
+
+    // Reward referral: trigger = trial EFFETTIVAMENTE concesso (raggiunto
+    // solo se il ledger sopra ha accettato la P.IVA — nuovo cliente vero).
+    // Gatare qui, e non sulla sola verifica P.IVA, chiude il farming di
+    // reward con una P.IVA riciclata: un referee in sola-lettura (P.IVA già
+    // consumata) non frutta nulla al referrer. Claim atomico via
     // UPDATE ... WHERE rewarded_at IS NULL: idempotente sotto retry della
     // stessa finalizeAdeVerification, niente doppio reward.
     const [refereeProfile] = await tx
@@ -512,29 +541,6 @@ async function finalizeAdeVerification(params: {
           })
           .where(eq(profiles.id, claimed[0].referrerId));
       }
-    }
-
-    // Anti-abuso trial cross-cancellazione: il vincolo UNIQUE su
-    // profiles.partita_iva sparisce quando l'account viene cancellato,
-    // liberando la P.IVA per un secondo trial. `trial_vat_ledger`
-    // sopravvive alla cancellazione e registra ogni P.IVA che ha già
-    // consumato un trial. ON CONFLICT DO NOTHING RETURNING è race-safe:
-    // se non torna righe la P.IVA era già nel ledger da un account
-    // PRECEDENTE → trial già consumato → niente nuovo trial.
-    const inserted = await tx
-      .insert(trialVatLedger)
-      .values({ pivaHash: hashPiva(vatNumber) })
-      .onConflictDoNothing()
-      .returning({ id: trialVatLedger.id });
-
-    if (inserted.length === 0) {
-      // trialStartedAt = null → isTrialExpired() true → sola lettura
-      // immediata, riusando i gate esistenti (canEmit/canAddCatalogItem).
-      await tx
-        .update(profiles)
-        .set({ trialStartedAt: null })
-        .where(eq(profiles.authUserId, userId));
-      trialAlreadyUsed = true;
     }
   });
 

--- a/supabase/migrations/0021_referral_program.sql
+++ b/supabase/migrations/0021_referral_program.sql
@@ -1,0 +1,113 @@
+-- Migration: 0021_referral_program
+-- Referral program (member-get-member), v1.4.0. Distinto dal futuro
+-- programma Partner/reseller (NDS, monouso, B2B) — nomi colonna scelti per
+-- non collidere quando quel programma verrà implementato.
+--
+-- `referral_code`: codice personale riusabile, derivato deterministicamente
+-- dall'authUserId (src/lib/referral-code.ts: SHA-256 troncato a 40 bit,
+-- alfabeto base32 senza ambigui). NOT NULL: i profili pre-esistenti vengono
+-- backfillati qui sotto con una funzione SQL che replica esattamente
+-- l'algoritmo JS (stesso digest, stesso bit-packing, stesso alfabeto) — non
+-- serve intervento manuale. I nuovi INSERT applicativi lo settano comunque
+-- sempre da `src/lib/referral-code.ts`, questa funzione serve solo qui.
+--
+-- `referred_by_referral_code`: codice usato da QUESTO utente in fase di
+-- signup (NULL se nessun referral). Solo audit, nessun vincolo.
+--
+-- `referral_bonus_days`: giorni bonus accumulati, additivo. Applicato in
+-- src/lib/plans.ts fetchPlan() traslando trialStartedAt/planExpiresAt prima
+-- di ritornarli — non viene mai letto né scritto dal webhook Stripe, quindi
+-- sopravvive a qualunque rinnovo subscription che sovrascrive
+-- `plan_expires_at` in toto.
+--
+-- `referral_redemptions`: una riga per ogni signup con `?rcode=` valido.
+-- `rewarded_at` resta NULL finché il referee non completa la verifica P.IVA
+-- (stesso checkpoint anti-abuso di trial_vat_ledger, migration 0018); solo a
+-- quel punto il referrer riceve +30 giorni. `referee_id` UNIQUE impedisce il
+-- doppio reward anche sotto race (claim via UPDATE ... WHERE rewarded_at IS NULL).
+--
+-- Idempotente: ADD COLUMN IF NOT EXISTS / CREATE TABLE IF NOT EXISTS.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+ALTER TABLE "profiles"
+  ADD COLUMN IF NOT EXISTS "referral_code" text,
+  ADD COLUMN IF NOT EXISTS "referred_by_referral_code" text,
+  ADD COLUMN IF NOT EXISTS "referral_bonus_days" integer NOT NULL DEFAULT 0;
+
+-- Replica esatta di generateReferralCode() (src/lib/referral-code.ts): primi
+-- 5 byte di sha256(seed) -> 40 bit -> 8 simboli da 5 bit sull'alfabeto senza
+-- ambigui. Funzione temporanea, usata solo per il backfill qui sotto e poi
+-- droppata: i nuovi INSERT applicativi generano il codice in JS, non in SQL.
+CREATE OR REPLACE FUNCTION "pg_temp"."referral_code_from_seed"(seed text)
+RETURNS text
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+  alphabet text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  digest_bytes bytea;
+  bits bigint := 0;
+  code text := '';
+  idx int;
+  i int;
+BEGIN
+  digest_bytes := digest(seed, 'sha256');
+  FOR i IN 0..4 LOOP
+    bits := (bits << 8) | get_byte(digest_bytes, i);
+  END LOOP;
+  FOR i IN REVERSE 7..0 LOOP
+    idx := (bits >> (i * 5)) & 31;
+    code := code || substr(alphabet, idx + 1, 1);
+  END LOOP;
+  RETURN code;
+END;
+$fn$;
+
+-- Backfill deterministico dei profili pre-esistenti senza referral_code.
+-- Possibili duplicati teorici (collisione SHA-256 troncata) risolti con un
+-- suffisso incrementale prima di applicare lo UNIQUE — irrilevante in
+-- pratica (40 bit di entropia) ma evita che la migration fallisca.
+DO $$
+DECLARE
+  r RECORD;
+  candidate text;
+  suffix int;
+BEGIN
+  FOR r IN SELECT "id", "auth_user_id" FROM "profiles" WHERE "referral_code" IS NULL LOOP
+    candidate := "pg_temp"."referral_code_from_seed"(r."auth_user_id"::text);
+    suffix := 0;
+    WHILE EXISTS (SELECT 1 FROM "profiles" WHERE "referral_code" = candidate) LOOP
+      suffix := suffix + 1;
+      candidate := "pg_temp"."referral_code_from_seed"(r."auth_user_id"::text || ':' || suffix::text);
+    END LOOP;
+    UPDATE "profiles" SET "referral_code" = candidate WHERE "id" = r."id";
+  END LOOP;
+END $$;
+
+DROP FUNCTION "pg_temp"."referral_code_from_seed"(text);
+
+ALTER TABLE "profiles"
+  ALTER COLUMN "referral_code" SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'profiles_referral_code_unique'
+  ) THEN
+    ALTER TABLE "profiles"
+      ADD CONSTRAINT "profiles_referral_code_unique" UNIQUE ("referral_code");
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "referral_redemptions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "referrer_id" uuid NOT NULL REFERENCES "profiles" ("id"),
+  "referee_id" uuid NOT NULL REFERENCES "profiles" ("id"),
+  "referral_code" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "rewarded_at" timestamptz,
+  CONSTRAINT "referral_redemptions_referee_id_unique" UNIQUE ("referee_id")
+);
+
+-- RLS: service-role only, stesso pattern di trial_vat_ledger (migration 0018).
+ALTER TABLE "referral_redemptions" ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/0021_referral_program.sql
+++ b/supabase/migrations/0021_referral_program.sql
@@ -44,7 +44,7 @@ RETURNS text
 LANGUAGE plpgsql
 AS $fn$
 DECLARE
-  alphabet text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  alphabet text := '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
   digest_bytes bytea;
   bits bigint := 0;
   code text := '';

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1780099204000,
       "tag": "0020_stripe_webhook_events_completed_at",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1780099205000,
+      "tag": "0021_referral_program",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/auth-actions-signup.test.ts
+++ b/tests/unit/auth-actions-signup.test.ts
@@ -107,7 +107,9 @@ function setupDbNoExistingEmail() {
   mockSelectLimit.mockResolvedValue([]); // no existing profile
 
   mockInsertProfiles.mockReturnValue({ values: mockInsertValues });
-  mockInsertValues.mockResolvedValue(undefined);
+  mockInsertValues.mockReturnValue({
+    returning: vi.fn().mockResolvedValue([{ id: "profile-id" }]),
+  });
 }
 
 // --- Tests ---
@@ -175,9 +177,13 @@ describe("signUp — email normalisation and uniqueness", () => {
   it("compensating delete + redirect when profile insert violates unique email constraint (race)", async () => {
     setupCaptchaOk();
     setupDbNoExistingEmail();
-    mockInsertValues.mockRejectedValue(
-      Object.assign(new Error("duplicate key value"), { code: "23505" }),
-    );
+    mockInsertValues.mockReturnValue({
+      returning: vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error("duplicate key value"), { code: "23505" }),
+        ),
+    });
 
     const { signUp } = await import("@/server/auth-actions");
     await expect(signUp(makeFormData())).rejects.toMatchObject({

--- a/tests/unit/auth-actions-signup.test.ts
+++ b/tests/unit/auth-actions-signup.test.ts
@@ -100,6 +100,11 @@ function setupDbNoExistingEmail() {
   mockGetDb.mockReturnValue({
     select: mockSelectProfiles,
     insert: mockInsertProfiles,
+    // insertProfileOrRollback ora avvolge profilo + redemption in una
+    // transazione: il tx espone lo stesso mock insert così la catena
+    // values().returning() resta invariata.
+    transaction: async (cb: (tx: unknown) => unknown) =>
+      cb({ insert: mockInsertProfiles }),
   });
   mockSelectProfiles.mockReturnValue({ from: mockSelectFrom });
   mockSelectFrom.mockReturnValue({ where: mockSelectWhere });

--- a/tests/unit/settings-page-card-state.test.ts
+++ b/tests/unit/settings-page-card-state.test.ts
@@ -31,6 +31,8 @@ const {
 
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
 
+vi.mock("@/server/auth-actions", () => ({ signOut: vi.fn() }));
+
 vi.mock("@/lib/supabase/server", () => ({
   createServerSupabaseClient: vi.fn().mockResolvedValue({
     auth: { getUser: mockGetUser },
@@ -63,6 +65,7 @@ vi.mock("@/db/schema", () => ({
   profiles: "profiles-table",
   businesses: "businesses-table",
   adeCredentials: "adeCredentials-table",
+  referralRedemptions: "referral-redemptions-table",
 }));
 
 // Mock all UI components to return null (no-op in node environment)
@@ -102,11 +105,19 @@ vi.mock("@/components/settings/change-password-section", () => ({
 vi.mock("@/components/settings/edit-ade-credentials-section", () => ({
   EditAdeCredentialsSection: () => null,
 }));
+vi.mock("@/components/settings/referral-section", () => ({
+  ReferralSection: () => null,
+}));
 vi.mock("@/types/cassa", () => ({
   VAT_DESCRIPTIONS: {},
   VAT_CODES: [],
 }));
-vi.mock("drizzle-orm", () => ({ eq: vi.fn() }));
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  count: vi.fn(),
+  isNotNull: vi.fn(),
+}));
 
 import SettingsPage from "@/app/dashboard/settings/page";
 import { PlanSelection } from "@/components/billing/plan-selection";


### PR DESCRIPTION
## Summary

Adds a complete referral program (member-get-member) allowing users to share personal referral codes and earn trial bonus days when referred users complete P.IVA verification. Includes deterministic referral code generation, signup flow integration, reward claiming on verification, and settings UI to display referral metrics.

## Key Changes

**Database & Schema**
- Migration `0021_referral_program.sql`: adds `referral_code`, `referred_by_referral_code`, `referral_bonus_days` columns to `profiles` table; creates `referral_redemptions` table for audit and idempotent reward claiming; backfills all existing profiles with deterministic codes via SQL replica of JS algorithm
- New Drizzle schema file `src/db/schema/referral-redemptions.ts` with `referrerId`, `refereeId`, `referralCode`, `rewardedAt` fields; `refereeId` UNIQUE prevents double-reward

**Referral Code Generation & Validation**
- `src/lib/referral-code.ts`: deterministic code generation from `authUserId` via SHA-256 (first 5 bytes, 40 bits) → 8-char Crockford base32 (no ambiguous chars O/I/L/U); `normalizeReferralCode()` validates format without DB access
- Comprehensive test coverage in `src/lib/referral-code.test.ts` (format, determinism, alphabet, edge cases)

**Signup Flow**
- `src/server/auth-actions.ts`: 
  - Validates `?rcode=` parameter; hard-blocks signup if present but malformed (not soft enumeration)
  - Looks up referrer profile by normalized code; returns explicit error if not found
  - Wraps profile + redemption insert in single transaction (`db.transaction()`) to prevent orphaned profiles on failure
  - Sets `referralBonusDays: 30` on new profile when referral valid, `0` otherwise
  - Generates unique `referralCode` for every new user
- Updated test mocks to support transaction pattern and verify both profile and redemption inserts

**Reward Claiming**
- `src/server/onboarding-actions.ts` `finalizeAdeVerification()`: claims reward atomically via `UPDATE ... WHERE rewarded_at IS NULL` when referee completes P.IVA verification (same anti-abuse checkpoint as trial ledger); adds +30 days to referrer's `referralBonusDays`; idempotent under retry

**Plan Calculation**
- `src/lib/plans.ts`: applies `referralBonusDays` bonus by translating `trialStartedAt` backward and `planExpiresAt` forward before returning `PlanInfo`; bonus is additive and independent of Stripe sync
- Test coverage in `src/lib/plans.test.ts` for bonus application and edge cases (zero bonus, missing field)

**UI & Settings**
- `src/app/(auth)/register/page.tsx`: adds optional `rcode` form field with toggle (hidden by default, auto-shown if `?rcode=` param present); passes to server action
- `src/app/dashboard/settings/page.tsx`: queries completed referrals count; renders new `ReferralSection` card
- New `src/components/settings/referral-section.tsx`: displays user's referral code, share button with custom labels, completed referral count
- Enhanced `src/app/r/[documentId]/share-button.tsx` with optional `label` and `copiedLabel` props for reuse in referral context
- Test coverage for referral section rendering and share button label customization

**Documentation**
- Updated `docs/architecture/INDEX.md` with referral program entry in "Dove vivo X?" table

## Implementation Details

- **Deterministic codes**: same algorithm in JS (`src/lib/referral-code.ts`) and SQL (migration backfill) ensures consistency; 40-bit entropy (5 bytes of SHA-256) on 32-symbol alphabet = negligible collision risk
- **Transaction safety**: profile + redemption in single DB transaction prevents race conditions and orphaned data
- **

https://claude.ai/code/session_018XnKyDxaZAh6Rq5av4Gsv4