### PR TITLE
Reorganize settings page into semantic sections with collapsible extras

### DIFF
--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -50,7 +50,7 @@ export default function ApiDocsPage() {
             {"Una chiave API di tipo "}
             <strong>business</strong>
             {" generata dalla dashboard: vai su "}
-            <strong>Impostazioni → API key</strong>
+            <strong>Impostazioni → Altre impostazioni → API key</strong>
             {", clicca "}
             <em>+ Nuova API key</em>
             {', assegnale un nome descrittivo (es. "POS principale"), clicca '}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -77,6 +77,33 @@ function computeBillingCardState(
   return "trial-active";
 }
 
+/**
+ * Compone la riga "Sede" dell'attività. Estratta a livello di modulo per
+ * tenere bassa la Cognitive Complexity di SettingsPage (S3776): concentra qui
+ * la logica città/provincia/CAP. Ritorna null se non c'è né indirizzo né città.
+ */
+function formatBusinessLocation(business: {
+  address: string | null | undefined;
+  streetNumber: string | null | undefined;
+  city: string | null | undefined;
+  province: string | null | undefined;
+  zipCode: string | null | undefined;
+}): string | null {
+  if (!business.address && !business.city) return null;
+  const cityProvince =
+    business.city && business.province
+      ? `${business.city} (${business.province})`
+      : (business.city ?? business.province);
+  return [
+    business.address,
+    business.streetNumber,
+    cityProvince,
+    business.zipCode,
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
+
 export default async function SettingsPage({
   searchParams,
 }: {
@@ -133,6 +160,8 @@ export default async function SettingsPage({
     VAT_CODES.includes(business.preferredVatCode as VatCode)
       ? VAT_DESCRIPTIONS[business.preferredVatCode as VatCode]
       : null;
+
+  const businessLocation = business ? formatBusinessLocation(business) : null;
 
   const completedReferrals = profile
     ? ((
@@ -273,19 +302,10 @@ export default async function SettingsPage({
                     {business.fiscalCode}
                   </p>
                 )}
-                {(business.address || business.city) && (
+                {businessLocation && (
                   <p>
                     <span className="text-muted-foreground">Sede:</span>{" "}
-                    {[
-                      business.address,
-                      business.streetNumber,
-                      business.city && business.province
-                        ? `${business.city} (${business.province})`
-                        : (business.city ?? business.province),
-                      business.zipCode,
-                    ]
-                      .filter(Boolean)
-                      .join(", ")}
+                    {businessLocation}
                   </p>
                 )}
                 {preferredVatLabel && (

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -26,6 +26,7 @@ import {
   canUseApi,
   isPaidPlanExpired,
   isTrialExpired,
+  type Plan,
   TRIAL_DAYS,
 } from "@/lib/plans";
 import { PRICE_IDS } from "@/lib/stripe";
@@ -37,6 +38,44 @@ import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
 import { ScrollToHash } from "@/components/billing/scroll-to-hash";
 import { CONTACT_EMAIL } from "@/lib/contact";
 import { APP_VERSION, getBuildLabel } from "@/lib/version";
+
+type BillingCardState =
+  | "trial-active"
+  | "trial-expired"
+  | "subscribed"
+  | "past-due"
+  | "unlimited";
+
+/**
+ * Determina lo stato della card "Piano e Abbonamento". Estratta a livello di
+ * modulo per tenere bassa la Cognitive Complexity di SettingsPage (S3776).
+ */
+function computeBillingCardState(
+  planData: {
+    plan: Plan;
+    trialStartedAt: Date | null;
+    planExpiresAt: Date | null;
+    hasSubscription: boolean;
+    subscriptionStatus: string | null;
+  } | null,
+): BillingCardState {
+  if (!planData) return "trial-active";
+  if (planData.plan === "unlimited") return "unlimited";
+  if (planData.hasSubscription && planData.subscriptionStatus === "past_due")
+    return "past-due";
+  // Safety-net per webhook `customer.subscription.deleted` persi (REVIEW #31):
+  // se il piano pagato e' scaduto oltre la grazia i gate sono gia' read-only
+  // (isPaidPlanExpired). La subscription row puo' essere rimasta `active`:
+  // senza questo check la card mostrerebbe "Pro attivo" mentre cassa/catalogo/
+  // API rispondono sola-lettura. Riusa lo stato read-only "trial-expired".
+  // Va DOPO il ramo past_due per non oscurare il dunning legittimo.
+  if (isPaidPlanExpired(planData.plan, planData.planExpiresAt))
+    return "trial-expired";
+  if (planData.hasSubscription && planData.subscriptionStatus === "active")
+    return "subscribed";
+  if (isTrialExpired(planData.trialStartedAt)) return "trial-expired";
+  return "trial-active";
+}
 
 export default async function SettingsPage({
   searchParams,
@@ -122,31 +161,7 @@ export default async function SettingsPage({
           subscriptionInterval: planResult.subscriptionInterval,
         };
 
-  type BillingCardState =
-    | "trial-active"
-    | "trial-expired"
-    | "subscribed"
-    | "past-due"
-    | "unlimited";
-
-  const cardState: BillingCardState = (() => {
-    if (!planData) return "trial-active";
-    if (planData.plan === "unlimited") return "unlimited";
-    if (planData.hasSubscription && planData.subscriptionStatus === "past_due")
-      return "past-due";
-    // Safety-net per webhook `customer.subscription.deleted` persi (REVIEW #31):
-    // se il piano pagato e' scaduto oltre la grazia i gate sono gia' read-only
-    // (isPaidPlanExpired). La subscription row puo' essere rimasta `active`:
-    // senza questo check la card mostrerebbe "Pro attivo" mentre cassa/catalogo/
-    // API rispondono sola-lettura. Riusa lo stato read-only "trial-expired".
-    // Va DOPO il ramo past_due per non oscurare il dunning legittimo.
-    if (isPaidPlanExpired(planData.plan, planData.planExpiresAt))
-      return "trial-expired";
-    if (planData.hasSubscription && planData.subscriptionStatus === "active")
-      return "subscribed";
-    if (isTrialExpired(planData.trialStartedAt)) return "trial-expired";
-    return "trial-active";
-  })();
+  const cardState = computeBillingCardState(planData);
 
   const trialExpiryDate = planData?.trialStartedAt
     ? new Date(

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/plans";
 import { PRICE_IDS } from "@/lib/stripe";
 import { ApiKeySection } from "@/components/settings/api-key-section";
+import { ExtraSettingsSection } from "@/components/settings/extra-settings-section";
 import { PlanBadge } from "@/components/billing/plan-badge";
 import { PlanSelection } from "@/components/billing/plan-selection";
 import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
@@ -156,297 +157,341 @@ export default async function SettingsPage({
   const intervalLabel =
     planData?.subscriptionInterval === "year" ? "annuale" : "mensile";
 
+  // Heading di sezione: raggruppa visivamente le card per area tematica.
+  const sectionHeadingClass =
+    "text-muted-foreground text-sm font-semibold tracking-wide uppercase";
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <RefreshOnSuccess active={success === "1"} />
       <ScrollToHash />
       <h1 className="text-2xl font-bold">Impostazioni</h1>
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Profilo</CardTitle>
-          <EditProfileSection
-            firstName={profile?.firstName ?? null}
-            lastName={profile?.lastName ?? null}
-          />
-        </CardHeader>
-        <CardContent className="space-y-2">
-          <p>
-            <span className="text-muted-foreground">Nome:</span>{" "}
-            {displayName || "Non impostato"}
-          </p>
-          <p>
-            <span className="text-muted-foreground">Email:</span> {user.email}
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Sicurezza</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ChangePasswordSection />
-        </CardContent>
-      </Card>
-
-      {business && (
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Attività</CardTitle>
-            <EditBusinessSection
-              businessId={business.id}
-              businessName={business.businessName ?? null}
-              address={business.address ?? null}
-              streetNumber={business.streetNumber ?? null}
-              city={business.city ?? null}
-              province={business.province ?? null}
-              zipCode={business.zipCode ?? null}
-              preferredVatCode={business.preferredVatCode ?? null}
-            />
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {business.businessName && (
-              <p>
-                <span className="text-muted-foreground">Nome attività:</span>{" "}
-                {business.businessName}
-              </p>
-            )}
-            {business.vatNumber && (
-              <p>
-                <span className="text-muted-foreground">P.IVA:</span>{" "}
-                {business.vatNumber}
-              </p>
-            )}
-            {business.fiscalCode && (
-              <p>
-                <span className="text-muted-foreground">C.F.:</span>{" "}
-                {business.fiscalCode}
-              </p>
-            )}
-            {(business.address || business.city) && (
-              <p>
-                <span className="text-muted-foreground">Sede:</span>{" "}
-                {[
-                  business.address,
-                  business.streetNumber,
-                  business.city && business.province
-                    ? `${business.city} (${business.province})`
-                    : (business.city ?? business.province),
-                  business.zipCode,
-                ]
-                  .filter(Boolean)
-                  .join(", ")}
-              </p>
-            )}
-            {preferredVatLabel && (
-              <p>
-                <span className="text-muted-foreground">IVA prevalente:</span>{" "}
-                {preferredVatLabel}
-              </p>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Credenziali AdE</CardTitle>
-          {business && <EditAdeCredentialsSection businessId={business.id} />}
-        </CardHeader>
-        <CardContent>
-          <AdeCredentialsSection
-            businessId={business?.id ?? null}
-            hasCredentials={!!cred}
-            verifiedAt={cred?.verifiedAt ?? null}
-          />
-        </CardContent>
-      </Card>
-
-      {profile && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Referral</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ReferralSection
-              referralCode={profile.referralCode}
-              completedReferrals={completedReferrals}
-            />
-          </CardContent>
-        </Card>
-      )}
-
-      {planData && (
-        // id="billing" → ancora del deep-link BILLING_SETTINGS_HREF
-        // (/dashboard/settings#billing). scroll-mt evita che la sticky header
-        // copra il titolo quando si atterra sull'ancora.
-        <Card id="billing" className="scroll-mt-20">
-          <CardHeader>
-            <CardTitle>Piano e Abbonamento</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* Trial scaduto — banner warning */}
-            {cardState === "trial-expired" && (
-              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-                Il periodo di prova è scaduto. Scegli un piano per continuare ad
-                emettere scontrini.
-              </div>
-            )}
-
-            {/* Pagamento fallito — banner errore */}
-            {cardState === "past-due" && (
-              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
-                Pagamento fallito — aggiorna il metodo di pagamento per evitare
-                l&apos;interruzione del servizio.
-              </div>
-            )}
-
-            {/* Piano corrente */}
-            <div>
-              <p className="text-muted-foreground mb-2 text-sm font-medium">
-                Piano corrente
-              </p>
-              <div className="flex items-center gap-3">
-                <PlanBadge plan={planData.plan} />
-
-                {cardState === "trial-active" && trialExpiryDate && (
-                  <span className="text-muted-foreground text-sm">
-                    Prova attiva — scade il{" "}
-                    {trialExpiryDate.toLocaleDateString("it-IT")}
-                  </span>
-                )}
-
-                {cardState === "trial-expired" && trialExpiryDate && (
-                  <span className="text-sm text-red-600">
-                    Scaduto il {trialExpiryDate.toLocaleDateString("it-IT")}
-                  </span>
-                )}
-
-                {cardState === "subscribed" && (
-                  <span className="text-muted-foreground text-sm">
-                    Abbonamento {intervalLabel}
-                    {planData.planExpiresAt &&
-                      ` — rinnovo il ${planData.planExpiresAt.toLocaleDateString("it-IT")}`}
-                  </span>
-                )}
-
-                {cardState === "past-due" && (
-                  <span className="text-sm text-red-600">
-                    Abbonamento {intervalLabel} — pagamento scaduto
-                  </span>
-                )}
-
-                {cardState === "unlimited" && (
-                  <span className="text-muted-foreground text-sm">
-                    Piano illimitato — gestito direttamente.
-                  </span>
-                )}
-              </div>
-            </div>
-
-            {/* Scegli piano — solo senza abbonamento attivo */}
-            {(cardState === "trial-active" ||
-              cardState === "trial-expired") && (
-              <PlanSelection
-                starterMonthly={PRICE_IDS.starterMonthly}
-                starterYearly={PRICE_IDS.starterYearly}
-                proMonthly={PRICE_IDS.proMonthly}
-                proYearly={PRICE_IDS.proYearly}
+      {/* Account — profilo, sicurezza, sessione */}
+      <section className="space-y-4">
+        <h2 className={sectionHeadingClass}>Account</h2>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>Profilo</CardTitle>
+              <EditProfileSection
+                firstName={profile?.firstName ?? null}
+                lastName={profile?.lastName ?? null}
               />
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p>
+                <span className="text-muted-foreground">Nome:</span>{" "}
+                {displayName || "Non impostato"}
+              </p>
+              <p>
+                <span className="text-muted-foreground">Email:</span>{" "}
+                {user.email}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Sicurezza</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ChangePasswordSection />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Sessione</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground mb-4 text-sm">
+                Esci dall&apos;account su questo dispositivo.
+              </p>
+              <form action={signOut}>
+                <Button variant="outline" type="submit">
+                  Esci
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* Attività e fisco — dati attività, credenziali AdE */}
+      <section className="space-y-4">
+        <h2 className={sectionHeadingClass}>Attività e fisco</h2>
+        <div className="space-y-6">
+          {business && (
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Attività</CardTitle>
+                <EditBusinessSection
+                  businessId={business.id}
+                  businessName={business.businessName ?? null}
+                  address={business.address ?? null}
+                  streetNumber={business.streetNumber ?? null}
+                  city={business.city ?? null}
+                  province={business.province ?? null}
+                  zipCode={business.zipCode ?? null}
+                  preferredVatCode={business.preferredVatCode ?? null}
+                />
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {business.businessName && (
+                  <p>
+                    <span className="text-muted-foreground">
+                      Nome attività:
+                    </span>{" "}
+                    {business.businessName}
+                  </p>
+                )}
+                {business.vatNumber && (
+                  <p>
+                    <span className="text-muted-foreground">P.IVA:</span>{" "}
+                    {business.vatNumber}
+                  </p>
+                )}
+                {business.fiscalCode && (
+                  <p>
+                    <span className="text-muted-foreground">C.F.:</span>{" "}
+                    {business.fiscalCode}
+                  </p>
+                )}
+                {(business.address || business.city) && (
+                  <p>
+                    <span className="text-muted-foreground">Sede:</span>{" "}
+                    {[
+                      business.address,
+                      business.streetNumber,
+                      business.city && business.province
+                        ? `${business.city} (${business.province})`
+                        : (business.city ?? business.province),
+                      business.zipCode,
+                    ]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </p>
+                )}
+                {preferredVatLabel && (
+                  <p>
+                    <span className="text-muted-foreground">
+                      IVA prevalente:
+                    </span>{" "}
+                    {preferredVatLabel}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>Credenziali AdE</CardTitle>
+              {business && (
+                <EditAdeCredentialsSection businessId={business.id} />
+              )}
+            </CardHeader>
+            <CardContent>
+              <AdeCredentialsSection
+                businessId={business?.id ?? null}
+                hasCredentials={!!cred}
+                verifiedAt={cred?.verifiedAt ?? null}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* Abbonamento — piano corrente, referral.
+          Reso solo se almeno una card è presente, per non lasciare un
+          heading orfano (utente autenticato senza profilo/piano). */}
+      {(planData || profile) && (
+        <section className="space-y-4">
+          <h2 className={sectionHeadingClass}>Abbonamento</h2>
+          <div className="space-y-6">
+            {planData && (
+              // id="billing" → ancora del deep-link BILLING_SETTINGS_HREF
+              // (/dashboard/settings#billing). scroll-mt evita che la sticky header
+              // copra il titolo quando si atterra sull'ancora.
+              <Card id="billing" className="scroll-mt-20">
+                <CardHeader>
+                  <CardTitle>Piano e Abbonamento</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  {/* Trial scaduto — banner warning */}
+                  {cardState === "trial-expired" && (
+                    <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+                      Il periodo di prova è scaduto. Scegli un piano per
+                      continuare ad emettere scontrini.
+                    </div>
+                  )}
+
+                  {/* Pagamento fallito — banner errore */}
+                  {cardState === "past-due" && (
+                    <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                      Pagamento fallito — aggiorna il metodo di pagamento per
+                      evitare l&apos;interruzione del servizio.
+                    </div>
+                  )}
+
+                  {/* Piano corrente */}
+                  <div>
+                    <p className="text-muted-foreground mb-2 text-sm font-medium">
+                      Piano corrente
+                    </p>
+                    <div className="flex items-center gap-3">
+                      <PlanBadge plan={planData.plan} />
+
+                      {cardState === "trial-active" && trialExpiryDate && (
+                        <span className="text-muted-foreground text-sm">
+                          Prova attiva — scade il{" "}
+                          {trialExpiryDate.toLocaleDateString("it-IT")}
+                        </span>
+                      )}
+
+                      {cardState === "trial-expired" && trialExpiryDate && (
+                        <span className="text-sm text-red-600">
+                          Scaduto il{" "}
+                          {trialExpiryDate.toLocaleDateString("it-IT")}
+                        </span>
+                      )}
+
+                      {cardState === "subscribed" && (
+                        <span className="text-muted-foreground text-sm">
+                          Abbonamento {intervalLabel}
+                          {planData.planExpiresAt &&
+                            ` — rinnovo il ${planData.planExpiresAt.toLocaleDateString("it-IT")}`}
+                        </span>
+                      )}
+
+                      {cardState === "past-due" && (
+                        <span className="text-sm text-red-600">
+                          Abbonamento {intervalLabel} — pagamento scaduto
+                        </span>
+                      )}
+
+                      {cardState === "unlimited" && (
+                        <span className="text-muted-foreground text-sm">
+                          Piano illimitato — gestito direttamente.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Scegli piano — solo senza abbonamento attivo */}
+                  {(cardState === "trial-active" ||
+                    cardState === "trial-expired") && (
+                    <PlanSelection
+                      starterMonthly={PRICE_IDS.starterMonthly}
+                      starterYearly={PRICE_IDS.starterYearly}
+                      proMonthly={PRICE_IDS.proMonthly}
+                      proYearly={PRICE_IDS.proYearly}
+                    />
+                  )}
+
+                  {/* Gestisci abbonamento — solo con abbonamento attivo */}
+                  {cardState === "subscribed" && (
+                    <div>
+                      <p className="text-muted-foreground mb-2 text-sm font-medium">
+                        Gestisci abbonamento
+                      </p>
+                      <p className="text-muted-foreground mb-3 text-sm">
+                        Modifica il piano, aggiorna il metodo di pagamento o
+                        annulla l&apos;abbonamento tramite il portale sicuro di
+                        Stripe.
+                      </p>
+                      <a
+                        href="/api/stripe/portal"
+                        className="text-primary text-sm underline underline-offset-4"
+                      >
+                        Vai al portale Stripe →
+                      </a>
+                    </div>
+                  )}
+
+                  {/* Pagamento scaduto — link urgente al portal */}
+                  {cardState === "past-due" && (
+                    <a
+                      href="/api/stripe/portal"
+                      className="text-sm font-medium text-red-600 underline underline-offset-4"
+                    >
+                      Aggiorna metodo di pagamento →
+                    </a>
+                  )}
+                </CardContent>
+              </Card>
             )}
 
-            {/* Gestisci abbonamento — solo con abbonamento attivo */}
-            {cardState === "subscribed" && (
-              <div>
-                <p className="text-muted-foreground mb-2 text-sm font-medium">
-                  Gestisci abbonamento
-                </p>
-                <p className="text-muted-foreground mb-3 text-sm">
-                  Modifica il piano, aggiorna il metodo di pagamento o annulla
-                  l&apos;abbonamento tramite il portale sicuro di Stripe.
-                </p>
-                <a
-                  href="/api/stripe/portal"
-                  className="text-primary text-sm underline underline-offset-4"
-                >
-                  Vai al portale Stripe →
-                </a>
-              </div>
+            {profile && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Referral</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ReferralSection
+                    referralCode={profile.referralCode}
+                    completedReferrals={completedReferrals}
+                  />
+                </CardContent>
+              </Card>
             )}
-
-            {/* Pagamento scaduto — link urgente al portal */}
-            {cardState === "past-due" && (
-              <a
-                href="/api/stripe/portal"
-                className="text-sm font-medium text-red-600 underline underline-offset-4"
-              >
-                Aggiorna metodo di pagamento →
-              </a>
-            )}
-          </CardContent>
-        </Card>
+          </div>
+        </section>
       )}
 
-      {business && planData && canUseApi(planData.plan) && (
+      {/* Preferenze — aspetto */}
+      <section className="space-y-4">
+        <h2 className={sectionHeadingClass}>Preferenze</h2>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Aspetto</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ThemeSection />
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* Altre impostazioni — sezioni a basso uso, nascoste di default */}
+      <ExtraSettingsSection>
+        {business && planData && canUseApi(planData.plan) && (
+          <Card>
+            <CardHeader>
+              <CardTitle>API key</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ApiKeySection businessId={business.id} />
+            </CardContent>
+          </Card>
+        )}
+
+        <ExportDataSection />
+
+        <AccountDeleteSection />
+
         <Card>
           <CardHeader>
-            <CardTitle>API key</CardTitle>
+            <CardTitle>Informazioni</CardTitle>
           </CardHeader>
-          <CardContent>
-            <ApiKeySection businessId={business.id} />
+          <CardContent className="text-muted-foreground space-y-2 text-sm">
+            <p>
+              ScontrinoZero {APP_VERSION} &mdash; build {getBuildLabel()}
+            </p>
+            <p>
+              Per dubbi, domande o feedback contattaci:{" "}
+              <a
+                className="text-primary underline"
+                href={`mailto:${CONTACT_EMAIL}`}
+              >
+                {CONTACT_EMAIL}
+              </a>
+            </p>
           </CardContent>
         </Card>
-      )}
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Aspetto</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ThemeSection />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Sessione</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground mb-4 text-sm">
-            Esci dall&apos;account su questo dispositivo.
-          </p>
-          <form action={signOut}>
-            <Button variant="outline" type="submit">
-              Esci
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
-
-      <ExportDataSection />
-
-      <AccountDeleteSection />
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Informazioni</CardTitle>
-        </CardHeader>
-        <CardContent className="text-muted-foreground space-y-2 text-sm">
-          <p>
-            ScontrinoZero {APP_VERSION} &mdash; build {getBuildLabel()}
-          </p>
-          <p>
-            Per dubbi, domande o feedback contattaci:{" "}
-            <a
-              className="text-primary underline"
-              href={`mailto:${CONTACT_EMAIL}`}
-            >
-              {CONTACT_EMAIL}
-            </a>
-          </p>
-        </CardContent>
-      </Card>
+      </ExtraSettingsSection>
     </div>
   );
 }

--- a/src/components/settings/extra-settings-section.test.tsx
+++ b/src/components/settings/extra-settings-section.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ExtraSettingsSection } from "./extra-settings-section";
+
+// --- Tests ---
+
+describe("ExtraSettingsSection", () => {
+  it("nasconde i children di default e segnala il toggle come non espanso", () => {
+    render(
+      <ExtraSettingsSection>
+        <p>Contenuto nascosto</p>
+      </ExtraSettingsSection>,
+    );
+
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByText("Contenuto nascosto")).not.toBeInTheDocument();
+  });
+
+  it("mostra i children al click sul toggle", () => {
+    render(
+      <ExtraSettingsSection>
+        <p>Contenuto nascosto</p>
+      </ExtraSettingsSection>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Contenuto nascosto")).toBeInTheDocument();
+  });
+
+  it("richiude i children al secondo click", () => {
+    render(
+      <ExtraSettingsSection>
+        <p>Contenuto nascosto</p>
+      </ExtraSettingsSection>,
+    );
+
+    const toggle = screen.getByRole("button");
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Contenuto nascosto")).not.toBeInTheDocument();
+  });
+
+  it("espone il toggle con il testo 'Altre impostazioni'", () => {
+    render(
+      <ExtraSettingsSection>
+        <p>Contenuto nascosto</p>
+      </ExtraSettingsSection>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /altre impostazioni/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("collega il toggle alla regione dei children via aria-controls", () => {
+    render(
+      <ExtraSettingsSection>
+        <p>Contenuto nascosto</p>
+      </ExtraSettingsSection>,
+    );
+
+    const toggle = screen.getByRole("button");
+    const controlledId = toggle.getAttribute("aria-controls");
+
+    expect(controlledId).toBeTruthy();
+
+    fireEvent.click(toggle);
+
+    const region = document.getElementById(controlledId as string);
+    expect(region).toContainElement(screen.getByText("Contenuto nascosto"));
+  });
+});

--- a/src/components/settings/extra-settings-section.tsx
+++ b/src/components/settings/extra-settings-section.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useId, useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Wrapper "Altre impostazioni": raccoglie le sezioni a basso uso (API key,
+ * export GDPR, eliminazione account, informazioni app) dietro un toggle, per
+ * non allungare lo scroll della pagina Impostazioni. I children sono
+ * renderizzati nel server component (`settings/page.tsx`) e passati come prop.
+ */
+export function ExtraSettingsSection({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div className="space-y-6">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+        onClick={() => setIsOpen((open) => !open)}
+        className="text-muted-foreground"
+      >
+        <ChevronDown
+          className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+        Altre impostazioni
+      </Button>
+
+      {isOpen && (
+        <div id={contentId} className="space-y-6">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/unit/settings-page-card-state.test.ts
+++ b/tests/unit/settings-page-card-state.test.ts
@@ -84,6 +84,11 @@ vi.mock("@/components/billing/plan-selection", () => ({
 vi.mock("@/components/settings/api-key-section", () => ({
   ApiKeySection: vi.fn(() => null),
 }));
+// Passthrough: rende i children così findInJsx continua a trovare le card
+// annidate (es. ApiKeySection) nell'albero JSX.
+vi.mock("@/components/settings/extra-settings-section", () => ({
+  ExtraSettingsSection: ({ children }: { children: unknown }) => children,
+}));
 vi.mock("@/components/settings/ade-credentials-section", () => ({
   AdeCredentialsSection: () => null,
 }));


### PR DESCRIPTION
## Summary

Restructured the settings page (`src/app/dashboard/settings/page.tsx`) to group related settings into semantic sections (Account, Business & Tax, Subscription, Preferences) with visual hierarchy via section headings. Low-frequency settings (API key, GDPR export, account deletion, app info) are now hidden behind a collapsible "Altre impostazioni" toggle to reduce page scroll and improve UX.

## Key Changes

- **Semantic section grouping:** Wrapped related cards into `<section>` elements with uppercase headings:
  - **Account** — Profile, Security, Session
  - **Business & Tax** — Business info, AdE credentials
  - **Subscription** — Plan/billing, Referral (conditional on `planData || profile`)
  - **Preferences** — Theme/appearance
  - **Extra Settings** — API key, GDPR export, account deletion, app info (behind toggle)

- **New `ExtraSettingsSection` component** (`src/components/settings/extra-settings-section.tsx`):
  - Client component with `useState` toggle for expand/collapse
  - Accessible: `aria-expanded`, `aria-controls` attributes
  - Smooth UX: ChevronDown icon rotates on toggle
  - Includes comprehensive unit tests (`extra-settings-section.test.tsx`)

- **Improved spacing:** Changed root container from `space-y-6` to `space-y-8` for better visual separation between sections

- **Session card moved:** Relocated from bottom to Account section (logically grouped with Profile and Security)

- **Conditional rendering:** Subscription section only renders if `planData || profile` exists, preventing orphaned headings

- **Updated test mocks:** Added passthrough mock for `ExtraSettingsSection` in `settings-page-card-state.test.ts` to preserve nested card discovery

- **Documentation link updated:** Changed API docs reference from "Impostazioni → API key" to "Impostazioni → Altre impostazioni → API key" in `/help/api/page.tsx`

## Implementation Details

- Section headings use a shared `sectionHeadingClass` variable for consistency (uppercase, muted color, small font)
- Extra settings toggle uses `useId()` for unique `aria-controls` binding
- All children of `ExtraSettingsSection` are rendered server-side in `settings/page.tsx` and passed as props (no client-side fetching)
- Maintains all existing functionality and conditional logic (e.g., API key only shown if `canUseApi(planData.plan)`)

https://claude.ai/code/session_019ikuroFvnNbmJB1wyhwCtH