### PR TITLE
fix(server-actions): degrada sessione scaduta anche su storico/api-ke…

### DIFF
--- a/src/server/api-key-actions.test.ts
+++ b/src/server/api-key-actions.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UnauthenticatedError } from "@/lib/auth-errors";
 
 // --- Mocks ---
 
@@ -165,6 +166,16 @@ describe("listApiKeys", () => {
     expect(result.keys).toBeUndefined();
   });
 
+  it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+    mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
+
+    const { listApiKeys } = await import("./api-key-actions");
+    const result = await listApiKeys("biz-uuid");
+
+    expect(result.error).toBe("Non autenticato.");
+    expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+  });
+
   it("ritorna errore se piano non supporta API", async () => {
     mockCanUseApi.mockReturnValue(false);
 
@@ -262,6 +273,17 @@ describe("createApiKey", () => {
     const result = await createApiKey("biz-uuid", "Test Key");
 
     expect(result.error).toBeDefined();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+    mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
+
+    const { createApiKey } = await import("./api-key-actions");
+    const result = await createApiKey("biz-uuid", "Test Key");
+
+    expect(result.error).toBe("Non autenticato.");
+    expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
@@ -424,6 +446,16 @@ describe("revokeApiKey", () => {
 
     expect(result.error).toBeUndefined();
     expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+    mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
+
+    const { revokeApiKey } = await import("./api-key-actions");
+    const result = await revokeApiKey("key-uuid");
+
+    expect(result.error).toBe("Non autenticato.");
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it("ritorna errore se la chiave non esiste o non appartiene all'utente", async () => {

--- a/src/server/api-key-actions.ts
+++ b/src/server/api-key-actions.ts
@@ -21,15 +21,30 @@ export type ApiKeyListItem = {
   revokedAt: Date | null;
 };
 
-export async function listApiKeys(
+/**
+ * Guard condiviso da listApiKeys/createApiKey: autentica degradando invece di
+ * lanciare (sessione assente → { error }, regola 19/20), verifica l'ownership
+ * del business e applica il gate di piano (Pro+). Fattorizzato per non
+ * duplicare il prefisso identico tra le due azioni — la duplicazione
+ * ownership+plan era pre-esistente e l'auth-guard l'aveva spinta oltre la
+ * soglia CPD di SonarCloud (new_duplicated_lines, PR #699).
+ */
+async function authorizeApiKeyBusiness(
+  action: string,
   businessId: string,
-): Promise<{ error?: string; keys?: ApiKeyListItem[] }> {
-  // Sessione assente → degrada a { error } inline (regola 19/20).
+  planDeniedMessage: string,
+): Promise<
+  | {
+      user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+      effectivePlan: Awaited<ReturnType<typeof getEffectivePlan>>;
+    }
+  | { error: string }
+> {
   let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
   try {
     user = await getAuthenticatedUser();
   } catch (err) {
-    return authErrorResult(err, "listApiKeys");
+    return authErrorResult(err, action);
   }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
@@ -40,10 +55,21 @@ export async function listApiKeys(
     getPlan(user.id),
   ]);
   if (!canUseApi(effectivePlan, planInfo.planExpiresAt)) {
-    return {
-      error: "Per accedere alle API key serve il piano Pro o superiore.",
-    };
+    return { error: planDeniedMessage };
   }
+
+  return { user, effectivePlan };
+}
+
+export async function listApiKeys(
+  businessId: string,
+): Promise<{ error?: string; keys?: ApiKeyListItem[] }> {
+  const auth = await authorizeApiKeyBusiness(
+    "listApiKeys",
+    businessId,
+    "Per accedere alle API key serve il piano Pro o superiore.",
+  );
+  if ("error" in auth) return auth;
 
   const db = getDb();
   const keys = await db
@@ -65,26 +91,13 @@ export async function createApiKey(
   businessId: string,
   name: string,
 ): Promise<{ error?: string; apiKeyRaw?: string; keyId?: string }> {
-  // Sessione assente → degrada a { error } inline (regola 19/20).
-  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
-  try {
-    user = await getAuthenticatedUser();
-  } catch (err) {
-    return authErrorResult(err, "createApiKey");
-  }
-
-  const ownershipError = await checkBusinessOwnership(user.id, businessId);
-  if (ownershipError) return ownershipError;
-
-  const [effectivePlan, planInfo] = await Promise.all([
-    getEffectivePlan(user.id),
-    getPlan(user.id),
-  ]);
-  if (!canUseApi(effectivePlan, planInfo.planExpiresAt)) {
-    return {
-      error: "Per generare API key serve il piano Pro o superiore.",
-    };
-  }
+  const auth = await authorizeApiKeyBusiness(
+    "createApiKey",
+    businessId,
+    "Per generare API key serve il piano Pro o superiore.",
+  );
+  if ("error" in auth) return auth;
+  const { user, effectivePlan } = auth;
 
   const trimmedName = name.trim();
   if (!trimmedName) {

--- a/src/server/api-key-actions.ts
+++ b/src/server/api-key-actions.ts
@@ -10,6 +10,7 @@ import {
   checkBusinessOwnership,
   getAuthenticatedUser,
 } from "@/lib/server-auth";
+import { authErrorResult } from "@/lib/auth-errors";
 
 export type ApiKeyListItem = {
   id: string;
@@ -23,7 +24,13 @@ export type ApiKeyListItem = {
 export async function listApiKeys(
   businessId: string,
 ): Promise<{ error?: string; keys?: ApiKeyListItem[] }> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "listApiKeys");
+  }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) return ownershipError;
@@ -58,7 +65,13 @@ export async function createApiKey(
   businessId: string,
   name: string,
 ): Promise<{ error?: string; apiKeyRaw?: string; keyId?: string }> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "createApiKey");
+  }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) return ownershipError;
@@ -139,7 +152,13 @@ export async function createApiKey(
 }
 
 export async function revokeApiKey(keyId: string): Promise<{ error?: string }> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "revokeApiKey");
+  }
 
   const db = getDb();
 

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -200,6 +200,15 @@ describe("onboarding-actions", () => {
       zipCode: "00100",
     };
 
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      // Sessione assente → getAuthenticatedUser lancia UnauthenticatedError;
+      // l'action degrada a { error } inline (regola 19/20), non propaga.
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { saveBusiness } = await import("./onboarding-actions");
+      const result = await saveBusiness(formData(VALID_DATA));
+      expect(result.error).toBe("Non autenticato.");
+    });
+
     it("returns error for missing first name", async () => {
       const { saveBusiness } = await import("./onboarding-actions");
       const result = await saveBusiness(
@@ -465,6 +474,15 @@ describe("onboarding-actions", () => {
   });
 
   describe("saveAdeCredentials", () => {
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({ businessId: "biz-789" }),
+      );
+      expect(result.error).toBe("Non autenticato.");
+    });
+
     it("encrypts and saves credentials", async () => {
       // Ownership check: JOIN profile+business
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
@@ -693,6 +711,13 @@ describe("onboarding-actions", () => {
       // with mockResolvedValueOnce({ fiscalCode: "..." }) AFTER queuing the
       // ownership + credentials mocks.
       mockLimit.mockResolvedValue([{ fiscalCode: null }]);
+    });
+
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("biz-789");
+      expect(result.error).toBe("Non autenticato.");
     });
 
     it("R36: alla soglia rate limit → warn + errore standard, senza toccare AdE", async () => {
@@ -1988,6 +2013,14 @@ describe("onboarding-actions", () => {
   });
 
   describe("markOnboardingTourSeen", () => {
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { markOnboardingTourSeen } = await import("./onboarding-actions");
+      const result = await markOnboardingTourSeen();
+      expect(result.error).toBe("Non autenticato.");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
     it("updates the profile and returns no error on success", async () => {
       const { markOnboardingTourSeen } = await import("./onboarding-actions");
       const result = await markOnboardingTourSeen();
@@ -2008,6 +2041,21 @@ describe("onboarding-actions", () => {
       const result = await markOnboardingTourSeen();
 
       expect(result.error).toBeTruthy();
+    });
+  });
+
+  describe("changeAdePassword", () => {
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      // Sessione assente → degrada prima di ownership/rate-limit/AdE (regola 19/20).
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { changeAdePassword } = await import("./onboarding-actions");
+      const result = await changeAdePassword(
+        "biz-789",
+        "OldPass1!",
+        "NewPass1!",
+        "NewPass1!",
+      );
+      expect(result.error).toBe("Non autenticato.");
     });
   });
 });

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -40,6 +40,7 @@ import {
   getAuthenticatedUser,
   checkBusinessOwnership,
 } from "@/lib/server-auth";
+import { authErrorResult } from "@/lib/auth-errors";
 import {
   adePinSchema,
   BUSINESS_PROFILE_LIMITS,
@@ -151,7 +152,13 @@ function validateSaveBusinessInput(input: SaveBusinessInput): string | null {
 export async function saveBusiness(
   formData: FormData,
 ): Promise<OnboardingActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "saveBusiness");
+  }
 
   const firstName = getFormString(formData, "firstName");
   const lastName = getFormString(formData, "lastName");
@@ -357,7 +364,13 @@ function buildCieValues(
 export async function saveAdeCredentials(
   formData: FormData,
 ): Promise<OnboardingActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "saveAdeCredentials");
+  }
 
   const businessId = getFormString(formData, "businessId");
   if (!businessId) {
@@ -856,7 +869,13 @@ async function fetchFiscalDataAndCloseSession(
 export async function verifyAdeCredentials(
   businessId: string,
 ): Promise<OnboardingActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "verifyAdeCredentials");
+  }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) return ownershipError;
@@ -1125,7 +1144,13 @@ export const getOnboardingTourSeen = cache(async (): Promise<boolean> => {
  * cosmetica, il client l'ha già nascosto in modo optimistic.
  */
 export async function markOnboardingTourSeen(): Promise<{ error?: string }> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "markOnboardingTourSeen");
+  }
   const db = getDb();
   try {
     await db
@@ -1152,7 +1177,13 @@ export async function changeAdePassword(
   newPassword: string,
   confirmNewPassword: string,
 ): Promise<OnboardingActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "changeAdePassword");
+  }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) return ownershipError;

--- a/src/server/profile-actions.test.ts
+++ b/src/server/profile-actions.test.ts
@@ -1,7 +1,19 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UnauthenticatedError } from "@/lib/auth-errors";
 
 // --- Hoisted mocks ---
+
+// Override una-tantum di getAuthenticatedUser per simulare sessione assente.
+// `@/lib/server-auth` è mockato con un factory che referenzia const non-hoisted,
+// quindi NON si può importare staticamente qui (romperebbe l'hoisting di vi.mock):
+// import dinamico dentro il test, quando i const sono già inizializzati.
+async function rejectAuthOnce(): Promise<void> {
+  const { getAuthenticatedUser } = await import("@/lib/server-auth");
+  vi.mocked(getAuthenticatedUser).mockRejectedValueOnce(
+    new UnauthenticatedError(),
+  );
+}
 
 const {
   mockGetUser,
@@ -182,10 +194,12 @@ describe("profile-actions", () => {
       expect(result.error).toMatch(/troppi/i);
     });
 
-    it("throws when user is unauthenticated", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      await rejectAuthOnce();
       const { updateProfile } = await import("./profile-actions");
-      await expect(updateProfile(formData(VALID))).rejects.toThrow();
+      const result = await updateProfile(formData(VALID));
+      expect(result.error).toBe("Non autenticato.");
+      expect(mockRevalidatePath).not.toHaveBeenCalled();
     });
   });
 
@@ -267,6 +281,14 @@ describe("profile-actions", () => {
       const { updateBusiness } = await import("./profile-actions");
       const result = await updateBusiness(formData(VALID));
       expect(result.error).toMatch(/troppi/i);
+    });
+
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      await rejectAuthOnce();
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(formData(VALID));
+      expect(result.error).toBe("Non autenticato.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
     });
   });
 
@@ -439,10 +461,12 @@ describe("profile-actions", () => {
       expect(result.error).toMatch(/troppi/i);
     });
 
-    it("throws when user is unauthenticated", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
+      await rejectAuthOnce();
       const { changePassword } = await import("./profile-actions");
-      await expect(changePassword(formData(VALID))).rejects.toThrow();
+      const result = await changePassword(formData(VALID));
+      expect(result.error).toBe("Non autenticato.");
+      expect(mockSignInWithPassword).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/profile-actions.ts
+++ b/src/server/profile-actions.ts
@@ -11,6 +11,7 @@ import {
   getAuthenticatedUser,
   checkBusinessOwnership,
 } from "@/lib/server-auth";
+import { authErrorResult } from "@/lib/auth-errors";
 import {
   BUSINESS_PROFILE_LIMITS,
   isStrongPassword,
@@ -103,7 +104,13 @@ async function preparePreferredVatCodeUpdate(opts: {
 export async function updateProfile(
   formData: FormData,
 ): Promise<ProfileActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "updateProfile");
+  }
 
   const firstName = getFormString(formData, "firstName");
   const lastName = getFormString(formData, "lastName");
@@ -140,7 +147,13 @@ export async function updateProfile(
 export async function updateBusiness(
   formData: FormData,
 ): Promise<ProfileActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "updateBusiness");
+  }
 
   // CLAUDE.md regola 29: ordine difensivo rate-limit → ownership →
   // validation → UPDATE. La ownership query (DB read) NON deve essere
@@ -226,7 +239,13 @@ export async function updateBusiness(
 export async function changePassword(
   formData: FormData,
 ): Promise<ProfileActionResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente → degrada a { error } inline (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return authErrorResult(err, "changePassword");
+  }
 
   // Raw read sui campi password: il trim() cambierebbe la semantica delle
   // credenziali e bloccherebbe login a utenti registrati con whitespace

--- a/src/server/storico-actions.test.ts
+++ b/src/server/storico-actions.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UnauthenticatedError } from "@/lib/auth-errors";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -145,11 +146,19 @@ describe("storico-actions", () => {
       expect(mockSelect).toHaveBeenCalledTimes(2);
     });
 
-    it("throws when user is not authenticated", async () => {
-      mockGetAuthenticatedUser.mockRejectedValue(new Error("Unauthorized"));
+    it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw, no Sentry)", async () => {
+      // Sessione scaduta con lo storico aperto: getAuthenticatedUser lancia
+      // UnauthenticatedError; searchReceipts deve degradare a { error } inline
+      // (regola 19/20), non propagare all'error boundary di Next.
+      mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
 
       const { searchReceipts } = await import("./storico-actions");
-      await expect(searchReceipts("biz-789")).rejects.toThrow();
+      const result = await searchReceipts("biz-789");
+
+      expect(result.error).toBe("Non autenticato.");
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
     });
 
     it("returns error envelope when business ownership check fails", async () => {

--- a/src/server/storico-actions.ts
+++ b/src/server/storico-actions.ts
@@ -7,6 +7,7 @@ import {
   checkBusinessOwnership,
   getAuthenticatedUser,
 } from "@/lib/server-auth";
+import { authErrorResult } from "@/lib/auth-errors";
 import {
   fetchLinesByDocIds,
   groupLinesByDocId,
@@ -40,7 +41,14 @@ export async function searchReceipts(
   businessId: string,
   params: SearchReceiptsParams = {},
 ): Promise<SearchReceiptsResult> {
-  const user = await getAuthenticatedUser();
+  // Sessione assente (scaduta con lo storico aperto) → degrada a { error }
+  // inline invece di propagare all'error boundary di Next (regola 19/20).
+  let user: Awaited<ReturnType<typeof getAuthenticatedUser>>;
+  try {
+    user = await getAuthenticatedUser();
+  } catch (err) {
+    return { ...authErrorResult(err, "searchReceipts"), items: [], total: 0 };
+  }
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) {
     // Allinea il contratto a tutte le altre server actions: error envelope


### PR DESCRIPTION
…y/profile/onboarding

Estende il pattern di SCONTRINOZERO-S (commit precedente su emit/void) a tutte le server action UI-facing / client-invoked che ancora chiamavano getAuthenticatedUser() direttamente e propagavano UnauthenticatedError all'onRequestError di Next → Sentry + error boundary.

Azioni convertite (wrap try/catch + authErrorResult, solo sull'auth):
- storico: searchReceipts
- api-key: listApiKeys, createApiKey, revokeApiKey
- profile: updateProfile, updateBusiness, changePassword
- onboarding: saveBusiness, saveAdeCredentials, verifyAdeCredentials, changeAdePassword, markOnboardingTourSeen

Una sessione scaduta e' input utente prevedibile (regola 20 -> warn, no Sentry) e va degradata a { error: "Non autenticato." } inline (regola 19), non propagata. Coerente con catalog/export/account/billing/analytics che gia' usano authErrorResult.

Lasciati invariati (throw voluto -> redirect/error boundary, return type senza `error`): getOnboardingStatus e getOnboardingTourSeen (cache(), RSC-only) e le pagine RSC. completePasswordReset era gia' degradata.

Test: un caso degrade per azione convertita (sessione assente -> "Non autenticato.", nessun side-effect). Aggiornati i due test storico/profile che asserivano il vecchio throw al nuovo contratto degrade.


Claude-Session: https://claude.ai/code/session_017rdXUEWbotyTaH4tkb8wZ5