### PR TITLE
ci(actions): pin audit-ci, unifica pipeline deploy, dedupe setup e token minimi

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -1,0 +1,26 @@
+name: Setup Node + dependencies
+description: >
+  Blocco condiviso dai job lint/type-check/test/build di ci.yml:
+  setup-node 22 con cache npm, cache di node_modules keyed sul lockfile,
+  npm ci solo su cache miss. Il checkout resta nel workflow chiamante
+  (una composite action non può fare checkout di sé stessa).
+  NB: una modifica qui ri-triggera i job code via il filtro `config`
+  ('.github/actions/**') del job `changes`.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 22
+        cache: npm
+    - name: Cache node_modules
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
+      id: nm-cache
+      with:
+        path: node_modules
+        key: nm-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+    - name: Install dependencies
+      if: steps.nm-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,21 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Token minimo per tutti i job (default repo più largo del necessario).
+# secret-scan riottiene pull-requests: write per i commenti di gitleaks.
+permissions:
+  contents: read
+
 jobs:
   # Smart skip: only run if relevant files changed
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      # dorny/paths-filter lista i file delle PR via API: senza questo,
+      # col blocco permissions workflow-level il job fallirebbe sulle PR.
+      pull-requests: read
     outputs:
       code: ${{ steps.agg.outputs.code }}
       marketing: ${{ steps.f.outputs.marketing }}
@@ -46,6 +56,7 @@ jobs:
               - 'eslint.config.mjs'
               - 'scripts/**'
               - '.github/workflows/ci.yml'
+              - '.github/actions/**'
             lockfile:
               - 'package-lock.json'
             migrations:
@@ -148,6 +159,9 @@ jobs:
   secret-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -175,7 +189,11 @@ jobs:
       - name: Run actionlint
         run: ${{ steps.get_actionlint.outputs.executable }} -color
 
-  # Audit dipendenze — gira anche su modifiche al solo lockfile
+  # Audit dipendenze — gira anche su modifiche al solo lockfile.
+  # audit-ci legge package-lock.json e interroga il registry npm: non gli
+  # serve node_modules, quindi niente npm ci / cache. Versione pinnata
+  # (un `npx audit-ci` nudo scaricherebbe l'ultima a ogni run — incoerente
+  # col pinning SHA delle action, proprio sul job di security audit).
   audit:
     needs: changes
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.lockfile == 'true'
@@ -186,18 +204,8 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
-        id: nm-cache
-        with:
-          path: node_modules
-          key: nm-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline --no-audit --no-fund
       - name: Security audit
-        run: npx audit-ci --config audit-ci.json
+        run: npx --yes audit-ci@7.1.0 --config audit-ci.json
 
   # Parallel checks — lint, type-check e test girano in contemporanea.
   # lint e type-check girano anche su marketing-only (catturano refusi JSX/TS).
@@ -208,19 +216,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
-        id: nm-cache
-        with:
-          path: node_modules
-          key: nm-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline --no-audit --no-fund
+      - uses: ./.github/actions/setup-deps
       - name: Lint
         run: npm run lint
 
@@ -231,19 +227,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
-        id: nm-cache
-        with:
-          path: node_modules
-          key: nm-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline --no-audit --no-fund
+      - uses: ./.github/actions/setup-deps
       - name: Type check
         run: npm run type-check
 
@@ -257,19 +241,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
-        id: nm-cache
-        with:
-          path: node_modules
-          key: nm-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline --no-audit --no-fund
+      - uses: ./.github/actions/setup-deps
       - name: Test with coverage
         run: npm run test:coverage
       - name: Upload coverage report
@@ -349,19 +321,7 @@ jobs:
       NEXT_PUBLIC_APP_URL: "http://localhost:3000"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.4
-        id: nm-cache
-        with:
-          path: node_modules
-          key: nm-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline --no-audit --no-fund
+      - uses: ./.github/actions/setup-deps
       # Cache incrementale di Next.js (pattern ufficiale): key esatta su
       # lockfile+sorgenti, restore-key di fallback sul solo lockfile così
       # ogni build riparte dalla cache più recente compatibile.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,6 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IMAGE_ARTIFACT_NAME: docker-image
-  IMAGE_ARCHIVE_PATH: /tmp/scontrinozero-image.tar
 
 jobs:
   check-ci:
@@ -60,12 +58,24 @@ jobs:
               core.info(`All ${ciChecks.length} CI checks passed on ${sha.substring(0, 7)}`);
             }
 
-  build-image:
+  # Build → smoke test → Trivy → push in un unico job: l'immagine buildata
+  # resta nel daemon Docker locale, senza il round-trip docker save →
+  # upload-artifact → download → load (×2) e senza due runner spin-up
+  # intermedi della precedente catena build-image → smoke-test → push-image.
+  # I gate restano gli stessi, in sequenza: il push su GHCR avviene solo se
+  # l'health probe del container e lo scan Trivy passano.
+  build-smoke-push:
     needs: [check-ci]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     permissions:
       contents: read
+      packages: write
+    env:
+      # Opt into Node.js 24 runtime now; trivy-action@v0.35.0 pins
+      # actions/cache@v4.2.4 (node20) internally — force node24 until
+      # trivy-action ships a release that depends on actions/cache@v5.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -101,49 +111,18 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Export built image archive
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          docker save \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
-            --output "${IMAGE_ARCHIVE_PATH}"
-
-      - name: Upload built image archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ${{ env.IMAGE_ARTIFACT_NAME }}
-          path: ${{ env.IMAGE_ARCHIVE_PATH }}
-          retention-days: 1
-
-  smoke-test:
-    needs: [build-image]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
-      SUPABASE_SECRET_KEY: ${{ secrets.TEST_SUPABASE_SECRET_KEY }}
-      DATABASE_URL: "postgresql://smoke:smoke@localhost:5432/smoke"
-      ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY }}
-      ENCRYPTION_KEY_VERSION: "1"
-      SKIP_MIGRATIONS: "true"
-      ADE_MODE: "mock"
-      NEXT_PUBLIC_APP_URL: "http://localhost:3000"
-      TURNSTILE_SECRET_KEY: "1x0000000000000000000000000000000AA"
-    steps:
-      - name: Download built image archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ env.IMAGE_ARTIFACT_NAME }}
-          path: /tmp
-
-      - name: Load built image
-        run: docker load --input "${IMAGE_ARCHIVE_PATH}"
-
-      - name: Start container
+      - name: Smoke test — start container
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.TEST_NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.TEST_SUPABASE_SECRET_KEY }}
+          DATABASE_URL: "postgresql://smoke:smoke@localhost:5432/smoke"
+          ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY }}
+          ENCRYPTION_KEY_VERSION: "1"
+          SKIP_MIGRATIONS: "true"
+          ADE_MODE: "mock"
+          NEXT_PUBLIC_APP_URL: "http://localhost:3000"
+          TURNSTILE_SECRET_KEY: "1x0000000000000000000000000000000AA"
         run: |
           docker run -d \
             --name scontrinozero-smoke \
@@ -160,7 +139,7 @@ jobs:
             -e TURNSTILE_SECRET_KEY \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
-      - name: Wait for container health
+      - name: Smoke test — wait for container health
         run: |
           for i in $(seq 1 60); do
             status="$(docker inspect --format='{{.State.Status}}' scontrinozero-smoke 2>/dev/null || true)"
@@ -181,31 +160,9 @@ jobs:
         if: failure()
         run: docker logs scontrinozero-smoke || true
 
-      - name: Stop container
+      - name: Stop smoke container
         if: always()
         run: docker rm -f scontrinozero-smoke || true
-
-  push-image:
-    needs: [build-image, smoke-test]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      packages: write
-    env:
-      # Opt into Node.js 24 runtime now; trivy-action@v0.35.0 pins
-      # actions/cache@v4.2.4 (node20) internally — force node24 until
-      # trivy-action ships a release that depends on actions/cache@v5.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-    steps:
-      - name: Download built image archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ env.IMAGE_ARTIFACT_NAME }}
-          path: /tmp
-
-      - name: Load built image archive
-        run: docker load --input "${IMAGE_ARCHIVE_PATH}"
 
       - name: Set image ref
         id: image-ref

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -16,10 +19,8 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
+      # audit-ci legge package-lock.json e interroga il registry npm:
+      # niente npm ci. Versione pinnata, come nel job audit di ci.yml.
       - name: Security audit
-        run: npx audit-ci --config audit-ci.json
+        run: npx --yes audit-ci@7.1.0 --config audit-ci.json


### PR DESCRIPTION
## Contesto

Review delle GitHub Actions incrociata coi tempi reali dei run (CI su PR: ~3 min, deploy taggato v1.4.1: ~7,5 min). I workflow erano già ben ottimizzati (path filtering, cache nm/Next/Sonar, ARM nativo, SHA pinning): questa PR sistema i tre punti rimasti, concordati in sessione.

## Modifiche

### 1. audit-ci pinnato + job audit snelliti
- `audit-ci` non era in `package.json` né nel lockfile: `npx audit-ci` scaricava **l'ultima versione dal registry a ogni run** — incoerente col pinning SHA usato ovunque, proprio sul job di security audit. Ora pinnato: `npx --yes audit-ci@7.1.0`.
- audit-ci legge solo `package-lock.json` e interroga il registry npm: rimossi `npm ci` + cache node_modules dal job `audit` di ci.yml (~15s) e dal run settimanale `scheduled-audit.yml` (~1-2 min, non aveva nemmeno la cache).
- Verificato in locale: `npx --yes audit-ci@7.1.0 --config audit-ci.json` → "Passed npm security audit".

### 2. deploy.yml: pipeline unificata
`build-image → smoke-test → push-image` erano tre job seriali che si passavano l'immagine via `docker save` + artifact (1 upload + 2 download + 2 load) e due runner spin-up intermedi (~40-60s misurati su 7,5 min). Fusi in un unico job `build-smoke-push`: l'immagine resta nel daemon Docker locale, **i gate restano identici e nello stesso ordine** (health probe del container → Trivy → push su GHCR con retry). `check-ci` resta invariato come gate iniziale. −80 righe di plumbing.

### 3. ci.yml: composite action + token minimi
- Il blocco checkout+setup-node+cache+install era duplicato 5×: estratto in `.github/actions/setup-deps` (usato da lint, type-check, test, build). Il path `.github/actions/**` è aggiunto al filtro `config` del job `changes`, così una modifica alla composite ri-triggera i job code.
- `permissions: contents: read` a livello workflow (prima nessun blocco → default repo più largo), con override per-job: `changes` riottiene `pull-requests: read` (dorny/paths-filter lista i file delle PR via API), `secret-scan` riottiene `pull-requests: write` (commenti gitleaks). Stesso hardening su scheduled-audit.yml.

## Escluso di proposito
- Parallelizzare `build` coi test in CI (valutato, scartato in sessione: si preferisce il fail-fast).
- Sharding vitest, cache actionlint, tuning `cache: npm` di setup-node: costo/beneficio non giustificato.

## Verifiche
- YAML parse + invarianti strutturali (ordine step deploy, uso composite, `shell` sugli step `run` della composite) ✅
- `npm run arch:check` ✅
- `npx --yes audit-ci@7.1.0 --config audit-ci.json` in locale ✅
- actionlint: il binario non è scaricabile dall'ambiente remoto (proxy 403 sugli asset GitHub releases), ma il job `actionlint` della CI gira su questa PR (il filtro `workflows` matcha) — da verificare verde qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f8m6gXd3hquNtwyB2tuxH

---
_Generated by [Claude Code](https://claude.ai/code/session_019f8m6gXd3hquNtwyB2tuxH)_