### PR TITLE
fix(receipts): degrada sessione scaduta su emit/void invece di lanciare

### DIFF
--- a/src/server/receipt-actions.test.ts
+++ b/src/server/receipt-actions.test.ts
@@ -106,6 +106,7 @@ vi.mock("@/lib/logger", () => ({
 // --- Fixtures ---
 
 import type { SubmitReceiptInput } from "@/types/cassa";
+import { UnauthenticatedError } from "@/lib/auth-errors";
 
 const FAKE_USER = { id: "user-123" };
 const FAKE_PREREQUISITES = {
@@ -215,6 +216,20 @@ describe("receipt-actions", () => {
       expect(setArg.status).toBe("ACCEPTED");
       expect(setArg.adeTransactionId).toBe("trx-001");
       expect(setArg.adeProgressive).toBe("001");
+    });
+
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw, no Sentry)", async () => {
+      // SCONTRINOZERO-S: sessione scaduta col carrello aperto. getAuthenticatedUser
+      // lancia UnauthenticatedError; l'action deve degradare a { error } inline
+      // invece di propagare (regola 19) e finire in Sentry come issue (regola 20).
+      mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
+
+      const { emitReceipt } = await import("./receipt-actions");
+      const result = await emitReceipt(VALID_INPUT);
+
+      expect(result.error).toBe("Non autenticato.");
+      expect(mockRateLimiterCheck).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
     });
 
     it("returns error when emit rate limit is exceeded", async () => {

--- a/src/server/receipt-actions.ts
+++ b/src/server/receipt-actions.ts
@@ -17,6 +17,7 @@ import {
   getAuthenticatedUser,
   checkBusinessOwnership,
 } from "@/lib/server-auth";
+import { authErrorResult } from "@/lib/auth-errors";
 import { emitReceiptForBusiness } from "@/lib/services/receipt-service";
 import type { SubmitReceiptInput, SubmitReceiptResult } from "@/types/cassa";
 
@@ -45,7 +46,16 @@ const receiptLimiter = new RateLimiter({
 export async function emitReceipt(
   input: SubmitReceiptInput,
 ): Promise<SubmitReceiptResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente (scaduta col carrello aperto) → degrada a { error }
+  // inline invece di propagare all'error boundary di Next (regola 19) e di
+  // finire in Sentry come issue (regola 20). Stesso pattern delle altre server
+  // action UI-facing (catalog/export/account/billing/analytics).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "emitReceipt");
+  }
 
   const rateLimitResult = receiptLimiter.check(`emit:${user.id}`);
   if (!rateLimitResult.success) {

--- a/src/server/void-actions.test.ts
+++ b/src/server/void-actions.test.ts
@@ -130,6 +130,7 @@ const mockTransaction = vi
 // ---------------------------------------------------------------------------
 
 import type { VoidReceiptInput } from "@/types/storico";
+import { UnauthenticatedError } from "@/lib/auth-errors";
 
 const FAKE_USER = { id: "user-123" };
 
@@ -303,6 +304,21 @@ describe("void-actions", () => {
       // Second update: original SALE → VOID_ACCEPTED
       const secondUpdateSet = mockUpdateSet.mock.calls[1][0];
       expect(secondUpdateSet.status).toBe("VOID_ACCEPTED");
+    });
+
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw, no Sentry)", async () => {
+      // SCONTRINOZERO-S (stesso latente di emitReceipt): sessione scaduta con lo
+      // storico aperto. getAuthenticatedUser lancia UnauthenticatedError; l'action
+      // deve degradare a { error } inline invece di propagare (regola 19) e finire
+      // in Sentry come issue (regola 20).
+      mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
+
+      const { voidReceipt } = await import("./void-actions");
+      const result = await voidReceipt(VALID_VOID_INPUT);
+
+      expect(result.error).toBe("Non autenticato.");
+      expect(mockRateLimiterCheck).not.toHaveBeenCalled();
+      expect(mockLogin).not.toHaveBeenCalled();
     });
 
     it("returns error when void rate limit is exceeded", async () => {

--- a/src/server/void-actions.ts
+++ b/src/server/void-actions.ts
@@ -8,6 +8,7 @@ import {
   checkBusinessOwnership,
   getAuthenticatedUser,
 } from "@/lib/server-auth";
+import { authErrorResult } from "@/lib/auth-errors";
 import { voidReceiptForBusiness } from "@/lib/services/void-service";
 import type { VoidReceiptInput, VoidReceiptResult } from "@/types/storico";
 
@@ -30,7 +31,15 @@ const voidReceiptSchema = z.object({
 export async function voidReceipt(
   input: VoidReceiptInput,
 ): Promise<VoidReceiptResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente (scaduta con lo storico aperto) → degrada a { error }
+  // inline invece di propagare all'error boundary di Next (regola 19) e di
+  // finire in Sentry come issue (regola 20). Stesso pattern di emitReceipt.
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "voidReceipt");
+  }
 
   const rateLimitResult = voidLimiter.check(`void:${user.id}`);
   if (!rateLimitResult.success) {


### PR DESCRIPTION
emitReceipt e voidReceipt chiamavano getAuthenticatedUser() direttamente:
su una sessione scaduta (utente col carrello/storico aperto al submit)
l'UnauthenticatedError risaliva non gestita all'onRequestError di Next e
finiva in Sentry come issue (SCONTRINOZERO-S), oltre a mostrare all'utente
il generico "Errore durante l'emissione" via il ramo mutation.isError.

Applico lo stesso wrap try/catch + authErrorResult gia' usato da
catalog/export/account/billing/analytics: la sessione assente e' una
condizione prevedibile da input utente (regola 20 -> warn, no Sentry) e va
degradata a { error: "Non autenticato." } inline (regola 19), non propagata.
getAuthenticatedUser logga gia' warn sul session-invalid, quindi nessun
doppio log. I return type accettano gia' { error }.

Fixes SCONTRINOZERO-S

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017rdXUEWbotyTaH4tkb8wZ5