### PR TITLE
Extend network failure detection to match Sentry fetch-instrumentation enriched messages

### DIFF
--- a/src/lib/sentry-filters.test.ts
+++ b/src/lib/sentry-filters.test.ts
@@ -119,6 +119,30 @@ describe("isClientNetworkFailure", () => {
     expect(isClientNetworkFailure(event, hint)).toBe(true);
   });
 
+  it('filtra la forma arricchita col suffisso host "Failed to fetch (<host>)" (issue SCONTRINOZERO-R, estensione browser)', () => {
+    const event = makeEvent("/help/credenziali-fisconline");
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to fetch (safesearchinc.com)"),
+    };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(true);
+  });
+
+  it('filtra "Load failed (<host>)" arricchito dalla fetch-instrumentation', () => {
+    const event = makeEvent("/dashboard", "Load failed (example.com)");
+
+    expect(isClientNetworkFailure(event)).toBe(true);
+  });
+
+  it('non filtra un messaggio che estende la base senza il suffisso " (" (es. "Failed to fetchX")', () => {
+    const event = makeEvent("/login");
+    const hint: EventHint = {
+      originalException: new TypeError("Failed to fetchX"),
+    };
+
+    expect(isClientNetworkFailure(event, hint)).toBe(false);
+  });
+
   it("filtra quando il messaggio è in originalException stringa", () => {
     const event = makeEvent("/login");
     const hint: EventHint = { originalException: "Load failed" };

--- a/src/lib/sentry-filters.ts
+++ b/src/lib/sentry-filters.ts
@@ -29,19 +29,29 @@ export function extractErrorMessage(
  * (TCP/TLS drop, nessuna connessione, app iOS in background).
  * Non vengono mai generati da codice applicativo — sono sempre non azionabili.
  */
-const NETWORK_FAILURE_MESSAGES = new Set(["Load failed", "Failed to fetch"]);
+const NETWORK_FAILURE_MESSAGES = ["Load failed", "Failed to fetch"];
 
 /**
  * True se l'evento è un fallimento di rete client-side — il browser non è
  * riuscito a completare la chiamata fetch() prima di ricevere una risposta.
  * Tipico su mobile con connessione instabile (issue SCONTRINOZERO-J).
+ *
+ * La fetch-instrumentation di Sentry (`@sentry/core/instrument/fetch.ts`)
+ * arricchisce il messaggio col suffisso `(<host>)` — es.
+ * `"Failed to fetch (safesearchinc.com)"` da uno script iniettato da
+ * un'estensione browser (issue SCONTRINOZERO-R), o `(app.scontrinozero.it)`
+ * su un `fetchServerAction` caduto. Matchiamo quindi sia la forma nuda sia
+ * quella col suffisso, restando stretti (`base` seguita da ` (`) per non
+ * catturare messaggi applicativi che iniziano per caso con la stessa base.
  */
 export function isClientNetworkFailure(
   event: ErrorEvent,
   hint?: EventHint,
 ): boolean {
   const message = extractErrorMessage(event, hint);
-  return NETWORK_FAILURE_MESSAGES.has(message);
+  return NETWORK_FAILURE_MESSAGES.some(
+    (base) => message === base || message.startsWith(`${base} (`),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends the `isClientNetworkFailure()` filter to recognize network failure messages enriched by Sentry's fetch-instrumentation, which appends a `(<host>)` suffix to the base error message. This prevents false negatives when browser extensions or Sentry's own instrumentation augment the error message.

## Changes

- **`src/lib/sentry-filters.ts`**
  - Changed `NETWORK_FAILURE_MESSAGES` from a `Set` to an array to enable flexible matching logic
  - Updated `isClientNetworkFailure()` to match both the exact base message (`"Load failed"`, `"Failed to fetch"`) and the enriched form with host suffix (`"Failed to fetch (safesearchinc.com)"`, `"Load failed (example.com)"`)
  - Uses `startsWith()` with strict prefix check (`base` + ` (`) to avoid false positives on messages like `"Failed to fetchX"`
  - Added detailed JSDoc explaining the Sentry fetch-instrumentation behavior and matching strategy

- **`src/lib/sentry-filters.test.ts`**
  - Added test for enriched `"Failed to fetch (<host>)"` from browser extension (issue SCONTRINOZERO-R)
  - Added test for enriched `"Load failed (<host>)"` from fetch-instrumentation
  - Added negative test to ensure messages without the ` (` suffix (e.g., `"Failed to fetchX"`) are not matched

## Implementation Details

The matching logic uses `message.startsWith(\`${base} (\`)` to ensure we only match the Sentry-enriched form (with space and opening parenthesis), not arbitrary extensions of the base message. This maintains precision while handling both the raw browser error and the instrumentation-enriched variant.

https://claude.ai/code/session_01NrsHjijbQJDAexCgP2Ddxu