### PR TITLE
Normalize Turnstile hostname allowlist (trim/lowercase)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,8 +5,9 @@
 > **Audit incrementale 2026-06-27:** code review mirata sui percorsi critici
 > (registrazione/accesso/onboarding · emissione/annullo scontrini · billing/
 > Stripe-webhook), con verifica manuale di ogni finding sul codice corrente.
-> Nuovi finding: #38 (P2), #37 (P3) — #35 (mark `ERROR` su AdE transient) e #36
-> (rate limit `verifyAdeCredentials`) risolti. Falsi positivi/duplicati scartati
+> Nuovi finding: #38 (P2) — #35 (mark `ERROR` su AdE transient), #36
+> (rate limit `verifyAdeCredentials`) e #37 (normalizzazione allowlist hostname
+> Turnstile) risolti. Falsi positivi/duplicati scartati
 > (identity guard, vatNumber overwrite, wizardTemplate PIva, referral, key
 > rotation, cursor pagination, CSP, SPID; lato billing: race
 > subscription.updated↔stripeCustomerId, normalizzazione email su
@@ -338,32 +339,6 @@ mostra già la data nel proprio portale.
 `syncSubscriptionData` dal `customer.subscription.updated` + nuovo ramo in
 `computeBillingCardState` ("in cancellazione") che mostra `currentPeriodEnd`.
 Accettato come rifinitura, fuori dal diff partner (v1.4.0).
-
-### 37. Allowlist hostname Turnstile non normalizzata (trim/lowercase)
-
-- **Categoria:** correttezza/robustezza config · **Severità:** Low (contingente a misconfig env)
-- **File:** `src/server/auth-actions.ts:145` (`getAcceptedTurnstileHostnames`); pattern di riferimento già normalizzato: `src/lib/partners/partner-host.ts:16` (`getAppHostname`)
-
-**Problema.** Cloudflare Turnstile `siteverify` ritorna `data.hostname` sempre in
-**lowercase**. `getAcceptedTurnstileHostnames` costruisce il `Set` di confronto
-direttamente dagli env (`APP_HOSTNAME` / `NEXT_PUBLIC_APP_HOSTNAME` /
-`NEXT_PUBLIC_MARKETING_HOSTNAME`) **senza** `.trim().toLowerCase()`, mentre
-`getAppHostname()` in `partner-host.ts:16` normalizza già. Se uno di questi env
-fosse configurato con maiuscole o spazi (es. `"App.ScontrinoZero.IT"` o
-`"scontrinozero.it "`), il confronto `Set.has(data.hostname)` (match esatto)
-fallirebbe → **ogni** login/register/reset (tutti dietro Turnstile) verrebbe
-bloccato con `captcha_hostname_mismatch`. È contingente a una misconfig dell'env
-d'identità, ma coerente con la postura fail-fast/normalizzazione delle regole
-18/24 (present-but-empty, validazione env): un valore "quasi giusto" non deve
-rompere l'auth.
-
-**Fix (non ambiguo).**
-
-1. Normalizzare (`.trim().toLowerCase()`) i due hostname dentro
-   `getAcceptedTurnstileHostnames` prima di costruire il `Set` (incluso il
-   `www.${marketingHostname}`), riusando il pattern di `getAppHostname`.
-2. **Test:** env con maiuscole/spazi → l'hostname lowercase di Turnstile è
-   accettato; env già lowercase → comportamento invariato.
 
 ---
 

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -1304,6 +1304,105 @@ describe("auth-actions", () => {
       expect(mockSignUp).not.toHaveBeenCalled();
     });
 
+    it("accepts the lowercase Turnstile hostname even when the app env has mixed case", async () => {
+      // Turnstile siteverify ritorna data.hostname sempre in lowercase; se l'env
+      // d'identità è misconfigurato con maiuscole (es. "App.ScontrinoZero.IT")
+      // il match esatto fallirebbe senza normalizzazione → ogni login bloccato
+      // con captcha_hostname_mismatch (REVIEW.md #37).
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = "App.ScontrinoZero.IT";
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+      mockFetch.mockResolvedValueOnce(
+        captchaResponse("signup", "app.scontrinozero.it"),
+      );
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        if (!isRedirectError(err)) throw err;
+      }
+
+      expect(mockSignUp).toHaveBeenCalled();
+    });
+
+    it("accepts the marketing hostname even when its env has surrounding whitespace", async () => {
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "  scontrinozero.it  ";
+      mockFetch.mockResolvedValueOnce(
+        captchaResponse("signup", "scontrinozero.it"),
+      );
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        if (!isRedirectError(err)) throw err;
+      }
+
+      expect(mockSignUp).toHaveBeenCalled();
+    });
+
+    it("falls back to the next hostname env when APP_HOSTNAME is present but empty", async () => {
+      // Regola 18: un `??` non scatta su `""` (present-but-empty). Senza lo
+      // scarto esplicito delle stringhe vuote, un build-arg dimenticato
+      // produrrebbe un appHostname vuoto e ogni captcha verrebbe rifiutato.
+      process.env.APP_HOSTNAME = "";
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+      mockFetch.mockResolvedValueOnce(
+        captchaResponse("signup", "app.scontrinozero.it"),
+      );
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        if (!isRedirectError(err)) throw err;
+      }
+
+      expect(mockSignUp).toHaveBeenCalled();
+      delete process.env.APP_HOSTNAME;
+    });
+
     it("logs captcha_verification_failed with error-codes when Turnstile returns success:false", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -143,13 +143,37 @@ type CaptchaAction =
  * bloccare ogni login.
  */
 function getAcceptedTurnstileHostnames(): ReadonlySet<string> {
+  // Cloudflare Turnstile `siteverify` ritorna `data.hostname` sempre in
+  // lowercase, e il confronto è `Set.has` (match esatto). Normalizziamo
+  // (`.trim().toLowerCase()`) come in `getAppHostname` (partner-host.ts):
+  // un env d'identità "quasi giusto" (`"App.ScontrinoZero.IT"`,
+  // `"scontrinozero.it "`) non deve rompere l'auth con
+  // `captcha_hostname_mismatch`. Empty-safe (regola 18): un `??` non scatta
+  // su una env presente ma vuota (`""`), quindi scartiamo le stringhe vuote.
   const appHostname =
-    process.env.APP_HOSTNAME ?? // runtime override (sandbox, self-hosted)
-    process.env.NEXT_PUBLIC_APP_HOSTNAME ?? // baked at build time
-    "app.scontrinozero.it";
+    pickHostnameEnv(
+      process.env.APP_HOSTNAME, // runtime override (sandbox, self-hosted)
+      process.env.NEXT_PUBLIC_APP_HOSTNAME, // baked at build time
+    ) ?? "app.scontrinozero.it";
   const marketingHostname =
-    process.env.NEXT_PUBLIC_MARKETING_HOSTNAME ?? "scontrinozero.it";
+    pickHostnameEnv(process.env.NEXT_PUBLIC_MARKETING_HOSTNAME) ??
+    "scontrinozero.it";
   return new Set([appHostname, marketingHostname, `www.${marketingHostname}`]);
+}
+
+/**
+ * Prima env non-vuota dopo `.trim().toLowerCase()`, o `undefined` se nessuna
+ * è valorizzata. Centralizza la normalizzazione (regola 18 present-but-empty +
+ * lowercase per il match esatto con `data.hostname` di Turnstile).
+ */
+function pickHostnameEnv(
+  ...candidates: ReadonlyArray<string | undefined>
+): string | undefined {
+  for (const candidate of candidates) {
+    const normalised = candidate?.trim().toLowerCase();
+    if (normalised) return normalised;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes issue #37 from the security audit: the Turnstile hostname allowlist was not normalized, causing authentication failures when environment variables contained uppercase letters or surrounding whitespace.

Cloudflare Turnstile's `siteverify` endpoint always returns `data.hostname` in lowercase. The allowlist comparison uses `Set.has()` (exact match), so any misconfiguration of `APP_HOSTNAME`, `NEXT_PUBLIC_APP_HOSTNAME`, or `NEXT_PUBLIC_MARKETING_HOSTNAME` with uppercase or whitespace would cause every login/register/reset to fail with `captcha_hostname_mismatch`.

## Changes

- **`src/server/auth-actions.ts`**
  - Extracted hostname normalization logic into a new `pickHostnameEnv()` helper that applies `.trim().toLowerCase()` to environment variables
  - Updated `getAcceptedTurnstileHostnames()` to use `pickHostnameEnv()` for all three hostname sources (`APP_HOSTNAME`, `NEXT_PUBLIC_APP_HOSTNAME`, `NEXT_PUBLIC_MARKETING_HOSTNAME`)
  - Implements "rule 18" (present-but-empty safety): empty strings are skipped in favor of the next fallback, preventing a forgotten build arg from breaking authentication
  - Aligns with the existing normalization pattern in `partner-host.ts:getAppHostname()`

- **`src/server/auth-actions.test.ts`**
  - Added test: mixed-case `APP_HOSTNAME` ("App.ScontrinoZero.IT") is normalized and matches lowercase Turnstile response
  - Added test: `MARKETING_HOSTNAME` with surrounding whitespace is trimmed and accepted
  - Added test: empty `APP_HOSTNAME` falls back to `NEXT_PUBLIC_APP_HOSTNAME` without breaking validation

- **`REVIEW.md`**
  - Removed issue #37 from the open findings list (marked as resolved)

## Implementation Details

The `pickHostnameEnv()` function centralizes the normalization rule: it iterates through candidate environment variables, applies `.trim().toLowerCase()` to each, and returns the first non-empty result. This ensures:
- Uppercase letters don't break exact-match comparison with Turnstile's lowercase hostname
- Leading/trailing whitespace is stripped
- Empty strings are skipped (fail-safe for misconfigured build args)
- Fallback chain is preserved (APP_HOSTNAME → NEXT_PUBLIC_APP_HOSTNAME → default)

https://claude.ai/code/session_014fUPUQSrg3pG5PepJnFFBq