### PR TITLE
feat(gdpr): cancellazione utenti inattivi >12 mesi (v1.4.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,26 @@ TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 # ANNOUNCEMENT_LEVEL=warning
 
 # =============================================================================
+# GDPR — cancellazione utenti inattivi >12 mesi (PLAN.md v1.4.2)
+# =============================================================================
+# Sweep in-process (src/instrumentation.ts) che preavvisa via email e poi
+# cancella gli account inattivi da oltre 12 mesi (minimizzazione dati GDPR).
+# Inattività = ultimo scontrino OPPURE ultimo login. Escludi unlimited e
+# abbonati a pagamento attivi. Lette a RUNTIME (nessun rebuild).
+#
+# ⚠️ Feature OPT-IN e DISTRUTTIVA: parte SOLO se ENABLED è esattamente "true".
+# Lasciala spenta finché non vuoi attivarla per l'ambiente.
+# INACTIVE_USER_PRUNE_ENABLED=true
+# Giorni di inattività oltre cui l'account è cancellabile (default 365).
+# In dev puoi essere più aggressivo, es. 90 giorni.
+# INACTIVE_USER_DELETE_AFTER_DAYS=365
+# Giorni di preavviso email prima della cancellazione (default 30). Deve
+# essere < DELETE_AFTER_DAYS (clampato altrimenti).
+# INACTIVE_USER_WARN_BEFORE_DAYS=30
+# Periodo dello sweep in ms (default 86400000 = 24h).
+# INACTIVE_USER_PRUNE_INTERVAL_MS=86400000
+
+# =============================================================================
 # Development / build
 # =============================================================================
 # Suppress @serwist/next informational warning about Turbopack (Next.js 16

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,12 +19,14 @@ banco e le feature Pro committed.
 | **v1.7.0** | **Stampa termica Bluetooth** 58/80mm (Web Bluetooth). _Alta utilità operativa (scontrino fisico al banco): prioritaria rispetto al sync AdE._                                                                                                                                                                                                                                              |
 | **v1.8.0** | **Storno avanzato**: memorizzare progressivo documento AdE di annullamento e stampare ricevuta di annullamento                                                                                                                                                                                                                                                                             |
 | **v1.9.0** | **Sync documenti commerciali da AdE** (feature **Pro**, ex #107): recupero/importazione dei documenti commerciali/corrispettivi storici emessi, per riconciliazione e continuità dati. _Committed («in arrivo» sul Pro), pianificata dopo stampa BT e storno. Groundwork già presente: `searchDocuments`/`getDocument` in `src/lib/ade/client.ts` (oggi usati solo per recovery interno)._ |
-| **v1.x**   | **GDPR — cancellazione utenti inattivi >12 mesi** (ex #97): rilevazione inattività (ultimo scontrino), email di avviso ≥30 giorni prima, cancellazione dati correlati. Base legale: minimizzazione dati                                                                                                                                                                                    |
 | **v1.x**   | Umami analytics (event tracking lato app) — voce minore, accorpabile a una release vicina                                                                                                                                                                                                                                                                                                  |
 
 > **Già spedite** (storico nei tag git, non più in roadmap): onboarding tour
 > dashboard (v1.4.1), catalogo con CRUD completo inclusa la **modifica prodotto**
-> (`updateCatalogItem` in `src/server/catalog-actions.ts`).
+> (`updateCatalogItem` in `src/server/catalog-actions.ts`), **GDPR —
+> cancellazione utenti inattivi >12 mesi** (v1.4.2, ex #97): sweep in-process
+> opt-in con preavviso email ≥30 giorni; inattività = ultimo scontrino o login;
+> `src/lib/services/inactive-user-prune.ts`.
 
 ---
 

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -85,6 +85,8 @@ partner per il branding subdomain), e i data file marketing
 | Schema DB (una tabella per file)                  | `src/db/schema` (es. `src/db/schema/profiles.ts`, `src/db/schema/commercial-documents.ts`)                                                                                                                                    |
 | Contenuti marketing/SEO (data file)               | `src/lib/guide`, `src/lib/help`, `src/lib/per`, `src/lib/confronto`, `src/lib/strumenti`                                                                                                                                      |
 | Health/diagnostica post-deploy                    | `src/app/api/health`, `src/app/api/_health`, `src/app/api/_debug`                                                                                                                                                             |
+| Cancellazione account (self-service + purge)      | `src/server/account-actions.ts` (`deleteAccount`), helper condiviso `src/lib/services/purge-user.ts`                                                                                                                          |
+| GDPR pruning utenti inattivi >12 mesi             | `src/lib/services/inactive-user-prune.ts` + config `src/lib/services/inactive-user-prune-config.ts`, sweep in `src/instrumentation.ts`                                                                                        |
 
 ## Indice Server Actions (`src/server/*-actions.ts`)
 

--- a/docs/architecture/config-manifest.md
+++ b/docs/architecture/config-manifest.md
@@ -20,6 +20,7 @@
 | CSP / security headers                                                   | `src/lib/csp.ts`, `src/lib/security-headers.ts`                                           | —                                                                                 |
 | Limiti lunghezza/valore campi (business, righe, catalogo, email)         | `src/lib/validation.ts` (`BUSINESS_PROFILE_LIMITS`), `src/lib/receipts/receipt-schema.ts` | Zod = SoT; mirror DB CHECK in `supabase/migrations/0019_db_check_constraints.sql` |
 | Chiave/secret Turnstile per ambiente                                     | `src/components/turnstile-widget.tsx`                                                     | `NEXT_PUBLIC_*` baked al build (CLAUDE.md, sezione Deploy)                        |
+| Soglie GDPR pruning utenti inattivi (enabled/giorni/intervallo)          | `src/lib/services/inactive-user-prune-config.ts`                                          | Env `INACTIVE_USER_PRUNE_*` opt-in, runtime; sweep in `src/instrumentation.ts`    |
 
 **Trial:** 30 giorni Starter/Pro, senza carta — gate in `src/lib/plans.ts`,
 copy/dettagli in `CLAUDE.md` (sezione Pricing).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"

--- a/src/db/schema/profiles.ts
+++ b/src/db/schema/profiles.ts
@@ -65,6 +65,14 @@ export const profiles = pgTable(
     onboardingTourSeenAt: timestamp("onboarding_tour_seen_at", {
       withTimezone: true,
     }),
+    // GDPR — cancellazione utenti inattivi >12 mesi (PLAN.md v1.4.2, migration
+    // 0026): timestamp dell'invio dell'email di PREAVVISO cancellazione. Lo
+    // sweep periodico (src/lib/services/inactive-user-prune.ts) cancella solo se
+    // questo valore è ≥30 giorni fa (grace period), e lo azzera se l'utente
+    // torna attivo (nuovo scontrino o login). NULL = nessun preavviso pendente.
+    inactivityWarningSentAt: timestamp("inactivity_warning_sent_at", {
+      withTimezone: true,
+    }),
   },
   (table) => [
     // Defense-in-depth (migration 0019): 254 = RFC 5321 max address length.

--- a/src/emails/account-inactivity-deletion.test.tsx
+++ b/src/emails/account-inactivity-deletion.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AccountInactivityDeletionEmail } from "./account-inactivity-deletion";
+
+describe("AccountInactivityDeletionEmail", () => {
+  it("renders without throwing", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityDeletionEmail, {
+        email: "test@example.com",
+      }),
+    );
+    expect(html).toBeTruthy();
+  });
+
+  it("include l'indirizzo email destinatario", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityDeletionEmail, {
+        email: "utente@test.it",
+      }),
+    );
+    expect(html).toContain("utente@test.it");
+  });
+
+  it("esplicita il motivo dell'inattività", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityDeletionEmail, {
+        email: "test@example.com",
+      }),
+    );
+    expect(html).toContain("inattività");
+  });
+
+  it("menziona il portale AdE per i documenti commerciali", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityDeletionEmail, {
+        email: "test@example.com",
+      }),
+    );
+    expect(html).toContain("Fatture e Corrispettivi");
+  });
+});

--- a/src/emails/account-inactivity-deletion.tsx
+++ b/src/emails/account-inactivity-deletion.tsx
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { emailStyles } from "./styles";
+import { CONTACT_EMAIL } from "@/lib/contact";
+
+type AccountInactivityDeletionEmailProps = Readonly<{
+  email: string;
+}>;
+
+/**
+ * Conferma di cancellazione per inattività (GDPR). Distinta da
+ * `AccountDeletionEmail` (self-service): esplicita il motivo — inattività
+ * prolungata — per trasparenza verso l'interessato.
+ */
+export function AccountInactivityDeletionEmail({
+  email,
+}: AccountInactivityDeletionEmailProps) {
+  return (
+    <Html lang="it">
+      <Head />
+      <Preview>Il tuo account ScontrinoZero è stato eliminato</Preview>
+      <Body style={emailStyles.body}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.content}>
+            <Text style={emailStyles.text}>
+              L&apos;account associato all&apos;indirizzo{" "}
+              <strong>{email}</strong> è stato eliminato per inattività
+              prolungata (oltre 12 mesi senza accessi né scontrini), in
+              applicazione del principio di minimizzazione dei dati previsto dal
+              GDPR.
+            </Text>
+            <Text style={emailStyles.text}>
+              I tuoi dati personali (profilo, credenziali, scontrini) sono stati
+              rimossi dai sistemi di ScontrinoZero.
+            </Text>
+            <Text style={emailStyles.text}>
+              I documenti commerciali già trasmessi all&apos;Agenzia delle
+              Entrate restano disponibili sul portale{" "}
+              <strong>Fatture e Corrispettivi</strong>, accessibile con le tue
+              credenziali Fisconline.
+            </Text>
+            <Text style={emailStyles.text}>
+              Vuoi tornare a usare ScontrinoZero? Puoi registrarti di nuovo in
+              qualsiasi momento. Per dubbi contattaci a{" "}
+              <strong>{CONTACT_EMAIL}</strong>.
+            </Text>
+          </Section>
+          <Hr style={emailStyles.hr} />
+          <Text style={emailStyles.footer}>
+            ScontrinoZero · scontrinozero.it
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/emails/account-inactivity-warning.test.tsx
+++ b/src/emails/account-inactivity-warning.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AccountInactivityWarningEmail } from "./account-inactivity-warning";
+
+const PROPS = {
+  firstName: "Mario",
+  deletionDate: new Date("2026-08-15T00:00:00.000Z"),
+  loginUrl: "https://app.test/login",
+};
+
+describe("AccountInactivityWarningEmail", () => {
+  it("renders without throwing", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityWarningEmail, PROPS),
+    );
+    expect(html).toBeTruthy();
+  });
+
+  it("saluta l'utente col nome quando presente", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityWarningEmail, PROPS),
+    );
+    expect(html).toContain("Mario");
+  });
+
+  it("non stampa un saluto rotto quando firstName è vuoto", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityWarningEmail, { ...PROPS, firstName: "" }),
+    );
+    expect(html).toContain("Ciao,");
+  });
+
+  it("mostra la data di cancellazione in italiano", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityWarningEmail, PROPS),
+    );
+    expect(html).toContain("15 agosto 2026");
+  });
+
+  it("include il link di login per mantenere l'account", () => {
+    const html = renderToStaticMarkup(
+      createElement(AccountInactivityWarningEmail, PROPS),
+    );
+    expect(html).toContain("https://app.test/login");
+  });
+});

--- a/src/emails/account-inactivity-warning.tsx
+++ b/src/emails/account-inactivity-warning.tsx
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { emailStyles } from "./styles";
+import { CONTACT_EMAIL } from "@/lib/contact";
+
+type AccountInactivityWarningEmailProps = Readonly<{
+  firstName: string;
+  deletionDate: Date;
+  loginUrl: string;
+}>;
+
+/**
+ * Preavviso di cancellazione per inattività (GDPR, minimizzazione dati). Inviato
+ * ≥30 giorni prima della cancellazione effettiva. Basta un accesso per azzerare
+ * il conteggio (lo sweep resetta il flag quando l'utente torna attivo).
+ */
+export function AccountInactivityWarningEmail({
+  firstName,
+  deletionDate,
+  loginUrl,
+}: AccountInactivityWarningEmailProps) {
+  const formattedDate = deletionDate.toLocaleDateString("it-IT", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  const greeting = firstName ? `Ciao ${firstName}, ` : "Ciao, ";
+
+  return (
+    <Html lang="it">
+      <Head />
+      <Preview>
+        Il tuo account ScontrinoZero sta per essere eliminato per inattività
+      </Preview>
+      <Body style={emailStyles.body}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.header}>
+            <Text style={emailStyles.headerTitle}>ScontrinoZero</Text>
+            <Text style={emailStyles.headerSubtitle}>
+              Registratore di cassa virtuale
+            </Text>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Heading as="h2" style={emailStyles.subheading}>
+              Il tuo account sta per essere eliminato
+            </Heading>
+            <Text style={emailStyles.text}>
+              {greeting}non registriamo attività sul tuo account ScontrinoZero
+              da oltre 12 mesi. Per rispetto del principio di minimizzazione dei
+              dati (GDPR), gli account inattivi vengono eliminati insieme ai
+              dati collegati.
+            </Text>
+            <Text style={emailStyles.text}>
+              Se non intervieni, il tuo account verrà eliminato definitivamente
+              il <strong>{formattedDate}</strong>.
+            </Text>
+            <Text style={emailStyles.text}>
+              <strong>Vuoi mantenerlo?</strong> Ti basta accedere:
+              l&apos;accesso azzera il conteggio dell&apos;inattività.
+            </Text>
+            <Button style={emailStyles.button} href={loginUrl}>
+              Accedi e mantieni l&apos;account
+            </Button>
+            <Text style={emailStyles.text}>
+              I documenti commerciali già trasmessi all&apos;Agenzia delle
+              Entrate restano comunque disponibili sul portale{" "}
+              <strong>Fatture e Corrispettivi</strong>. Per dubbi scrivici a{" "}
+              <strong>{CONTACT_EMAIL}</strong>.
+            </Text>
+          </Section>
+          <Hr style={emailStyles.hr} />
+          <Text style={emailStyles.footer}>
+            ScontrinoZero · scontrinozero.it
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/instrumentation-inactive-prune.test.ts
+++ b/src/instrumentation-inactive-prune.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPruneInactiveUsers, mockLoggerWarn } = vi.hoisted(() => ({
+  mockPruneInactiveUsers: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock("@/lib/services/inactive-user-prune", () => ({
+  pruneInactiveUsers: mockPruneInactiveUsers,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: mockLoggerWarn },
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureRequestError: vi.fn() }));
+
+describe("startInactiveUserPruneSweep()", () => {
+  let capturedCallback: (() => Promise<void>) | undefined;
+  let mockUnref: ReturnType<typeof vi.fn>;
+  let startInactiveUserPruneSweep: (intervalMs: number) => void;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ startInactiveUserPruneSweep } = await import("./instrumentation"));
+
+    mockUnref = vi.fn();
+    const mockTimer = { unref: mockUnref } as unknown as ReturnType<
+      typeof setInterval
+    >;
+    vi.spyOn(global, "setInterval").mockImplementation((callback) => {
+      capturedCallback = callback as () => Promise<void>;
+      return mockTimer;
+    });
+
+    mockPruneInactiveUsers.mockResolvedValue({
+      warned: 0,
+      deleted: 0,
+      reset: 0,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    capturedCallback = undefined;
+  });
+
+  it("chiama setInterval con l'intervallo passato", () => {
+    startInactiveUserPruneSweep(3_600_000);
+    expect(global.setInterval).toHaveBeenCalledWith(
+      expect.any(Function),
+      3_600_000,
+    );
+  });
+
+  it("chiama .unref() per non bloccare lo shutdown", () => {
+    startInactiveUserPruneSweep(1000);
+    expect(mockUnref).toHaveBeenCalled();
+  });
+
+  it("non tocca il DB prima che scatti il timer", () => {
+    startInactiveUserPruneSweep(1000);
+    expect(mockPruneInactiveUsers).not.toHaveBeenCalled();
+  });
+
+  it("esegue pruneInactiveUsers quando il callback scatta", async () => {
+    startInactiveUserPruneSweep(1000);
+    await capturedCallback!();
+    expect(mockPruneInactiveUsers).toHaveBeenCalledOnce();
+  });
+
+  it("logga warn senza lanciare se lo sweep fallisce", async () => {
+    const error = new Error("sweep boom");
+    mockPruneInactiveUsers.mockRejectedValue(error);
+    startInactiveUserPruneSweep(1000);
+    await capturedCallback!();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      { err: error },
+      "Inactive user prune sweep fallito",
+    );
+  });
+
+  it("due chiamate avviano un solo setInterval (idempotenza)", () => {
+    startInactiveUserPruneSweep(1000);
+    startInactiveUserPruneSweep(1000);
+    expect(global.setInterval).toHaveBeenCalledOnce();
+  });
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -77,6 +77,35 @@ export function startStripeWebhookClaimSweep() {
   interval.unref();
 }
 
+let inactiveUserPruneStarted = false;
+
+/**
+ * Sweep GDPR di cancellazione utenti inattivi >12 mesi (PLAN.md v1.4.2).
+ * Stesso pattern di `startSupabaseKeepAlive`/`startStripeWebhookClaimSweep`:
+ * `setInterval` unref'd con guardia d'idempotenza. L'intervallo arriva dalla
+ * config env (`INACTIVE_USER_PRUNE_INTERVAL_MS`, default 24h): `register()`
+ * avvia lo sweep SOLO se la feature è abilitata (`INACTIVE_USER_PRUNE_ENABLED`),
+ * quindi qui l'`intervalMs` è già risolto. Il carico DB/email è tutto lazy
+ * dentro il callback: al boot non si tocca il DB.
+ */
+export function startInactiveUserPruneSweep(intervalMs: number) {
+  if (inactiveUserPruneStarted) return;
+  inactiveUserPruneStarted = true;
+
+  const interval: ReturnType<typeof setInterval> = setInterval(async () => {
+    try {
+      const { pruneInactiveUsers } =
+        await import("@/lib/services/inactive-user-prune");
+      await pruneInactiveUsers();
+    } catch (err) {
+      const { logger } = await import("@/lib/logger");
+      logger.warn({ err }, "Inactive user prune sweep fallito");
+    }
+  }, intervalMs);
+
+  interval.unref();
+}
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     // Fail-fast sulle env d'identita' (NEXT_PUBLIC_APP_URL, *_HOSTNAME, …).
@@ -111,6 +140,17 @@ export async function register() {
     // Sweep dei claim webhook Stripe "stuck" (REVIEW.md #20): stessa guardia
     // di idempotenza e pattern setInterval unref'd di startSupabaseKeepAlive.
     startStripeWebhookClaimSweep();
+
+    // Sweep GDPR cancellazione utenti inattivi >12 mesi (PLAN.md v1.4.2).
+    // Feature OPT-IN e distruttiva: parte SOLO se INACTIVE_USER_PRUNE_ENABLED=true.
+    // La config (pure, no deps DB) è letta a parte per non tirare dentro la
+    // pipeline di cancellazione quando la feature è spenta (default).
+    const { readPruneConfig } =
+      await import("@/lib/services/inactive-user-prune-config");
+    const pruneConfig = readPruneConfig();
+    if (pruneConfig.enabled) {
+      startInactiveUserPruneSweep(pruneConfig.intervalMs);
+    }
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {

--- a/src/lib/services/inactive-user-prune-config.test.ts
+++ b/src/lib/services/inactive-user-prune-config.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  readPruneConfig,
+  DEFAULT_DELETE_AFTER_DAYS,
+  DEFAULT_WARN_BEFORE_DAYS,
+  DEFAULT_PRUNE_INTERVAL_MS,
+} from "./inactive-user-prune-config";
+
+describe("readPruneConfig", () => {
+  it("è disabilitato di default (feature opt-in)", () => {
+    const config = readPruneConfig({});
+    expect(config.enabled).toBe(false);
+  });
+
+  it("abilita solo con il valore esatto 'true' (case-insensitive)", () => {
+    expect(
+      readPruneConfig({ INACTIVE_USER_PRUNE_ENABLED: "true" }).enabled,
+    ).toBe(true);
+    expect(
+      readPruneConfig({ INACTIVE_USER_PRUNE_ENABLED: "TRUE" }).enabled,
+    ).toBe(true);
+    expect(readPruneConfig({ INACTIVE_USER_PRUNE_ENABLED: "1" }).enabled).toBe(
+      false,
+    );
+    expect(
+      readPruneConfig({ INACTIVE_USER_PRUNE_ENABLED: "false" }).enabled,
+    ).toBe(false);
+  });
+
+  it("usa i default quando le soglie sono assenti", () => {
+    const config = readPruneConfig({});
+    expect(config.deleteAfterDays).toBe(DEFAULT_DELETE_AFTER_DAYS);
+    expect(config.warnBeforeDays).toBe(DEFAULT_WARN_BEFORE_DAYS);
+    expect(config.intervalMs).toBe(DEFAULT_PRUNE_INTERVAL_MS);
+  });
+
+  it("legge soglie custom valide (es. dev più aggressivo)", () => {
+    const config = readPruneConfig({
+      INACTIVE_USER_DELETE_AFTER_DAYS: "90",
+      INACTIVE_USER_WARN_BEFORE_DAYS: "7",
+      INACTIVE_USER_PRUNE_INTERVAL_MS: "3600000",
+    });
+    expect(config.deleteAfterDays).toBe(90);
+    expect(config.warnBeforeDays).toBe(7);
+    expect(config.intervalMs).toBe(3_600_000);
+  });
+
+  it("ricade sul default su valori non numerici o ≤ 0", () => {
+    const config = readPruneConfig({
+      INACTIVE_USER_DELETE_AFTER_DAYS: "abc",
+      INACTIVE_USER_WARN_BEFORE_DAYS: "-5",
+      INACTIVE_USER_PRUNE_INTERVAL_MS: "0",
+    });
+    expect(config.deleteAfterDays).toBe(DEFAULT_DELETE_AFTER_DAYS);
+    expect(config.warnBeforeDays).toBe(DEFAULT_WARN_BEFORE_DAYS);
+    expect(config.intervalMs).toBe(DEFAULT_PRUNE_INTERVAL_MS);
+  });
+
+  it("clampa warnBeforeDays sotto deleteAfterDays (invariante preavviso)", () => {
+    const config = readPruneConfig({
+      INACTIVE_USER_DELETE_AFTER_DAYS: "10",
+      INACTIVE_USER_WARN_BEFORE_DAYS: "30",
+    });
+    expect(config.warnBeforeDays).toBe(9);
+    expect(config.warnBeforeDays).toBeLessThan(config.deleteAfterDays);
+  });
+
+  it("clampa warnBeforeDays a minimo 1 quando deleteAfterDays è 1", () => {
+    const config = readPruneConfig({
+      INACTIVE_USER_DELETE_AFTER_DAYS: "1",
+      INACTIVE_USER_WARN_BEFORE_DAYS: "5",
+    });
+    expect(config.warnBeforeDays).toBe(1);
+  });
+});

--- a/src/lib/services/inactive-user-prune-config.ts
+++ b/src/lib/services/inactive-user-prune-config.ts
@@ -1,0 +1,72 @@
+/**
+ * Config (pure) dello sweep GDPR di cancellazione utenti inattivi.
+ *
+ * Tenuto SEPARATO da `inactive-user-prune.ts` (che importa `getDb`/Drizzle/
+ * email — server-only e pesante) così `src/instrumentation.ts` può leggere la
+ * config al boot per decidere se avviare lo sweep, SENZA tirare dentro l'intera
+ * pipeline DB quando la feature è disabilitata (default). Nessuna dipendenza
+ * oltre `process.env`.
+ */
+
+export type PruneConfig = {
+  /** Se false lo sweep non viene avviato (default: feature opt-in). */
+  enabled: boolean;
+  /** Giorni di inattività oltre cui l'account è cancellabile (default 365). */
+  deleteAfterDays: number;
+  /** Giorni di preavviso prima della cancellazione (default 30). */
+  warnBeforeDays: number;
+  /** Periodo dello sweep in ms (default 24h). */
+  intervalMs: number;
+};
+
+export const DEFAULT_DELETE_AFTER_DAYS = 365;
+export const DEFAULT_WARN_BEFORE_DAYS = 30;
+export const DEFAULT_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * Legge un intero positivo da una env; ritorna `fallback` se assente, non
+ * numerico o ≤ 0 (un valore malformato non deve disabilitare silenziosamente
+ * la fase, né produrre soglie assurde negative).
+ */
+function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+/**
+ * Costruisce la `PruneConfig` dalle env. `enabled` è opt-in: solo il valore
+ * esatto `"true"` (case-insensitive, trimmed) attiva lo sweep — qualsiasi altro
+ * valore (assente, "false", "1", "") lo lascia spento, coerente con una feature
+ * distruttiva che deve essere accesa esplicitamente per ambiente.
+ *
+ * ⚠️ Invariante: `warnBeforeDays` DEVE essere < `deleteAfterDays`, altrimenti la
+ * finestra di preavviso coinciderebbe/supererebbe la soglia di cancellazione e
+ * un utente potrebbe essere cancellato senza un preavviso ≥ warnBeforeDays. Se
+ * la config viola l'invariante, `warnBeforeDays` è clampato a `deleteAfterDays`
+ * meno un giorno (minimo 1) e la violazione è segnalata dal chiamante.
+ */
+export function readPruneConfig(
+  env: Record<string, string | undefined> = process.env,
+): PruneConfig {
+  const enabled =
+    env.INACTIVE_USER_PRUNE_ENABLED?.trim().toLowerCase() === "true";
+  const deleteAfterDays = readPositiveInt(
+    env.INACTIVE_USER_DELETE_AFTER_DAYS,
+    DEFAULT_DELETE_AFTER_DAYS,
+  );
+  let warnBeforeDays = readPositiveInt(
+    env.INACTIVE_USER_WARN_BEFORE_DAYS,
+    DEFAULT_WARN_BEFORE_DAYS,
+  );
+  if (warnBeforeDays >= deleteAfterDays) {
+    warnBeforeDays = Math.max(1, deleteAfterDays - 1);
+  }
+  const intervalMs = readPositiveInt(
+    env.INACTIVE_USER_PRUNE_INTERVAL_MS,
+    DEFAULT_PRUNE_INTERVAL_MS,
+  );
+
+  return { enabled, deleteAfterDays, warnBeforeDays, intervalMs };
+}

--- a/src/lib/services/inactive-user-prune.test.ts
+++ b/src/lib/services/inactive-user-prune.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PruneConfig } from "./inactive-user-prune-config";
+
+const mockExecute = vi.fn();
+const mockWhere = vi.fn().mockResolvedValue(undefined);
+const mockSet = vi.fn((_values: { inactivityWarningSentAt: Date | null }) => ({
+  where: mockWhere,
+}));
+const mockUpdate = vi.fn(() => ({ set: mockSet }));
+vi.mock("@/db", () => ({
+  getDb: () => ({ execute: mockExecute, update: mockUpdate }),
+}));
+
+const mockPurgeUserById = vi.fn();
+vi.mock("@/lib/services/purge-user", () => ({
+  purgeUserById: (id: string) => mockPurgeUserById(id),
+}));
+
+const mockSendEmail = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/email", () => ({ sendEmail: (o: unknown) => mockSendEmail(o) }));
+
+vi.mock("@/lib/trusted-app-url", () => ({
+  getTrustedAppUrl: () => "https://app.test",
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/emails/account-inactivity-warning", () => ({
+  AccountInactivityWarningEmail: vi.fn(() => null),
+}));
+vi.mock("@/emails/account-inactivity-deletion", () => ({
+  AccountInactivityDeletionEmail: vi.fn(() => null),
+}));
+
+const NOW = new Date("2026-07-01T00:00:00.000Z");
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000);
+
+const CONFIG: PruneConfig = {
+  enabled: true,
+  deleteAfterDays: 365,
+  warnBeforeDays: 30,
+  intervalMs: 86_400_000,
+};
+
+describe("isProtectedFromPrune", () => {
+  it("protegge unlimited sempre", async () => {
+    const { isProtectedFromPrune } = await import("./inactive-user-prune");
+    expect(isProtectedFromPrune("unlimited", null, NOW.getTime())).toBe(true);
+  });
+
+  it("NON protegge il trial", async () => {
+    const { isProtectedFromPrune } = await import("./inactive-user-prune");
+    expect(isProtectedFromPrune("trial", null, NOW.getTime())).toBe(false);
+  });
+
+  it("protegge un piano a pagamento ancora attivo", async () => {
+    const { isProtectedFromPrune } = await import("./inactive-user-prune");
+    const future = new Date(NOW.getTime() + 30 * 86_400_000);
+    expect(isProtectedFromPrune("pro", future, NOW.getTime())).toBe(true);
+  });
+
+  it("protegge un piano a pagamento con scadenza sconosciuta (null) — fail-safe", async () => {
+    const { isProtectedFromPrune } = await import("./inactive-user-prune");
+    expect(isProtectedFromPrune("pro", null, NOW.getTime())).toBe(true);
+  });
+
+  it("NON protegge un piano a pagamento scaduto oltre la grazia", async () => {
+    const { isProtectedFromPrune } = await import("./inactive-user-prune");
+    const longExpired = new Date(NOW.getTime() - 400 * 86_400_000);
+    expect(isProtectedFromPrune("pro", longExpired, NOW.getTime())).toBe(false);
+  });
+
+  it("protegge un plan sconosciuto (drift schema)", async () => {
+    const { isProtectedFromPrune } = await import("./inactive-user-prune");
+    expect(isProtectedFromPrune("mystery", null, NOW.getTime())).toBe(true);
+  });
+});
+
+describe("pruneInactiveUsers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPurgeUserById.mockResolvedValue({
+      authDeleted: true,
+      profileDeleted: true,
+    });
+    mockSendEmail.mockResolvedValue(undefined);
+    mockWhere.mockResolvedValue(undefined);
+  });
+
+  it("preavvisa, cancella e resetta secondo lo stato di ogni utente", async () => {
+    mockExecute.mockResolvedValue([
+      // WARN: inattivo oltre 335gg, mai preavvisato, trial
+      {
+        auth_user_id: "w1",
+        email: "w@t.it",
+        first_name: "Wanda",
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: null,
+        last_activity_at: daysAgo(340),
+      },
+      // DELETE: inattivo >365gg, preavvisato 31gg fa, trial
+      {
+        auth_user_id: "d1",
+        email: "d@t.it",
+        first_name: null,
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: daysAgo(31),
+        last_activity_at: daysAgo(400),
+      },
+      // RESET: tornato attivo (10gg fa) pur essendo stato preavvisato
+      {
+        auth_user_id: "r1",
+        email: "r@t.it",
+        first_name: "Rino",
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: daysAgo(40),
+        last_activity_at: daysAgo(10),
+      },
+      // PROTECTED: abbonato pro attivo, nessuna azione
+      {
+        auth_user_id: "p1",
+        email: "p@t.it",
+        first_name: "Pia",
+        plan: "pro",
+        plan_expires_at: new Date(NOW.getTime() + 30 * 86_400_000),
+        inactivity_warning_sent_at: null,
+        last_activity_at: daysAgo(400),
+      },
+      // WAITING: inattivo >365gg ma preavvisato solo 10gg fa (grazia non scaduta)
+      {
+        auth_user_id: "g1",
+        email: "g@t.it",
+        first_name: "Gino",
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: daysAgo(10),
+        last_activity_at: daysAgo(400),
+      },
+      // RESET-PROTECTED: preavvisato ma ora unlimited → azzera
+      {
+        auth_user_id: "rp1",
+        email: "rp@t.it",
+        first_name: "Ada",
+        plan: "unlimited",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: daysAgo(40),
+        last_activity_at: daysAgo(400),
+      },
+    ]);
+
+    const { pruneInactiveUsers } = await import("./inactive-user-prune");
+    const result = await pruneInactiveUsers(NOW, CONFIG);
+
+    expect(result).toEqual({ warned: 1, deleted: 1, reset: 2 });
+
+    // Solo d1 viene cancellato
+    expect(mockPurgeUserById).toHaveBeenCalledTimes(1);
+    expect(mockPurgeUserById).toHaveBeenCalledWith("d1");
+
+    // Due email: preavviso a w1, conferma cancellazione a d1
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "w@t.it",
+        subject: expect.stringContaining("sta per essere eliminato"),
+      }),
+    );
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "d@t.it",
+        subject: "Il tuo account ScontrinoZero è stato eliminato",
+      }),
+    );
+
+    // Tre update: w1 (set now), r1 (null), rp1 (null) — non g1/p1
+    const setValues = mockSet.mock.calls.map(
+      (c) => c[0].inactivityWarningSentAt,
+    );
+    expect(setValues).toHaveLength(3);
+    expect(setValues.filter((v) => v === null)).toHaveLength(2);
+    expect(setValues.filter((v) => v instanceof Date)).toHaveLength(1);
+  });
+
+  it("degrada a zero senza lanciare se la query candidati fallisce", async () => {
+    mockExecute.mockRejectedValue(new Error("DB down"));
+
+    const { pruneInactiveUsers } = await import("./inactive-user-prune");
+    const result = await pruneInactiveUsers(NOW, CONFIG);
+
+    expect(result).toEqual({ warned: 0, deleted: 0, reset: 0 });
+    expect(mockPurgeUserById).not.toHaveBeenCalled();
+  });
+
+  it("un fallimento su un utente non aborta il batch", async () => {
+    mockExecute.mockResolvedValue([
+      {
+        auth_user_id: "w1",
+        email: "w@t.it",
+        first_name: "Wanda",
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: null,
+        last_activity_at: daysAgo(340),
+      },
+      {
+        auth_user_id: "w2",
+        email: "w2@t.it",
+        first_name: "Bea",
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: null,
+        last_activity_at: daysAgo(341),
+      },
+    ]);
+    // Il primo invio email lancia, il secondo va a buon fine
+    mockSendEmail
+      .mockRejectedValueOnce(new Error("Resend down"))
+      .mockResolvedValueOnce(undefined);
+
+    const { pruneInactiveUsers } = await import("./inactive-user-prune");
+    const result = await pruneInactiveUsers(NOW, CONFIG);
+
+    // w1 fallisce (non conteggiato), w2 preavvisato
+    expect(result.warned).toBe(1);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("non cancella se purgeUserById riporta authDeleted false", async () => {
+    mockPurgeUserById.mockResolvedValue({
+      authDeleted: false,
+      profileDeleted: false,
+    });
+    mockExecute.mockResolvedValue([
+      {
+        auth_user_id: "d1",
+        email: "d@t.it",
+        first_name: null,
+        plan: "trial",
+        plan_expires_at: null,
+        inactivity_warning_sent_at: daysAgo(31),
+        last_activity_at: daysAgo(400),
+      },
+    ]);
+
+    const { pruneInactiveUsers } = await import("./inactive-user-prune");
+    const result = await pruneInactiveUsers(NOW, CONFIG);
+
+    expect(result.deleted).toBe(0);
+    // Nessuna email di conferma se la cancellazione auth non è avvenuta
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/services/inactive-user-prune.ts
+++ b/src/lib/services/inactive-user-prune.ts
@@ -144,72 +144,26 @@ export async function pruneInactiveUsers(
     return { warned: 0, deleted: 0, reset: 0 };
   }
 
-  let warned = 0;
-  let deleted = 0;
-  let reset = 0;
-  const loginUrl = safeLoginUrl();
+  const ctx: PruneContext = {
+    now,
+    nowMs,
+    warnCutoff,
+    deleteCutoff,
+    warnGraceCutoff,
+    warnBeforeDays: config.warnBeforeDays,
+    loginUrl: safeLoginUrl(),
+  };
+
+  const counts: Record<PruneAction, number> = {
+    warned: 0,
+    deleted: 0,
+    reset: 0,
+    none: 0,
+  };
 
   for (const row of rows) {
     try {
-      const lastActivity = toDate(row.last_activity_at);
-      if (!lastActivity) continue;
-      const planExpiresAt = toDate(row.plan_expires_at);
-      const warningSentAt = toDate(row.inactivity_warning_sent_at);
-      const protectedNow = isProtectedFromPrune(row.plan, planExpiresAt, nowMs);
-      const inactivePastWarn = lastActivity < warnCutoff;
-
-      // RESET: preavvisato ma non più eleggibile (tornato attivo o protetto).
-      if (warningSentAt && (!inactivePastWarn || protectedNow)) {
-        await setWarningSentAt(row.auth_user_id, null);
-        reset++;
-        continue;
-      }
-
-      if (protectedNow) continue;
-
-      // DELETE: 12 mesi di inattività + preavviso inviato ≥ warnBeforeDays fa.
-      if (
-        lastActivity < deleteCutoff &&
-        warningSentAt &&
-        warningSentAt <= warnGraceCutoff
-      ) {
-        const { authDeleted } = await purgeUserById(row.auth_user_id);
-        if (authDeleted) {
-          deleted++;
-          void sendEmail({
-            to: row.email,
-            subject: "Il tuo account ScontrinoZero è stato eliminato",
-            react: createElement(AccountInactivityDeletionEmail, {
-              email: row.email,
-            }),
-          }).catch((err) =>
-            logger.warn(
-              { err },
-              "pruneInactiveUsers: email conferma cancellazione fallita",
-            ),
-          );
-        }
-        continue;
-      }
-
-      // WARN: inattivo oltre la soglia di preavviso, nessun avviso pendente.
-      if (inactivePastWarn && !warningSentAt) {
-        const deletionDate = new Date(
-          nowMs + config.warnBeforeDays * MS_PER_DAY,
-        );
-        await sendEmail({
-          to: row.email,
-          subject:
-            "Il tuo account ScontrinoZero sta per essere eliminato per inattività",
-          react: createElement(AccountInactivityWarningEmail, {
-            firstName: row.first_name ?? "",
-            deletionDate,
-            loginUrl,
-          }),
-        });
-        await setWarningSentAt(row.auth_user_id, now);
-        warned++;
-      }
+      counts[await processCandidate(row, ctx)]++;
     } catch (err) {
       logger.warn(
         { err },
@@ -218,6 +172,7 @@ export async function pruneInactiveUsers(
     }
   }
 
+  const { warned, deleted, reset } = counts;
   if (warned > 0 || deleted > 0 || reset > 0) {
     logger.info(
       { warned, deleted, reset },
@@ -226,6 +181,101 @@ export async function pruneInactiveUsers(
   }
 
   return { warned, deleted, reset };
+}
+
+type PruneAction = "warned" | "deleted" | "reset" | "none";
+
+type PruneContext = {
+  now: Date;
+  nowMs: number;
+  warnCutoff: Date;
+  deleteCutoff: Date;
+  warnGraceCutoff: Date;
+  warnBeforeDays: number;
+  loginUrl: string;
+};
+
+/**
+ * Classifica ed esegue l'azione (warn/delete/reset/none) per un singolo
+ * candidato. Estratta da `pruneInactiveUsers` per contenere la complessità
+ * cognitiva: qui vive tutta la logica decisionale, là resta solo il loop.
+ */
+async function processCandidate(
+  row: CandidateRow,
+  ctx: PruneContext,
+): Promise<PruneAction> {
+  const lastActivity = toDate(row.last_activity_at);
+  if (!lastActivity) return "none";
+  const planExpiresAt = toDate(row.plan_expires_at);
+  const warningSentAt = toDate(row.inactivity_warning_sent_at);
+  const protectedNow = isProtectedFromPrune(row.plan, planExpiresAt, ctx.nowMs);
+  const inactivePastWarn = lastActivity < ctx.warnCutoff;
+
+  // RESET: preavvisato ma non più eleggibile (tornato attivo o protetto).
+  if (warningSentAt && (!inactivePastWarn || protectedNow)) {
+    await setWarningSentAt(row.auth_user_id, null);
+    return "reset";
+  }
+
+  if (protectedNow) return "none";
+
+  // DELETE: 12 mesi di inattività + preavviso inviato ≥ warnBeforeDays fa.
+  if (
+    lastActivity < ctx.deleteCutoff &&
+    warningSentAt &&
+    warningSentAt <= ctx.warnGraceCutoff
+  ) {
+    return (await deleteCandidate(row)) ? "deleted" : "none";
+  }
+
+  // WARN: inattivo oltre la soglia di preavviso, nessun avviso pendente.
+  if (inactivePastWarn && !warningSentAt) {
+    await warnCandidate(row, ctx);
+    return "warned";
+  }
+
+  return "none";
+}
+
+/**
+ * Cancella l'account (cascata) e invia l'email di conferma (fire-and-forget).
+ * Ritorna true se l'auth user è stato effettivamente rimosso.
+ */
+async function deleteCandidate(row: CandidateRow): Promise<boolean> {
+  const { authDeleted } = await purgeUserById(row.auth_user_id);
+  if (!authDeleted) return false;
+  void sendEmail({
+    to: row.email,
+    subject: "Il tuo account ScontrinoZero è stato eliminato",
+    react: createElement(AccountInactivityDeletionEmail, {
+      email: row.email,
+    }),
+  }).catch((err) =>
+    logger.warn(
+      { err },
+      "pruneInactiveUsers: email conferma cancellazione fallita",
+    ),
+  );
+  return true;
+}
+
+/** Invia l'email di preavviso e registra il timestamp di invio. */
+async function warnCandidate(
+  row: CandidateRow,
+  ctx: PruneContext,
+): Promise<void> {
+  const deletionDate = new Date(ctx.nowMs + ctx.warnBeforeDays * MS_PER_DAY);
+  await sendEmail({
+    to: row.email,
+    subject:
+      "Il tuo account ScontrinoZero sta per essere eliminato per inattività",
+    react: createElement(AccountInactivityWarningEmail, {
+      firstName: row.first_name ?? "",
+      deletionDate,
+      loginUrl: ctx.loginUrl,
+    }),
+  });
+  await setWarningSentAt(row.auth_user_id, ctx.now);
 }
 
 /** URL di login per la CTA dell'email di preavviso; degrada al dominio prod. */

--- a/src/lib/services/inactive-user-prune.ts
+++ b/src/lib/services/inactive-user-prune.ts
@@ -1,0 +1,238 @@
+import { createElement } from "react";
+import { eq, sql } from "drizzle-orm";
+import { getDb } from "@/db";
+import { profiles } from "@/db/schema";
+import { logger } from "@/lib/logger";
+import { sendEmail } from "@/lib/email";
+import { getTrustedAppUrl } from "@/lib/trusted-app-url";
+import { isPaidPlanExpired, isPlan, type Plan } from "@/lib/plans-shared";
+import { purgeUserById } from "@/lib/services/purge-user";
+import { AccountInactivityWarningEmail } from "@/emails/account-inactivity-warning";
+import { AccountInactivityDeletionEmail } from "@/emails/account-inactivity-deletion";
+import {
+  readPruneConfig,
+  type PruneConfig,
+} from "./inactive-user-prune-config";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Un account è PROTETTO dalla cancellazione per inattività (mai warn, mai
+ * delete, e se già preavvisato viene azzerato) se:
+ *   - `unlimited` (invite-only, esente per design), oppure
+ *   - piano a pagamento (`starter`/`pro`/`developer_*`) ANCORA attivo — cioè NON
+ *     scaduto oltre la grazia (`isPaidPlanExpired` = false). Un piano pagato con
+ *     `planExpiresAt` null è considerato attivo → protetto (fail-safe: nel dubbio
+ *     non si cancella chi paga).
+ *
+ * NON protetti: `trial` (qualsiasi stato) e i piani a pagamento scaduti oltre la
+ * grazia. Un valore `plan` non riconosciuto (drift schema) è trattato come
+ * protetto — non si cancella su un dato ambiguo.
+ */
+export function isProtectedFromPrune(
+  plan: string,
+  planExpiresAt: Date | null,
+  now: number = Date.now(),
+): boolean {
+  if (!isPlan(plan)) return true;
+  if (plan === "unlimited") return true;
+  if (plan === "trial") return false;
+  return !isPaidPlanExpired(plan as Plan, planExpiresAt, now);
+}
+
+type CandidateRow = {
+  auth_user_id: string;
+  email: string;
+  first_name: string | null;
+  plan: string;
+  plan_expires_at: Date | string | null;
+  inactivity_warning_sent_at: Date | string | null;
+  last_activity_at: Date | string;
+};
+
+function toDate(value: Date | string | null): Date | null {
+  if (value === null) return null;
+  return value instanceof Date ? value : new Date(value);
+}
+
+async function setWarningSentAt(
+  authUserId: string,
+  value: Date | null,
+): Promise<void> {
+  const db = getDb();
+  await db
+    .update(profiles)
+    .set({ inactivityWarningSentAt: value })
+    .where(eq(profiles.authUserId, authUserId));
+}
+
+/**
+ * Sweep GDPR di cancellazione utenti inattivi (PLAN.md v1.4.2, base legale:
+ * minimizzazione dati, art. 5(1)(e) GDPR). Processo in due fasi, entrambe
+ * eseguite in questa passata:
+ *
+ *   1. PREAVVISO — inattività ≥ (deleteAfterDays − warnBeforeDays) e nessun
+ *      preavviso pendente → email di avviso + `inactivity_warning_sent_at = now`.
+ *   2. CANCELLAZIONE — inattività ≥ deleteAfterDays E preavviso inviato ≥
+ *      warnBeforeDays fa → `purgeUserById` (cascata) + email di conferma.
+ *
+ * Inattività = `MAX(ultimo scontrino, last_sign_in_at, profiles.created_at)`:
+ * l'utente è "attivo" se ha emesso uno scontrino OPPURE ha effettuato login. Il
+ * floor a `created_at` evita di cancellare un iscritto recente senza attività.
+ *
+ * RESET — se un utente preavvisato torna attivo (attività rientrata nella
+ * finestra di warn) o diventa protetto (es. si abbona), il flag viene azzerato,
+ * così una futura inattività riparte con un preavviso completo.
+ *
+ * Esclusi (`isProtectedFromPrune`): `unlimited` e abbonati a pagamento attivi.
+ *
+ * Resiliente: ogni utente è processato in try/catch isolato — un fallimento
+ * (email/DB/purge) logga `warn` e non aborta il batch. È una server-side sweep:
+ * degrada, non lancia (CLAUDE.md regola 19).
+ */
+export async function pruneInactiveUsers(
+  now: Date = new Date(),
+  config: PruneConfig = readPruneConfig(),
+): Promise<{ warned: number; deleted: number; reset: number }> {
+  const nowMs = now.getTime();
+  const warnCutoff = new Date(
+    nowMs - (config.deleteAfterDays - config.warnBeforeDays) * MS_PER_DAY,
+  );
+  const deleteCutoff = new Date(nowMs - config.deleteAfterDays * MS_PER_DAY);
+  const warnGraceCutoff = new Date(nowMs - config.warnBeforeDays * MS_PER_DAY);
+
+  const db = getDb();
+
+  // Un solo giro DB: seleziona i profili inattivi oltre la soglia di preavviso
+  // OPPURE con un preavviso pendente (per gestire delete/reset). `last_sign_in_at`
+  // vive in `auth.users` (schema auth di Supabase): la connessione diretta
+  // Postgres (non PostgREST) la legge senza problemi di RLS.
+  let rows: CandidateRow[];
+  try {
+    const result = await db.execute<CandidateRow>(sql`
+      SELECT
+        p.auth_user_id AS auth_user_id,
+        p.email AS email,
+        p.first_name AS first_name,
+        p.plan AS plan,
+        p.plan_expires_at AS plan_expires_at,
+        p.inactivity_warning_sent_at AS inactivity_warning_sent_at,
+        GREATEST(
+          p.created_at,
+          COALESCE(u.last_sign_in_at, p.created_at),
+          COALESCE(d.last_doc_at, p.created_at)
+        ) AS last_activity_at
+      FROM profiles p
+      LEFT JOIN auth.users u ON u.id = p.auth_user_id
+      LEFT JOIN (
+        SELECT b.profile_id AS profile_id, MAX(cd.created_at) AS last_doc_at
+        FROM businesses b
+        JOIN commercial_documents cd ON cd.business_id = b.id
+        GROUP BY b.profile_id
+      ) d ON d.profile_id = p.id
+      WHERE
+        GREATEST(
+          p.created_at,
+          COALESCE(u.last_sign_in_at, p.created_at),
+          COALESCE(d.last_doc_at, p.created_at)
+        ) < ${warnCutoff.toISOString()}::timestamptz
+        OR p.inactivity_warning_sent_at IS NOT NULL
+    `);
+    rows = result as unknown as CandidateRow[];
+  } catch (err) {
+    logger.error({ err }, "pruneInactiveUsers: query candidati fallita");
+    return { warned: 0, deleted: 0, reset: 0 };
+  }
+
+  let warned = 0;
+  let deleted = 0;
+  let reset = 0;
+  const loginUrl = safeLoginUrl();
+
+  for (const row of rows) {
+    try {
+      const lastActivity = toDate(row.last_activity_at);
+      if (!lastActivity) continue;
+      const planExpiresAt = toDate(row.plan_expires_at);
+      const warningSentAt = toDate(row.inactivity_warning_sent_at);
+      const protectedNow = isProtectedFromPrune(row.plan, planExpiresAt, nowMs);
+      const inactivePastWarn = lastActivity < warnCutoff;
+
+      // RESET: preavvisato ma non più eleggibile (tornato attivo o protetto).
+      if (warningSentAt && (!inactivePastWarn || protectedNow)) {
+        await setWarningSentAt(row.auth_user_id, null);
+        reset++;
+        continue;
+      }
+
+      if (protectedNow) continue;
+
+      // DELETE: 12 mesi di inattività + preavviso inviato ≥ warnBeforeDays fa.
+      if (
+        lastActivity < deleteCutoff &&
+        warningSentAt &&
+        warningSentAt <= warnGraceCutoff
+      ) {
+        const { authDeleted } = await purgeUserById(row.auth_user_id);
+        if (authDeleted) {
+          deleted++;
+          void sendEmail({
+            to: row.email,
+            subject: "Il tuo account ScontrinoZero è stato eliminato",
+            react: createElement(AccountInactivityDeletionEmail, {
+              email: row.email,
+            }),
+          }).catch((err) =>
+            logger.warn(
+              { err },
+              "pruneInactiveUsers: email conferma cancellazione fallita",
+            ),
+          );
+        }
+        continue;
+      }
+
+      // WARN: inattivo oltre la soglia di preavviso, nessun avviso pendente.
+      if (inactivePastWarn && !warningSentAt) {
+        const deletionDate = new Date(
+          nowMs + config.warnBeforeDays * MS_PER_DAY,
+        );
+        await sendEmail({
+          to: row.email,
+          subject:
+            "Il tuo account ScontrinoZero sta per essere eliminato per inattività",
+          react: createElement(AccountInactivityWarningEmail, {
+            firstName: row.first_name ?? "",
+            deletionDate,
+            loginUrl,
+          }),
+        });
+        await setWarningSentAt(row.auth_user_id, now);
+        warned++;
+      }
+    } catch (err) {
+      logger.warn(
+        { err },
+        "pruneInactiveUsers: elaborazione utente fallita (batch continua)",
+      );
+    }
+  }
+
+  if (warned > 0 || deleted > 0 || reset > 0) {
+    logger.info(
+      { warned, deleted, reset },
+      "pruneInactiveUsers: sweep completato",
+    );
+  }
+
+  return { warned, deleted, reset };
+}
+
+/** URL di login per la CTA dell'email di preavviso; degrada al dominio prod. */
+function safeLoginUrl(): string {
+  try {
+    return `${getTrustedAppUrl()}/login`;
+  } catch {
+    return "https://app.scontrinozero.it/login";
+  }
+}

--- a/src/lib/services/purge-user.test.ts
+++ b/src/lib/services/purge-user.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockDeleteReturning = vi.fn();
+vi.mock("@/db", () => ({
+  getDb: vi.fn().mockReturnValue({
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: mockDeleteReturning,
+      }),
+    }),
+  }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  profiles: { authUserId: "auth_user_id" },
+}));
+
+const mockAdminDeleteUser = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminSupabaseClient: vi.fn().mockReturnValue({
+    auth: { admin: { deleteUser: mockAdminDeleteUser } },
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const USER_ID = "user-123";
+
+describe("purgeUserById", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdminDeleteUser.mockResolvedValue({ error: null });
+    mockDeleteReturning.mockResolvedValue([{ id: "profile-1" }]);
+  });
+
+  it("cancella auth PRIMA del profilo e ritorna authDeleted+profileDeleted", async () => {
+    const order: string[] = [];
+    mockAdminDeleteUser.mockImplementation(async () => {
+      order.push("auth");
+      return { error: null };
+    });
+    mockDeleteReturning.mockImplementation(async () => {
+      order.push("profile");
+      return [{ id: "profile-1" }];
+    });
+
+    const { purgeUserById } = await import("./purge-user");
+    const result = await purgeUserById(USER_ID);
+
+    expect(mockAdminDeleteUser).toHaveBeenCalledWith(USER_ID);
+    expect(order).toEqual(["auth", "profile"]);
+    expect(result).toEqual({ authDeleted: true, profileDeleted: true });
+  });
+
+  it("ritenta la delete auth fino a 3 volte poi si arrende (profilo intatto)", async () => {
+    vi.useFakeTimers();
+    mockAdminDeleteUser.mockResolvedValue({ error: { message: "boom" } });
+
+    const { purgeUserById } = await import("./purge-user");
+    const promise = purgeUserById(USER_ID);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(mockAdminDeleteUser).toHaveBeenCalledTimes(3);
+    expect(mockDeleteReturning).not.toHaveBeenCalled();
+    expect(result).toEqual({ authDeleted: false, profileDeleted: false });
+    vi.useRealTimers();
+  });
+
+  it("smette di ritentare appena la delete auth riesce", async () => {
+    vi.useFakeTimers();
+    mockAdminDeleteUser
+      .mockResolvedValueOnce({ error: { message: "transient" } })
+      .mockResolvedValueOnce({ error: null });
+
+    const { purgeUserById } = await import("./purge-user");
+    const promise = purgeUserById(USER_ID);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(mockAdminDeleteUser).toHaveBeenCalledTimes(2);
+    expect(result.authDeleted).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("ritorna profileDeleted:false e logga se il profilo non esiste", async () => {
+    mockDeleteReturning.mockResolvedValue([]);
+
+    const { purgeUserById } = await import("./purge-user");
+    const { logger } = await import("@/lib/logger");
+    const result = await purgeUserById(USER_ID);
+
+    expect(result).toEqual({ authDeleted: true, profileDeleted: false });
+    expect(logger.error).toHaveBeenCalledWith(
+      { userId: USER_ID },
+      expect.stringContaining("profile not found"),
+    );
+  });
+
+  it("logga error critico se la delete profilo lancia dopo la delete auth", async () => {
+    mockDeleteReturning.mockRejectedValue(new Error("DB lost"));
+
+    const { purgeUserById } = await import("./purge-user");
+    const { logger } = await import("@/lib/logger");
+    const result = await purgeUserById(USER_ID);
+
+    expect(result).toEqual({ authDeleted: true, profileDeleted: false });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ critical: true, userId: USER_ID }),
+      expect.stringContaining("manual cleanup"),
+    );
+  });
+});

--- a/src/lib/services/purge-user.ts
+++ b/src/lib/services/purge-user.ts
@@ -1,0 +1,89 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "@/db";
+import { profiles } from "@/db/schema";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+/** Numero massimo di tentativi per la delete dell'auth user (admin API). */
+export const MAX_AUTH_DELETE_ATTEMPTS = 3;
+
+export type PurgeUserResult = {
+  /** true se l'auth user è stato rimosso (dopo eventuali retry). */
+  authDeleted: boolean;
+  /** true se la riga `profiles` (e la sua cascata FK) è stata rimossa. */
+  profileDeleted: boolean;
+};
+
+/**
+ * Cancella in modo permanente un auth user e tutta la cascata dati collegata,
+ * dato il suo `authUserId`.
+ *
+ * Cascata (via FK in 0000_initial.sql):
+ *   profiles → businesses → ade_credentials
+ *                         → commercial_documents → commercial_document_lines
+ *                         → catalog_items
+ *
+ * Ordine auth-first: l'auth user è cancellato PRIMA della riga applicativa, con
+ * retry + backoff. Se la delete auth fallisce dopo i retry, `profiles` resta
+ * intatto e si ritorna `{ authDeleted: false }` — il chiamante può ripresentare
+ * un errore all'utente o ritentare più tardi. Se la delete auth riesce ma la
+ * delete di `profiles` fallisce, si logga un `error` critico (profilo orfano →
+ * cleanup manuale) e si ritorna `{ authDeleted: true, profileDeleted: false }`:
+ * il chiamante NON deve trattarlo come hard failure, perché l'utente non può
+ * più autenticarsi comunque.
+ *
+ * Condiviso tra `deleteAccount` (self-service, src/server/account-actions.ts) e
+ * lo sweep GDPR di cancellazione inattivi (src/lib/services/inactive-user-prune.ts).
+ * Non emette email né gestisce sessione/redirect: quelle sono responsabilità
+ * del chiamante, che differisce per contesto.
+ */
+export async function purgeUserById(
+  authUserId: string,
+): Promise<PurgeUserResult> {
+  // 1. Delete auth user via admin API (service role). Retry con backoff.
+  const adminClient = createAdminSupabaseClient();
+  let deleteAuthError: Error | null = null;
+  for (let attempt = 1; attempt <= MAX_AUTH_DELETE_ATTEMPTS; attempt++) {
+    const { error } = await adminClient.auth.admin.deleteUser(authUserId);
+    if (!error) {
+      deleteAuthError = null;
+      break;
+    }
+    deleteAuthError = error;
+    if (attempt < MAX_AUTH_DELETE_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 500));
+    }
+  }
+  if (deleteAuthError) {
+    logger.error(
+      { userId: authUserId, err: deleteAuthError, critical: true },
+      "purgeUserById: auth user deletion failed after retries — account not deleted",
+    );
+    return { authDeleted: false, profileDeleted: false };
+  }
+
+  // 2. Delete profile — FK cascade rimuove tutto il collegato. L'auth entry è
+  //    già andata: un fallimento qui lascia un profilo orfano da pulire a mano.
+  const db = getDb();
+  try {
+    const deleted = await db
+      .delete(profiles)
+      .where(eq(profiles.authUserId, authUserId))
+      .returning({ id: profiles.id });
+
+    if (deleted.length === 0) {
+      logger.error(
+        { userId: authUserId },
+        "purgeUserById: auth user deleted but profile not found",
+      );
+      return { authDeleted: true, profileDeleted: false };
+    }
+    return { authDeleted: true, profileDeleted: true };
+  } catch (err) {
+    logger.error(
+      { userId: authUserId, err, critical: true },
+      "purgeUserById: profile deletion failed after auth user removed — manual cleanup required",
+    );
+    return { authDeleted: true, profileDeleted: false };
+  }
+}

--- a/src/server/account-actions.ts
+++ b/src/server/account-actions.ts
@@ -2,16 +2,13 @@
 
 import { createElement } from "react";
 import { redirect } from "next/navigation";
-import { eq } from "drizzle-orm";
-import { getDb } from "@/db";
-import { profiles } from "@/db/schema";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { getAuthenticatedUser } from "@/lib/server-auth";
 import { authErrorResult } from "@/lib/auth-errors";
 import { sendEmail } from "@/lib/email";
 import { AccountDeletionEmail } from "@/emails/account-deletion";
+import { purgeUserById } from "@/lib/services/purge-user";
 
 export type AccountActionResult = {
   error?: string;
@@ -20,15 +17,10 @@ export type AccountActionResult = {
 /**
  * Permanently deletes the authenticated user's account and all associated data.
  *
- * Deletion cascade (via FK constraints in 0000_initial.sql):
- *   profiles → businesses → ade_credentials
- *                         → commercial_documents → commercial_document_lines
- *                         → catalog_items
- *
- * Order: auth user is deleted FIRST so that if it fails we can return an error
- * without having touched any application data. If the profile delete fails after
- * auth deletion, we log a critical error (auth entry is gone so the user cannot
- * log in again, but a profile orphan requires manual cleanup via Supabase dashboard).
+ * The actual purge (auth-first delete + profile FK cascade, with retries) lives
+ * in the shared `purgeUserById` helper, reused by the GDPR inactive-user prune
+ * sweep. This action wraps it with the session-specific concerns: auth gate,
+ * sign-out, confirmation email and redirect.
  */
 export async function deleteAccount(): Promise<AccountActionResult> {
   let user;
@@ -38,67 +30,17 @@ export async function deleteAccount(): Promise<AccountActionResult> {
     return authErrorResult(err, "deleteAccount");
   }
 
-  // 1. Delete auth user via admin API first (service role key).
-  //    Retry up to 3 times with exponential backoff. If all retries fail, return
-  //    an error — the profile is still intact so the user can log in and retry.
-  //    Supabase automatically invalidates all sessions when the auth user is
-  //    removed, so an explicit signOut before deletion is not needed here.
-  const adminClient = createAdminSupabaseClient();
-  let deleteAuthError: Error | null = null;
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    const { error } = await adminClient.auth.admin.deleteUser(user.id);
-    if (!error) {
-      deleteAuthError = null;
-      break;
-    }
-    deleteAuthError = error;
-    if (attempt < 3) {
-      await new Promise((resolve) => setTimeout(resolve, attempt * 500));
-    }
-  }
-  if (deleteAuthError) {
-    // All retries exhausted. Profile is still intact — the user can log in
-    // and retry the deletion later.
-    logger.error(
-      { userId: user.id, err: deleteAuthError, critical: true },
-      "deleteAccount: auth user deletion failed after retries — account not deleted",
-    );
+  // 1-2. Delete auth user (retry) then the profile cascade. If the auth delete
+  //      fails after retries the profile is untouched → surface an error so the
+  //      user can log in and retry. If auth succeeded but the profile delete
+  //      failed, purgeUserById has already logged a critical error; we still
+  //      proceed to sign out/redirect because the user can no longer log in.
+  const { authDeleted } = await purgeUserById(user.id);
+  if (!authDeleted) {
     return {
       error:
         "Eliminazione account fallita. Riprova oppure contatta il supporto.",
     };
-  }
-
-  // 2. Delete profile — FK cascade removes everything linked to this user.
-  //    Auth entry is already gone at this point. If this fails (transient DB error
-  //    or row not found), we log a critical error and continue to redirect:
-  //    the user can no longer log in (auth is gone) so returning { error } would
-  //    leave them stranded. Manual cleanup: DELETE FROM profiles WHERE
-  //    auth_user_id = '<userId>' in Supabase dashboard.
-  const db = getDb();
-  try {
-    const deleted = await db
-      .delete(profiles)
-      .where(eq(profiles.authUserId, user.id))
-      .returning({ id: profiles.id });
-
-    if (deleted.length === 0) {
-      // Auth deleted but no profile found — already partially cleaned up or
-      // profile was never created. Log for awareness.
-      logger.error(
-        { userId: user.id },
-        "deleteAccount: auth user deleted but profile not found",
-      );
-    }
-  } catch (err) {
-    // Auth is already deleted — the user cannot log in. The profile is now
-    // orphaned and requires manual cleanup. Log critical so ops are alerted.
-    logger.error(
-      { userId: user.id, err, critical: true },
-      "deleteAccount: profile deletion failed after auth user removed — manual cleanup required",
-    );
-    // Do not return { error } here: the user's auth entry is gone, so they
-    // cannot retry via the UI. Redirect so they are cleanly signed out.
   }
 
   // 3. Sign out current session (best-effort: auth user is already deleted;

--- a/supabase/migrations/0026_profiles_inactivity_warning.sql
+++ b/supabase/migrations/0026_profiles_inactivity_warning.sql
@@ -1,0 +1,19 @@
+-- Migration: 0026_profiles_inactivity_warning
+-- Timestamp preavviso cancellazione GDPR utenti inattivi (PLAN.md v1.x → v1.4.2).
+--
+-- La cancellazione automatica degli account inattivi >12 mesi (minimizzazione
+-- dati GDPR, base legale: art. 5(1)(e) GDPR) richiede una fase di PREAVVISO:
+-- l'utente riceve un'email di avviso ≥30 giorni prima della cancellazione.
+-- `inactivity_warning_sent_at` traccia QUANDO il preavviso è stato inviato, così
+-- lo sweep periodico (src/lib/services/inactive-user-prune.ts) può:
+--   - cancellare solo se il preavviso è partito ≥30 giorni fa (grace period);
+--   - azzerare il flag se l'utente torna attivo (nuovo scontrino o login),
+--     garantendo un nuovo preavviso completo prima di una futura cancellazione.
+--
+-- NULL = nessun preavviso pendente. Nessun backfill: i profili esistenti
+-- nascono a NULL e verranno preavvisati solo se/quando diventano inattivi.
+--
+-- Solo ADD COLUMN IF NOT EXISTS → idempotente al re-run.
+
+ALTER TABLE "profiles"
+  ADD COLUMN IF NOT EXISTS "inactivity_warning_sent_at" timestamptz;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1780099209000,
       "tag": "0025_profiles_onboarding_tour_seen",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1780099210000,
+      "tag": "0026_profiles_inactivity_warning",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Sweep in-process opt-in che preavvisa via email e cancella gli account
inattivi da oltre 12 mesi (minimizzazione dati GDPR, art. 5(1)(e)).

- Inattività = MAX(ultimo scontrino, last_sign_in_at, profiles.created_at)
- Due fasi: preavviso email ≥30 giorni prima, poi cancellazione cascata
- Reset del preavviso se l'utente torna attivo o diventa protetto
- Esclusi: unlimited e abbonati a pagamento attivi (isProtectedFromPrune)
- Config runtime via env INACTIVE_USER_PRUNE_* (default OFF, opt-in)
- Sweep setInterval unref'd in instrumentation.ts, stesso pattern del
  keep-alive Supabase e dello sweep webhook Stripe
- purgeUserById estratto e condiviso con deleteAccount (self-service)
- Migration 0026: colonna profiles.inactivity_warning_sent_at

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwuVcMbjeT1Jar5DTcWf9V