### PR TITLE
Fix: prevent duplicate Stripe subscriptions on checkout

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -158,45 +158,6 @@ fatto che i payload sono statici, ma è un single point of failure.
 
 ---
 
-### 38. Checkout: il gate server-side blocca solo `active` → subscription Stripe duplicate
-
-- **Categoria:** correttezza/billing · **Severità:** Medium (mitigata lato UI, ma il server non deve dipenderne)
-- **File:** `src/app/api/stripe/checkout/route.ts:76` (`getOrCreateStripeCustomerId`); sync che sovrascrive la riga `src/app/api/stripe/webhook/route.ts:373` (`syncSubscriptionData`) e ramo "no row found" `:304` (`applySubscriptionUpdate`); card UI `src/app/dashboard/settings/page.tsx:64` (`computeBillingCardState`)
-
-**Problema.** Il gate pre-checkout in `getOrCreateStripeCustomerId` ritorna 409
-**solo** se `existingSub?.status === "active"`. Un utente con subscription
-`past_due` / `unpaid` (subscription **viva** su Stripe) supera il check: alla riga
-83 `existingSub.stripeCustomerId` esiste → riuso del customer → al completamento
-dell'hosted checkout Stripe crea una **seconda** subscription sullo stesso
-customer. Poi `syncSubscriptionData` sovrascrive l'**unica** riga DB (una per
-`userId`, lookup per `stripeCustomerId`) con la nuova sub: la vecchia resta
-**viva e non tracciata** su Stripe (i suoi futuri eventi cadono nel ramo
-`"no subscription row found — event acknowledged"` di `applySubscriptionUpdate`),
-con rischio **doppio addebito** sul path di dunning `past_due`.
-
-**Mitigazione esistente (solo UI).** `computeBillingCardState` instrada i
-`past_due` al **portale** Stripe, non al checkout — ma è difesa lato UI:
-l'endpoint `/api/stripe/checkout` resta chiamabile direttamente, e gli stati
-`unpaid` non sono special-cased nella card (cadono su `trial-expired` → CTA
-checkout). Il server non deve dipendere dalla UI per l'integrità del billing.
-
-**Fix (non ambiguo).**
-
-1. Estendere il gate in `getOrCreateStripeCustomerId` a tutti gli stati Stripe
-   "vivi/billabili": bloccare (409 + invito al portale) per `active`, `past_due`,
-   `unpaid` (valutare `trialing` — oggi non usato, il trial è interno).
-2. **Non** bloccare `incomplete`/`incomplete_expired`: sono il pre-attivazione del
-   primo pagamento, bloccarli impedirebbe il retry SCA legittimo
-   (l'`idempotencyKey` orario su `session:${priceId}` già de-duplica il retry a
-   breve termine).
-3. Coerenza UI: la card deve mostrare il ramo "gestisci dal portale" anche per
-   `unpaid` (oggi solo `past_due`), così CTA UI e gate server combaciano.
-4. **Test:** checkout con sub `past_due`/`unpaid` → 409 senza creare sessione
-   Stripe; `canceled`/`pending`/nessuna sub → checkout consentito; `incomplete`
-   → consentito (retry primo pagamento).
-
----
-
 ## P3 — Bassa priorità
 
 ### 17. Key rotation zero-downtime: i caller passano sempre una sola chiave

--- a/src/app/api/stripe/checkout/route.test.ts
+++ b/src/app/api/stripe/checkout/route.test.ts
@@ -184,6 +184,96 @@ describe("POST /api/stripe/checkout", () => {
     expect(res.status).toBe(400);
   });
 
+  it("restituisce 409 se esiste una subscription active", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { stripeCustomerId: "cus_existing", status: "active" },
+      ]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(409);
+    expect(mockCustomerCreate).not.toHaveBeenCalled();
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("restituisce 409 se esiste una subscription past_due (evita sub duplicata)", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { stripeCustomerId: "cus_existing", status: "past_due" },
+      ]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(409);
+    expect(mockCustomerCreate).not.toHaveBeenCalled();
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("restituisce 409 se esiste una subscription unpaid (evita sub duplicata)", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { stripeCustomerId: "cus_existing", status: "unpaid" },
+      ]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(409);
+    expect(mockCustomerCreate).not.toHaveBeenCalled();
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("consente il checkout se la subscription è incomplete (retry primo pagamento)", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { stripeCustomerId: "cus_existing", status: "incomplete" },
+      ]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(200);
+    expect(mockCustomerCreate).not.toHaveBeenCalled();
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_existing" }),
+      expect.anything(),
+    );
+  });
+
+  it("consente il checkout se la subscription è canceled (riattivazione)", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-1",
+      email: "a@b.it",
+    });
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { stripeCustomerId: "cus_existing", status: "canceled" },
+      ]),
+    );
+
+    const res = await POST(makeRequest({ priceId: "price_pro" }));
+    expect(res.status).toBe(200);
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_existing" }),
+      expect.anything(),
+    );
+  });
+
   it("usa il customer esistente se già in DB", async () => {
     mockGetAuthenticatedUser.mockResolvedValue({
       id: "user-1",

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -27,6 +27,20 @@ function serviceUnavailableResponse(): Response {
 
 type Db = ReturnType<typeof getDb>;
 
+/**
+ * Stati Stripe "vivi/billabili": una subscription esistente in uno di questi
+ * non deve mai generare un secondo checkout, altrimenti Stripe crea una sub
+ * duplicata sullo stesso customer e `syncSubscriptionData` sovrascrive l'unica
+ * riga DB lasciando la vecchia sub viva e non tracciata (rischio doppio
+ * addebito sul dunning `past_due` — REVIEW #38).
+ *
+ * `incomplete`/`incomplete_expired` NON inclusi: sono il pre-attivazione del
+ * primo pagamento, bloccarli impedirebbe il retry SCA legittimo. `trialing`
+ * non è usato (il trial è interno a ScontrinoZero). `canceled`/`pending` →
+ * checkout consentito (riattivazione).
+ */
+const BILLABLE_STATUSES = new Set(["active", "past_due", "unpaid"]);
+
 function operationInProgressResponse(): Response {
   return Response.json(
     { error: "Operazione in corso, riprova tra qualche secondo." },
@@ -53,9 +67,10 @@ function buildIdempotencyKey(userId: string, suffix: string): string {
  * l'INSERT crea il customer Stripe, evitando l'orfano che si generava prima
  * quando due richieste concorrenti creavano entrambe un customer.
  *
- * Ritorna una `Response` (409 se l'utente ha già un abbonamento attivo, 503
- * se la creazione Stripe fallisce o se un'altra richiesta sta già creando il
- * customer per lo stesso utente).
+ * Ritorna una `Response` (409 se l'utente ha già una subscription in uno stato
+ * "vivo/billabile" — vedi `BILLABLE_STATUSES`, 503 se la creazione Stripe
+ * fallisce o se un'altra richiesta sta già creando il customer per lo stesso
+ * utente).
  */
 async function getOrCreateStripeCustomerId(args: {
   user: { id: string; email?: string };
@@ -73,9 +88,9 @@ async function getOrCreateStripeCustomerId(args: {
     .where(eq(subscriptions.userId, user.id))
     .limit(1);
 
-  if (existingSub?.status === "active") {
+  if (existingSub?.status && BILLABLE_STATUSES.has(existingSub.status)) {
     return Response.json(
-      { error: "Hai già un abbonamento attivo." },
+      { error: "Hai già un abbonamento. Gestiscilo dal portale Stripe." },
       { status: 409 },
     );
   }

--- a/src/app/dashboard/settings/billing-card-state.test.ts
+++ b/src/app/dashboard/settings/billing-card-state.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeBillingCardState,
+  type BillingPlanData,
+} from "./billing-card-state";
+
+/** trialStartedAt abbastanza recente da NON essere scaduto. */
+const FRESH_TRIAL = new Date();
+/** planExpiresAt nel futuro → piano pagato non scaduto. */
+const FUTURE = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+/** planExpiresAt nel passato oltre la grazia → piano pagato scaduto. */
+const LONG_PAST = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+
+function planData(overrides: Partial<BillingPlanData>): BillingPlanData {
+  return {
+    plan: "pro",
+    trialStartedAt: FRESH_TRIAL,
+    planExpiresAt: FUTURE,
+    hasSubscription: true,
+    subscriptionStatus: "active",
+    ...overrides,
+  };
+}
+
+describe("computeBillingCardState", () => {
+  it("ritorna trial-active se planData è null", () => {
+    expect(computeBillingCardState(null)).toBe("trial-active");
+  });
+
+  it("ritorna unlimited per il piano unlimited", () => {
+    expect(
+      computeBillingCardState(
+        planData({ plan: "unlimited", subscriptionStatus: null }),
+      ),
+    ).toBe("unlimited");
+  });
+
+  it("ritorna subscribed per una subscription active", () => {
+    expect(
+      computeBillingCardState(planData({ subscriptionStatus: "active" })),
+    ).toBe("subscribed");
+  });
+
+  it("ritorna past-due per una subscription past_due", () => {
+    expect(
+      computeBillingCardState(planData({ subscriptionStatus: "past_due" })),
+    ).toBe("past-due");
+  });
+
+  it("ritorna past-due per una subscription unpaid (coerenza col gate checkout)", () => {
+    expect(
+      computeBillingCardState(planData({ subscriptionStatus: "unpaid" })),
+    ).toBe("past-due");
+  });
+
+  it("ritorna trial-expired se il piano pagato è scaduto oltre la grazia (safety-net)", () => {
+    // status active ma planExpiresAt nel passato → i gate sono già read-only.
+    expect(
+      computeBillingCardState(
+        planData({ subscriptionStatus: "active", planExpiresAt: LONG_PAST }),
+      ),
+    ).toBe("trial-expired");
+  });
+
+  it("il ramo past_due precede il safety-net trial-expired (dunning non oscurato)", () => {
+    expect(
+      computeBillingCardState(
+        planData({ subscriptionStatus: "past_due", planExpiresAt: LONG_PAST }),
+      ),
+    ).toBe("past-due");
+  });
+
+  it("ritorna trial-expired se non c'è subscription e il trial è scaduto", () => {
+    expect(
+      computeBillingCardState(
+        planData({
+          plan: "trial",
+          hasSubscription: false,
+          subscriptionStatus: null,
+          trialStartedAt: new Date("2000-01-01"),
+        }),
+      ),
+    ).toBe("trial-expired");
+  });
+
+  it("ritorna trial-active se non c'è subscription e il trial è in corso", () => {
+    expect(
+      computeBillingCardState(
+        planData({
+          plan: "trial",
+          hasSubscription: false,
+          subscriptionStatus: null,
+          trialStartedAt: FRESH_TRIAL,
+        }),
+      ),
+    ).toBe("trial-active");
+  });
+});

--- a/src/app/dashboard/settings/billing-card-state.ts
+++ b/src/app/dashboard/settings/billing-card-state.ts
@@ -1,0 +1,52 @@
+import { isPaidPlanExpired, isTrialExpired, type Plan } from "@/lib/plans";
+
+export type BillingCardState =
+  | "trial-active"
+  | "trial-expired"
+  | "subscribed"
+  | "past-due"
+  | "unlimited";
+
+export type BillingPlanData = {
+  plan: Plan;
+  trialStartedAt: Date | null;
+  planExpiresAt: Date | null;
+  hasSubscription: boolean;
+  subscriptionStatus: string | null;
+};
+
+/**
+ * Determina lo stato della card "Piano e Abbonamento". Estratta in un modulo
+ * dedicato (vs funzione privata di SettingsPage) per testabilità — e per tenere
+ * bassa la Cognitive Complexity di SettingsPage (S3776).
+ *
+ * `past_due` e `unpaid` mappano entrambi su `past-due` (CTA portale): sono gli
+ * stati di dunning Stripe in cui il checkout server-side è bloccato
+ * (`BILLABLE_STATUSES` in api/stripe/checkout/route.ts — REVIEW #38), quindi la
+ * UI deve coerentemente instradare al portale invece di offrire un nuovo
+ * checkout che genererebbe una subscription duplicata.
+ */
+export function computeBillingCardState(
+  planData: BillingPlanData | null,
+): BillingCardState {
+  if (!planData) return "trial-active";
+  if (planData.plan === "unlimited") return "unlimited";
+  if (
+    planData.hasSubscription &&
+    (planData.subscriptionStatus === "past_due" ||
+      planData.subscriptionStatus === "unpaid")
+  )
+    return "past-due";
+  // Safety-net per webhook `customer.subscription.deleted` persi (REVIEW #31):
+  // se il piano pagato e' scaduto oltre la grazia i gate sono gia' read-only
+  // (isPaidPlanExpired). La subscription row puo' essere rimasta `active`:
+  // senza questo check la card mostrerebbe "Pro attivo" mentre cassa/catalogo/
+  // API rispondono sola-lettura. Riusa lo stato read-only "trial-expired".
+  // Va DOPO il ramo past_due per non oscurare il dunning legittimo.
+  if (isPaidPlanExpired(planData.plan, planData.planExpiresAt))
+    return "trial-expired";
+  if (planData.hasSubscription && planData.subscriptionStatus === "active")
+    return "subscribed";
+  if (isTrialExpired(planData.trialStartedAt)) return "trial-expired";
+  return "trial-active";
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -22,13 +22,8 @@ import { EditBusinessSection } from "@/components/settings/edit-business-section
 import { ChangePasswordSection } from "@/components/settings/change-password-section";
 import { ThemeSection } from "@/components/settings/theme-section";
 import { getProfilePlan } from "@/server/billing-actions";
-import {
-  canUseApi,
-  isPaidPlanExpired,
-  isTrialExpired,
-  type Plan,
-  TRIAL_DAYS,
-} from "@/lib/plans";
+import { canUseApi, TRIAL_DAYS } from "@/lib/plans";
+import { computeBillingCardState } from "./billing-card-state";
 import { PRICE_IDS } from "@/lib/stripe";
 import { ApiKeySection } from "@/components/settings/api-key-section";
 import { ExtraSettingsSection } from "@/components/settings/extra-settings-section";
@@ -38,44 +33,6 @@ import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
 import { ScrollToHash } from "@/components/billing/scroll-to-hash";
 import { CONTACT_EMAIL } from "@/lib/contact";
 import { APP_VERSION, getBuildLabel } from "@/lib/version";
-
-type BillingCardState =
-  | "trial-active"
-  | "trial-expired"
-  | "subscribed"
-  | "past-due"
-  | "unlimited";
-
-/**
- * Determina lo stato della card "Piano e Abbonamento". Estratta a livello di
- * modulo per tenere bassa la Cognitive Complexity di SettingsPage (S3776).
- */
-function computeBillingCardState(
-  planData: {
-    plan: Plan;
-    trialStartedAt: Date | null;
-    planExpiresAt: Date | null;
-    hasSubscription: boolean;
-    subscriptionStatus: string | null;
-  } | null,
-): BillingCardState {
-  if (!planData) return "trial-active";
-  if (planData.plan === "unlimited") return "unlimited";
-  if (planData.hasSubscription && planData.subscriptionStatus === "past_due")
-    return "past-due";
-  // Safety-net per webhook `customer.subscription.deleted` persi (REVIEW #31):
-  // se il piano pagato e' scaduto oltre la grazia i gate sono gia' read-only
-  // (isPaidPlanExpired). La subscription row puo' essere rimasta `active`:
-  // senza questo check la card mostrerebbe "Pro attivo" mentre cassa/catalogo/
-  // API rispondono sola-lettura. Riusa lo stato read-only "trial-expired".
-  // Va DOPO il ramo past_due per non oscurare il dunning legittimo.
-  if (isPaidPlanExpired(planData.plan, planData.planExpiresAt))
-    return "trial-expired";
-  if (planData.hasSubscription && planData.subscriptionStatus === "active")
-    return "subscribed";
-  if (isTrialExpired(planData.trialStartedAt)) return "trial-expired";
-  return "trial-active";
-}
 
 /**
  * Compone la riga "Sede" dell'attività. Estratta a livello di modulo per


### PR DESCRIPTION
## Summary

Fixes REVIEW #38 by implementing server-side validation to prevent duplicate Stripe subscriptions when users with existing `past_due` or `unpaid` subscriptions attempt checkout. Also aligns UI state mapping with the corrected server behavior.

## Changes

- **`src/app/api/stripe/checkout/route.ts`**
  - Added `BILLABLE_STATUSES` constant defining "live/billable" subscription states: `active`, `past_due`, `unpaid`
  - Extended the pre-checkout gate in `getOrCreateStripeCustomerId` to block (409) all billable statuses, not just `active`
  - Updated error message to guide users to Stripe portal for subscription management
  - Allows `incomplete` and `canceled` statuses to proceed (retry first payment and reactivation flows)

- **`src/app/dashboard/settings/billing-card-state.ts`** (new file)
  - Extracted `computeBillingCardState` logic from `SettingsPage` into a dedicated, testable module
  - Added support for `unpaid` status mapping to `past-due` UI state (coerces with checkout gate)
  - Maintains safety-net for missed `customer.subscription.deleted` webhooks via `isPaidPlanExpired` check
  - Ensures dunning flow (`past_due`) takes precedence over safety-net to avoid obscuring legitimate payment recovery

- **`src/app/dashboard/settings/page.tsx`**
  - Removed inline `computeBillingCardState` function and type definition
  - Imported extracted function from `billing-card-state` module
  - Removed unused imports (`isPaidPlanExpired`, `isTrialExpired`, `Plan`)

- **`src/app/api/stripe/checkout/route.test.ts`**
  - Added test: 409 response when `active` subscription exists
  - Added test: 409 response when `past_due` subscription exists (prevents duplicate)
  - Added test: 409 response when `unpaid` subscription exists (prevents duplicate)
  - Added test: 200 response when `incomplete` subscription exists (allows retry)
  - Added test: 200 response when `canceled` subscription exists (allows reactivation)

- **`src/app/dashboard/settings/billing-card-state.test.ts`** (new file)
  - Comprehensive test suite covering all state transitions
  - Tests null planData, unlimited plan, subscription states, trial expiry, and safety-net scenarios
  - Validates precedence: `past_due` before safety-net to preserve dunning visibility

- **`REVIEW.md`**
  - Removed REVIEW #38 entry (issue resolved)

## Implementation Details

**Root cause:** The checkout gate only blocked `active` subscriptions. Users with `past_due`/`unpaid` (live on Stripe) could proceed, causing Stripe to create a second subscription on the same customer. `syncSubscriptionData` would then overwrite the single DB row, leaving the old subscription live and untracked—risking double-charge during dunning.

**Fix strategy:**
1. Gate now blocks all billable statuses (`active`, `past_due`, `unpaid`)
2. Allows `incomplete`/`canceled` for legitimate retry and reactivation flows
3. UI state mapping now handles `unpaid` consistently with server gate
4. Tests ensure all subscription states are handled correctly

**Coherence:** Server-side gate and UI state mapping now align—both treat `past_due` and `unpaid` as requiring portal management, preventing users from attempting duplicate checkouts.

https://claude.ai/code/session_01MVYjvjjnW5x6JsVpG92pAF