### PR TITLE
Fix #35: Don't mark ERROR on AdE transient failures

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,7 +5,8 @@
 > **Audit incrementale 2026-06-27:** code review mirata sui percorsi critici
 > (registrazione/accesso/onboarding · emissione/annullo scontrini · billing/
 > Stripe-webhook), con verifica manuale di ogni finding sul codice corrente.
-> Nuovi finding: #35 e #38 (P2), #36/#37 (P3). Falsi positivi/duplicati scartati
+> Nuovi finding: #38 (P2), #36/#37 (P3) — #35 (mark `ERROR` su AdE transient)
+> risolto. Falsi positivi/duplicati scartati
 > (identity guard, vatNumber overwrite, wizardTemplate PIva, referral, key
 > rotation, cursor pagination, CSP, SPID; lato billing: race
 > subscription.updated↔stripeCustomerId, normalizzazione email su
@@ -154,57 +155,6 @@ fatto che i payload sono statici, ma è un single point of failure.
 4. Da affrontare quando la frequenza di edit dei JSON-LD è bassa; verificare su
    sandbox prima di prod (uno script bloccato dalla CSP rompe il widget Turnstile
    o i dati strutturati silenziosamente — controllare la console e i report CSP).
-
----
-
-### 35. Mark `ERROR` sugli errori AdE _transient_ aggira la stale-recovery (emit + void)
-
-- **Categoria:** correttezza/concorrenza su mutazione fiscale irreversibile · **Severità:** Medium
-- **File:** `src/lib/services/receipt-service.ts:687` (emit), `src/lib/services/void-service.ts:803` (void); selezione recovery `src/lib/services/ade-recovery.ts:64`; riconciliazione pre-resubmit `src/lib/services/void-service.ts:640` (`reconcileVoidBeforeResubmit`)
-
-**Problema.** In entrambi gli orchestratori l'outer-catch fa
-`if (!isStatementTimeoutError(err)) { …set status "ERROR"… }`: salta il mark
-`ERROR` **solo** sul DB statement-timeout, ma lo applica a **ogni altro** errore,
-inclusi gli AdE _transient_ (timeout di rete / 5xx / SPID) — proprio il caso in
-cui, come dice il commento del codice stesso (`receipt-service.ts:684-686`: «we
-don't know whether submitSale succeeded on AdE»), lo stato su AdE è **ignoto**.
-Quando AdE ha _forse_ già registrato il documento ma la risposta è andata in
-timeout, marcare `ERROR` (invece di lasciare `PENDING`) ha due conseguenze:
-
-1. Il partial unique index (`status IN ('PENDING','VOID_ACCEPTED')`, migration
-   `0012`) **non copre `ERROR`** → un retry guidato dall'utente (nuova
-   idempotency key) prende il path _fresh-insert_ di `insertOrResolveVoid`
-   (`recovery:false`) → **salta** `reconcileVoidBeforeResubmit` e ri-sottomette a
-   AdE alla cieca. Sul **void** AdE respinge il secondo annullo di un documento
-   già annullato (mitigazione lato AdE → si finisce in `REJECTED`); sull'**emit**
-   non esiste un guard equivalente lato AdE → rischio doppia emissione dello
-   stesso scontrino.
-2. `ade-recovery.ts:64` seleziona `status IN ('PENDING','ERROR')`, quindi la
-   stale-recovery _automatica_ riprende anche le righe `ERROR` riusando la stessa
-   riga/sessione e riconcilia — ma la riconciliazione pre-resubmit vive **solo**
-   nel path PENDING/recovery, non nel fresh-insert dell'utente sopra.
-
-Lo stato `ERROR` diverge così dalla verità AdE invece di lasciare la riga
-`PENDING` e delegare la riconciliazione. **Non coperto da test:** il caso
-`void-service.test.ts:806` («NON deve marcare ERROR») copre il path
-`VOID_SYNC_FAILED` (finalize-_dopo_-submit, già corretto a parte), **non**
-l'outer-catch oggetto di questo finding.
-
-**Fix (non ambiguo).**
-
-1. Estendere la guardia in entrambi gli orchestratori a
-   `if (!isStatementTimeoutError(err) && !isTransientAdeError(err))`
-   (`isTransientAdeError` è già in `src/lib/ade/error-messages.ts`):
-   lasciare `PENDING` anche sugli AdE transient, così la stale-recovery
-   riconcilia contro AdE prima di qualsiasi re-submit.
-2. Marcare `ERROR` **solo** per errori definitivamente _pre-submit_ (decrypt,
-   mapping payload, auth AdE permanente): in quei casi AdE non ha ricevuto nulla
-   e il retry è sicuro.
-3. **Test:** AdE transient sollevato dopo `submitSale`/`submitVoid` → la riga
-   resta `PENDING` (mai `ERROR`) in emit **e** in void; statement-timeout →
-   invariato (già `PENDING`); errore pre-submit permanente → `ERROR` come oggi.
-4. Tenere allineati i due path (stessa guardia in emit e void) e i rispettivi
-   commenti, che già descrivono l'intento corretto ma sono sotto-applicati.
 
 ---
 
@@ -528,8 +478,8 @@ forte: stessa classe di operazione, protezione incoerente.
    5/15 min `AUTH_15_MIN`) sul modello di `changePasswordLimiter`, controllato
    **subito dopo** `checkBusinessOwnership` e prima del decrypt/login AdE.
 2. Sul superamento: `logger.warn` (input prevedibile, regola 20 — niente Sentry)
-   + ritorno `{ error }` con il messaggio rate-limit standard (degradare, non
-   lanciare — regola 19).
+   - ritorno `{ error }` con il messaggio rate-limit standard (degradare, non
+     lanciare — regola 19).
 3. **Test:** sotto soglia → OK; alla soglia → warn + errore senza chiamare AdE;
    reset alla nuova finestra; chiave per-utente (un business non blocca l'altro).
 

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -798,6 +798,34 @@ describe("emitReceiptForBusiness", () => {
     );
   });
 
+  it("REVIEW #35: AdE transient (AdePortalError 5xx) dopo submitSale NON marca ERROR (resta PENDING)", async () => {
+    // AdE potrebbe aver già registrato il documento ma la risposta è andata in
+    // timeout/5xx: marcare ERROR escluderebbe la riga dal partial unique index
+    // e dalla riconciliazione pre-resubmit, rischiando una doppia emissione
+    // fiscale. La riga resta PENDING e la stale-recovery riconcilia con AdE.
+    const { AdePortalError } = await import("@/lib/ade/errors");
+    mockSubmitSale.mockRejectedValue(
+      new AdePortalError(503, "service unavailable"),
+    );
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const updateSets = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(updateSets).not.toContain("ERROR");
+  });
+
+  it("REVIEW #35: AdeNetworkError dopo submitSale NON marca ERROR (resta PENDING)", async () => {
+    const { AdeNetworkError } = await import("@/lib/ade/errors");
+    mockSubmitSale.mockRejectedValue(new AdeNetworkError(new Error("ECONN")));
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const updateSets = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(updateSets).not.toContain("ERROR");
+  });
+
   it("R21: AdeAuthError (credenziali sbagliate) logga warn con errorClass ade_user_error (no Sentry noise)", async () => {
     // Credenziali Fisconline sbagliate sono input utente, non bug nostro:
     // logger.warn + errorClass ade_user_error -> niente issue Sentry.

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -14,7 +14,10 @@ import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
 import { withAdeSession } from "@/lib/ade";
 import type { AdeClient } from "@/lib/ade/client";
 import { AdePasswordExpiredError } from "@/lib/ade/errors";
-import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import {
+  getUserFacingAdeErrorMessage,
+  isTransientAdeError,
+} from "@/lib/ade/error-messages";
 import { logAdeFailure } from "@/lib/ade/log-failure";
 import { mapSaleToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
@@ -681,10 +684,13 @@ async function submitSaleToAde(
       },
     );
 
-    // Don't mark ERROR if the failure is a statement timeout — the row
-    // stays PENDING and stale recovery will retry. Marking ERROR here would
-    // be wrong because we don't know whether submitSale succeeded on AdE.
-    if (!isStatementTimeoutError(err)) {
+    // Don't mark ERROR on a statement timeout OR an AdE transient failure
+    // (network / 5xx / SPID timeout) — in both cases we don't know whether
+    // submitSale succeeded on AdE, so the row must stay PENDING and let stale
+    // recovery reconcile against AdE before any re-submit (REVIEW.md #35).
+    // Marking ERROR would drop the row out of the partial unique index and the
+    // pre-resubmit reconciliation, risking a duplicate fiscal emission.
+    if (!isStatementTimeoutError(err) && !isTransientAdeError(err)) {
       // Best-effort UPDATE to ERROR; if it also times out we swallow it
       // (the row stays PENDING — stale recovery applies on next retry).
       try {

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -808,4 +808,45 @@ describe("voidReceiptForBusiness", () => {
     const statusUpdates = mockUpdateSet.mock.calls.map((c) => c[0].status);
     expect(statusUpdates).not.toContain("ERROR");
   });
+
+  it("REVIEW #35: AdE transient (AdePortalError 5xx) dopo submitVoid NON marca ERROR (resta PENDING)", async () => {
+    // Stesso intento dell'outer-catch emit: se submitVoid è forse arrivato ad
+    // AdE ma la risposta è 5xx/timeout, marcare ERROR escluderebbe la riga dal
+    // partial unique index e dalla riconciliazione, permettendo un secondo VOID
+    // per la stessa SALE. La riga resta PENDING (REVIEW.md #35).
+    const { AdePortalError } = await import("@/lib/ade/errors");
+    mockSubmitVoid.mockRejectedValue(
+      new AdePortalError(503, "service unavailable"),
+    );
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    const statusUpdates = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(statusUpdates).not.toContain("ERROR");
+  });
+
+  it("REVIEW #35: AdeNetworkError dopo submitVoid NON marca ERROR (resta PENDING)", async () => {
+    const { AdeNetworkError } = await import("@/lib/ade/errors");
+    mockSubmitVoid.mockRejectedValue(new AdeNetworkError(new Error("ECONN")));
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    const statusUpdates = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(statusUpdates).not.toContain("ERROR");
+  });
+
+  it("REVIEW #35: errore pre-submit permanente (non transient) marca ancora ERROR", async () => {
+    // Un errore generico non-transient e non-timeout (es. fallimento permanente
+    // pre-submit) deve continuare a marcare ERROR: AdE non ha ricevuto nulla e
+    // il retry è sicuro. Guardia di non-regressione sul ramo permanente.
+    mockSubmitVoid.mockRejectedValue(new Error("permanent failure"));
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    const statusUpdates = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(statusUpdates).toContain("ERROR");
+  });
 });

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -13,7 +13,10 @@ import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
 import { withAdeSession } from "@/lib/ade";
 import type { AdeClient } from "@/lib/ade/client";
-import { getUserFacingAdeErrorMessage } from "@/lib/ade/error-messages";
+import {
+  getUserFacingAdeErrorMessage,
+  isTransientAdeError,
+} from "@/lib/ade/error-messages";
 import { logAdeFailure } from "@/lib/ade/log-failure";
 import { mapVoidToAdePayload } from "@/lib/ade/mapper";
 import { isStatementTimeoutError } from "@/lib/api-errors";
@@ -796,11 +799,12 @@ export async function voidReceiptForBusiness(
       },
     );
 
-    // Don't mark ERROR on timeout. Leave the row PENDING so:
+    // Don't mark ERROR on a statement timeout OR an AdE transient failure
+    // (network / 5xx / SPID timeout — REVIEW.md #35). Leave the row PENDING so:
     // - Stale recovery can re-attempt (submitVoid not yet called → safe)
     // - OR if submitVoid already succeeded, the partial unique index still
     //   blocks duplicate VOIDs (which would NOT be the case if status=ERROR).
-    if (!isStatementTimeoutError(err)) {
+    if (!isStatementTimeoutError(err) && !isTransientAdeError(err)) {
       try {
         await db
           .update(commercialDocuments)


### PR DESCRIPTION
## Summary

Resolves REVIEW.md #35 by preventing the `ERROR` status from being set when AdE transient failures (network timeouts, 5xx responses, SPID timeouts) occur after `submitSale` or `submitVoid`. This ensures rows remain `PENDING` so stale recovery can reconcile with AdE before any re-submit, preventing duplicate fiscal emissions and respecting the partial unique index.

## Changes

- **receipt-service.ts**: Extended the outer-catch guard to check both `isStatementTimeoutError()` AND `isTransientAdeError()` before marking `ERROR`. Updated comments to clarify the intent: when we don't know if AdE received the request, the row must stay `PENDING` for stale recovery to reconcile.

- **void-service.ts**: Applied the same guard pattern (`!isStatementTimeoutError(err) && !isTransientAdeError(err)`) to the void orchestrator, keeping both paths aligned. Updated comments to reference REVIEW.md #35.

- **receipt-service.test.ts**: Added two new test cases:
  - AdE transient (5xx) after `submitSale` → row stays `PENDING`
  - Network error after `submitSale` → row stays `PENDING`

- **void-service.test.ts**: Added three new test cases:
  - AdE transient (5xx) after `submitVoid` → row stays `PENDING`
  - Network error after `submitVoid` → row stays `PENDING`
  - Permanent pre-submit error → row still marks `ERROR` (non-regression guard)

- **REVIEW.md**: Removed the #35 finding entry (resolved) and updated the audit summary to reflect the fix.

## Implementation Details

The fix leverages the existing `isTransientAdeError()` helper from `src/lib/ade/error-messages.ts`, which already identifies network/5xx/SPID timeout failures. By extending the guard condition in both orchestrators, rows now correctly remain `PENDING` when the outcome at AdE is unknown, allowing:

1. Stale recovery to reconcile against AdE before re-submission
2. The partial unique index to continue blocking duplicate operations
3. Pre-resubmit reconciliation to run on the correct path

Permanent pre-submit errors (decrypt, mapping, auth failures) still mark `ERROR` as intended, since AdE never received the request in those cases.

https://claude.ai/code/session_01DjZY1njyb24AGvCYpcgvXj