### PR TITLE
Add support contact section to settings with pre-filled mailto

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -27,11 +27,11 @@ import { computeBillingCardState } from "./billing-card-state";
 import { PRICE_IDS } from "@/lib/stripe";
 import { ApiKeySection } from "@/components/settings/api-key-section";
 import { ExtraSettingsSection } from "@/components/settings/extra-settings-section";
+import { SupportSection } from "@/components/settings/support-section";
 import { PlanBadge } from "@/components/billing/plan-badge";
 import { PlanSelection } from "@/components/billing/plan-selection";
 import { RefreshOnSuccess } from "@/components/billing/refresh-on-success";
 import { ScrollToHash } from "@/components/billing/scroll-to-hash";
-import { CONTACT_EMAIL } from "@/lib/contact";
 import { APP_VERSION, getBuildLabel } from "@/lib/version";
 
 /**
@@ -447,6 +447,25 @@ export default async function SettingsPage({
         </div>
       </section>
 
+      {/* Supporto — Help Center + contatto email pre-compilato */}
+      <section className="space-y-4">
+        <h2 className={sectionHeadingClass}>Supporto</h2>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Assistenza</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SupportSection
+                accountEmail={user.email}
+                plan={planData?.plan ?? null}
+                appVersion={APP_VERSION}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
       {/* Altre impostazioni — sezioni a basso uso, nascoste di default */}
       <ExtraSettingsSection>
         {business && planData && canUseApi(planData.plan) && (
@@ -471,15 +490,6 @@ export default async function SettingsPage({
           <CardContent className="text-muted-foreground space-y-2 text-sm">
             <p>
               ScontrinoZero {APP_VERSION} &mdash; build {getBuildLabel()}
-            </p>
-            <p>
-              Per dubbi, domande o feedback contattaci:{" "}
-              <a
-                className="text-primary underline"
-                href={`mailto:${CONTACT_EMAIL}`}
-              >
-                {CONTACT_EMAIL}
-              </a>
             </p>
           </CardContent>
         </Card>

--- a/src/components/settings/support-section.test.tsx
+++ b/src/components/settings/support-section.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { SupportSection } from "./support-section";
+
+describe("SupportSection", () => {
+  it("linka il Centro assistenza con un path relativo (hop di dominio via middleware)", () => {
+    render(
+      <SupportSection
+        accountEmail="mario@example.com"
+        plan="pro"
+        appVersion="1.4.1"
+      />,
+    );
+
+    const helpLink = screen.getByRole("link", { name: /centro assistenza/i });
+    expect(helpLink).toHaveAttribute("href", "/help/contatto-assistenza");
+  });
+
+  it("espone un link email che apre un mailto pre-compilato", () => {
+    render(
+      <SupportSection
+        accountEmail="mario@example.com"
+        plan="pro"
+        appVersion="1.4.1"
+      />,
+    );
+
+    const mailLink = screen.getByRole("link", { name: /scrivici via email/i });
+    const href = mailLink.getAttribute("href") ?? "";
+
+    expect(href).toMatch(/^mailto:info@scontrinozero\.it\?/);
+    expect(href).toContain("subject=");
+    expect(href).toContain("body=");
+  });
+
+  it("inserisce email account e versione nel corpo del mailto", () => {
+    render(
+      <SupportSection
+        accountEmail="mario@example.com"
+        plan="pro"
+        appVersion="1.4.1"
+      />,
+    );
+
+    const href =
+      screen
+        .getByRole("link", { name: /scrivici via email/i })
+        .getAttribute("href") ?? "";
+    const body =
+      new URLSearchParams(href.split("?")[1] ?? "").get("body") ?? "";
+
+    expect(body).toContain("mario@example.com");
+    expect(body).toContain("1.4.1");
+  });
+
+  it("non rompe il mailto quando email account e piano sono assenti", () => {
+    render(
+      <SupportSection accountEmail={null} plan={null} appVersion="1.4.1" />,
+    );
+
+    const href =
+      screen
+        .getByRole("link", { name: /scrivici via email/i })
+        .getAttribute("href") ?? "";
+
+    expect(href).toMatch(/^mailto:/);
+    expect(href).not.toContain("undefined");
+  });
+});

--- a/src/components/settings/support-section.tsx
+++ b/src/components/settings/support-section.tsx
@@ -1,0 +1,52 @@
+import { ExternalLink, Mail } from "lucide-react";
+import { buildSupportMailtoHref } from "@/lib/contact";
+
+/**
+ * Contenuto della card "Supporto" delle impostazioni: rende l'Help Center e una
+ * email pre-compilata. Componente presentazionale puro (nessun hook), così è
+ * renderizzabile nel server component `settings/page.tsx` e testabile con
+ * `render()`.
+ *
+ * Il link al Centro assistenza usa un path RELATIVO `/help/contatto-assistenza`:
+ * dal dominio app il middleware (`hostnameRedirect`, src/proxy.ts) fa l'hop
+ * cross-origin verso il dominio marketing. Stesso pattern di
+ * `ade-credentials-section.tsx`. La regola 15 (`appHref`) riguarda i link
+ * auth marketing→app, non questo verso opposto.
+ */
+export function SupportSection({
+  accountEmail,
+  plan,
+  appVersion,
+}: {
+  readonly accountEmail: string | null | undefined;
+  readonly plan: string | null | undefined;
+  readonly appVersion: string;
+}) {
+  const mailtoHref = buildSupportMailtoHref({ accountEmail, plan, appVersion });
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">
+        Hai bisogno di aiuto? Consulta il Centro assistenza per le domande
+        frequenti, oppure scrivici via email: ti rispondiamo nei tempi indicati
+        in base al tuo piano.
+      </p>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <a
+          href="/help/contatto-assistenza"
+          className="border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors"
+        >
+          <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          Centro assistenza
+        </a>
+        <a
+          href={mailtoHref}
+          className="border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors"
+        >
+          <Mail className="h-4 w-4" aria-hidden="true" />
+          Scrivici via email
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/contact.test.ts
+++ b/src/lib/contact.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { CONTACT_EMAIL, buildSupportMailtoHref } from "./contact";
+
+/**
+ * Decodifica i parametri query di un href `mailto:` in una mappa
+ * `{ subject, body }`. Tiene il test leggibile senza ripetere lo split.
+ */
+function parseMailto(href: string): {
+  address: string;
+  params: URLSearchParams;
+} {
+  const [scheme, query] = href.split("?");
+  return {
+    address: scheme,
+    params: new URLSearchParams(query ?? ""),
+  };
+}
+
+describe("buildSupportMailtoHref", () => {
+  it("punta all'indirizzo di contatto canonico", () => {
+    const href = buildSupportMailtoHref({
+      accountEmail: "mario@example.com",
+      plan: "pro",
+      appVersion: "1.4.1",
+    });
+
+    expect(parseMailto(href).address).toBe(`mailto:${CONTACT_EMAIL}`);
+  });
+
+  it("imposta l'oggetto pre-compilato", () => {
+    const href = buildSupportMailtoHref({
+      accountEmail: "mario@example.com",
+      plan: "pro",
+      appVersion: "1.4.1",
+    });
+
+    expect(parseMailto(href).params.get("subject")).toBe(
+      "Richiesta assistenza ScontrinoZero",
+    );
+  });
+
+  it("pre-compila il corpo con email account, piano e versione", () => {
+    const href = buildSupportMailtoHref({
+      accountEmail: "mario@example.com",
+      plan: "pro",
+      appVersion: "1.4.1",
+    });
+    const body = parseMailto(href).params.get("body") ?? "";
+
+    expect(body).toContain("mario@example.com");
+    expect(body).toContain("pro");
+    expect(body).toContain("1.4.1");
+    expect(body).toContain("Descrizione del problema");
+  });
+
+  it("usa un segnaposto quando l'email account è assente (mai 'undefined')", () => {
+    const href = buildSupportMailtoHref({
+      accountEmail: null,
+      plan: null,
+      appVersion: "1.4.1",
+    });
+    const body = parseMailto(href).params.get("body") ?? "";
+
+    expect(body).not.toContain("undefined");
+    expect(body).not.toContain("null");
+    expect(body).toContain("non disponibile");
+  });
+
+  it("codifica i caratteri speciali (href valido, parametri ricostruibili)", () => {
+    const href = buildSupportMailtoHref({
+      accountEmail: "anna+test@example.com",
+      plan: "starter",
+      appVersion: "1.4.1",
+    });
+
+    // Lo spazio nell'oggetto non deve comparire grezzo: deve essere
+    // percent-encoded (%20) o codificato come '+'.
+    expect(href).not.toContain("Richiesta assistenza");
+    // La '+' nell'email non deve rompere il parsing del corpo.
+    expect(parseMailto(href).params.get("body") ?? "").toContain(
+      "anna+test@example.com",
+    );
+  });
+});

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,2 +1,41 @@
 export const CONTACT_EMAIL = "info@scontrinozero.it";
 export const VAT_NUMBER = "11836750015";
+
+/** Oggetto pre-compilato dell'email di assistenza. */
+const SUPPORT_SUBJECT = "Richiesta assistenza ScontrinoZero";
+
+/** Segnaposto usato quando un campo del contesto non è disponibile. */
+const NOT_AVAILABLE = "(non disponibile)";
+
+/**
+ * Costruisce l'href `mailto:` verso il supporto, con oggetto e corpo
+ * pre-compilati. Il corpo riporta i dati che la pagina
+ * `/help/contatto-assistenza` chiede di includere (email account, piano,
+ * versione app) più un segnaposto per la descrizione del problema, così
+ * l'utente non deve ricopiarli a mano.
+ *
+ * Tutti i parametri sono codificati con `encodeURIComponent`: un account email
+ * o un piano assenti diventano un segnaposto leggibile, mai la stringa
+ * `undefined`/`null` nel corpo dell'email.
+ */
+export function buildSupportMailtoHref({
+  accountEmail,
+  plan,
+  appVersion,
+}: {
+  readonly accountEmail: string | null | undefined;
+  readonly plan: string | null | undefined;
+  readonly appVersion: string;
+}): string {
+  const body = [
+    `Email account: ${accountEmail || NOT_AVAILABLE}`,
+    `Piano: ${plan || NOT_AVAILABLE}`,
+    `Versione: ${appVersion}`,
+    "",
+    "Descrizione del problema:",
+    "",
+  ].join("\n");
+
+  const params = new URLSearchParams({ subject: SUPPORT_SUBJECT, body });
+  return `mailto:${CONTACT_EMAIL}?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary

Adds a new "Supporto" (Support) section to the settings page with two contact options: a link to the Help Center and a pre-filled email form. The email is pre-populated with the user's account email, plan, and app version to streamline support requests.

## Changes

- **`src/lib/contact.ts`** — Added `buildSupportMailtoHref()` function that constructs a `mailto:` URL with pre-filled subject and body. Handles null/undefined values gracefully by substituting a readable placeholder instead of literal "undefined"/"null" strings.

- **`src/components/settings/support-section.tsx`** — New presentational component rendering two action buttons:
  - Help Center link (relative path `/help/contatto-assistenza` for cross-origin hop via middleware)
  - Email link with pre-compiled `mailto:` href containing account email, plan, and app version
  - Pure component (no hooks) for server-side renderability and testability

- **`src/app/dashboard/settings/page.tsx`** — Integrated `SupportSection` into the settings page under a new "Supporto" section. Removed the old inline email contact text from the "Altre impostazioni" section.

- **`src/lib/contact.test.ts`** — Comprehensive test suite for `buildSupportMailtoHref()` covering:
  - Correct email address in href
  - Pre-filled subject line
  - Body contains account email, plan, version, and placeholder text
  - Graceful handling of null/undefined values (no "undefined"/"null" strings)
  - Proper URL encoding of special characters (spaces, `+` in email addresses)

- **`src/components/settings/support-section.test.tsx`** — Integration tests for `SupportSection` component:
  - Help Center link uses correct relative path
  - Email link generates valid `mailto:` with query parameters
  - Body includes account email and version
  - Robustness when account email and plan are absent

## Implementation Details

- The `buildSupportMailtoHref()` function uses `URLSearchParams` for proper encoding of subject and body parameters, ensuring special characters don't break the mailto link.
- Null/undefined context values (account email, plan) are replaced with `"(non disponibile)"` to keep the email body readable and prevent literal "undefined" strings.
- The Help Center link uses a relative path to leverage the existing middleware hostname redirect pattern (same as `ade-credentials-section.tsx`), enabling cross-origin navigation from app to marketing domain.
- All tests follow TDD convention and cover edge cases (missing data, special characters, encoding).

https://claude.ai/code/session_019rrxW5yb13iZghzT6ok6iW