### PR TITLE
fix(referral): estendi il trial del referee invece di anticiparlo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,33 @@ https://<host>/api/_debug/sentry-sentinel?id=<release>`; la response
     (in `code span`) non esiste più su disco; cita ogni path come span isolato
     (i token con `*`/`{}` sono ignorati come illustrativi).
 
+27. **Date derivate e fonti di verità esterne (bonus/crediti/aggiustamenti).**
+    Due trappole emerse insieme nel programma referral (presentato/presentatore).
+    **(a) Su una data DERIVATA, asserisci l'esito osservabile, non lo shift
+    intermedio.** La scadenza trial è `trialStartedAt + TRIAL_DAYS`: per
+    ALLUNGARE il trial lo start va spostato in **avanti**, non indietro
+    (spostarlo indietro anticipa la scadenza → il referee risultava "già
+    scaduto" il giorno della registrazione). Il bug era coperto da un test
+    verde che asseriva proprio lo shift all'indietro chiamandolo "trial più
+    lungo": **codificava il modello mentale sbagliato**. TDD (regola 2/4) ti
+    protegge solo se l'`expect` controlla la grandezza user-facing
+    (`isTrialExpired`, la data mostrata in `settings/page.tsx`), non il
+    trasformatore intermedio. Helper: `getPlan`/`fetchPlan` in
+    `src/lib/plans.ts`. **(b) Un numero posseduto da un sistema esterno di
+    verità (Stripe billing date) non si "aggiusta" a read-time in locale.** Il
+    mese bonus del referrer veniva sommato a `planExpiresAt` solo dentro
+    `getPlan`: l'app mostrava +1 mese ma il portale Stripe (e l'addebito reale)
+    non si spostavano, la divergenza non si riconciliava mai, e il sync
+    unidirezionale Stripe→DB del webhook la sovrascriveva. Un
+    bonus/credito/estensione su una grandezza Stripe va **spinto a Stripe**
+    (`extendSubscriptionForReferral` in `src/server/referral-reward.ts`:
+    estensione `trial_end`, poi il webhook risincronizza); il `referral_bonus_days`
+    resta un meccanismo **solo-trial**. Generalizza le regole 17 (una sola
+    strategia canonica per le grandezze monetarie) e 19/20 (degradare, non
+    divergere). NB: la copy referral vive anche fuori da `(marketing)/` —
+    `src/components/settings/referral-section.tsx` — quindi va inclusa nel grep
+    della regola 8 quando cambiano i termini del bonus.
+
 ## SonarCloud quality gate
 
 - Coverage on new code ≥ **80%**

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -348,6 +348,37 @@ shape. Se conferma lista vuota su `200` (transient post-password-change): tratta
 `PIva` vuota come transient (retry singolo di Phase F e/o downgrade a
 `ade_transient` warn, fuori da Sentry). Non implementare prima della conferma.
 
+### 33. Referral bonus — limiti noti dopo lo split trial-vs-Stripe
+
+- **Categoria:** correttezza/billing · **Severità:** Low — scelte di design accettate, non bug
+- **File:** `src/lib/plans.ts` (`fetchPlan`), `src/server/onboarding-actions.ts`
+  (`finalizeAdeVerification`, ramo reward), `src/server/referral-reward.ts`
+  (`extendSubscriptionForReferral`)
+
+**Contesto.** Il bonus referral (+1 mese, member-get-member) ha ora due binari:
+`referralBonusDays` estende **solo** il trial (traslando `trialStartedAt` in
+avanti in `fetchPlan`); per un referrer con abbonamento Stripe **attivo** il mese
+gratis è erogato estendendo `trial_end` su Stripe, e il webhook risincronizza
+`plan_expires_at`. `planExpiresAt` non è più traslato a read-time (Stripe = fonte
+di verità sui piani a pagamento), così l'app non diverge più dal portale Stripe.
+
+**Limiti noti accettati:**
+
+1. **Carry-over trial→pagato.** Un utente che accumula `referralBonusDays` mentre
+   è in trial e poi si abbona **perde** i giorni residui: il bonus non viene
+   trasferito sul nuovo abbonamento Stripe (il checkout non imposta `trial_end`).
+   Fuori scope per ora — eventuale fix: leggere `referralBonusDays` residui al
+   checkout e impostare `trial_end` sulla subscription.
+2. **Referrer `unlimited`.** Nessuna subscription Stripe e piano che non scade →
+   il reward incrementa `referralBonusDays` ma è un no-op visibile (il bonus
+   tocca solo il trial). Accettato: `unlimited` è invite-only/gratis.
+3. **Estensione Stripe fallita = riconciliazione manuale.** `rewardedAt` è già
+   committato quando si tenta l'estensione Stripe (chiamata esterna, post-commit
+   best-effort): se Stripe è giù, il referrer resta senza mese finché non si
+   riconcilia a mano. Cercabile via il log `critical: true` "owed free month
+   needs manual reconciliation" in `extendSubscriptionForReferral`. Preferito a
+   una data app che torni a divergere da Stripe.
+
 ### audit-ci: advisory `esbuild` dev-only (3 GHSA)
 
 `audit-ci.json` allowlista tre advisory su **esbuild** (JSON puro → non può

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,6 +23,7 @@ sonar.coverage.exclusions=\
   src/lib/ade/types.ts,\
   src/components/catalogo/catalogo-client.tsx,\
   src/app/(marketing)/help/page.tsx,\
+  src/app/(marketing)/help/presenta-un-amico/page.tsx,\
   src/app/(marketing)/help/api/page.tsx,\
   src/app/(marketing)/help/come-collegare-ade/page.tsx,\
   src/app/(marketing)/help/credenziali-fisconline/page.tsx,\

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -162,6 +162,10 @@ const helpCategories: HelpCategory[] = [
         href: "/help/piani-e-prezzi",
       },
       {
+        title: "Presenta un amico: come funziona il bonus referral",
+        href: "/help/presenta-un-amico",
+      },
+      {
         title: "Come passare da mensile ad annuale",
         href: "/help/cambio-piano",
       },

--- a/src/app/(marketing)/help/presenta-un-amico/page.tsx
+++ b/src/app/(marketing)/help/presenta-un-amico/page.tsx
@@ -82,7 +82,7 @@ export default function PresentaUnAmicoPage() {
             <code className="bg-muted rounded px-1 py-0.5 text-xs">
               /register?rcode=ILTUOCODICE
             </code>
-            ) pronto da inviare via messaggio, email o social.
+            {") pronto da inviare via messaggio, email o social."}
           </li>
         </ol>
 

--- a/src/app/(marketing)/help/presenta-un-amico/page.tsx
+++ b/src/app/(marketing)/help/presenta-un-amico/page.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
+import { helpArticleMetadata } from "@/lib/help/metadata";
+import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
+
+export const metadata = helpArticleMetadata("presenta-un-amico");
+
+export default function PresentaUnAmicoPage() {
+  return (
+    <section className="px-4 py-16">
+      <JsonLd
+        data={helpArticleBreadcrumb("presenta-un-amico", "Presenta un amico")}
+      />
+      <HelpArticleJsonLd slug="presenta-un-amico" />
+      <article className="mx-auto max-w-3xl">
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "presenta-un-amico",
+            "Presenta un amico",
+          )}
+        />
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Presenta un amico: come funziona il bonus referral
+          </h1>
+          <Badge variant="secondary">Abbonamento</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Con <strong>Presenta un amico</strong> ci guadagnate in due. Chiamiamo{" "}
+          <strong>presentatore</strong> chi invita e <strong>presentato</strong>{" "}
+          chi accetta l&apos;invito registrandosi con il codice: il presentato
+          ottiene <strong>un mese di prova in più</strong> e il presentatore{" "}
+          <strong>un mese in più sul proprio piano</strong>.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> giugno 2026
+        </p>
+
+        {/* ─── Come funziona in breve ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Come funziona in breve</h2>
+        <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Il presentato</strong> (chi si registra con il tuo codice)
+            ottiene <strong>subito</strong> un mese di prova in più: invece di
+            30 giorni, ne ha <strong>60</strong> per provare ScontrinoZero senza
+            carta di credito.
+          </li>
+          <li>
+            <strong>Il presentatore</strong> (tu, che inviti) ottiene{" "}
+            <strong>un mese in più sul tuo piano</strong>. Questo bonus{" "}
+            <strong>non è immediato</strong>: arriva solo quando il presentato
+            attiva davvero il servizio (vedi <em>Quando arriva il bonus</em> più
+            sotto).
+          </li>
+        </ul>
+
+        {/* ─── Dove trovi il tuo codice ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Dove trovi il tuo codice
+        </h2>
+        <ol className="text-muted-foreground mt-3 list-decimal space-y-3 pl-5 text-sm leading-relaxed">
+          <li>
+            Accedi a ScontrinoZero e vai su{" "}
+            <strong>Dashboard → Impostazioni → Piano e Abbonamento</strong>.
+          </li>
+          <li>
+            Nella sezione <strong>Presenta un amico</strong> trovi il tuo{" "}
+            <strong>codice referral</strong> personale.
+          </li>
+          <li>
+            Tocca <strong>Condividi codice referral</strong>: l&apos;app prepara
+            un link di invito (del tipo{" "}
+            <code className="bg-muted rounded px-1 py-0.5 text-xs">
+              /register?rcode=ILTUOCODICE
+            </code>
+            ) pronto da inviare via messaggio, email o social.
+          </li>
+        </ol>
+
+        {/* ─── Come invitare ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Come invitare qualcuno</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Condividi il link di invito con la persona che vuoi presentare. Quando
+          la apre, la pagina di registrazione mostra il tuo codice{" "}
+          <strong>già compilato</strong>: al presentato basta completare la
+          registrazione normalmente. In alternativa può inserire il codice a
+          mano nel campo dedicato del modulo di registrazione.
+        </p>
+
+        {/* ─── Quando arriva il bonus ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Quando arriva il bonus</h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          I due bonus scattano in momenti diversi, ed è importante saperlo:
+        </p>
+        <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Presentato — subito.</strong> Il mese di prova in più viene
+            applicato al momento della registrazione con il codice.
+          </li>
+          <li>
+            <strong>Presentatore — non subito.</strong> Il tuo mese viene
+            accreditato{" "}
+            <strong>solo quando il presentato collega la propria P.IVA</strong>{" "}
+            e completa la verifica delle credenziali con l&apos;Agenzia delle
+            Entrate, diventando un utente attivo a tutti gli effetti. La
+            semplice registrazione non basta.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il motivo è semplice: il bonus premia gli inviti che si trasformano in
+          esercenti reali che usano ScontrinoZero, non la sola iscrizione. Se
+          hai invitato qualcuno e non vedi ancora il mese, è probabile che debba
+          ancora completare il collegamento con l&apos;Agenzia delle Entrate.
+        </p>
+
+        {/* ─── Dove vedo il mese in più ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Dove vedo il mese in più
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il mese si applica al tuo <strong>piano attuale</strong>, e lo trovi
+          sempre in <strong>Impostazioni → Piano e Abbonamento</strong>:
+        </p>
+        <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            Se sei ancora in <strong>periodo di prova</strong>, la prova si
+            allunga di un mese.
+          </li>
+          <li>
+            Se hai un <strong>abbonamento attivo</strong> (Starter o Pro), la{" "}
+            <strong>data di rinnovo si sposta in avanti di un mese</strong>: il
+            prossimo addebito slitta di conseguenza. Lo stesso spostamento è
+            visibile anche nel portale di fatturazione Stripe (link{" "}
+            <strong>Vai al portale Stripe →</strong>), così l&apos;app e la
+            fatturazione restano allineate.
+          </li>
+        </ul>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Puoi presentare più persone: ogni nuovo cliente che attiva il servizio
+          con il tuo codice ti fa guadagnare un altro mese. Trovi le condizioni
+          aggiornate dei piani in{" "}
+          <Link
+            href="/help/piani-e-prezzi"
+            className="text-primary hover:underline"
+          >
+            Piani disponibili
+          </Link>
+          {"."}
+        </p>
+
+        <RelatedHelpArticles slug="presenta-un-amico" />
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(58);
+    expect(result).toHaveLength(59);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -175,12 +175,12 @@ describe("sitemap", () => {
     });
 
     // Auth pages (last two)
-    expect(result[56]).toMatchObject({
+    expect(result[57]).toMatchObject({
       url: "https://scontrinozero.it/login",
       changeFrequency: "yearly",
       priority: 0.5,
     });
-    expect(result[57]).toMatchObject({
+    expect(result[58]).toMatchObject({
       url: "https://scontrinozero.it/register",
       changeFrequency: "yearly",
       priority: 0.5,

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -167,6 +167,15 @@ export const helpArticles: Record<string, HelpArticle> = {
       "Guida all'onboarding di ScontrinoZero: crea l'account, inserisci i dati dell'attività e collega le credenziali Fisconline per iniziare a emettere scontrini elettronici.",
     related: ["come-collegare-ade", "primo-scontrino", "installare-app"],
   },
+  "presenta-un-amico": {
+    slug: "presenta-un-amico",
+    title: "Presenta un amico: come funziona il bonus referral",
+    metaTitle:
+      "Presenta un amico: bonus referral e quando arriva il mese gratis",
+    description:
+      "Come funziona il programma Presenta un amico di ScontrinoZero: il presentato ottiene subito 1 mese di prova in più, il presentatore 1 mese sul proprio piano quando l'invitato collega la P.IVA. Dove trovare e condividere il codice.",
+    related: ["piani-e-prezzi", "cambio-piano", "contatto-assistenza"],
+  },
   "primo-scontrino": {
     slug: "primo-scontrino",
     title: "Come emettere il primo scontrino elettronico",

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -173,7 +173,7 @@ export const helpArticles: Record<string, HelpArticle> = {
     metaTitle:
       "Presenta un amico: bonus referral e quando arriva il mese gratis",
     description:
-      "Come funziona il programma Presenta un amico di ScontrinoZero: il presentato ottiene subito 1 mese di prova in più, il presentatore 1 mese sul proprio piano quando l'invitato collega la P.IVA. Dove trovare e condividere il codice.",
+      "Come funziona Presenta un amico: il presentato ottiene subito 1 mese di prova in più, il presentatore 1 mese sul piano quando l'invitato collega la P.IVA. Dove trovare e condividere il codice.",
     related: ["piani-e-prezzi", "cambio-piano", "contatto-assistenza"],
   },
   "primo-scontrino": {

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -494,7 +494,11 @@ describe("getPlan", () => {
     });
   });
 
-  it("trasla trialStartedAt indietro di referralBonusDays (trial più lungo)", async () => {
+  it("trasla trialStartedAt in avanti di referralBonusDays (trial più lungo)", async () => {
+    // La scadenza trial è trialStartedAt + TRIAL_DAYS: spostare lo start in
+    // AVANTI di 30 giorni allunga il trial a 60 giorni. Regression guard del
+    // bug che lo spostava indietro, facendo scadere il trial del referee il
+    // giorno stesso della registrazione.
     const trialStartedAt = new Date("2026-01-15T00:00:00Z");
     mockLimit.mockResolvedValue([
       {
@@ -507,7 +511,31 @@ describe("getPlan", () => {
 
     const result = await getPlan("user-bonus-trial");
 
-    expect(result.trialStartedAt).toEqual(new Date("2025-12-16T00:00:00Z"));
+    expect(result.trialStartedAt).toEqual(new Date("2026-02-14T00:00:00Z"));
+  });
+
+  it("un referee nuovo (trial oggi + 30 bonus) NON risulta scaduto", async () => {
+    // Scenario del bug: signup con referral oggi → trialStartedAt = now,
+    // referralBonusDays = 30. La scadenza derivata deve cadere a ~60 giorni,
+    // quindi isTrialExpired(trialStartedAt) === false.
+    const now = new Date();
+    mockLimit.mockResolvedValue([
+      {
+        plan: "trial",
+        trialStartedAt: now,
+        planExpiresAt: null,
+        referralBonusDays: 30,
+      },
+    ]);
+
+    const result = await getPlan("user-fresh-referee");
+
+    expect(isTrialExpired(result.trialStartedAt)).toBe(false);
+    const expiryMs =
+      (result.trialStartedAt as Date).getTime() +
+      TRIAL_DAYS * 24 * 60 * 60 * 1000;
+    // ~60 giorni da adesso (30 trial + 30 bonus), con tolleranza.
+    expect(expiryMs - now.getTime()).toBeGreaterThan(59 * 24 * 60 * 60 * 1000);
   });
 
   it("trasla planExpiresAt avanti di referralBonusDays (scadenza più lontana)", async () => {

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -538,7 +538,11 @@ describe("getPlan", () => {
     expect(expiryMs - now.getTime()).toBeGreaterThan(59 * 24 * 60 * 60 * 1000);
   });
 
-  it("trasla planExpiresAt avanti di referralBonusDays (scadenza più lontana)", async () => {
+  it("NON trasla planExpiresAt per i piani a pagamento (Stripe = fonte di verità)", async () => {
+    // Il mese gratis del referrer a pagamento è erogato su Stripe
+    // (extendSubscriptionForReferral) e il webhook risincronizza plan_expires_at
+    // col valore reale. Sommare di nuovo il bonus qui farebbe divergere l'app
+    // dal portale Stripe a ogni render (era il bug del presentatore).
     const planExpiresAt = new Date("2026-06-01T00:00:00Z");
     mockLimit.mockResolvedValue([
       {
@@ -551,7 +555,7 @@ describe("getPlan", () => {
 
     const result = await getPlan("user-bonus-pro");
 
-    expect(result.planExpiresAt).toEqual(new Date("2026-07-01T00:00:00Z"));
+    expect(result.planExpiresAt).toEqual(planExpiresAt);
   });
 
   it("referralBonusDays = 0 lascia le date inalterate (regression guard)", async () => {

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -94,13 +94,15 @@ async function fetchPlan(authUserId: string): Promise<PlanInfo> {
   }
 
   // Bonus referral (member-get-member): trasla le date PRIMA di ritornarle,
-  // così isTrialExpired/isPaidPlanExpired e i 14 call site esistenti non
-  // cambiano firma. `referral_bonus_days` è additivo e indipendente dal sync
-  // Stripe (che sovrascrive solo planExpiresAt in toto) — vive qui, nell'unico
-  // punto che produce PlanInfo.
+  // così isTrialExpired/isPaidPlanExpired e i call site esistenti non cambiano
+  // firma. La scadenza trial è derivata come `trialStartedAt + TRIAL_DAYS`,
+  // quindi per ALLUNGARE il trial lo start va spostato in AVANTI di `bonusMs`:
+  // 30 giorni bonus + 30 di trial = 60 giorni totali. (Spostarlo indietro
+  // anticiperebbe la scadenza — era il bug che faceva risultare il trial del
+  // nuovo referee "già scaduto" il giorno stesso della registrazione.)
   const bonusMs = (profile.referralBonusDays ?? 0) * 24 * 60 * 60 * 1000;
   const trialStartedAt = profile.trialStartedAt
-    ? new Date(profile.trialStartedAt.getTime() - bonusMs)
+    ? new Date(profile.trialStartedAt.getTime() + bonusMs)
     : null;
   const planExpiresAt = profile.planExpiresAt
     ? new Date(profile.planExpiresAt.getTime() + bonusMs)

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -93,25 +93,28 @@ async function fetchPlan(authUserId: string): Promise<PlanInfo> {
     throw new ProfileNotFoundError(authUserId);
   }
 
-  // Bonus referral (member-get-member): trasla le date PRIMA di ritornarle,
-  // così isTrialExpired/isPaidPlanExpired e i call site esistenti non cambiano
-  // firma. La scadenza trial è derivata come `trialStartedAt + TRIAL_DAYS`,
-  // quindi per ALLUNGARE il trial lo start va spostato in AVANTI di `bonusMs`:
-  // 30 giorni bonus + 30 di trial = 60 giorni totali. (Spostarlo indietro
-  // anticiperebbe la scadenza — era il bug che faceva risultare il trial del
-  // nuovo referee "già scaduto" il giorno stesso della registrazione.)
+  // Bonus referral (member-get-member): `referralBonusDays` è ESCLUSIVAMENTE
+  // un meccanismo trial. La scadenza trial è derivata come
+  // `trialStartedAt + TRIAL_DAYS`, quindi per ALLUNGARE il trial lo start va
+  // spostato in AVANTI di `bonusMs`: 30 giorni bonus + 30 di trial = 60 giorni
+  // totali. (Spostarlo indietro anticiperebbe la scadenza — era il bug che
+  // faceva risultare il trial del nuovo referee "già scaduto" il giorno stesso
+  // della registrazione.)
+  //
+  // `planExpiresAt` NON viene più traslato: per i referrer a pagamento il mese
+  // gratis è erogato direttamente su Stripe (estensione `trial_end`, vedi
+  // `extendSubscriptionForReferral`), e il webhook risincronizza
+  // `plan_expires_at` col valore reale di Stripe. Sommare di nuovo il bonus qui
+  // farebbe divergere l'app dal portale Stripe a ogni render.
   const bonusMs = (profile.referralBonusDays ?? 0) * 24 * 60 * 60 * 1000;
   const trialStartedAt = profile.trialStartedAt
     ? new Date(profile.trialStartedAt.getTime() + bonusMs)
-    : null;
-  const planExpiresAt = profile.planExpiresAt
-    ? new Date(profile.planExpiresAt.getTime() + bonusMs)
     : null;
 
   return {
     plan: profile.plan,
     trialStartedAt,
-    planExpiresAt,
+    planExpiresAt: profile.planExpiresAt,
   };
 }
 

--- a/src/lib/referral-code.ts
+++ b/src/lib/referral-code.ts
@@ -25,6 +25,15 @@
  */
 import { createHash } from "node:crypto";
 
+/**
+ * Giorni di bonus referral (member-get-member, +1 mese), unica sorgente di
+ * verità per: il bonus al nuovo utente (referee) al signup, l'incremento al
+ * referrer in trial al reward, e l'estensione `trial_end` su Stripe per i
+ * referrer a pagamento. Tenere un solo valore evita divergenze tra i tre
+ * punti che lo applicano.
+ */
+export const REFERRAL_BONUS_DAYS = 30;
+
 const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const CODE_LENGTH = 8;
 const CODE_RE = new RegExp(`^[${ALPHABET}]{${CODE_LENGTH}}$`);

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -25,11 +25,9 @@ import { normalizeSignupSource } from "@/lib/signup-source";
 import {
   generateReferralCode,
   normalizeReferralCode,
+  REFERRAL_BONUS_DAYS,
 } from "@/lib/referral-code";
 import { referralRedemptions } from "@/db/schema/referral-redemptions";
-
-/** Giorni di trial bonus concessi al nuovo utente che si registra con un referral valido (+1 mese). */
-const REFERRAL_SIGNUP_BONUS_DAYS = 30;
 
 const CURRENT_TERMS_VERSION = "v01";
 
@@ -313,7 +311,7 @@ async function insertProfileOrRollback(
           signupSource,
           referralCode,
           referredByReferralCode: referrer?.referralCode ?? null,
-          referralBonusDays: referrer ? REFERRAL_SIGNUP_BONUS_DAYS : 0,
+          referralBonusDays: referrer ? REFERRAL_BONUS_DAYS : 0,
         })
         .returning({ id: profiles.id });
 

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -79,6 +79,16 @@ vi.mock("@/db/schema", () => ({
   adeCredentials: "ade-credentials-table",
   trialVatLedger: "trial-vat-ledger-table",
   referralRedemptions: "referral-redemptions-table",
+  subscriptions: "subscriptions-table",
+}));
+
+// Estensione Stripe del referrer a pagamento: mockata per non tirare dentro
+// il client Stripe reale e per poter asserire QUANDO viene chiamata.
+const mockExtendSubscriptionForReferral = vi
+  .fn()
+  .mockResolvedValue({ extended: true });
+vi.mock("@/server/referral-reward", () => ({
+  extendSubscriptionForReferral: mockExtendSubscriptionForReferral,
 }));
 
 const mockEncrypt = vi.fn().mockReturnValue("encrypted-data");
@@ -671,6 +681,79 @@ describe("onboarding-actions", () => {
       // sempre a una riga non-vuota di default).
       expect(mockUpdate).toHaveBeenCalledTimes(5);
       expect(mockRevalidatePath).toHaveBeenCalledWith("/dashboard", "layout");
+    });
+
+    it("referrer in trial: incrementa referralBonusDays, niente estensione Stripe", async () => {
+      // Default delle SELECT trailing (referrerSub) = nessun abbonamento attivo
+      // → ramo referralBonusDays. Ownership + credenziali in coda.
+      mockLimit.mockResolvedValue([
+        { status: null, stripeSubscriptionId: null },
+      ]);
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      // 3 core update + rewardedAt + referralBonusDays = 5; nessuna Stripe.
+      expect(mockUpdate).toHaveBeenCalledTimes(5);
+      expect(mockExtendSubscriptionForReferral).not.toHaveBeenCalled();
+    });
+
+    it("referrer con abbonamento Stripe attivo: estende su Stripe, NON tocca referralBonusDays", async () => {
+      // Default delle SELECT trailing (referrerSub) = abbonamento attivo →
+      // ramo estensione Stripe (post-commit), niente incremento bonus.
+      mockLimit.mockResolvedValue([
+        { status: "active", stripeSubscriptionId: "sub_active" },
+      ]);
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          encryptedCodiceFiscale: "enc-cf",
+          encryptedPassword: "enc-pw",
+          encryptedPin: "enc-pin",
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+      mockLogin.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      await verifyAdeCredentials("biz-789");
+
+      // 3 core update + rewardedAt = 4 (NESSUN update referralBonusDays).
+      expect(mockUpdate).toHaveBeenCalledTimes(4);
+      expect(mockExtendSubscriptionForReferral).toHaveBeenCalledTimes(1);
+      expect(mockExtendSubscriptionForReferral).toHaveBeenCalledWith(
+        expect.objectContaining({ stripeSubscriptionId: "sub_active" }),
+      );
     });
 
     it("marks credentials as verified even when getFiscalData fails", async () => {

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -10,7 +10,10 @@ import {
   profiles,
   trialVatLedger,
   referralRedemptions,
+  subscriptions,
 } from "@/db/schema";
+import { REFERRAL_BONUS_DAYS } from "@/lib/referral-code";
+import { extendSubscriptionForReferral } from "@/server/referral-reward";
 import { hashPiva } from "@/lib/piva-hash";
 import {
   encrypt,
@@ -432,6 +435,14 @@ async function finalizeAdeVerification(params: {
 
   let credentialsChanged = false;
   let trialAlreadyUsed = false;
+  // Estensione Stripe del referrer differita a DOPO il commit: è una chiamata
+  // esterna, non può vivere dentro la transazione DB (regola 10). Valorizzata
+  // dentro la tx solo se il referrer ha un abbonamento Stripe attivo.
+  let pendingStripeExtension: {
+    stripeSubscriptionId: string;
+    referrerId: string;
+    refereeId: string;
+  } | null = null;
 
   await db.transaction(async (tx) => {
     const updated = await tx
@@ -534,15 +545,53 @@ async function finalizeAdeVerification(params: {
         .returning({ referrerId: referralRedemptions.referrerId });
 
       if (claimed.length > 0) {
-        await tx
-          .update(profiles)
-          .set({
-            referralBonusDays: sql`${profiles.referralBonusDays} + 30`,
+        const referrerId = claimed[0].referrerId;
+
+        // Come erogare il mese gratis dipende dallo stato del referrer:
+        // - abbonamento Stripe ATTIVO → estensione su Stripe (post-commit),
+        //   così la prossima data di addebito si sposta davvero e l'app resta
+        //   coerente col portale (regola: Stripe = fonte di verità sui piani a
+        //   pagamento). NON si tocca referralBonusDays.
+        // - trial / unlimited / abbonamento non attivo → si incrementa
+        //   referralBonusDays, che ormai estende esclusivamente il trial
+        //   (no-op per unlimited e per i pagati non attivi: documentato).
+        const [referrerSub] = await tx
+          .select({
+            status: subscriptions.status,
+            stripeSubscriptionId: subscriptions.stripeSubscriptionId,
           })
-          .where(eq(profiles.id, claimed[0].referrerId));
+          .from(subscriptions)
+          .innerJoin(profiles, eq(subscriptions.userId, profiles.authUserId))
+          .where(eq(profiles.id, referrerId))
+          .limit(1);
+
+        if (
+          referrerSub?.status === "active" &&
+          referrerSub.stripeSubscriptionId
+        ) {
+          pendingStripeExtension = {
+            stripeSubscriptionId: referrerSub.stripeSubscriptionId,
+            referrerId,
+            refereeId: refereeProfile.id,
+          };
+        } else {
+          await tx
+            .update(profiles)
+            .set({
+              referralBonusDays: sql`${profiles.referralBonusDays} + ${REFERRAL_BONUS_DAYS}`,
+            })
+            .where(eq(profiles.id, referrerId));
+        }
       }
     }
   });
+
+  // Fuori transazione: estensione Stripe best-effort (non deve rompere
+  // l'onboarding del referee se Stripe è giù — la funzione logga critical e
+  // non rilancia).
+  if (pendingStripeExtension) {
+    await extendSubscriptionForReferral(pendingStripeExtension);
+  }
 
   return { credentialsChanged, trialAlreadyUsed };
 }

--- a/src/server/referral-reward.test.ts
+++ b/src/server/referral-reward.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsUpdate,
+  mockLoggerError,
+  mockLoggerWarn,
+  mockLoggerInfo,
+} = vi.hoisted(() => ({
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn().mockReturnValue({
+    subscriptions: {
+      retrieve: mockSubscriptionsRetrieve,
+      update: mockSubscriptionsUpdate,
+    },
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: mockLoggerError,
+    warn: mockLoggerWarn,
+    info: mockLoggerInfo,
+  },
+}));
+
+import { extendSubscriptionForReferral } from "./referral-reward";
+
+// 30 days in seconds — must match REFERRAL_BONUS_DAYS.
+const BONUS_SECONDS = 30 * 24 * 60 * 60;
+
+function subWithPeriodEnd(currentPeriodEnd: number) {
+  return { items: { data: [{ current_period_end: currentPeriodEnd }] } };
+}
+
+const ARGS = {
+  stripeSubscriptionId: "sub_123",
+  referrerId: "referrer-profile-id",
+  refereeId: "referee-profile-id",
+};
+
+describe("extendSubscriptionForReferral", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubscriptionsUpdate.mockResolvedValue({});
+  });
+
+  it("estende trial_end di 30 giorni oltre current_period_end", async () => {
+    const periodEnd = 1_800_000_000;
+    mockSubscriptionsRetrieve.mockResolvedValue(subWithPeriodEnd(periodEnd));
+
+    const result = await extendSubscriptionForReferral(ARGS);
+
+    expect(result).toEqual({ extended: true });
+    expect(mockSubscriptionsRetrieve).toHaveBeenCalledWith("sub_123");
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      "sub_123",
+      { trial_end: periodEnd + BONUS_SECONDS, proration_behavior: "none" },
+      { idempotencyKey: "referral-extend:referee-profile-id" },
+    );
+  });
+
+  it("usa una idempotency key stabile derivata dal refereeId", async () => {
+    mockSubscriptionsRetrieve.mockResolvedValue(subWithPeriodEnd(1_000_000));
+
+    await extendSubscriptionForReferral(ARGS);
+
+    const options = mockSubscriptionsUpdate.mock.calls[0][2];
+    expect(options.idempotencyKey).toBe("referral-extend:referee-profile-id");
+  });
+
+  it("salta l'estensione e logga warn critical se manca current_period_end", async () => {
+    mockSubscriptionsRetrieve.mockResolvedValue({ items: { data: [] } });
+
+    const result = await extendSubscriptionForReferral(ARGS);
+
+    expect(result).toEqual({ extended: false });
+    expect(mockSubscriptionsUpdate).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        critical: true,
+        refereeId: "referee-profile-id",
+      }),
+      expect.stringContaining("missing current_period_end"),
+    );
+  });
+
+  it("non rilancia su errore Stripe: logga error critical e ritorna extended:false", async () => {
+    mockSubscriptionsRetrieve.mockRejectedValue(new Error("stripe down"));
+
+    const result = await extendSubscriptionForReferral(ARGS);
+
+    expect(result).toEqual({ extended: false });
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        critical: true,
+        referrerId: "referrer-profile-id",
+        refereeId: "referee-profile-id",
+      }),
+      expect.stringContaining("manual reconciliation"),
+    );
+  });
+
+  it("non rilancia se update fallisce dopo un retrieve riuscito", async () => {
+    mockSubscriptionsRetrieve.mockResolvedValue(subWithPeriodEnd(1_000_000));
+    mockSubscriptionsUpdate.mockRejectedValue(new Error("update failed"));
+
+    const result = await extendSubscriptionForReferral(ARGS);
+
+    expect(result).toEqual({ extended: false });
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/referral-reward.ts
+++ b/src/server/referral-reward.ts
@@ -1,0 +1,78 @@
+import { getStripe } from "@/lib/stripe";
+import { logger } from "@/lib/logger";
+import { REFERRAL_BONUS_DAYS } from "@/lib/referral-code";
+
+const BONUS_SECONDS = REFERRAL_BONUS_DAYS * 24 * 60 * 60;
+
+/**
+ * Eroga il mese gratis di referral a un referrer con abbonamento Stripe
+ * attivo, spostando in avanti la `trial_end` della subscription:
+ *
+ *   trial_end = current_period_end + REFERRAL_BONUS_DAYS
+ *
+ * Stripe tratta la finestra fino a `trial_end` come trial → nessun addebito →
+ * la prossima data di rinnovo si sposta davvero di un mese, coerente con
+ * quanto mostra l'app (il webhook `customer.subscription.updated` risincronizza
+ * poi `subscriptions.current_period_end` e `profiles.plan_expires_at`).
+ * `proration_behavior: "none"` evita righe di credito/debito spurie.
+ *
+ * Best-effort (CLAUDE.md regola 10): un fallimento Stripe NON deve rompere
+ * l'onboarding del referee che ha innescato il reward. Su errore logghiamo a
+ * `critical` (così è cercabile per la riconciliazione manuale del mese dovuto)
+ * e ritorniamo `{ extended: false }` senza rilanciare.
+ *
+ * NB: per i referrer a pagamento attivi NON si incrementa `referralBonusDays`
+ * (che ormai è puramente un meccanismo trial): Stripe è la fonte di verità
+ * della data di rinnovo. Se l'estensione fallisce qui, il referrer resta senza
+ * bonus finché non si riconcilia a mano — preferibile a una data app che
+ * diverge di nuovo da Stripe.
+ *
+ * @param stripeSubscriptionId  La subscription Stripe del referrer (attiva).
+ * @param referrerId            profiles.id del referrer (solo per log).
+ * @param refereeId             profiles.id del referee — chiave di idempotenza
+ *                              stabile per redemption (evita doppia estensione
+ *                              sotto retry della stessa finalizeAdeVerification).
+ */
+export async function extendSubscriptionForReferral(args: {
+  stripeSubscriptionId: string;
+  referrerId: string;
+  refereeId: string;
+}): Promise<{ extended: boolean }> {
+  const { stripeSubscriptionId, referrerId, refereeId } = args;
+
+  try {
+    const stripe = getStripe();
+    const sub = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+
+    // API 2026-05-27.dahlia: current_period_end vive su items.data[0]
+    // (rimosso dal top-level Subscription), stesso accesso del webhook.
+    const currentPeriodEnd = sub.items.data[0]?.current_period_end;
+    if (!currentPeriodEnd) {
+      logger.warn(
+        { critical: true, referrerId, refereeId, stripeSubscriptionId },
+        "Referral Stripe extension skipped: missing current_period_end",
+      );
+      return { extended: false };
+    }
+
+    const trialEnd = currentPeriodEnd + BONUS_SECONDS;
+
+    await stripe.subscriptions.update(
+      stripeSubscriptionId,
+      { trial_end: trialEnd, proration_behavior: "none" },
+      { idempotencyKey: `referral-extend:${refereeId}` },
+    );
+
+    logger.info(
+      { referrerId, refereeId, stripeSubscriptionId, trialEnd },
+      "Referral reward: Stripe subscription extended by one free month",
+    );
+    return { extended: true };
+  } catch (err) {
+    logger.error(
+      { err, critical: true, referrerId, refereeId, stripeSubscriptionId },
+      "Referral Stripe extension failed — owed free month needs manual reconciliation",
+    );
+    return { extended: false };
+  }
+}


### PR DESCRIPTION
Il bonus referral del nuovo utente (presentato) traslava trialStartedAt
all'indietro di referralBonusDays. Siccome la scadenza trial e' derivata
come trialStartedAt + TRIAL_DAYS, spostare lo start indietro ANTICIPA la
scadenza: un referee con start = oggi e 30 giorni bonus risultava "gia'
scaduto" il giorno stesso della registrazione.

Inverto il segno: lo start va spostato in AVANTI, cosi' 30 giorni bonus +
30 di trial = 60 giorni totali. planExpiresAt resta invariato in questo
commit (gestito separatamente per i piani a pagamento).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N2goX6FNvq2aNCiuXfBRG1