### PR TITLE
feat(ade): onboarding multi-metodo con accesso CIE (SPID escluso)

### DIFF
--- a/scripts/rotate-encryption-key.ts
+++ b/scripts/rotate-encryption-key.ts
@@ -111,27 +111,22 @@ export async function rotateEncryptionKey(opts: {
           continue;
         }
 
-        // Decrypt with old key
+        // Decrypt+re-encrypt ogni campo presente. I campi encrypted* sono
+        // nullable (migrazione 0027): CIE valorizza username+password, SPID
+        // nessuno. Un campo NULL resta NULL.
         const oldKeys = new Map<number, Buffer>([[oldVersion, oldKeyBuf]]);
-        const codiceFiscale = decrypt(row.encryptedCodiceFiscale, oldKeys);
-        const password = decrypt(row.encryptedPassword, oldKeys);
-        const pin = decrypt(row.encryptedPin, oldKeys);
-
-        // Re-encrypt with new key
-        const encryptedCodiceFiscale = encrypt(
-          codiceFiscale,
-          newKeyBuf,
-          newVersion,
-        );
-        const encryptedPassword = encrypt(password, newKeyBuf, newVersion);
-        const encryptedPin = encrypt(pin, newKeyBuf, newVersion);
+        const reEncrypt = (value: string | null): string | null =>
+          value === null
+            ? null
+            : encrypt(decrypt(value, oldKeys), newKeyBuf, newVersion);
 
         await tx
           .update(schema.adeCredentials)
           .set({
-            encryptedCodiceFiscale,
-            encryptedPassword,
-            encryptedPin,
+            encryptedCodiceFiscale: reEncrypt(row.encryptedCodiceFiscale),
+            encryptedUsername: reEncrypt(row.encryptedUsername),
+            encryptedPassword: reEncrypt(row.encryptedPassword),
+            encryptedPin: reEncrypt(row.encryptedPin),
             keyVersion: newVersion,
           })
           .where(eq(schema.adeCredentials.id, row.id));

--- a/scripts/rotate-encryption-key.ts
+++ b/scripts/rotate-encryption-key.ts
@@ -113,10 +113,10 @@ export async function rotateEncryptionKey(opts: {
 
         // Decrypt+re-encrypt ogni campo presente. I campi encrypted* sono
         // nullable (migrazione 0027): CIE valorizza username+password, SPID
-        // nessuno. Un campo NULL resta NULL.
+        // nessuno. Un campo assente (NULL/undefined) resta NULL.
         const oldKeys = new Map<number, Buffer>([[oldVersion, oldKeyBuf]]);
-        const reEncrypt = (value: string | null): string | null =>
-          value === null
+        const reEncrypt = (value: string | null | undefined): string | null =>
+          value == null
             ? null
             : encrypt(decrypt(value, oldKeys), newKeyBuf, newVersion);
 

--- a/src/app/api/v1/receipts/[id]/void/route.ts
+++ b/src/app/api/v1/receipts/[id]/void/route.ts
@@ -67,6 +67,18 @@ export async function POST(
     auth.apiKey.id,
   );
 
+  if (result.reauthRequired) {
+    return withCors(
+      Response.json(
+        {
+          error:
+            "Sessione AdE (CIE) scaduta: ricollegati dall'app web ScontrinoZero prima di riprovare.",
+        },
+        { status: 409 },
+      ),
+    );
+  }
+
   if (result.error) {
     return serviceErrorResponse({ error: result.error, code: result.code });
   }

--- a/src/app/api/v1/receipts/route.ts
+++ b/src/app/api/v1/receipts/route.ts
@@ -91,6 +91,20 @@ export async function POST(request: Request): Promise<Response> {
   // ── Emit ──────────────────────────────────────────────────────────────────
   const result = await emitReceiptForBusiness(input, auth.apiKey.id);
 
+  if (result.reauthRequired) {
+    // Sessione AdE interattiva (CIE) scaduta: richiede un ri-collegamento
+    // dall'app web (secondo fattore umano), non automatizzabile via API.
+    return withCors(
+      Response.json(
+        {
+          error:
+            "Sessione AdE (CIE) scaduta: ricollegati dall'app web ScontrinoZero prima di riprovare.",
+        },
+        { status: 409 },
+      ),
+    );
+  }
+
   if (result.error) {
     return serviceErrorResponse({ error: result.error, code: result.code });
   }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -17,6 +17,7 @@ import { AccountDeleteSection } from "@/components/settings/account-delete-secti
 import { ExportDataSection } from "@/components/settings/export-data-section";
 import { AdeCredentialsSection } from "@/components/settings/ade-credentials-section";
 import { EditAdeCredentialsSection } from "@/components/settings/edit-ade-credentials-section";
+import type { AdeLoginMethod } from "@/lib/ade/types";
 import { EditProfileSection } from "@/components/settings/edit-profile-section";
 import { EditBusinessSection } from "@/components/settings/edit-business-section";
 import { ChangePasswordSection } from "@/components/settings/change-password-section";
@@ -104,7 +105,10 @@ export default async function SettingsPage({
   const cred = business
     ? ((
         await db
-          .select({ verifiedAt: adeCredentials.verifiedAt })
+          .select({
+            verifiedAt: adeCredentials.verifiedAt,
+            loginMethod: adeCredentials.loginMethod,
+          })
           .from(adeCredentials)
           .where(eq(adeCredentials.businessId, business.id))
           .limit(1)
@@ -286,7 +290,13 @@ export default async function SettingsPage({
             <CardHeader className="flex flex-row items-center justify-between">
               <CardTitle>Credenziali AdE</CardTitle>
               {business && (
-                <EditAdeCredentialsSection businessId={business.id} />
+                <EditAdeCredentialsSection
+                  businessId={business.id}
+                  currentMethod={
+                    (cred?.loginMethod as AdeLoginMethod | undefined) ??
+                    "fisconline"
+                  }
+                />
               )}
             </CardHeader>
             <CardContent>

--- a/src/app/onboarding/onboarding-form.tsx
+++ b/src/app/onboarding/onboarding-form.tsx
@@ -58,8 +58,15 @@ const step2Schema = z.object({
   pin: adePinSchema,
 });
 
+const cieSchema = z.object({
+  username: z.email("Inserisci l'email dell'app CIE ID."),
+  password: z.string().min(1, "La password CIE è obbligatoria."),
+});
+
+type AdeMethod = "fisconline" | "cie";
 type Step1Data = z.infer<typeof step1Schema>;
 type Step2Data = z.infer<typeof step2Schema>;
+type CieData = z.infer<typeof cieSchema>;
 
 function StepIndicator({ current }: Readonly<{ current: number }>) {
   return (
@@ -132,6 +139,13 @@ export function OnboardingForm({
     defaultValues: { codiceFiscale: "", password: "", pin: "" },
   });
 
+  // Metodo di accesso AdE: Fisconline è il default; "Altre opzioni" rivela CIE.
+  const [method, setMethod] = useState<AdeMethod>("fisconline");
+  const cieForm = useForm<CieData>({
+    resolver: zodResolver(cieSchema),
+    defaultValues: { username: "", password: "" },
+  });
+
   function handleBusinessSubmit(data: Step1Data) {
     const formData = objectToFormData({ ...data, nation: "IT" });
 
@@ -148,12 +162,34 @@ export function OnboardingForm({
 
   function handleCredentialsSubmit(data: Step2Data) {
     if (!businessId) return;
-    const formData = objectToFormData({ businessId, ...data });
+    const formData = objectToFormData({
+      businessId,
+      loginMethod: "fisconline",
+      ...data,
+    });
 
     startTransition(async () => {
       const result = await saveAdeCredentials(formData);
       if (result.error) {
         step2Form.setError("root", { message: result.error });
+        return;
+      }
+      setStep(2);
+    });
+  }
+
+  function handleCieSubmit(data: CieData) {
+    if (!businessId) return;
+    const formData = objectToFormData({
+      businessId,
+      loginMethod: "cie",
+      ...data,
+    });
+
+    startTransition(async () => {
+      const result = await saveAdeCredentials(formData);
+      if (result.error) {
+        cieForm.setError("root", { message: result.error });
         return;
       }
       setStep(2);
@@ -306,7 +342,7 @@ export function OnboardingForm({
             </Form>
           )}
 
-          {step === 1 && (
+          {step === 1 && method === "fisconline" && (
             <Form {...step2Form}>
               <form
                 onSubmit={step2Form.handleSubmit(handleCredentialsSubmit)}
@@ -372,6 +408,72 @@ export function OnboardingForm({
                     {isPending ? "Salvataggio…" : "Continua"}
                   </Button>
                 </div>
+
+                <button
+                  type="button"
+                  onClick={() => setMethod("cie")}
+                  className="text-muted-foreground hover:text-foreground w-full text-center text-sm underline underline-offset-2"
+                >
+                  Altre opzioni di accesso
+                </button>
+              </form>
+            </Form>
+          )}
+
+          {step === 1 && method === "cie" && (
+            <Form {...cieForm}>
+              <form
+                onSubmit={cieForm.handleSubmit(handleCieSubmit)}
+                className="space-y-4"
+                noValidate
+              >
+                <p className="text-muted-foreground text-sm">
+                  Accedi con <strong>CIE</strong> usando le credenziali
+                  dell&apos;app <strong>CIE ID</strong> (email e password). Dopo
+                  il salvataggio ti chiederemo di approvare la notifica
+                  sull&apos;app per completare il collegamento all&apos;Agenzia
+                  delle Entrate.
+                </p>
+
+                <FormInputField
+                  control={cieForm.control}
+                  name="username"
+                  label="Email dell'app CIE ID *"
+                  placeholder="La tua email registrata su CIE ID"
+                />
+
+                <FormPasswordField
+                  control={cieForm.control}
+                  name="password"
+                  label="Password CIE ID *"
+                />
+
+                {cieForm.formState.errors.root && (
+                  <p className="text-destructive text-sm" role="alert">
+                    {cieForm.formState.errors.root.message}
+                  </p>
+                )}
+
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setStep(0)}
+                  >
+                    Indietro
+                  </Button>
+                  <Button type="submit" className="flex-1" disabled={isPending}>
+                    {isPending ? "Salvataggio…" : "Continua"}
+                  </Button>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => setMethod("fisconline")}
+                  className="text-muted-foreground hover:text-foreground w-full text-center text-sm underline underline-offset-2"
+                >
+                  Usa invece le credenziali Fisconline
+                </button>
               </form>
             </Form>
           )}
@@ -379,8 +481,9 @@ export function OnboardingForm({
           {step === 2 && (
             <div className="space-y-4 text-center">
               <p className="text-muted-foreground text-sm">
-                Verifica che le credenziali funzionino effettuando un test di
-                connessione all&apos;Agenzia delle Entrate.
+                {method === "cie"
+                  ? "Avvia il test di connessione, poi approva la notifica sull'app CIE ID sul tuo telefono per completare il collegamento all'Agenzia delle Entrate."
+                  : "Verifica che le credenziali funzionino effettuando un test di connessione all'Agenzia delle Entrate."}
               </p>
 
               {verifyError && (

--- a/src/components/cassa/cassa-client.tsx
+++ b/src/components/cassa/cassa-client.tsx
@@ -125,8 +125,11 @@ export function CassaClient({
   const mutation = useMutation({
     mutationFn: emitReceipt,
     onSuccess: (result) => {
-      if (result.error) {
-        return; // Handled below via mutation.data
+      if (result.error || result.reauthRequired) {
+        // reauthRequired: sessione CIE scaduta, nessuno scontrino emesso. Non
+        // svuotare il carrello: l'utente si ricollega e riprova. Gestito nel
+        // render via mutation.data.
+        return;
       }
       clearCart();
       track(UMAMI_EVENTS.receiptEmitted);
@@ -307,6 +310,24 @@ export function CassaClient({
   if (step === "summary") {
     return (
       <div className="mx-auto max-w-sm space-y-2">
+        {mutation.data?.reauthRequired && (
+          <div
+            role="alert"
+            className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm"
+          >
+            <p>
+              {
+                "Sessione CIE scaduta. Ricollegati approvando la notifica sull'app CIE ID, poi riprova."
+              }{" "}
+              <Link
+                href="/dashboard/settings"
+                className="font-medium underline"
+              >
+                {"Ricollega ora"}
+              </Link>
+            </p>
+          </div>
+        )}
         {mutationError && (
           <div
             role="alert"

--- a/src/components/settings/edit-ade-credentials-section.test.tsx
+++ b/src/components/settings/edit-ade-credentials-section.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { EditAdeCredentialsSection } from "./edit-ade-credentials-section";
+import type { AdeLoginMethod } from "@/lib/ade/types";
+
+const mockSaveAdeCredentials = vi.fn();
+vi.mock("@/server/onboarding-actions", () => ({
+  saveAdeCredentials: (fd: FormData) => mockSaveAdeCredentials(fd),
+}));
+
+const mockRouterRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSaveAdeCredentials.mockResolvedValue({ businessId: "biz-1" });
+});
+
+function renderSection(currentMethod?: AdeLoginMethod) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <EditAdeCredentialsSection
+        businessId="biz-1"
+        currentMethod={currentMethod}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function openDialog() {
+  fireEvent.click(
+    screen.getByRole("button", { name: "Modifica credenziali AdE" }),
+  );
+}
+
+describe("EditAdeCredentialsSection", () => {
+  it("apre con Fisconline di default e mostra il campo codice fiscale", () => {
+    renderSection();
+    openDialog();
+
+    expect(screen.getByText("Codice fiscale")).toBeInTheDocument();
+    expect(screen.queryByText("Email dell'app CIE ID")).not.toBeInTheDocument();
+  });
+
+  it("il toggle CIE mostra il campo email al posto di CF/PIN", () => {
+    renderSection();
+    openDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "CIE" }));
+
+    expect(screen.getByText("Email dell'app CIE ID")).toBeInTheDocument();
+    expect(screen.queryByText("Codice fiscale")).not.toBeInTheDocument();
+  });
+
+  it("preseleziona CIE quando currentMethod è 'cie'", () => {
+    renderSection("cie");
+    openDialog();
+
+    expect(screen.getByText("Email dell'app CIE ID")).toBeInTheDocument();
+  });
+
+  it("salva con login_method 'cie' e lo username email", async () => {
+    renderSection("cie");
+    openDialog();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("La tua email registrata su CIE ID"),
+      { target: { value: "mario.rossi@example.com" } },
+    );
+    fireEvent.change(screen.getByLabelText("Password CIE ID"), {
+      target: { value: "cie-pass" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salva" }));
+
+    await waitFor(() => expect(mockSaveAdeCredentials).toHaveBeenCalled());
+    const fd = mockSaveAdeCredentials.mock.calls[0][0] as FormData;
+    expect(fd.get("loginMethod")).toBe("cie");
+    expect(fd.get("username")).toBe("mario.rossi@example.com");
+    expect(fd.get("codiceFiscale")).toBeNull();
+  });
+
+  it("mostra l'errore restituito dalla server action", async () => {
+    mockSaveAdeCredentials.mockResolvedValue({
+      error: "L'accesso con SPID non è disponibile.",
+    });
+    renderSection();
+    openDialog();
+
+    fireEvent.change(screen.getByLabelText("Codice fiscale"), {
+      target: { value: "RSSMRA80A01H501U" },
+    });
+    fireEvent.change(screen.getByLabelText("Password Fisconline"), {
+      target: { value: "pw" },
+    });
+    fireEvent.change(screen.getByLabelText("PIN Fisconline"), {
+      target: { value: "1234567890" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salva" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("L'accesso con SPID non è disponibile."),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/settings/edit-ade-credentials-section.tsx
+++ b/src/components/settings/edit-ade-credentials-section.tsx
@@ -152,7 +152,10 @@ export function EditAdeCredentialsSection({
         onSubmit={form.handleSubmit((data) => mutation.mutate(data))}
       >
         {/* Selettore metodo: Fisconline (default) / CIE. */}
-        <div className="flex gap-2" role="group" aria-label="Metodo di accesso">
+        <fieldset
+          className="m-0 flex gap-2 border-0 p-0"
+          aria-label="Metodo di accesso"
+        >
           <Button
             type="button"
             variant={method === "fisconline" ? "default" : "outline"}
@@ -173,7 +176,7 @@ export function EditAdeCredentialsSection({
           >
             CIE
           </Button>
-        </div>
+        </fieldset>
 
         {method === "cie" ? (
           <>

--- a/src/components/settings/edit-ade-credentials-section.tsx
+++ b/src/components/settings/edit-ade-credentials-section.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
-import { adePinSchema } from "@/lib/validation";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import {
@@ -14,45 +13,103 @@ import {
   FormLabel,
   FormControl,
   FormMessage,
+  FormInputField,
   FormPasswordField,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { saveAdeCredentials } from "@/server/onboarding-actions";
+import type { AdeLoginMethod } from "@/lib/ade/types";
 import { EditSettingsDialog } from "./edit-settings-dialog";
 
-const editAdeCredentialsSchema = z.object({
-  codiceFiscale: z
-    .string()
-    .min(16, "Codice fiscale non valido (16 caratteri).")
-    .max(16, "Codice fiscale non valido (16 caratteri)."),
-  password: z.string().min(1, "La password Fisconline è obbligatoria."),
-  pin: adePinSchema,
-});
+// Form unico con campo `method`: la validazione dipende dal metodo scelto
+// (superRefine). Evita il tipo union su <Form> di due schemi separati.
+// SPID non è supportato dalla PWA: solo Fisconline e CIE.
+const editAdeSchema = z
+  .object({
+    method: z.enum(["fisconline", "cie"]),
+    codiceFiscale: z.string(),
+    pin: z.string(),
+    username: z.string(),
+    password: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.password) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["password"],
+        message: "La password è obbligatoria.",
+      });
+    }
+    if (data.method === "cie") {
+      if (!z.email().safeParse(data.username).success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["username"],
+          message: "Inserisci l'email dell'app CIE ID.",
+        });
+      }
+    } else {
+      if (data.codiceFiscale.length !== 16) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["codiceFiscale"],
+          message: "Codice fiscale non valido (16 caratteri).",
+        });
+      }
+      if (!/^\d{10}$/.test(data.pin)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["pin"],
+          message: "Il PIN Fisconline è composto da 10 cifre numeriche.",
+        });
+      }
+    }
+  });
 
-type EditAdeCredentialsData = z.infer<typeof editAdeCredentialsSchema>;
+type EditAdeData = z.infer<typeof editAdeSchema>;
 
 interface EditAdeCredentialsSectionProps {
   readonly businessId: string;
+  /** Metodo attualmente salvato: preseleziona il toggle. */
+  readonly currentMethod?: AdeLoginMethod;
 }
 
 export function EditAdeCredentialsSection({
   businessId,
+  currentMethod = "fisconline",
 }: EditAdeCredentialsSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
 
-  const form = useForm<EditAdeCredentialsData>({
-    resolver: zodResolver(editAdeCredentialsSchema),
-    defaultValues: { codiceFiscale: "", password: "", pin: "" },
+  const defaultMethod: "fisconline" | "cie" =
+    currentMethod === "cie" ? "cie" : "fisconline";
+
+  const form = useForm<EditAdeData>({
+    resolver: zodResolver(editAdeSchema),
+    defaultValues: {
+      method: defaultMethod,
+      codiceFiscale: "",
+      pin: "",
+      username: "",
+      password: "",
+    },
   });
 
+  const method = useWatch({ control: form.control, name: "method" });
+
   const mutation = useMutation({
-    mutationFn: (data: EditAdeCredentialsData) => {
+    mutationFn: (data: EditAdeData) => {
       const fd = new FormData();
       fd.set("businessId", businessId);
-      fd.set("codiceFiscale", data.codiceFiscale);
+      fd.set("loginMethod", data.method);
       fd.set("password", data.password);
-      fd.set("pin", data.pin);
+      if (data.method === "cie") {
+        fd.set("username", data.username);
+      } else {
+        fd.set("codiceFiscale", data.codiceFiscale);
+        fd.set("pin", data.pin);
+      }
       return saveAdeCredentials(fd);
     },
     onSuccess: (result) => {
@@ -71,7 +128,13 @@ export function EditAdeCredentialsSection({
   });
 
   function handleOpen() {
-    form.reset();
+    form.reset({
+      method: defaultMethod,
+      codiceFiscale: "",
+      pin: "",
+      username: "",
+      password: "",
+    });
     setIsOpen(true);
   }
 
@@ -79,8 +142,8 @@ export function EditAdeCredentialsSection({
     <Form {...form}>
       <EditSettingsDialog
         ariaLabel="Modifica credenziali AdE"
-        title="Modifica credenziali Fisconline"
-        description="Inserisci le nuove credenziali. Dopo il salvataggio dovrai riverificare la connessione con l'AdE."
+        title="Modifica credenziali AdE"
+        description="Scegli il metodo di accesso e inserisci le nuove credenziali. Dopo il salvataggio dovrai riverificare la connessione con l'AdE."
         isOpen={isOpen}
         isPending={mutation.isPending}
         rootError={form.formState.errors.root?.message}
@@ -88,43 +151,91 @@ export function EditAdeCredentialsSection({
         onClose={() => setIsOpen(false)}
         onSubmit={form.handleSubmit((data) => mutation.mutate(data))}
       >
-        {/* codiceFiscale: auto-uppercase transform */}
-        <FormField
-          control={form.control}
-          name="codiceFiscale"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Codice fiscale</FormLabel>
-              <FormControl>
-                <Input
-                  maxLength={16}
-                  spellCheck={false}
-                  autoComplete="off"
-                  disabled={mutation.isPending}
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.value.toUpperCase())}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {/* Selettore metodo: Fisconline (default) / CIE. */}
+        <div className="flex gap-2" role="group" aria-label="Metodo di accesso">
+          <Button
+            type="button"
+            variant={method === "fisconline" ? "default" : "outline"}
+            size="sm"
+            className="flex-1"
+            disabled={mutation.isPending}
+            onClick={() => form.setValue("method", "fisconline")}
+          >
+            Fisconline
+          </Button>
+          <Button
+            type="button"
+            variant={method === "cie" ? "default" : "outline"}
+            size="sm"
+            className="flex-1"
+            disabled={mutation.isPending}
+            onClick={() => form.setValue("method", "cie")}
+          >
+            CIE
+          </Button>
+        </div>
 
-        <FormPasswordField
-          control={form.control}
-          name="password"
-          label="Password Fisconline"
-          autoComplete="off"
-          disabled={mutation.isPending}
-        />
+        {method === "cie" ? (
+          <>
+            <FormInputField
+              control={form.control}
+              name="username"
+              label="Email dell'app CIE ID"
+              placeholder="La tua email registrata su CIE ID"
+              disabled={mutation.isPending}
+            />
 
-        <FormPasswordField
-          control={form.control}
-          name="pin"
-          label="PIN Fisconline"
-          autoComplete="off"
-          disabled={mutation.isPending}
-        />
+            <FormPasswordField
+              control={form.control}
+              name="password"
+              label="Password CIE ID"
+              autoComplete="off"
+              disabled={mutation.isPending}
+            />
+          </>
+        ) : (
+          <>
+            {/* codiceFiscale: auto-uppercase transform */}
+            <FormField
+              control={form.control}
+              name="codiceFiscale"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Codice fiscale</FormLabel>
+                  <FormControl>
+                    <Input
+                      maxLength={16}
+                      spellCheck={false}
+                      autoComplete="off"
+                      disabled={mutation.isPending}
+                      {...field}
+                      onChange={(e) =>
+                        field.onChange(e.target.value.toUpperCase())
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormPasswordField
+              control={form.control}
+              name="password"
+              label="Password Fisconline"
+              autoComplete="off"
+              disabled={mutation.isPending}
+            />
+
+            <FormPasswordField
+              control={form.control}
+              name="pin"
+              label="PIN Fisconline"
+              autoComplete="off"
+              disabled={mutation.isPending}
+            />
+          </>
+        )}
       </EditSettingsDialog>
     </Form>
   );

--- a/src/components/storico/void-receipt-dialog.tsx
+++ b/src/components/storico/void-receipt-dialog.tsx
@@ -62,8 +62,9 @@ export function VoidReceiptDialog({
       });
     },
     onSuccess: (result) => {
-      if (result.error) {
-        // Error is shown inline — mutation still "succeeds" from React Query's POV
+      if (result.error || result.reauthRequired) {
+        // Error / reauthRequired mostrati inline. reauthRequired: sessione CIE
+        // scaduta, nessun annullo trasmesso — l'utente si ricollega e riprova.
         return;
       }
       setView("voidSuccess");
@@ -149,6 +150,15 @@ export function VoidReceiptDialog({
                 ) : (
                   (mutation.data?.error ?? "Errore imprevisto. Riprova.")
                 )}
+              </div>
+            )}
+
+            {/* CIE: sessione scaduta → ricollegarsi prima di ritentare l'annullo. */}
+            {mutation.data?.reauthRequired && (
+              <div className="rounded-md bg-amber-50 p-3 text-sm text-amber-800">
+                {
+                  "Sessione CIE scaduta. Ricollegati dalle impostazioni approvando la notifica sull'app CIE ID, poi riprova l'annullo."
+                }
               </div>
             )}
 

--- a/src/db/schema/ade-credentials.ts
+++ b/src/db/schema/ade-credentials.ts
@@ -3,9 +3,18 @@ import { sql } from "drizzle-orm";
 import { businesses } from "./businesses";
 
 /**
- * Encrypted Fisconline credentials for AdE integration.
- * All credential fields are encrypted with AES-256-GCM (src/lib/crypto.ts).
- * One credential set per business (1:1).
+ * Encrypted AdE access credentials. One set per business (1:1).
+ *
+ * Il metodo di accesso (`loginMethod`) determina quali campi sono valorizzati
+ * (validato a livello applicativo, non dallo schema):
+ *  - `fisconline`: encryptedCodiceFiscale + encryptedPassword + encryptedPin
+ *  - `cie`:        encryptedUsername (email CIE ID) + encryptedPassword
+ *  - `spid`:       nessun segreto (solo loginMethod + spidProvider); username e
+ *                  password reinseriti a ogni rinnovo — regole AgID vietano di
+ *                  conservare la password SPID lato service provider.
+ *
+ * Tutti i campi `encrypted*` usano AES-256-GCM (src/lib/crypto.ts) e sono
+ * NULLABLE dalla migrazione 0027 in poi.
  */
 export const adeCredentials = pgTable("ade_credentials", {
   id: uuid("id")
@@ -15,9 +24,15 @@ export const adeCredentials = pgTable("ade_credentials", {
     .notNull()
     .unique()
     .references(() => businesses.id, { onDelete: "cascade" }),
-  encryptedCodiceFiscale: text("encrypted_codice_fiscale").notNull(),
-  encryptedPassword: text("encrypted_password").notNull(),
-  encryptedPin: text("encrypted_pin").notNull(),
+  /** Metodo di accesso AdE: 'fisconline' | 'cie' | 'spid'. */
+  loginMethod: text("login_method").notNull().default("fisconline"),
+  encryptedCodiceFiscale: text("encrypted_codice_fiscale"),
+  /** Username del metodo, quando distinto dal CF (email per CIE). */
+  encryptedUsername: text("encrypted_username"),
+  encryptedPassword: text("encrypted_password"),
+  encryptedPin: text("encrypted_pin"),
+  /** Provider SPID selezionato (es. 'sielte'); null per Fisconline/CIE. */
+  spidProvider: text("spid_provider"),
   keyVersion: integer("key_version").notNull().default(1),
   /** Null means never verified; set after a successful test login to AdE */
   verifiedAt: timestamp("verified_at", { withTimezone: true }),

--- a/src/lib/ade/client.ts
+++ b/src/lib/ade/client.ts
@@ -16,6 +16,7 @@ import type {
   AdeProduct,
   AdeResponse,
   AdeSearchParams,
+  CieCredentials,
   FisconlineCredentials,
   SpidCredentials,
 } from "./types";
@@ -37,11 +38,21 @@ export interface AdeClient {
   /**
    * Autentica sul portale AdE tramite SPID e restituisce una sessione.
    *
-   * HAR finding (login_spid.har): flusso SAML2 HTTP POST Binding via broker Sogei
-   * (spid.sogei.it). 2FA tramite push notification sul dispositivo mobile.
-   * NOTA: le sessioni SPID non supportano re-auth automatico (no PIN).
+   * HAR finding (login_spid_ok_*.har): flusso SAML2 HTTP POST Binding, entry
+   * AdE /rp/{provider}/sel. 2FA via OTP o push notification.
+   * NOTA: le sessioni SPID non supportano re-auth automatico (secondo fattore
+   * umano) — alla scadenza serve un nuovo login interattivo.
    */
   loginSpid(credentials: SpidCredentials): Promise<AdeSession>;
+
+  /**
+   * Autentica sul portale AdE tramite CIE e restituisce una sessione.
+   *
+   * HAR finding (login_cie_ok_notifica_app.har): IdP Shibboleth Ministero
+   * dell'Interno, login livello 2 (email CIE ID + password) confermato via push
+   * sull'app CIE ID. Come SPID, nessun re-auth automatico su 401.
+   */
+  loginCie(credentials: CieCredentials): Promise<AdeSession>;
 
   /** Invia un documento commerciale di vendita */
   submitSale(payload: AdePayload): Promise<AdeResponse>;

--- a/src/lib/ade/errors.ts
+++ b/src/lib/ade/errors.ts
@@ -70,6 +70,27 @@ export class AdeNetworkError extends AdeError {
 }
 
 /**
+ * La sessione AdE per un metodo interattivo (CIE/SPID) è assente o scaduta e
+ * non può essere ri-creata in autonomia dal server (il secondo fattore è
+ * un'azione umana: push/OTP). L'emissione/annullo la traduce in
+ * `{ reauthRequired: true }` così la UI chiede all'utente di ri-collegarsi.
+ * Distinta da `AdeSessionExpiredError` (Fisconline, dove il re-login silenzioso
+ * è possibile e il suo fallimento è un errore vero).
+ */
+export class AdeReauthRequiredError extends AdeError {
+  readonly method: string;
+
+  constructor(method: string) {
+    super(
+      "ADE_REAUTH_REQUIRED",
+      `Interactive re-authentication required (${method})`,
+    );
+    this.name = "AdeReauthRequiredError";
+    this.method = method;
+  }
+}
+
+/**
  * SPID push notification not confirmed within the polling window.
  *
  * HAR finding (login_spid.har): the mobile app must approve the login

--- a/src/lib/ade/index.test.ts
+++ b/src/lib/ade/index.test.ts
@@ -93,7 +93,11 @@ describe("withAdeSession (mock mode)", () => {
     const fn = vi.fn().mockResolvedValue("done");
 
     const result = await withAdeSession(
-      { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+      {
+        businessId: "biz-1",
+        method: "fisconline",
+        credentials: FAKE_CREDENTIALS,
+      },
       fn,
     );
 
@@ -111,7 +115,11 @@ describe("withAdeSession (mock mode)", () => {
     );
 
     const result = await withAdeSession(
-      { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+      {
+        businessId: "biz-1",
+        method: "fisconline",
+        credentials: FAKE_CREDENTIALS,
+      },
       () => Promise.resolve("ok"),
     );
 
@@ -127,7 +135,11 @@ describe("withAdeSession (mock mode)", () => {
 
     await expect(
       withAdeSession(
-        { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+        {
+          businessId: "biz-1",
+          method: "fisconline",
+          credentials: FAKE_CREDENTIALS,
+        },
         () => Promise.reject(new Error("boom")),
       ),
     ).rejects.toThrow("boom");
@@ -143,7 +155,11 @@ describe("withAdeSession (mock mode)", () => {
     const fn = vi.fn();
 
     const result = await withAdeSession(
-      { businessId: "biz-1", credentials: FAKE_CREDENTIALS },
+      {
+        businessId: "biz-1",
+        method: "fisconline",
+        credentials: FAKE_CREDENTIALS,
+      },
       fn,
     );
 

--- a/src/lib/ade/index.ts
+++ b/src/lib/ade/index.ts
@@ -9,6 +9,7 @@ import type { FisconlineCredentials } from "./types";
 import { MockAdeClient } from "./mock-client";
 import { RealAdeClient } from "./real-client";
 import { adeSessionCache } from "./session-cache";
+import { adeInteractiveSessionStore } from "./interactive-session-store";
 import { logger } from "@/lib/logger";
 
 export type AdeMode = "mock" | "real";
@@ -64,27 +65,45 @@ export function createAdeClient(mode: AdeMode): AdeClient {
 }
 
 /**
+ * Parametri di `withAdeSession`, discriminati sul metodo di accesso AdE.
+ *  - `fisconline`: il server ha le credenziali e può ri-loggarsi in silenzio →
+ *    sessione riusata/creata da `adeSessionCache`.
+ *  - `cie`: sessione stabilita interattivamente (push), non ri-creabile in
+ *    silenzio → riusata dallo store interattivo; se assente/scaduta →
+ *    `AdeReauthRequiredError`.
+ */
+export type WithAdeSessionParams =
+  | {
+      businessId: string;
+      method: "fisconline";
+      credentials: FisconlineCredentials;
+    }
+  | { businessId: string; method: "cie" };
+
+/**
  * Esegue `fn` con un client AdE autenticato per `businessId` (REVIEW #5).
  *
- * - `ADE_MODE=real`: riusa la sessione via `adeSessionCache` (un solo login
- *   Fisconline per più operazioni ravvicinate dello stesso business, serializzate
- *   da un lock per-business). Il logout NON avviene a fine operazione: la
- *   sessione resta in cache fino a TTL/eviction/invalidazione.
- * - `ADE_MODE=mock`: nessuna cache. login + logout per-operazione come prima,
- *   così il comportamento dei test mock resta invariato (login/logout no-op).
- *
- * Sostituisce il pattern `createAdeClient(getAdeMode())` + `login()` + `logout()`
- * nel `finally` nei call-site di emissione/annullo.
+ * - `ADE_MODE=real`, Fisconline: riusa la sessione via `adeSessionCache` (un solo
+ *   login per più operazioni ravvicinate, serializzate per-business). Invariato.
+ * - `ADE_MODE=real`, CIE: riusa la sessione depositata nello store interattivo;
+ *   se assente/scaduta solleva `AdeReauthRequiredError`. Nessun login qui (il
+ *   secondo fattore è umano).
+ * - `ADE_MODE=mock`: nessuna cache. login/loginCie + logout per-operazione, così
+ *   in dev/sandbox anche CIE dà un OK immediato senza sessione depositata.
  */
 export async function withAdeSession<T>(
-  params: { businessId: string; credentials: FisconlineCredentials },
+  params: WithAdeSessionParams,
   fn: (client: AdeClient) => Promise<T>,
 ): Promise<T> {
   const mode = getAdeMode();
 
   if (mode === "mock") {
     const client = createAdeClient("mock");
-    await client.login(params.credentials);
+    if (params.method === "cie") {
+      await client.loginCie({ username: "mock", password: "mock" });
+    } else {
+      await client.login(params.credentials);
+    }
     try {
       return await fn(client);
     } finally {
@@ -94,5 +113,19 @@ export async function withAdeSession<T>(
     }
   }
 
+  if (params.method === "cie") {
+    return adeInteractiveSessionStore.run(params.businessId, fn);
+  }
+
   return adeSessionCache.run(params.businessId, params.credentials, fn);
+}
+
+/**
+ * True se un business CIE non ha (più) una sessione interattiva viva e va
+ * chiesto il rinnovo. Usato da emit/void per ritornare `reauthRequired` PRIMA
+ * di inserire il documento PENDING (evita un documento bloccato dallo stale-gate
+ * dopo un rinnovo). Solo in `ADE_MODE=real`: in mock CIE dà sempre OK.
+ */
+export function isCieSessionMissing(businessId: string): boolean {
+  return getAdeMode() === "real" && !adeInteractiveSessionStore.has(businessId);
 }

--- a/src/lib/ade/interactive-session-store.test.ts
+++ b/src/lib/ade/interactive-session-store.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdeInteractiveSessionStore } from "./interactive-session-store";
+import { AdeReauthRequiredError, AdeSessionExpiredError } from "./errors";
+import type { AdeClient } from "./client";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+/** Fake client: solo `logout` è esercitato dallo store. */
+function fakeClient(): AdeClient {
+  return {
+    logout: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AdeClient;
+}
+
+describe("AdeInteractiveSessionStore", () => {
+  let now: number;
+  let store: AdeInteractiveSessionStore;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    store = new AdeInteractiveSessionStore({ now: () => now });
+  });
+
+  it("run without a stored session throws AdeReauthRequiredError", async () => {
+    await expect(store.run("biz-1", async () => "x")).rejects.toBeInstanceOf(
+      AdeReauthRequiredError,
+    );
+  });
+
+  it("set + run executes fn with the stored client", async () => {
+    const client = fakeClient();
+    store.set("biz-1", client);
+
+    const result = await store.run("biz-1", async (c) => {
+      expect(c).toBe(client);
+      return "done";
+    });
+
+    expect(result).toBe("done");
+    expect(store.has("biz-1")).toBe(true);
+  });
+
+  it("converts AdeSessionExpiredError (401) into AdeReauthRequiredError and evicts", async () => {
+    const client = fakeClient();
+    store.set("biz-1", client);
+
+    await expect(
+      store.run("biz-1", async () => {
+        throw new AdeSessionExpiredError();
+      }),
+    ).rejects.toBeInstanceOf(AdeReauthRequiredError);
+
+    // Sessione rimossa + logout best-effort.
+    expect(store.has("biz-1")).toBe(false);
+    expect(client.logout).toHaveBeenCalled();
+  });
+
+  it("propagates non-session errors unchanged (no eviction)", async () => {
+    store.set("biz-1", fakeClient());
+
+    await expect(
+      store.run("biz-1", async () => {
+        throw new Error("submit boom");
+      }),
+    ).rejects.toThrow("submit boom");
+
+    // La sessione resta: non è un problema di autenticazione.
+    expect(store.has("biz-1")).toBe(true);
+  });
+
+  it("expired TTL: has() is false and run() requires reauth", async () => {
+    store = new AdeInteractiveSessionStore({ ttlMs: 1000, now: () => now });
+    store.set("biz-1", fakeClient());
+    expect(store.has("biz-1")).toBe(true);
+
+    now += 1001;
+    expect(store.has("biz-1")).toBe(false);
+    await expect(store.run("biz-1", async () => "x")).rejects.toBeInstanceOf(
+      AdeReauthRequiredError,
+    );
+  });
+
+  it("set replaces a previous session (logs out the old client)", () => {
+    const oldClient = fakeClient();
+    const newClient = fakeClient();
+    store.set("biz-1", oldClient);
+    store.set("biz-1", newClient);
+
+    expect(oldClient.logout).toHaveBeenCalled();
+    expect(store.size).toBe(1);
+  });
+
+  it("invalidate removes and logs out the session", async () => {
+    const client = fakeClient();
+    store.set("biz-1", client);
+
+    await store.invalidate("biz-1");
+
+    expect(store.has("biz-1")).toBe(false);
+    expect(client.logout).toHaveBeenCalled();
+  });
+
+  it("serializes concurrent operations per business", async () => {
+    store.set("biz-1", fakeClient());
+    const order: string[] = [];
+
+    const p1 = store.run("biz-1", async () => {
+      order.push("start-1");
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("end-1");
+    });
+    const p2 = store.run("biz-1", async () => {
+      order.push("start-2");
+    });
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(["start-1", "end-1", "start-2"]);
+  });
+});

--- a/src/lib/ade/interactive-session-store.ts
+++ b/src/lib/ade/interactive-session-store.ts
@@ -1,0 +1,169 @@
+/**
+ * Store in-memory delle sessioni AdE stabilite in modo INTERATTIVO (CIE).
+ *
+ * A differenza di Fisconline — dove il server conserva le credenziali e può
+ * rifare il login in silenzio su 401 (`session-cache.ts`) — una sessione CIE è
+ * stabilita da un login con secondo fattore umano (push sull'app CIE ID) e NON
+ * è ri-creabile senza una nuova azione dell'utente. Quindi qui NON si fa login:
+ * il client già autenticato viene depositato da `verifyAdeCredentials` (il
+ * "collega/rinnova") e riusato per emissione/annullo finché AdE lo accetta.
+ *
+ * Rinnovo lazy: `run` prova la sessione depositata; se assente o rifiutata da
+ * AdE (401 → `AdeSessionExpiredError`) solleva `AdeReauthRequiredError`, che
+ * emit/void traducono in `{ reauthRequired }` per chiedere all'utente di
+ * ri-collegarsi. Nessun TTL "indovinato" come scadenza logica: il TTL è solo un
+ * cap di memoria ampio (sopra la durata tipica della sessione AdE); la scadenza
+ * reale è segnalata da AdE.
+ *
+ * Assunzione single-container (coerente con CLAUDE.md): lo store vive nel
+ * processo. Un deploy/restart perde le sessioni → l'utente ri-collega (atteso).
+ */
+
+import type { AdeClient } from "./client";
+import { AdeReauthRequiredError, AdeSessionExpiredError } from "./errors";
+import { logger } from "@/lib/logger";
+
+/** TTL di default: cap di memoria ampio (6h), NON la scadenza logica AdE. */
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** Cap LRU di default sul numero di sessioni interattive in memoria. */
+const DEFAULT_MAX_ENTRIES = 100;
+
+interface Entry {
+  client: AdeClient;
+  expiresAt: number;
+}
+
+export interface AdeInteractiveSessionStoreOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+}
+
+export class AdeInteractiveSessionStore {
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+
+  private readonly entries = new Map<string, Entry>();
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  constructor(options: AdeInteractiveSessionStoreOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Deposita un client CIE già autenticato per il business, sostituendo
+   * (con logout best-effort) un'eventuale sessione precedente.
+   */
+  set(businessId: string, client: AdeClient): void {
+    const existing = this.entries.get(businessId);
+    if (existing && existing.client !== client) {
+      void existing.client.logout().catch(() => {});
+    }
+    this.entries.delete(businessId);
+    this.entries.set(businessId, {
+      client,
+      expiresAt: this.now() + this.ttlMs,
+    });
+    this.evictIfNeeded();
+    logger.info(
+      { businessId, event: "ade_interactive_session_set" },
+      "AdE interactive session stored",
+    );
+  }
+
+  /** True se esiste una sessione interattiva viva per il business. */
+  has(businessId: string): boolean {
+    const entry = this.entries.get(businessId);
+    return !!entry && entry.expiresAt > this.now();
+  }
+
+  /**
+   * Esegue `fn` con il client CIE depositato, serializzando le operazioni per
+   * business. Solleva `AdeReauthRequiredError` se la sessione è assente/scaduta
+   * o se AdE la rifiuta durante l'operazione (`AdeSessionExpiredError`).
+   */
+  async run<T>(
+    businessId: string,
+    fn: (client: AdeClient) => Promise<T>,
+  ): Promise<T> {
+    const prev = this.chains.get(businessId) ?? Promise.resolve();
+    const task = prev.then(() => this.execute(businessId, fn));
+    const guard = task.catch(() => {});
+    this.chains.set(businessId, guard);
+    try {
+      return await task;
+    } finally {
+      if (this.chains.get(businessId) === guard) {
+        this.chains.delete(businessId);
+      }
+    }
+  }
+
+  private async execute<T>(
+    businessId: string,
+    fn: (client: AdeClient) => Promise<T>,
+  ): Promise<T> {
+    const entry = this.entries.get(businessId);
+    if (!entry || entry.expiresAt <= this.now()) {
+      if (entry) {
+        this.entries.delete(businessId);
+        void entry.client.logout().catch(() => {});
+      }
+      logger.warn(
+        { businessId, event: "ade_interactive_session_missing" },
+        "AdE interactive session missing/expired — reauth required",
+      );
+      throw new AdeReauthRequiredError("cie");
+    }
+
+    // MRU refresh (access order = LRU).
+    this.entries.delete(businessId);
+    this.entries.set(businessId, entry);
+
+    try {
+      return await fn(entry.client);
+    } catch (err) {
+      if (err instanceof AdeSessionExpiredError) {
+        // AdE ha rifiutato la sessione (401): non ri-creabile in silenzio.
+        this.entries.delete(businessId);
+        void entry.client.logout().catch(() => {});
+        logger.warn(
+          { businessId, event: "ade_interactive_session_expired" },
+          "AdE interactive session rejected by AdE — reauth required",
+        );
+        throw new AdeReauthRequiredError("cie");
+      }
+      throw err;
+    }
+  }
+
+  /** Rimuove (con logout best-effort) la sessione di un business. */
+  async invalidate(businessId: string): Promise<void> {
+    const entry = this.entries.get(businessId);
+    if (!entry) return;
+    this.entries.delete(businessId);
+    await entry.client.logout().catch(() => {});
+  }
+
+  private evictIfNeeded(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = this.entries.get(oldestKey);
+      this.entries.delete(oldestKey);
+      if (oldest) void oldest.client.logout().catch(() => {});
+    }
+  }
+
+  /** Numero di sessioni attualmente depositate (test/diagnostica). */
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+/** Store singleton usato in produzione. */
+export const adeInteractiveSessionStore = new AdeInteractiveSessionStore();

--- a/src/lib/ade/mock-client.test.ts
+++ b/src/lib/ade/mock-client.test.ts
@@ -240,6 +240,28 @@ describe("MockAdeClient", () => {
     });
   });
 
+  describe("loginCie", () => {
+    const cieCreds = {
+      username: "mario.rossi@example.com",
+      password: "ciepassword",
+    };
+
+    it("returns a mock session marked as cie", async () => {
+      const session = await client.loginCie(cieCreds);
+
+      expect(session.pAuth).toMatch(/^mock_p_auth_cie_/);
+      expect(session.partitaIva).toHaveLength(11);
+      expect(session.createdAt).toBeGreaterThan(0);
+    });
+
+    it("enables subsequent operations like a regular login", async () => {
+      await client.loginCie(cieCreds);
+      const response = await client.submitSale(makeSalePayload());
+
+      expect(response.esito).toBe(true);
+    });
+  });
+
   describe("getProducts", () => {
     it("returns an empty array when logged in", async () => {
       await client.login(mockCredentials);

--- a/src/lib/ade/mock-client.ts
+++ b/src/lib/ade/mock-client.ts
@@ -15,6 +15,7 @@ import type {
   AdeProduct,
   AdeResponse,
   AdeSearchParams,
+  CieCredentials,
   SpidCredentials,
 } from "./types";
 import { buildCedenteFromBusiness } from "./mapper";
@@ -41,6 +42,17 @@ export class MockAdeClient implements AdeClient {
     this.session = {
       pAuth: `mock_p_auth_spid_${Date.now()}`,
       partitaIva: credentials.codiceFiscale.slice(0, 11).padEnd(11, "0"),
+      createdAt: Date.now(),
+    };
+    return this.session;
+  }
+
+  async loginCie(_credentials: CieCredentials): Promise<AdeSession> {
+    // CIE: lo username è un'email, non il CF. In mock la P.IVA è fittizia
+    // (in real viene estratta dal portale post-login via wizardTemplate).
+    this.session = {
+      pAuth: `mock_p_auth_cie_${Date.now()}`,
+      partitaIva: "00000000000",
       createdAt: Date.now(),
     };
     return this.session;

--- a/src/lib/ade/real-client-cie.test.ts
+++ b/src/lib/ade/real-client-cie.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @vitest-environment node
+ *
+ * CIE authentication flow (HAR: login_cie_ok_notifica_app.har,
+ * login_cie_ko_credenziali_non_valide.har).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RealAdeClient } from "./real-client";
+import { AdeAuthError, AdeSpidTimeoutError } from "./errors";
+import type { CieCredentials } from "./types";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+function mockResponse(opts: {
+  status?: number;
+  body?: string | object;
+  headers?: [string, string][];
+  location?: string;
+}): Response {
+  const { status = 200, body = "", headers = [], location } = opts;
+  const responseHeaders: [string, string][] = [...headers];
+  if (location) responseHeaders.push(["Location", location]);
+  const responseBody = typeof body === "object" ? JSON.stringify(body) : body;
+  return new Response(responseBody, { status, headers: responseHeaders });
+}
+
+const IDP = "https://idserver.servizicie.interno.gov.it";
+const SP = "https://sp.agenziaentrate.gov.it";
+const IAMPE = "https://iampe.agenziaentrate.gov.it";
+const PORTALE = "https://portale.agenziaentrate.gov.it";
+
+/** HTML form auto-submit SAML (action + SAMLRequest/SAMLResponse + RelayState). */
+function samlForm(action: string, field: string, relayState: string): string {
+  return `<form action="${action}" method="post">
+    <input type="hidden" name="${field}" value="ABC123" />
+    <input type="hidden" name="RelayState" value="${relayState}" />
+  </form>`;
+}
+
+// KO livello2: pagina ri-renderizzata col messaggio esatto dell'IdP CIE
+// (login_cie_ko_credenziali_non_valide.har).
+const CIE_LOGIN_PAGE = `<!DOCTYPE html><html><head><title>CIE Login</title></head>
+  <body><form action="/idp/login/livello2" method="post">
+  <div class="row mb-4 mx-n2 error"> Credenziali non valide.</div>
+  <input name="username" class="form-control error" />
+  <input name="password" type="password" class="form-control input-password error " />
+  </form></body></html>`;
+
+const CREDENTIALS: CieCredentials = {
+  username: "mario.rossi@example.com",
+  password: "cie-password",
+};
+
+/**
+ * Queue the full CIE happy-path fetch sequence (23 request() calls).
+ * push approvato: il body di checkpush cambia dal baseline al secondo poll.
+ */
+function mockCieHappyPath(fetchMock: ReturnType<typeof vi.fn>): void {
+  // 1. GET /rp/cie/sel → form verso l'IdP
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      body: samlForm(
+        `${IDP}/idp/profile/SAML2/POST/SSO`,
+        "SAMLRequest",
+        "selcie",
+      ),
+    }),
+  );
+  // 2a. POST IdP SSO → 302 probe e1s1
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      status: 302,
+      location: `${IDP}/idp/profile/SAML2/POST/SSO?execution=e1s1`,
+    }),
+  );
+  // 2b. GET e1s1 → 200 probe page
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 3a. POST probe1 → 302 livello2
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({ status: 302, location: `${IDP}/idp/login/livello2?opId=X` }),
+  );
+  // 3b. GET livello2 → 200 credentials page
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 4. POST credentials → 200 (waiting page, no error markers)
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 5a. checkpush baseline
+  fetchMock.mockResolvedValueOnce(mockResponse({ body: "PENDING" }));
+  // 5b. checkpush approved (body changed)
+  fetchMock.mockResolvedValueOnce(mockResponse({ body: "APPROVED" }));
+  // 5c. GET postpush → 302 consent e1s4
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      status: 302,
+      location: `${IDP}/idp/profile/SAML2/POST/SSO?execution=e1s4`,
+    }),
+  );
+  // 5d. GET e1s4 → 200 consent page
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 6a. POST consent → 302 e1s5
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      status: 302,
+      location: `${IDP}/idp/profile/SAML2/POST/SSO?execution=e1s5`,
+    }),
+  );
+  // 6b. GET e1s5 → 200 final probe page
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 7. POST final probe → 200 SAMLResponse form verso AdE SP
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      body: samlForm(
+        `${SP}/sp/AssertionConsumerService7`,
+        "SAMLResponse",
+        "selcie",
+      ),
+    }),
+  );
+  // 8a. POST ACS → 302 make4SAM
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({ status: 302, location: `${SP}/make4SAM` }),
+  );
+  // 8b. GET make4SAM → 200 form verso iampe
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      body: samlForm(
+        `${IAMPE}/sam/Consumer/metaAlias/agenziaentrate/age-sp`,
+        "SAMLResponse",
+        `${PORTALE}/PortaleWeb/home`,
+      ),
+    }),
+  );
+  // 8c. POST iampe Consumer → 302 portale home
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      status: 302,
+      location: `${PORTALE}/PortaleWeb/home?to=FATBTB`,
+    }),
+  );
+  // 8d. GET portale home → 200
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 9a. initPortale → 501
+  fetchMock.mockResolvedValueOnce(mockResponse({ status: 501 }));
+  // 9b. InstradamentofcWeb/home → 200
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 9c. initLight → x-appl header
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({ headers: [["x-appl", "tok"]] }),
+  );
+  // 9d. dp/PI2FC → 200
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+  // 9e. wizardTemplate → PIva + cfUidUltimo
+  fetchMock.mockResolvedValueOnce(
+    mockResponse({
+      body: {
+        PIva: [{ piva: "10872631006", denominazione: "DE STEFANO MARCO" }],
+        cfUidUltimo: "DSTMRC86T02H501V",
+      },
+    }),
+  );
+  // 9f. setUserChoice → 200
+  fetchMock.mockResolvedValueOnce(mockResponse({}));
+}
+
+describe("RealAdeClient.loginCie", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("completes the CIE flow and extracts P.IVA + CF from wizardTemplate", async () => {
+    mockCieHappyPath(fetchMock);
+    const client = new RealAdeClient({ spidPollIntervalMs: 0 });
+
+    const session = await client.loginCie(CREDENTIALS);
+
+    expect(session.partitaIva).toBe("10872631006");
+
+    // setUserChoice deve usare il CF letto da cfUidUltimo (non lo username email).
+    const calls = fetchMock.mock.calls;
+    const setUserChoiceCall = calls.find(([url]) =>
+      String(url).includes("/setUserChoice"),
+    );
+    expect(setUserChoiceCall).toBeDefined();
+    const body = JSON.parse(String(setUserChoiceCall![1].body));
+    expect(body.cf).toBe("DSTMRC86T02H501V");
+    expect(body.pIva).toBe("10872631006");
+  });
+
+  it("posts CIE credentials to the livello2 endpoint", async () => {
+    mockCieHappyPath(fetchMock);
+    const client = new RealAdeClient({ spidPollIntervalMs: 0 });
+
+    await client.loginCie(CREDENTIALS);
+
+    const livello2Post = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/idp/login/livello2") &&
+        (init as RequestInit)?.method === "POST",
+    );
+    expect(livello2Post).toBeDefined();
+    const bodyStr = String((livello2Post![1] as RequestInit).body);
+    expect(bodyStr).toContain("username=mario.rossi");
+    expect(bodyStr).toContain("password=cie-password");
+  });
+
+  it("throws AdeAuthError when livello2 re-renders the login page (wrong credentials)", async () => {
+    // 1. sel, 2a POST SSO, 2b probe, 3a POST probe→livello2, 3b GET livello2,
+    // 4. POST credentials → login page ri-renderizzata (KO)
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(
+          `${IDP}/idp/profile/SAML2/POST/SSO`,
+          "SAMLRequest",
+          "selcie",
+        ),
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 302,
+        location: `${IDP}/idp/profile/SAML2/POST/SSO?execution=e1s1`,
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 302,
+        location: `${IDP}/idp/login/livello2?opId=X`,
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(mockResponse({ body: CIE_LOGIN_PAGE }));
+
+    const client = new RealAdeClient({ spidPollIntervalMs: 0 });
+    await expect(client.loginCie(CREDENTIALS)).rejects.toThrow(AdeAuthError);
+  });
+
+  it("throws AdeSpidTimeoutError when the push is never approved", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(
+          `${IDP}/idp/profile/SAML2/POST/SSO`,
+          "SAMLRequest",
+          "selcie",
+        ),
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 302,
+        location: `${IDP}/idp/profile/SAML2/POST/SSO?execution=e1s1`,
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 302,
+        location: `${IDP}/idp/login/livello2?opId=X`,
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(mockResponse({})); // credentials OK
+    // checkpush: body sempre uguale → mai approvato
+    for (let i = 0; i < 5; i++) {
+      fetchMock.mockResolvedValueOnce(mockResponse({ body: "PENDING" }));
+    }
+
+    const client = new RealAdeClient({
+      spidPollIntervalMs: 0,
+      spidMaxPolls: 3,
+    });
+    await expect(client.loginCie(CREDENTIALS)).rejects.toThrow(
+      AdeSpidTimeoutError,
+    );
+  });
+});

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -17,6 +17,7 @@ import type {
   AdeProduct,
   AdeResponse,
   AdeSearchParams,
+  CieCredentials,
   FisconlineCredentials,
   SpidCredentials,
 } from "./types";
@@ -59,6 +60,24 @@ const ADE_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
   "telematici.agenziaentrate.gov.it",
 ]);
 
+/** Entry point AdE (Service Provider) per il login federato SPID/CIE. */
+const ADE_SP_BASE_URL = "https://sp.agenziaentrate.gov.it";
+
+/** IdP CIE (Ministero dell'Interno / IPZS). */
+const CIE_IDP_BASE_URL = "https://idserver.servizicie.interno.gov.it";
+
+/**
+ * Allowlist estesa per il flusso federato: oltre agli host AdE, l'entry SP
+ * (sp.agenziaentrate.gov.it) e gli IdP di CIE/SPID di cui abbiamo evidenza HAR.
+ * Usata solo durante il login SPID/CIE, quando i redirect attraversano gli IdP.
+ */
+const FEDERATED_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
+  ...ADE_ALLOWED_HOSTS,
+  "sp.agenziaentrate.gov.it",
+  "idserver.servizicie.interno.gov.it",
+  "identity.sieltecloud.it",
+]);
+
 /**
  * Risolve un Location header rispetto alla URL corrente e ne valida
  * scheme + host contro la allowlist AdE (anti-SSRF).
@@ -74,6 +93,7 @@ const ADE_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
 export function resolveAdeRedirect(
   currentUrl: string,
   location: string,
+  allowedHosts: ReadonlySet<string> = ADE_ALLOWED_HOSTS,
 ): string {
   let resolved: URL;
   try {
@@ -101,7 +121,7 @@ export function resolveAdeRedirect(
     );
   }
 
-  if (!ADE_ALLOWED_HOSTS.has(resolved.hostname)) {
+  if (!allowedHosts.has(resolved.hostname)) {
     logger.warn(
       { fromHost: safeHost(currentUrl), toHost: resolved.hostname },
       "ade:redirect_blocked_host",
@@ -225,7 +245,8 @@ export class RealAdeClient implements AdeClient {
     startUrl: string,
     maxHops = 20,
     jar?: CookieJar,
-  ): Promise<Response> {
+    allowedHosts: ReadonlySet<string> = ADE_ALLOWED_HOSTS,
+  ): Promise<{ response: Response; url: string }> {
     let url = startUrl;
     let hops = 0;
 
@@ -234,15 +255,15 @@ export class RealAdeClient implements AdeClient {
 
       // Success (2xx) or server error: stop following
       if (response.status < 300 || response.status >= 400) {
-        return response;
+        return { response, url };
       }
 
       // Redirect: resolve Location relative to the current URL's origin and
-      // validate against the AdE host allowlist (anti-SSRF).
+      // validate against the host allowlist (anti-SSRF).
       const location = response.headers.get("Location");
-      if (!location) return response;
+      if (!location) return { response, url };
 
-      url = resolveAdeRedirect(url, location);
+      url = resolveAdeRedirect(url, location, allowedHosts);
       hops++;
     }
 
@@ -384,15 +405,24 @@ export class RealAdeClient implements AdeClient {
   }
 
   /**
-   * Phase F: Recupera la prima P.IVA disponibile per l'utente.
+   * Phase F: Recupera identità (P.IVA + codice fiscale) dal wizardTemplate.
    *
-   * HAR finding (login_credenziali_fisconline.har entry 59):
+   * HAR finding (login_credenziali_fisconline.har entry 59,
+   * login_cie_ok_notifica_app.har entry 31):
    *   GET /instr/instradamento-fatture-rest/rs/wizardTemplate
-   *   Response: {"PIva":[{"piva":"...","denominazione":"..."}],...}
-   * Richiede il token x-appl nell'header.
-   * Skippato durante la re-auth su 401 quando la P.IVA è già nota.
+   *   Response: {"PIva":[{"piva":"...","denominazione":"..."}],
+   *              "cfUidUltimo":"<CF>", ...}
+   * Richiede il token x-appl nell'header. Skippato durante la re-auth su 401
+   * quando la P.IVA è già nota.
+   *
+   * Il `cf` è essenziale per CIE, dove lo username del login è un'email e il
+   * codice fiscale non è un input: si legge qui da `cfUidUltimo`. Per Fisconline
+   * il CF è già noto (credenziali), quindi `cf` può risultare undefined senza
+   * errore — solo la P.IVA mancante è fatale.
    */
-  private async fetchWizardPiva(xAppl: string): Promise<string> {
+  private async fetchWizardIdentity(
+    xAppl: string,
+  ): Promise<{ cf: string | undefined; piva: string }> {
     const url = `${ADE_BASE_URL}${ADE_INSTR_PATH}/wizardTemplate`;
     const response = await this.request(url, {
       headers: { "x-appl": xAppl },
@@ -407,6 +437,7 @@ export class RealAdeClient implements AdeClient {
 
     const data = (await response.json()) as {
       PIva?: { piva?: string }[];
+      cfUidUltimo?: string;
     };
     const piva = data?.PIva?.[0]?.piva;
 
@@ -430,7 +461,7 @@ export class RealAdeClient implements AdeClient {
       );
     }
 
-    return piva;
+    return { cf: data?.cfUidUltimo, piva };
   }
 
   /**
@@ -625,6 +656,53 @@ export class RealAdeClient implements AdeClient {
   }
 
   /**
+   * Coda del portale condivisa tra Fisconline, CIE e SPID (Phases B2-G).
+   *
+   * Parte dalla home portale già raggiunta (post-login IAM per Fisconline,
+   * post-SAML per CIE/SPID) e arriva all'attivazione della sessione
+   * instradamento-fatture. Verificata identica in
+   * login_credenziali_fisconline.har e login_cie_ok_notifica_app.har (entry
+   * 22-35): initPortale → InstradamentofcWeb/home → initLight → dp/PI2FC →
+   * wizardTemplate → setUserChoice.
+   *
+   * @param knownCf   - CF già noto (Fisconline: username). Per CIE è undefined
+   *                    e viene letto da wizardTemplate (`cfUidUltimo`).
+   * @param knownPiva - P.IVA già nota (re-auth su 401): salta wizardTemplate.
+   */
+  private async completePortalHandshake(opts: {
+    knownCf?: string;
+    knownPiva?: string;
+  }): Promise<AdeSession> {
+    await this.initPortale(); // B2: JS-initiated initPortale (setta cookie portale)
+    await this.initInstradamento(); // C: instradamento home
+    logger.debug({ phase: "C", cookies: this.cookieJar.size }, "ade:auth");
+    const xAppl = await this.fetchXAppl(); // E: token x-appl
+    logger.debug({ phase: "E", cookies: this.cookieJar.size }, "ade:auth");
+    await this.initDataPowerBridge(); // D: DataPower session
+    logger.debug({ phase: "D", cookies: this.cookieJar.size }, "ade:auth");
+
+    // F: scopri CF/P.IVA se non già noti (skip durante re-auth su 401)
+    let cf = opts.knownCf;
+    let partitaIva = opts.knownPiva;
+    if (!cf || !partitaIva) {
+      const identity = await this.fetchWizardIdentity(xAppl);
+      cf ??= identity.cf;
+      partitaIva ??= identity.piva;
+    }
+
+    if (!cf) {
+      throw new AdePortalError(
+        200,
+        "Failed to determine codice fiscale for setUserChoice",
+      );
+    }
+
+    await this.setUserChoiceStep(cf, partitaIva, xAppl); // G: attiva sessione
+
+    return { pAuth: "", partitaIva, createdAt: Date.now() };
+  }
+
+  /**
    * Full Fisconline authentication flow (Phases A-G).
    *
    * @param credentials - Credenziali Fisconline
@@ -638,25 +716,11 @@ export class RealAdeClient implements AdeClient {
     logger.debug({ phase: "A", cookies: this.cookieJar.size }, "ade:auth");
     await this.initPortalHome(); // B: SSO bridge portale
     logger.debug({ phase: "B", cookies: this.cookieJar.size }, "ade:auth");
-    await this.initPortale(); // B2: JS-initiated initPortale (setta cookie portale)
-    await this.initInstradamento(); // C: instradamento home
-    logger.debug({ phase: "C", cookies: this.cookieJar.size }, "ade:auth");
-    const xAppl = await this.fetchXAppl(); // E: token x-appl
-    logger.debug({ phase: "E", cookies: this.cookieJar.size }, "ade:auth");
-    await this.initDataPowerBridge(); // D: DataPower session
-    logger.debug({ phase: "D", cookies: this.cookieJar.size }, "ade:auth");
 
-    // F: scopri P.IVA se non già nota (skip durante re-auth su 401)
-    const partitaIva = knownPartitaIva ?? (await this.fetchWizardPiva(xAppl));
-
-    await this.setUserChoiceStep(
-      // G: attiva sessione
-      credentials.codiceFiscale,
-      partitaIva,
-      xAppl,
-    );
-
-    return { pAuth: "", partitaIva, createdAt: Date.now() };
+    return this.completePortalHandshake({
+      knownCf: credentials.codiceFiscale,
+      knownPiva: knownPartitaIva,
+    });
   }
 
   // -----------------------------------------------------------------------
@@ -1144,6 +1208,383 @@ export class RealAdeClient implements AdeClient {
   }
 
   // -----------------------------------------------------------------------
+  // CIE authentication (HAR: login_cie_ok_notifica_app.har)
+  //
+  // IdP Shibboleth Ministero dell'Interno (idserver.servizicie.interno.gov.it).
+  // Entry AdE: /rp/cie/sel. Login "livello 2" = email CIE ID + password,
+  // confermato via push sull'app CIE ID. Dopo il SAML si rientra nella coda
+  // portale condivisa (completePortalHandshake).
+  //
+  // Due punti di rilevamento sono derivati dall'HAR:
+  //  - credenziali errate su livello2 → messaggio "Credenziali non valide." +
+  //    classe CSS `error` sui campi (login_cie_ko_credenziali_non_valide.har);
+  //  - approvazione push su checkpush → il body JSON cambia dal baseline
+  //    (dimensioni 20→20→18 byte nell'HAR OK confermano la transizione).
+  // Diagnostic logging attivo su entrambi per il primo rollout reale.
+  // -----------------------------------------------------------------------
+
+  /** Body del probe localStorage Shibboleth (prima occorrenza, e1s1). */
+  private static readonly CIE_LS_PROBE_FULL =
+    "shib_idp_ls_exception.shib_idp_session_ss=&shib_idp_ls_success.shib_idp_session_ss=true" +
+    "&shib_idp_ls_value.shib_idp_session_ss=&shib_idp_ls_exception.shib_idp_persistent_ss=" +
+    "&shib_idp_ls_success.shib_idp_persistent_ss=true&shib_idp_ls_value.shib_idp_persistent_ss=" +
+    "&shib_idp_ls_supported=true&_eventId_proceed=";
+
+  /** Body del probe localStorage Shibboleth (seconda occorrenza, e1s5). */
+  private static readonly CIE_LS_PROBE_SHORT =
+    "shib_idp_ls_exception.shib_idp_session_ss=&shib_idp_ls_success.shib_idp_session_ss=true&_eventId_proceed=";
+
+  /** Body del consenso attributi (e1s4). */
+  private static readonly CIE_CONSENT_BODY =
+    "_shib_idp_consentIds=Nome&_shib_idp_consentIds=Cognome&_shib_idp_consentIds=DataDiNascita" +
+    "&_shib_idp_consentIds=CodiceFiscale&_shib_idp_consentOptions=_shib_idp_doNotRememberConsent" +
+    "&_eventId_proceed=Prosegui";
+
+  private cieForm(body: string): RequestInit & { followRedirects?: boolean } {
+    return {
+      method: "POST",
+      body,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      followRedirects: false,
+    };
+  }
+
+  /**
+   * CIE-1: GET AdE SP entry → HTML auto-submit form con SAMLRequest verso l'IdP.
+   * HAR (entry 0): GET sp.agenziaentrate.gov.it/rp/cie/sel?RelayState=FATBTB.
+   */
+  private async cieFetchSamlRequest(): Promise<{
+    ssoUrl: string;
+    samlRequest: string;
+    relayState: string;
+  }> {
+    const url = `${ADE_SP_BASE_URL}/rp/cie/sel?RelayState=FATBTB`;
+    const response = await this.request(url);
+    const html = await response.text();
+
+    const ssoUrl = this.parseFormAction(html);
+    const samlRequest = this.parseHiddenInput(html, "SAMLRequest");
+    const relayState = this.parseHiddenInput(html, "RelayState");
+
+    if (!ssoUrl || !samlRequest || !relayState) {
+      throw new AdePortalError(
+        200,
+        "CIE: failed to parse SAMLRequest form from /rp/cie/sel",
+      );
+    }
+    return { ssoUrl, samlRequest, relayState };
+  }
+
+  /**
+   * CIE-2: POST SAMLRequest all'IdP → 302 → pagina probe localStorage (e1s1).
+   * HAR (entry 1-2). Segue il redirect fino alla pagina 200.
+   */
+  private async ciePostSamlRequest(
+    ssoUrl: string,
+    samlRequest: string,
+    relayState: string,
+    idpJar: CookieJar,
+  ): Promise<string> {
+    const body = new URLSearchParams({
+      SAMLRequest: samlRequest,
+      RelayState: relayState,
+    }).toString();
+
+    const response = await this.request(ssoUrl, this.cieForm(body), idpJar);
+    const location = response.headers.get("Location") ?? "";
+    if (!location) {
+      throw new AdePortalError(
+        response.status,
+        "CIE: no redirect from IdP after SAMLRequest POST",
+      );
+    }
+    const { url } = await this.followRedirectChain(
+      resolveAdeRedirect(ssoUrl, location, FEDERATED_ALLOWED_HOSTS),
+      20,
+      idpJar,
+      FEDERATED_ALLOWED_HOSTS,
+    );
+    return url;
+  }
+
+  /**
+   * CIE-3: POST del probe localStorage Shibboleth → segue i redirect fino alla
+   * pagina target (livello2 credenziali, oppure consenso e1s4).
+   * HAR (entry 3-5, 17): il probe risponde 302 verso lo step successivo.
+   */
+  private async ciePostLocalStorageProbe(
+    probeUrl: string,
+    body: string,
+    idpJar: CookieJar,
+  ): Promise<{ response: Response; url: string }> {
+    const response = await this.request(probeUrl, this.cieForm(body), idpJar);
+    const location = response.headers.get("Location");
+    if (!location) {
+      // Nessun redirect: la pagina stessa è il target (200).
+      return { response, url: probeUrl };
+    }
+    return this.followRedirectChain(
+      resolveAdeRedirect(probeUrl, location, FEDERATED_ALLOWED_HOSTS),
+      20,
+      idpJar,
+      FEDERATED_ALLOWED_HOSTS,
+    );
+  }
+
+  /**
+   * CIE-4: POST credenziali livello 2 (email + password) → pagina attesa push.
+   * HAR (entry 6): POST /idp/login/livello2. Body username+password.
+   *
+   * Rilevamento credenziali errate: il KO ri-renderizza la pagina livello2 con
+   * il messaggio "Credenziali non valide." e la classe CSS `error` sui campi
+   * del form (verificato in login_cie_ko_credenziali_non_valide.har). Il caso OK
+   * è la pagina di attesa push, priva di questi marker → nessun errore.
+   */
+  private async ciePostCredentials(
+    credentials: CieCredentials,
+    idpJar: CookieJar,
+  ): Promise<void> {
+    const url = `${CIE_IDP_BASE_URL}/idp/login/livello2`;
+    const body = new URLSearchParams({
+      username: credentials.username,
+      password: credentials.password,
+    }).toString();
+
+    const response = await this.request(
+      url,
+      {
+        method: "POST",
+        body,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      },
+      idpJar,
+    );
+
+    const html = await response.text();
+    if (
+      html.includes("Credenziali non valide") ||
+      /class="[^"]*form-control[^"]*\berror\b/i.test(html)
+    ) {
+      logger.warn(
+        { phase: "cie_livello2", bodyLen: html.length },
+        "ade:cie_credentials_rejected",
+      );
+      throw new AdeAuthError("CIE: invalid credentials");
+    }
+  }
+
+  /**
+   * CIE-5: Poll checkpush finché l'app CIE ID approva, poi GET postpush → segue
+   * il redirect fino alla pagina consenso (e1s4).
+   * HAR (entry 7-14): approvazione = il body JSON di checkpush cambia dal
+   * baseline (dimensioni 20→20→18 byte). Stesso pattern di spidPollNotify.
+   */
+  private async ciePollAndProceed(
+    idpJar: CookieJar,
+  ): Promise<{ response: Response; url: string }> {
+    const maxPolls = this.options.spidMaxPolls ?? 30;
+    const intervalMs = this.options.spidPollIntervalMs ?? 7000;
+    let baseline: string | null = null;
+
+    for (let i = 0; i < maxPolls; i++) {
+      const response = await this.request(
+        `${CIE_IDP_BASE_URL}/idp/login/livello1e2checkpush?_=${Date.now()}`,
+        { headers: { "X-Requested-With": "XMLHttpRequest" } },
+        idpJar,
+      );
+      const bodyText = await response.text();
+
+      if (baseline === null) {
+        baseline = bodyText;
+      } else if (bodyText !== baseline) {
+        break;
+      }
+
+      if (i === maxPolls - 1) {
+        logger.warn({ phase: "cie_checkpush" }, "ade:cie_push_timeout");
+        throw new AdeSpidTimeoutError(maxPolls);
+      }
+      if (intervalMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+      }
+    }
+
+    const post = await this.request(
+      `${CIE_IDP_BASE_URL}/idp/login/livello1e2postpush`,
+      { followRedirects: false },
+      idpJar,
+    );
+    const location = post.headers.get("Location");
+    if (!location) {
+      throw new AdePortalError(
+        post.status,
+        "CIE: no redirect from postpush after approval",
+      );
+    }
+    return this.followRedirectChain(
+      resolveAdeRedirect(
+        `${CIE_IDP_BASE_URL}/idp/login/livello1e2postpush`,
+        location,
+        FEDERATED_ALLOWED_HOSTS,
+      ),
+      20,
+      idpJar,
+      FEDERATED_ALLOWED_HOSTS,
+    );
+  }
+
+  /**
+   * CIE-6: POST consenso attributi (e1s4) → 302 → probe localStorage finale (e1s5).
+   * HAR (entry 15).
+   */
+  private async ciePostConsent(
+    consentUrl: string,
+    idpJar: CookieJar,
+  ): Promise<{ response: Response; url: string }> {
+    const response = await this.request(
+      consentUrl,
+      this.cieForm(RealAdeClient.CIE_CONSENT_BODY),
+      idpJar,
+    );
+    const location = response.headers.get("Location");
+    if (!location) return { response, url: consentUrl };
+    return this.followRedirectChain(
+      resolveAdeRedirect(consentUrl, location, FEDERATED_ALLOWED_HOSTS),
+      20,
+      idpJar,
+      FEDERATED_ALLOWED_HOSTS,
+    );
+  }
+
+  /**
+   * CIE-7: POST probe finale (e1s5) → 200 HTML auto-submit con SAMLResponse
+   * verso l'AdE SP (AssertionConsumerService7). HAR (entry 17).
+   */
+  private async ciePostFinalProbe(
+    probeUrl: string,
+    idpJar: CookieJar,
+  ): Promise<{ samlResponse: string; relayState: string; formAction: string }> {
+    const response = await this.request(
+      probeUrl,
+      {
+        method: "POST",
+        body: RealAdeClient.CIE_LS_PROBE_SHORT,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      },
+      idpJar,
+    );
+    const html = await response.text();
+    const samlResponse = this.parseHiddenInput(html, "SAMLResponse");
+    const relayState = this.parseHiddenInput(html, "RelayState");
+    const formAction =
+      this.parseFormAction(html) ??
+      `${ADE_SP_BASE_URL}/sp/AssertionConsumerService7`;
+
+    if (!samlResponse || !relayState) {
+      throw new AdePortalError(
+        200,
+        "CIE: failed to parse SAMLResponse from IdP final page",
+      );
+    }
+    return { samlResponse, relayState, formAction };
+  }
+
+  /**
+   * CIE-8: POST SAMLResponse all'AdE SP → make4SAM → iampe Consumer → portale
+   * home. HAR (entry 18-21). Il make4SAM ritorna un secondo form auto-submit
+   * (SAMLResponse verso iampe). Usa il cookie jar principale AdE.
+   */
+  private async cieSubmitSamlResponse(
+    samlResponse: string,
+    relayState: string,
+    formAction: string,
+  ): Promise<void> {
+    // POST all'ACS → 302 make4SAM (main jar: dominio AdE).
+    const acsBody = new URLSearchParams({
+      SAMLResponse: samlResponse,
+      RelayState: relayState,
+    }).toString();
+    const acs = await this.request(formAction, this.cieForm(acsBody));
+    const acsLoc = acs.headers.get("Location");
+    if (!acsLoc) {
+      throw new AdePortalError(acs.status, "CIE: no redirect from AdE SP ACS");
+    }
+
+    // GET make4SAM → HTML auto-submit form (SAMLResponse verso iampe).
+    const make4samUrl = resolveAdeRedirect(
+      formAction,
+      acsLoc,
+      FEDERATED_ALLOWED_HOSTS,
+    );
+    const make4samResp = await this.request(make4samUrl);
+    const make4samHtml = await make4samResp.text();
+    const iampeAction =
+      this.parseFormAction(make4samHtml) ??
+      `${ADE_IAM_BASE_URL}/sam/Consumer/metaAlias/agenziaentrate/age-sp`;
+    const iampeSaml = this.parseHiddenInput(make4samHtml, "SAMLResponse");
+    const iampeRelay = this.parseHiddenInput(make4samHtml, "RelayState") ?? "";
+    if (!iampeSaml) {
+      throw new AdePortalError(
+        200,
+        "CIE: failed to parse SAMLResponse from make4SAM",
+      );
+    }
+
+    // POST a iampe Consumer → 302 → portale home. Segue la catena.
+    const iampeBody = new URLSearchParams({
+      SAMLResponse: iampeSaml,
+      RelayState: iampeRelay,
+    }).toString();
+    const iampeResp = await this.request(
+      resolveAdeRedirect(make4samUrl, iampeAction, FEDERATED_ALLOWED_HOSTS),
+      this.cieForm(iampeBody),
+    );
+    const iampeLoc = iampeResp.headers.get("Location");
+    if (!iampeLoc) {
+      throw new AdePortalError(
+        iampeResp.status,
+        "CIE: no redirect from iampe Consumer",
+      );
+    }
+    await this.followRedirectChain(
+      resolveAdeRedirect(iampeAction, iampeLoc, FEDERATED_ALLOWED_HOSTS),
+    );
+  }
+
+  /** Full CIE authentication flow. */
+  private async authenticateCie(
+    credentials: CieCredentials,
+  ): Promise<AdeSession> {
+    const idpJar = new CookieJar();
+
+    const { ssoUrl, samlRequest, relayState } =
+      await this.cieFetchSamlRequest();
+    const probe1Url = await this.ciePostSamlRequest(
+      ssoUrl,
+      samlRequest,
+      relayState,
+      idpJar,
+    );
+    await this.ciePostLocalStorageProbe(
+      probe1Url,
+      RealAdeClient.CIE_LS_PROBE_FULL,
+      idpJar,
+    );
+    await this.ciePostCredentials(credentials, idpJar);
+    const consent = await this.ciePollAndProceed(idpJar);
+    const finalProbe = await this.ciePostConsent(consent.url, idpJar);
+    const {
+      samlResponse,
+      relayState: rs2,
+      formAction,
+    } = await this.ciePostFinalProbe(finalProbe.url, idpJar);
+    await this.cieSubmitSamlResponse(samlResponse, rs2, formAction);
+
+    // Coda portale condivisa: CF letto da wizardTemplate (cfUidUltimo).
+    return this.completePortalHandshake({});
+  }
+
+  // -----------------------------------------------------------------------
   // Public methods (AdeClient interface)
   // -----------------------------------------------------------------------
 
@@ -1181,6 +1622,14 @@ export class RealAdeClient implements AdeClient {
     this.credentials = null;
     this.cookieJar.clear();
     this.session = await this.authenticateSpid(credentials);
+    return this.session;
+  }
+
+  async loginCie(credentials: CieCredentials): Promise<AdeSession> {
+    // Come SPID: nessun re-auth automatico su 401 (secondo fattore umano).
+    this.credentials = null;
+    this.cookieJar.clear();
+    this.session = await this.authenticateCie(credentials);
     return this.session;
   }
 

--- a/src/lib/ade/session-cache.test.ts
+++ b/src/lib/ade/session-cache.test.ts
@@ -27,6 +27,7 @@ function makeFakeClient(): CachedAdeClient {
   return {
     login: vi.fn().mockResolvedValue(SESSION),
     loginSpid: vi.fn().mockResolvedValue(SESSION),
+    loginCie: vi.fn().mockResolvedValue(SESSION),
     submitSale: vi.fn(),
     submitVoid: vi.fn(),
     getFiscalData: vi.fn(),

--- a/src/lib/ade/types.ts
+++ b/src/lib/ade/types.ts
@@ -177,10 +177,17 @@ export interface FisconlineCredentials {
 }
 
 // ---------------------------------------------------------------------------
+// Metodo di accesso AdE (Fisconline / CIE / SPID)
+// ---------------------------------------------------------------------------
+
+export type AdeLoginMethod = "fisconline" | "cie" | "spid";
+
+// ---------------------------------------------------------------------------
 // Credenziali SPID (sez. 1.3)
-// HAR finding (login_spid.har): flusso SAML2 HTTP POST Binding via broker
-// Sogei (spid.sogei.it). Nessun PIN — 2FA tramite push notification (Level 2).
-// I valori corrispondono ai path segment usati da AdE: /dp/SPID/{provider}/s4
+// HAR finding (login_spid_ok_*.har): flusso SAML2 HTTP POST Binding. Entry AdE
+// per provider: /rp/{provider}/sel (es. /rp/sielte/sel). 2FA via OTP dall'app
+// del provider oppure push notification. Nessun PIN. Le credenziali SPID NON
+// vengono mai persistite (regole AgID): si passano solo, transitorie, al login.
 // ---------------------------------------------------------------------------
 
 export type SpidProvider =
@@ -198,6 +205,21 @@ export interface SpidCredentials {
   codiceFiscale: string;
   password: string;
   spidProvider: SpidProvider;
+}
+
+// ---------------------------------------------------------------------------
+// Credenziali CIE (Carta d'Identità Elettronica)
+// HAR finding (login_cie_ok_notifica_app.har): IdP Shibboleth del Ministero
+// dell'Interno (idserver.servizicie.interno.gov.it). Entry AdE: /rp/cie/sel.
+// Login "livello 2" = username (EMAIL dell'app CIE ID, NON il codice fiscale) +
+// password + conferma push sull'app CIE ID. Il codice fiscale non è un input:
+// viene estratto dal portale post-login (wizardTemplate → cfUidUltimo).
+// ---------------------------------------------------------------------------
+
+export interface CieCredentials {
+  /** Email registrata sull'app CIE ID (username del login livello 2). */
+  username: string;
+  password: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server-auth.test.ts
+++ b/src/lib/server-auth.test.ts
@@ -233,6 +233,8 @@ describe("server-auth", () => {
 
       expect("error" in result).toBe(false);
       if ("error" in result) return;
+      expect(result.method).toBe("fisconline");
+      if (result.method !== "fisconline") return;
       expect(result.codiceFiscale).toBe("decrypted-value");
       expect(result.password).toBe("decrypted-value");
       expect(result.pin).toBe("decrypted-value");

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -14,12 +14,20 @@ export type { User } from "@supabase/supabase-js";
 
 export type BusinessOwnershipError = { error: string };
 
-export type AdePrerequisites = {
-  codiceFiscale: string;
-  password: string;
-  pin: string;
-  cedentePrestatore: AdeCedentePrestatore;
-};
+export type AdePrerequisites =
+  | {
+      method: "fisconline";
+      codiceFiscale: string;
+      password: string;
+      pin: string;
+      cedentePrestatore: AdeCedentePrestatore;
+    }
+  | {
+      // CIE: nessuna credenziale ri-loggabile; la sessione è quella interattiva
+      // depositata nello store. Emit/void non passano credenziali.
+      method: "cie";
+      cedentePrestatore: AdeCedentePrestatore;
+    };
 
 /**
  * Returns the authenticated Supabase user or throws if not authenticated.
@@ -131,12 +139,38 @@ export async function fetchAdePrerequisites(
     };
   }
 
+  const cedentePrestatore = buildCedenteFromBusiness(row.business);
+
+  // CIE: nessuna credenziale da decifrare — la sessione è quella interattiva
+  // depositata dallo store. emit/void la riusano (o chiedono il rinnovo).
+  if (row.cred.loginMethod === "cie") {
+    return { method: "cie", cedentePrestatore };
+  }
+
+  // Fisconline: CF+password+PIN. I campi encrypted* sono nullable (migrazione
+  // 0027): se mancano su una riga Fisconline, non è utilizzabile qui.
+  if (
+    row.cred.encryptedCodiceFiscale === null ||
+    row.cred.encryptedPassword === null ||
+    row.cred.encryptedPin === null
+  ) {
+    return {
+      error:
+        "Credenziali AdE incomplete. Riverifica le credenziali nelle impostazioni.",
+    };
+  }
+
   const key = getEncryptionKey();
   const keys = new Map<number, Buffer>([[row.cred.keyVersion, key]]);
   const codiceFiscale = decrypt(row.cred.encryptedCodiceFiscale, keys);
   const password = decrypt(row.cred.encryptedPassword, keys);
   const pin = decrypt(row.cred.encryptedPin, keys);
 
-  const cedentePrestatore = buildCedenteFromBusiness(row.business);
-  return { codiceFiscale, password, pin, cedentePrestatore };
+  return {
+    method: "fisconline",
+    codiceFiscale,
+    password,
+    pin,
+    cedentePrestatore,
+  };
 }

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdeReauthRequiredError } from "@/lib/ade/errors";
 
 // --- Mocks ---
 
@@ -82,8 +83,10 @@ const mockAdeClient = {
 // withAdeSession (REVIEW #5) sostituisce createAdeClient + login/logout manuali.
 // Il mock riproduce il ciclo mock-mode: login → fn(client) → logout nel finally,
 // così le asserzioni su mockLogin/mockLogout/mockSubmitSale restano valide.
+const mockIsCieSessionMissing = vi.fn().mockReturnValue(false);
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
+  isCieSessionMissing: (...args: unknown[]) => mockIsCieSessionMissing(...args),
   withAdeSession: async (
     params: { credentials: unknown },
     fn: (client: typeof mockAdeClient) => unknown,
@@ -148,6 +151,7 @@ describe("emitReceiptForBusiness", () => {
     process.env.ADE_MODE = "mock";
 
     mockFetchAdePrerequisites.mockResolvedValue(FAKE_PREREQUISITES);
+    mockIsCieSessionMissing.mockReturnValue(false);
 
     mockTransaction.mockImplementation(
       async (callback: (tx: unknown) => Promise<unknown>) => {
@@ -193,6 +197,41 @@ describe("emitReceiptForBusiness", () => {
     });
     expect(mockSubmitSale).toHaveBeenCalled();
     expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it("CIE senza sessione interattiva → reauthRequired, nessun documento inserito", async () => {
+    mockFetchAdePrerequisites.mockResolvedValue({
+      method: "cie",
+      cedentePrestatore: { built: true },
+    });
+    mockIsCieSessionMissing.mockReturnValue(true);
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    const result = await emitReceiptForBusiness(VALID_INPUT);
+
+    expect(result.reauthRequired).toBe(true);
+    expect(result.documentId).toBeUndefined();
+    // Nessun documento fiscale inserito né trasmesso.
+    expect(mockDocumentInsertValues).not.toHaveBeenCalled();
+    expect(mockSubmitSale).not.toHaveBeenCalled();
+  });
+
+  it("CIE: sessione scaduta in-flight (AdeReauthRequiredError) → reauthRequired, riga non marcata ERROR", async () => {
+    mockFetchAdePrerequisites.mockResolvedValue({
+      method: "cie",
+      cedentePrestatore: { built: true },
+    });
+    mockIsCieSessionMissing.mockReturnValue(false);
+    mockSubmitSale.mockRejectedValue(new AdeReauthRequiredError("cie"));
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    const result = await emitReceiptForBusiness(VALID_INPUT);
+
+    expect(result.reauthRequired).toBe(true);
+    // submitSale tentato ma AdE ha rifiutato la sessione; la riga resta PENDING
+    // (nessun UPDATE a ERROR — 401 = documento non registrato, niente duplicato).
+    expect(mockSubmitSale).toHaveBeenCalled();
+    expect(mockUpdateSet).not.toHaveBeenCalledWith({ status: "ERROR" });
   });
 
   it("L2: defensive branch — transaction returns row without id → internal error + critical log", async () => {

--- a/src/lib/services/receipt-service.ts
+++ b/src/lib/services/receipt-service.ts
@@ -11,9 +11,12 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments, commercialDocumentLines } from "@/db/schema";
-import { withAdeSession } from "@/lib/ade";
+import { withAdeSession, isCieSessionMissing } from "@/lib/ade";
+import {
+  AdePasswordExpiredError,
+  AdeReauthRequiredError,
+} from "@/lib/ade/errors";
 import type { AdeClient } from "@/lib/ade/client";
-import { AdePasswordExpiredError } from "@/lib/ade/errors";
 import {
   getUserFacingAdeErrorMessage,
   isTransientAdeError,
@@ -27,7 +30,10 @@ import {
 } from "@/lib/db-timeout";
 import { logger } from "@/lib/logger";
 import { calcInputLinesTotalCents } from "@/lib/receipts/document-lines";
-import { fetchAdePrerequisites } from "@/lib/server-auth";
+import {
+  fetchAdePrerequisites,
+  type AdePrerequisites,
+} from "@/lib/server-auth";
 import { getFiscalDate } from "@/lib/date-utils";
 import { isValidLotteryCode } from "@/lib/validation";
 import type {
@@ -111,7 +117,13 @@ export async function emitReceiptForBusiness(
 
   const prerequisites = await fetchAdePrerequisites(input.businessId);
   if ("error" in prerequisites) return prerequisites;
-  const { codiceFiscale, password, pin, cedentePrestatore } = prerequisites;
+
+  // CIE: se la sessione interattiva manca/è scaduta, chiedi il rinnovo PRIMA di
+  // inserire il documento — così un retry post-rinnovo non trova un PENDING
+  // bloccato dallo stale-gate. Nessun documento fiscale viene trasmesso.
+  if (prerequisites.method === "cie" && isCieSessionMissing(input.businessId)) {
+    return { reauthRequired: true };
+  }
 
   // Insert document + lines atomically, with statement_timeout: if the
   // DB is overloaded we surface 503 invece di un 500 senza contesto.
@@ -175,7 +187,7 @@ export async function emitReceiptForBusiness(
     return handleExistingReceipt({
       input,
       lotteryCode,
-      prerequisites: { codiceFiscale, password, pin, cedentePrestatore },
+      prerequisites,
       apiKeyId,
     });
   }
@@ -201,7 +213,7 @@ export async function emitReceiptForBusiness(
     documentId,
     input,
     lotteryCode,
-    { codiceFiscale, password, pin, cedentePrestatore },
+    prerequisites,
     apiKeyId,
     { recovery: false },
   );
@@ -221,12 +233,7 @@ export async function emitReceiptForBusiness(
 async function handleExistingReceipt(args: {
   input: SubmitReceiptInput;
   lotteryCode: string | null;
-  prerequisites: {
-    codiceFiscale: string;
-    password: string;
-    pin: string;
-    cedentePrestatore: AdeCedentePrestatore;
-  };
+  prerequisites: AdePrerequisites;
   apiKeyId: string | null | undefined;
 }): Promise<SubmitReceiptResult> {
   const { input, lotteryCode, prerequisites, apiKeyId } = args;
@@ -345,12 +352,7 @@ async function recoverStaleReceipt(args: {
   };
   input: SubmitReceiptInput;
   lotteryCode: string | null;
-  prerequisites: {
-    codiceFiscale: string;
-    password: string;
-    pin: string;
-    cedentePrestatore: AdeCedentePrestatore;
-  };
+  prerequisites: AdePrerequisites;
   apiKeyId: string | null | undefined;
   createdAtMs: number;
 }): Promise<SubmitReceiptResult> {
@@ -601,17 +603,12 @@ async function submitSaleToAde(
   documentId: string,
   input: SubmitReceiptInput,
   lotteryCode: string | null,
-  prerequisites: {
-    codiceFiscale: string;
-    password: string;
-    pin: string;
-    cedentePrestatore: AdeCedentePrestatore;
-  },
+  prerequisites: AdePrerequisites,
   apiKeyId: string | null | undefined,
   options: { recovery: boolean; reconcile?: { createdAt: Date } },
 ): Promise<SubmitReceiptResult> {
   const db = getDb();
-  const { codiceFiscale, password, pin, cedentePrestatore } = prerequisites;
+  const { cedentePrestatore } = prerequisites;
 
   // Per-line cents (canonical, REVIEW.md #1): the amount sent to AdE must match
   // the total on the PDF / public page (computeReceiptTotals) and the storico
@@ -642,10 +639,17 @@ async function submitSaleToAde(
 
   try {
     return await withAdeSession(
-      {
-        businessId: input.businessId,
-        credentials: { codiceFiscale, password, pin },
-      },
+      prerequisites.method === "cie"
+        ? { businessId: input.businessId, method: "cie" }
+        : {
+            businessId: input.businessId,
+            method: "fisconline",
+            credentials: {
+              codiceFiscale: prerequisites.codiceFiscale,
+              password: prerequisites.password,
+              pin: prerequisites.pin,
+            },
+          },
       async (adeClient) => {
         // Lookup AdE pre-retry (REVIEW.md #4): solo in recovery, prima di
         // ri-sottomettere, riconcilia il documento con AdE nella stessa sessione.
@@ -670,6 +674,14 @@ async function submitSaleToAde(
       },
     );
   } catch (err) {
+    // Sessione CIE scaduta in-flight (rara: viva al pre-check, rifiutata da AdE
+    // durante il submit). Un 401 AdE = documento NON registrato → nessun rischio
+    // di duplicato. Lasciamo la riga PENDING (niente ERROR) e chiediamo il
+    // rinnovo. Non è un failure nostro: niente logAdeFailure/Sentry (regola 20).
+    if (err instanceof AdeReauthRequiredError) {
+      return { reauthRequired: true };
+    }
+
     logAdeFailure(
       err,
       {

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdeReauthRequiredError } from "@/lib/ade/errors";
 
 // --- Mocks ---
 
@@ -84,8 +85,10 @@ const mockAdeClient = {
 // withAdeSession (REVIEW #5) sostituisce createAdeClient + login/logout manuali.
 // Il mock riproduce il ciclo mock-mode: login → fn(client) → logout nel finally,
 // così le asserzioni su mockLogin/mockLogout/mockSubmitVoid restano valide.
+const mockIsCieSessionMissing = vi.fn().mockReturnValue(false);
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
+  isCieSessionMissing: (...args: unknown[]) => mockIsCieSessionMissing(...args),
   withAdeSession: async (
     params: { credentials: unknown },
     fn: (client: typeof mockAdeClient) => unknown,
@@ -189,6 +192,7 @@ describe("voidReceiptForBusiness", () => {
     process.env.ADE_MODE = "mock";
 
     mockFetchAdePrerequisites.mockResolvedValue(FAKE_PREREQUISITES);
+    mockIsCieSessionMissing.mockReturnValue(false);
 
     // select: first call returns saleDoc, subsequent calls return idempotency results
     mockSelect.mockReturnValue({ from: mockSelectFrom });
@@ -240,6 +244,38 @@ describe("voidReceiptForBusiness", () => {
     expect(mockGetDocument).toHaveBeenCalledWith("trx-001");
     expect(mockSubmitVoid).toHaveBeenCalled();
     expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it("CIE senza sessione interattiva → reauthRequired, nessuna riga VOID inserita", async () => {
+    mockFetchAdePrerequisites.mockResolvedValue({
+      method: "cie",
+      cedentePrestatore: { built: true },
+    });
+    mockIsCieSessionMissing.mockReturnValue(true);
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    const result = await voidReceiptForBusiness(VALID_INPUT);
+
+    expect(result.reauthRequired).toBe(true);
+    // Early-check: nessun insert VOID né submitVoid.
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(mockSubmitVoid).not.toHaveBeenCalled();
+  });
+
+  it("CIE: sessione scaduta in-flight (AdeReauthRequiredError) → reauthRequired", async () => {
+    mockFetchAdePrerequisites.mockResolvedValue({
+      method: "cie",
+      cedentePrestatore: { built: true },
+    });
+    mockIsCieSessionMissing.mockReturnValue(false);
+    mockSubmitVoid.mockRejectedValue(new AdeReauthRequiredError("cie"));
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    const result = await voidReceiptForBusiness(VALID_INPUT);
+
+    expect(result.reauthRequired).toBe(true);
+    // submitVoid è stato tentato ma AdE ha rifiutato la sessione.
+    expect(mockSubmitVoid).toHaveBeenCalled();
   });
 
   it("salva apiKeyId nel documento VOID quando fornito", async () => {

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -11,7 +11,8 @@
 import { and, eq } from "drizzle-orm";
 import { getDb } from "@/db";
 import { commercialDocuments } from "@/db/schema";
-import { withAdeSession } from "@/lib/ade";
+import { withAdeSession, isCieSessionMissing } from "@/lib/ade";
+import { AdeReauthRequiredError } from "@/lib/ade/errors";
 import type { AdeClient } from "@/lib/ade/client";
 import {
   getUserFacingAdeErrorMessage,
@@ -26,7 +27,10 @@ import {
 } from "@/lib/db-timeout";
 import { logger } from "@/lib/logger";
 import { getFiscalDate } from "@/lib/date-utils";
-import { fetchAdePrerequisites } from "@/lib/server-auth";
+import {
+  fetchAdePrerequisites,
+  type AdePrerequisites,
+} from "@/lib/server-auth";
 import type { VoidReceiptInput, VoidReceiptResult } from "@/types/storico";
 import type { VoidRequest } from "@/lib/ade/public-types";
 import type { AdeResponse } from "@/lib/ade/types";
@@ -398,18 +402,7 @@ type PrepareVoidOutcome =
       voidDocumentId: string;
       recovery: boolean;
       voidCreatedAt?: Date | null;
-      prerequisites: {
-        codiceFiscale: string;
-        password: string;
-        pin: string;
-        cedentePrestatore: NonNullable<
-          Awaited<ReturnType<typeof fetchAdePrerequisites>> extends infer T
-            ? T extends { cedentePrestatore: infer C }
-              ? C
-              : never
-            : never
-        >;
-      };
+      prerequisites: AdePrerequisites;
     };
 
 const dbTimeoutResult: VoidReceiptResult = {
@@ -507,6 +500,12 @@ async function prepareVoidDocument(
   const prerequisites = await fetchAdePrerequisites(input.businessId);
   if ("error" in prerequisites) {
     return { kind: "done", result: prerequisites };
+  }
+
+  // CIE: sessione interattiva assente/scaduta → chiedi il rinnovo PRIMA di
+  // inserire la riga VOID PENDING (evita un annullo bloccato dallo stale-gate).
+  if (prerequisites.method === "cie" && isCieSessionMissing(input.businessId)) {
+    return { kind: "done", result: { reauthRequired: true } };
   }
 
   const insertOutcome = await insertOrResolveVoid(input, apiKeyId);
@@ -734,15 +733,22 @@ export async function voidReceiptForBusiness(
     recovery,
     voidCreatedAt,
   } = prep;
-  const { codiceFiscale, password, pin, cedentePrestatore } =
-    prep.prerequisites;
+  const { prerequisites } = prep;
+  const { cedentePrestatore } = prerequisites;
 
   try {
     return await withAdeSession(
-      {
-        businessId: input.businessId,
-        credentials: { codiceFiscale, password, pin },
-      },
+      prerequisites.method === "cie"
+        ? { businessId: input.businessId, method: "cie" }
+        : {
+            businessId: input.businessId,
+            method: "fisconline",
+            credentials: {
+              codiceFiscale: prerequisites.codiceFiscale,
+              password: prerequisites.password,
+              pin: prerequisites.pin,
+            },
+          },
       async (adeClient) => {
         // Lookup AdE pre-retry (REVIEW.md #4): solo in recovery, prima di
         // ri-sottomettere, riconcilia l'annullo con AdE nella stessa sessione.
@@ -786,6 +792,13 @@ export async function voidReceiptForBusiness(
       },
     );
   } catch (err) {
+    // Sessione CIE scaduta in-flight: 401 AdE = annullo NON registrato → nessun
+    // duplicato. Riga PENDING lasciata intatta (niente ERROR), rinnovo richiesto.
+    // Non è un failure nostro: niente logAdeFailure/Sentry (regola 20).
+    if (err instanceof AdeReauthRequiredError) {
+      return { reauthRequired: true };
+    }
+
     logAdeFailure(
       err,
       {

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -101,12 +101,14 @@ vi.mock("@/lib/crypto", () => ({
 }));
 
 const mockLogin = vi.fn();
+const mockLoginCie = vi.fn();
 const mockLogout = vi.fn();
 const mockGetFiscalData = vi.fn();
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
     login: mockLogin,
+    loginCie: mockLoginCie,
     logout: mockLogout,
     getFiscalData: mockGetFiscalData,
   }),
@@ -647,6 +649,64 @@ describe("onboarding-actions", () => {
       expect(mockUpdate).not.toHaveBeenCalled();
       expect(mockRevalidatePath).not.toHaveBeenCalled();
     });
+
+    it("CIE: salva username(email)+password con login_method 'cie'", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          loginMethod: "cie",
+          username: "mario.rossi@example.com",
+          password: "cie-pass",
+        }),
+      );
+
+      expect(result.businessId).toBe("biz-789");
+      expect(mockInsert).toHaveBeenCalled();
+      // login_method 'cie' + reset dei campi Fisconline (CF/PIN null).
+      expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          set: expect.objectContaining({
+            loginMethod: "cie",
+            encryptedCodiceFiscale: null,
+            encryptedPin: null,
+            verifiedAt: null,
+          }),
+        }),
+      );
+    });
+
+    it("CIE: rifiuta uno username non-email prima dell'ownership check", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          loginMethod: "cie",
+          username: "non-una-email",
+          password: "cie-pass",
+        }),
+      );
+
+      expect(result.error).toContain("email");
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("SPID: rifiutato (non supportato da PWA), nessun insert", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "biz-789",
+          loginMethod: "spid",
+          username: "mario.rossi@example.com",
+          password: "pw",
+        }),
+      );
+
+      expect(result.error).toContain("SPID");
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
   });
 
   describe("verifyAdeCredentials", () => {
@@ -762,6 +822,62 @@ describe("onboarding-actions", () => {
       // sempre a una riga non-vuota di default).
       expect(mockUpdate).toHaveBeenCalledTimes(7);
       expect(mockRevalidatePath).toHaveBeenCalledWith("/dashboard", "layout");
+    });
+
+    it("CIE: verifica via loginCie (non login Fisconline)", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      // Riga credenziali con metodo CIE: username(email) + password, niente CF/PIN.
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          loginMethod: "cie",
+          encryptedCodiceFiscale: null,
+          encryptedUsername: "enc-email",
+          encryptedPassword: "enc-pw",
+          encryptedPin: null,
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+      mockLoginCie.mockResolvedValue({});
+      mockLogout.mockResolvedValue(undefined);
+      mockGetFiscalData.mockResolvedValue({
+        identificativiFiscali: {
+          codicePaese: "IT",
+          partitaIva: "12345678901",
+          codiceFiscale: "RSSMRA80A01H501U",
+        },
+      });
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      expect(result.error).toBeUndefined();
+      expect(mockLoginCie).toHaveBeenCalled();
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    it("SPID: riga con metodo spid degrada senza tentare login", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+      mockLimit.mockResolvedValueOnce([
+        {
+          businessId: "biz-789",
+          loginMethod: "spid",
+          encryptedCodiceFiscale: null,
+          encryptedUsername: null,
+          encryptedPassword: null,
+          encryptedPin: null,
+          keyVersion: 1,
+          updatedAt: new Date("2026-03-26T14:36:07.000Z"),
+        },
+      ]);
+
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+
+      expect(result.error).toContain("SPID");
+      expect(mockLogin).not.toHaveBeenCalled();
+      expect(mockLoginCie).not.toHaveBeenCalled();
     });
 
     it("referrer in trial: incrementa referralBonusDays, niente estensione Stripe", async () => {

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/crypto";
 import { createAdeClient, getAdeMode } from "@/lib/ade";
 import { adeSessionCache } from "@/lib/ade/session-cache";
+import { adeInteractiveSessionStore } from "@/lib/ade/interactive-session-store";
 import {
   AdeAuthError,
   AdeError,
@@ -269,24 +270,36 @@ export async function saveBusiness(
   });
 }
 
-export async function saveAdeCredentials(
-  formData: FormData,
-): Promise<OnboardingActionResult> {
-  const user = await getAuthenticatedUser();
+/**
+ * Campi cifrati/metodo che compongono una riga `ade_credentials`. Per metodo
+ * solo un sottoinsieme è valorizzato (gli altri restano NULL — migrazione 0027).
+ */
+type AdeCredentialValues = {
+  loginMethod: string;
+  encryptedCodiceFiscale: string | null;
+  encryptedUsername: string | null;
+  encryptedPassword: string | null;
+  encryptedPin: string | null;
+  spidProvider: string | null;
+  keyVersion: number;
+};
 
-  const businessId = getFormString(formData, "businessId");
+/**
+ * Costruisce i valori cifrati per Fisconline (CF + password + PIN). Ritorna
+ * `{ error }` su input non valido.
+ */
+function buildFisconlineValues(
+  formData: FormData,
+  key: Buffer,
+  keyVersion: number,
+): AdeCredentialValues | { error: string } {
   const codiceFiscale = getFormString(formData, "codiceFiscale");
   // La password Fisconline è una credenziale opaca (regole AdE: 8–15 char,
-  // charset misto). Non trimmare: ogni byte ha significato semantico —
-  // lo stesso principio della password app.
+  // charset misto). Non trimmare: ogni byte ha significato semantico.
   const password = getFormStringRaw(formData, "password");
-  // PIN già validato a regex `^\d{10}$`: trimming è sicuro perché
-  // qualsiasi whitespace verrebbe comunque rifiutato dallo schema.
+  // PIN già validato a regex `^\d{10}$`: trimming è sicuro.
   const pin = getFormString(formData, "pin");
 
-  if (!businessId) {
-    return { error: "Business ID mancante." };
-  }
   if (codiceFiscale.length !== 16) {
     return { error: "Codice fiscale non valido (16 caratteri)." };
   }
@@ -300,47 +313,105 @@ export async function saveAdeCredentials(
     };
   }
 
-  const ownershipError = await checkBusinessOwnership(user.id, businessId);
-  if (ownershipError) return ownershipError;
+  return {
+    loginMethod: "fisconline",
+    encryptedCodiceFiscale: encrypt(codiceFiscale, key, keyVersion),
+    encryptedUsername: null,
+    encryptedPassword: encrypt(password, key, keyVersion),
+    encryptedPin: encrypt(pin, key, keyVersion),
+    spidProvider: null,
+    keyVersion,
+  };
+}
+
+/**
+ * Costruisce i valori cifrati per CIE (email dell'app CIE ID + password). Il CF
+ * non è un input: viene estratto dal portale post-login (wizardTemplate).
+ */
+function buildCieValues(
+  formData: FormData,
+  key: Buffer,
+  keyVersion: number,
+): AdeCredentialValues | { error: string } {
+  const username = getFormString(formData, "username");
+  const password = getFormStringRaw(formData, "password");
+
+  if (!username.includes("@")) {
+    return { error: "Inserisci l'email dell'app CIE ID." };
+  }
+  if (!password) {
+    return { error: "Password CIE obbligatoria." };
+  }
+
+  return {
+    loginMethod: "cie",
+    encryptedCodiceFiscale: null,
+    encryptedUsername: encrypt(username, key, keyVersion),
+    encryptedPassword: encrypt(password, key, keyVersion),
+    encryptedPin: null,
+    spidProvider: null,
+    keyVersion,
+  };
+}
+
+export async function saveAdeCredentials(
+  formData: FormData,
+): Promise<OnboardingActionResult> {
+  const user = await getAuthenticatedUser();
+
+  const businessId = getFormString(formData, "businessId");
+  if (!businessId) {
+    return { error: "Business ID mancante." };
+  }
+
+  // Metodo di accesso (default 'fisconline' per retrocompatibilità dei form).
+  const loginMethod = getFormString(formData, "loginMethod") || "fisconline";
 
   const key = getEncryptionKey();
   const keyVersion = getKeyVersion();
 
-  const encryptedCodiceFiscale = encrypt(codiceFiscale, key, keyVersion);
-  const encryptedPassword = encrypt(password, key, keyVersion);
-  const encryptedPin = encrypt(pin, key, keyVersion);
+  // Validazione + cifratura PRIMA dell'ownership check: gli errori d'input non
+  // devono dipendere dall'accesso al business (coerente col comportamento
+  // storico Fisconline).
+  // SPID non è supportato dalla PWA (nessuna via provider-agnostica: la webview
+  // nativa dei competitor non è replicabile cross-origin nel browser). Rifiutato
+  // esplicitamente: solo Fisconline e CIE sono metodi validi.
+  let values: AdeCredentialValues | { error: string };
+  if (loginMethod === "cie") {
+    values = buildCieValues(formData, key, keyVersion);
+  } else if (loginMethod === "spid") {
+    return { error: "L'accesso con SPID non è disponibile." };
+  } else {
+    values = buildFisconlineValues(formData, key, keyVersion);
+  }
+
+  if ("error" in values) return values;
+
+  const ownershipError = await checkBusinessOwnership(user.id, businessId);
+  if (ownershipError) return ownershipError;
 
   const db = getDb();
 
   // Atomic upsert per evitare race condition (doppio submit del form, retry
   // di rete) — il vincolo UNIQUE su business_id garantisce 1:1.
   // verifiedAt: null al re-insert E al conflict update — credenziali nuove
-  // non sono ancora state verificate contro AdE.
+  // non sono ancora state verificate contro AdE. Lo spread di `values` azzera
+  // esplicitamente i campi non pertinenti al metodo (es. switch Fisconline→CIE
+  // pulisce CF/PIN).
   await db
     .insert(adeCredentials)
-    .values({
-      businessId,
-      encryptedCodiceFiscale,
-      encryptedPassword,
-      encryptedPin,
-      keyVersion,
-    })
+    .values({ businessId, ...values })
     .onConflictDoUpdate({
       target: adeCredentials.businessId,
-      set: {
-        encryptedCodiceFiscale,
-        encryptedPassword,
-        encryptedPin,
-        keyVersion,
-        verifiedAt: null,
-      },
+      set: { ...values, verifiedAt: null },
     });
 
-  logger.info({ businessId }, "ADE credentials updated");
+  logger.info({ businessId, loginMethod }, "ADE credentials updated");
 
   // Invalida la sessione AdE cached (REVIEW #5): le credenziali sono cambiate,
   // la prossima emissione/annullo deve rieffettuare il login con le nuove.
   await adeSessionCache.invalidate(businessId);
+  await adeInteractiveSessionStore.invalidate(businessId);
 
   // Invalida la Router Cache client-side del dashboard: dopo aver salvato le
   // credenziali l'utente è eleggibile ad accedere al dashboard, ma il redirect
@@ -614,12 +685,12 @@ async function finalizeAdeVerification(params: {
  * controllo la Cognitive Complexity (SonarCloud).
  */
 async function attemptAdeLoginForVerification(
-  adeClient: ReturnType<typeof createAdeClient>,
-  credentials: { codiceFiscale: string; password: string; pin: string },
+  doLogin: () => Promise<unknown>,
   businessId: string,
+  opts: { flow: string; defaultMessage: string },
 ): Promise<OnboardingActionResult | null> {
   try {
-    await adeClient.login(credentials);
+    await doLogin();
     return null;
   } catch (err) {
     if (err instanceof AdePasswordExpiredError) {
@@ -631,21 +702,72 @@ async function attemptAdeLoginForVerification(
     }
     logAdeFailure(
       err,
-      { businessId, flow: "onboarding-verify" },
+      { businessId, flow: opts.flow },
       {
         transient: "AdE credential verification: transient failure",
         failure: "AdE credential verification failed",
       },
     );
-    const userFacing = getUserFacingAdeErrorMessage(
-      err,
-      "Verifica fallita. Controlla le credenziali Fisconline.",
-    );
+    const userFacing = getUserFacingAdeErrorMessage(err, opts.defaultMessage);
     return {
       error: userFacing.message,
       ...(userFacing.passwordExpired ? { passwordExpired: true } : {}),
     };
   }
+}
+
+/**
+ * Costruisce la closure di login per la verifica in base al metodo salvato
+ * (`cred.loginMethod`). Ritorna la closure + i metadati per il logging, oppure
+ * `{ error }` se la riga credenziali è incompleta per il metodo.
+ *
+ * Fisconline: CF+password+PIN cifrati. CIE: username(email)+password cifrati.
+ * SPID: non verificabile qui — non memorizza segreti, il login è sempre
+ * interattivo (Fase 4, dietro flag).
+ */
+function buildVerificationLogin(
+  adeClient: ReturnType<typeof createAdeClient>,
+  cred: typeof adeCredentials.$inferSelect,
+  keys: Map<number, Buffer>,
+):
+  | { doLogin: () => Promise<unknown>; flow: string; defaultMessage: string }
+  | { error: string } {
+  if (cred.loginMethod === "cie") {
+    if (cred.encryptedUsername === null || cred.encryptedPassword === null) {
+      return { error: "Credenziali CIE incomplete." };
+    }
+    const username = decrypt(cred.encryptedUsername, keys);
+    const password = decrypt(cred.encryptedPassword, keys);
+    return {
+      doLogin: () => adeClient.loginCie({ username, password }),
+      flow: "onboarding-verify-cie",
+      defaultMessage: "Verifica fallita. Controlla le credenziali CIE.",
+    };
+  }
+
+  if (cred.loginMethod === "spid") {
+    // Guardia difensiva: la migrazione 0027 ammette 'spid' nel CHECK, ma la PWA
+    // non lo crea (saveAdeCredentials lo rifiuta). Se una riga esistesse
+    // comunque, degrada con un messaggio chiaro invece di tentare un login.
+    return { error: "L'accesso con SPID non è disponibile." };
+  }
+
+  // fisconline (default)
+  if (
+    cred.encryptedCodiceFiscale === null ||
+    cred.encryptedPassword === null ||
+    cred.encryptedPin === null
+  ) {
+    return { error: "Credenziali Fisconline incomplete." };
+  }
+  const codiceFiscale = decrypt(cred.encryptedCodiceFiscale, keys);
+  const password = decrypt(cred.encryptedPassword, keys);
+  const pin = decrypt(cred.encryptedPin, keys);
+  return {
+    doLogin: () => adeClient.login({ codiceFiscale, password, pin }),
+    flow: "onboarding-verify",
+    defaultMessage: "Verifica fallita. Controlla le credenziali Fisconline.",
+  };
 }
 
 /**
@@ -762,16 +884,17 @@ export async function verifyAdeCredentials(
   const key = getEncryptionKey();
   const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);
 
-  const codiceFiscale = decrypt(cred.encryptedCodiceFiscale, keys);
-  const password = decrypt(cred.encryptedPassword, keys);
-  const pin = decrypt(cred.encryptedPin, keys);
-
   const adeClient = createAdeClient(getAdeMode());
 
+  // Login method-aware (Fisconline / CIE). La coda post-login (getFiscalData,
+  // identity guard, finalize, notifiche) è identica per tutti i metodi.
+  const loginPlan = buildVerificationLogin(adeClient, cred, keys);
+  if ("error" in loginPlan) return loginPlan;
+
   const loginError = await attemptAdeLoginForVerification(
-    adeClient,
-    { codiceFiscale, password, pin },
+    loginPlan.doLogin,
     businessId,
+    { flow: loginPlan.flow, defaultMessage: loginPlan.defaultMessage },
   );
   if (loginError) return loginError;
 
@@ -785,9 +908,16 @@ export async function verifyAdeCredentials(
   } catch (err) {
     logger.error({ err, businessId }, "Failed to fetch fiscal data from AdE");
   } finally {
-    await adeClient
-      .logout()
-      .catch((err) => logger.warn({ err }, "AdE logout failed"));
+    if (cred.loginMethod === "cie" && getAdeMode() === "real") {
+      // La sessione CIE non è ri-creabile in silenzio (secondo fattore umano):
+      // depositala nello store interattivo per riusarla in emissione/annullo,
+      // invece di fare logout. "Verifica connessione" È il collega/rinnova CIE.
+      adeInteractiveSessionStore.set(businessId, adeClient);
+    } else {
+      await adeClient
+        .logout()
+        .catch((err) => logger.warn({ err }, "AdE logout failed"));
+    }
   }
 
   // Identity guard: blocca il cambio credenziali verso una P.IVA diversa su un
@@ -1043,6 +1173,9 @@ export async function changeAdePassword(
     .limit(1);
 
   if (!cred) return { error: "Credenziali non trovate." };
+  if (cred.encryptedCodiceFiscale === null) {
+    return { error: "Codice fiscale non disponibile per il cambio password." };
+  }
 
   const key = getEncryptionKey();
   const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -826,6 +826,34 @@ async function claimAndSendOnboardingNotifications(
   }
 }
 
+/**
+ * Recupera i dati fiscali dopo il login di verifica (best-effort) e chiude la
+ * sessione secondo il metodo: per CIE (real) deposita il client nello store
+ * interattivo — la sessione non è ri-creabile in silenzio (secondo fattore
+ * umano) — così emit/void la riusano; altrimenti logout. Estratto da
+ * verifyAdeCredentials per contenerne la Cognitive Complexity (SonarCloud).
+ */
+async function fetchFiscalDataAndCloseSession(
+  adeClient: ReturnType<typeof createAdeClient>,
+  businessId: string,
+  loginMethod: string,
+): Promise<Awaited<ReturnType<typeof adeClient.getFiscalData>> | null> {
+  try {
+    return await adeClient.getFiscalData();
+  } catch (err) {
+    logger.error({ err, businessId }, "Failed to fetch fiscal data from AdE");
+    return null;
+  } finally {
+    if (loginMethod === "cie" && getAdeMode() === "real") {
+      adeInteractiveSessionStore.set(businessId, adeClient);
+    } else {
+      await adeClient
+        .logout()
+        .catch((err) => logger.warn({ err }, "AdE logout failed"));
+    }
+  }
+}
+
 export async function verifyAdeCredentials(
   businessId: string,
 ): Promise<OnboardingActionResult> {
@@ -900,25 +928,13 @@ export async function verifyAdeCredentials(
 
   // Fetch fiscal data from AdE while the session is still active. Best-effort:
   // verification still succeeds (verifiedAt set) even if AdE doesn't return it;
-  // P.IVA/CF are then filled on a later run.
-  let fiscalData: Awaited<ReturnType<typeof adeClient.getFiscalData>> | null =
-    null;
-  try {
-    fiscalData = await adeClient.getFiscalData();
-  } catch (err) {
-    logger.error({ err, businessId }, "Failed to fetch fiscal data from AdE");
-  } finally {
-    if (cred.loginMethod === "cie" && getAdeMode() === "real") {
-      // La sessione CIE non è ri-creabile in silenzio (secondo fattore umano):
-      // depositala nello store interattivo per riusarla in emissione/annullo,
-      // invece di fare logout. "Verifica connessione" È il collega/rinnova CIE.
-      adeInteractiveSessionStore.set(businessId, adeClient);
-    } else {
-      await adeClient
-        .logout()
-        .catch((err) => logger.warn({ err }, "AdE logout failed"));
-    }
-  }
+  // P.IVA/CF are then filled on a later run. Per CIE la sessione resta viva
+  // (depositata nello store) invece del logout — vedi helper.
+  const fiscalData = await fetchFiscalDataAndCloseSession(
+    adeClient,
+    businessId,
+    cred.loginMethod,
+  );
 
   // Identity guard: blocca il cambio credenziali verso una P.IVA diversa su un
   // business già onboardato (logica in checkAdeIdentityGuard). Eseguito PRIMA

--- a/src/types/cassa.ts
+++ b/src/types/cassa.ts
@@ -137,4 +137,10 @@ export type SubmitReceiptResult = {
   adeTransactionId?: string;
   adeProgressive?: string;
   passwordExpired?: boolean;
+  /**
+   * La sessione AdE interattiva (CIE) è assente/scaduta: l'utente deve
+   * ri-collegarsi (approvare la notifica sull'app) prima di riprovare. Nessun
+   * documento fiscale è stato trasmesso.
+   */
+  reauthRequired?: boolean;
 };

--- a/src/types/storico.ts
+++ b/src/types/storico.ts
@@ -100,4 +100,9 @@ export interface VoidReceiptResult {
   voidDocumentId?: string;
   adeTransactionId?: string;
   adeProgressive?: string;
+  /**
+   * Sessione AdE interattiva (CIE) assente/scaduta: l'utente deve ri-collegarsi
+   * prima di riprovare. Nessun annullo è stato trasmesso.
+   */
+  reauthRequired?: boolean;
 }

--- a/supabase/migrations/0027_ade_credentials_login_method.sql
+++ b/supabase/migrations/0027_ade_credentials_login_method.sql
@@ -1,0 +1,43 @@
+-- Migration: 0027_ade_credentials_login_method
+-- Onboarding AdE multi-metodo: Fisconline (default) + CIE + SPID.
+--
+-- Finora `ade_credentials` modellava solo Fisconline (CF + password + PIN, tutti
+-- NOT NULL). Aggiungiamo il metodo di accesso e rilassiamo i vincoli perché i
+-- nuovi metodi memorizzano insiemi di campi diversi (validati a livello
+-- applicativo, non dallo schema):
+--   - Fisconline: encrypted_codice_fiscale + encrypted_password + encrypted_pin
+--   - CIE:        encrypted_username (email CIE ID) + encrypted_password
+--   - SPID:       NESSUN segreto memorizzato (solo login_method + spid_provider);
+--                 username/password reinseriti a ogni rinnovo (regole AgID:
+--                 la password SPID non va conservata da terzi).
+--
+-- Per questo `encrypted_codice_fiscale`, `encrypted_password` e `encrypted_pin`
+-- diventano NULLABLE. I record Fisconline esistenti restano validi (login_method
+-- default 'fisconline', tutti i campi già valorizzati).
+--
+-- Solo ADD COLUMN IF NOT EXISTS / DROP NOT NULL / CHECK idempotente → re-run safe.
+
+ALTER TABLE "ade_credentials"
+  ADD COLUMN IF NOT EXISTS "login_method" text NOT NULL DEFAULT 'fisconline';
+
+ALTER TABLE "ade_credentials"
+  ADD COLUMN IF NOT EXISTS "encrypted_username" text;
+
+ALTER TABLE "ade_credentials"
+  ADD COLUMN IF NOT EXISTS "spid_provider" text;
+
+ALTER TABLE "ade_credentials" ALTER COLUMN "encrypted_codice_fiscale" DROP NOT NULL;
+ALTER TABLE "ade_credentials" ALTER COLUMN "encrypted_password" DROP NOT NULL;
+ALTER TABLE "ade_credentials" ALTER COLUMN "encrypted_pin" DROP NOT NULL;
+
+-- Vincolo sui valori ammessi di login_method (idempotente via guard su pg_constraint).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ade_credentials_login_method_check'
+  ) THEN
+    ALTER TABLE "ade_credentials"
+      ADD CONSTRAINT "ade_credentials_login_method_check"
+      CHECK ("login_method" IN ('fisconline', 'cie', 'spid'));
+  END IF;
+END $$;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1780099210000,
       "tag": "0026_profiles_inactivity_warning",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1780099211000,
+      "tag": "0027_ade_credentials_login_method",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Cosa

Aggiunge la **CIE (Carta d'Identità Elettronica)** come metodo di accesso all'Agenzia delle Entrate accanto a Fisconline, sia in **onboarding** sia nella **card credenziali** delle impostazioni. **SPID escluso**: non è supportabile da una PWA (la webview nativa usata dai competitor non è replicabile cross-origin per la same-origin policy) ed è una zona grigia regolatoria AgID sullo storage delle credenziali.

## Perché

Semplificare l'onboarding: molti esercenti non hanno (più) credenziali Fisconline e accedono ad AdE con CIE. CIE ha un solo IdP nazionale (Ministero dell'Interno/IPZS), quindi è integrabile server-side da PWA con reverse-engineering HTTP diretto (coerente con il principio "no headless browser").

## Cosa cambia

**Client AdE**
- Nuovo flusso CIE reale: IdP Shibboleth, login livello 2 (email app CIE ID + password) confermato via **push**, poi rientro nella **coda portale condivisa** con Fisconline. Rilevamenti *credenziali errate* ("Credenziali non valide.") e *approvazione push* (cambio body `checkpush`) **ancorati agli HAR**, non euristici.
- Refactor `completePortalHandshake()` + `fetchWizardIdentity()` (estrae il CF da `cfUidUltimo` — per CIE lo username è un'email). `MockAdeClient.loginCie` per `ADE_MODE=mock`. Allowlist host IdP anti-SSRF.

**DB** — migrazione handwritten `0027`: `login_method`, `encrypted_username`, `spid_provider`; `encrypted_codice_fiscale/password/pin` resi **nullable** (i metodi valorizzano set di campi diversi). Le righe Fisconline restano valide.

**Server actions** — `saveAdeCredentials`/`verifyAdeCredentials` method-aware (CIE: email+password cifrate; SPID rifiutato). Rotazione chiavi field-by-field.

**Sessione CIE + rinnovo lazy (emit/void)**
- Store in-memory **parallelo** per le sessioni CIE (non ri-creabili in silenzio: il secondo fattore è umano). **Fisconline invariato byte-per-byte** (`session-cache`).
- emit/void ramificano su `login_method`; se la sessione CIE manca/scade ritornano `{ reauthRequired }` — **nessun documento trasmesso, nessun rischio di duplicato fiscale**. UI cassa/annullo mostrano l'avviso "Ricollegati"; Developer API v1 → **409**.

## Note per la review

- **Fisconline è intatto**: le ramificazioni CIE vivono dentro `withAdeSession`/`fetchAdePrerequisites`; il path reale `adeSessionCache.run` non è toccato.
- **Mock mode**: in dev/sandbox (`ADE_MODE=mock`) CIE dà un OK immediato senza sessione.
- **Idempotency**: la cassa genera una key nuova per submit → nessun blocco 30-min sul retry dopo un rinnovo.
- **Da validare su AdE reale** (owner, `ADE_MODE=real`): i due rilevamenti CIE derivati dagli HAR.
- **TODO post-merge**: aggiornare il copy marketing (CIE ora live), rinviato per la regola "niente promesse di feature non-live".

## Test

Nuovi test: flusso CIE (`real-client-cie.test.ts`), store interattivo, save/verify method-aware, emit/void reauth. Suite delle aree toccate **verde (719)**; type-check/ESLint/prettier puliti; `arch:check` e `check-migrations` OK. Migrazione DB da eseguire su un DB locale prima del deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)