### PR TITLE
test: parameterize duplicated lib tests (SonarCloud)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6652,9 +6652,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6672,9 +6669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6692,9 +6686,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6712,9 +6703,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/app/api/export/receipts/route.test.ts
+++ b/src/app/api/export/receipts/route.test.ts
@@ -135,18 +135,21 @@ describe("GET /api/export/receipts", () => {
     expect(res.status).toBe(404);
   });
 
-  it("restituisce 400 se la data 'from' non e' yyyy-MM-dd", async () => {
-    const res = await GET(makeRequest("?from=2026/01/01"));
-    expect(res.status).toBe(400);
-  });
-
-  it("restituisce 400 se status non e' tra i valori ammessi", async () => {
-    const res = await GET(makeRequest("?status=PENDING"));
-    expect(res.status).toBe(400);
-  });
-
-  it("restituisce 400 se dateFrom > dateTo", async () => {
-    const res = await GET(makeRequest("?from=2026-05-19&to=2026-01-01"));
+  it.each([
+    {
+      name: "restituisce 400 se la data 'from' non e' yyyy-MM-dd",
+      query: "?from=2026/01/01",
+    },
+    {
+      name: "restituisce 400 se status non e' tra i valori ammessi",
+      query: "?status=PENDING",
+    },
+    {
+      name: "restituisce 400 se dateFrom > dateTo",
+      query: "?from=2026-05-19&to=2026-01-01",
+    },
+  ])("$name", async ({ query }) => {
+    const res = await GET(makeRequest(query));
     expect(res.status).toBe(400);
   });
 

--- a/src/app/api/stripe/checkout/route.test.ts
+++ b/src/app/api/stripe/checkout/route.test.ts
@@ -184,49 +184,26 @@ describe("POST /api/stripe/checkout", () => {
     expect(res.status).toBe(400);
   });
 
-  it("restituisce 409 se esiste una subscription active", async () => {
+  it.each([
+    {
+      name: "restituisce 409 se esiste una subscription active",
+      status: "active",
+    },
+    {
+      name: "restituisce 409 se esiste una subscription past_due (evita sub duplicata)",
+      status: "past_due",
+    },
+    {
+      name: "restituisce 409 se esiste una subscription unpaid (evita sub duplicata)",
+      status: "unpaid",
+    },
+  ])("$name", async ({ status }) => {
     mockGetAuthenticatedUser.mockResolvedValue({
       id: "user-1",
       email: "a@b.it",
     });
     mockSelect.mockReturnValue(
-      makeSelectBuilder([
-        { stripeCustomerId: "cus_existing", status: "active" },
-      ]),
-    );
-
-    const res = await POST(makeRequest({ priceId: "price_pro" }));
-    expect(res.status).toBe(409);
-    expect(mockCustomerCreate).not.toHaveBeenCalled();
-    expect(mockSessionCreate).not.toHaveBeenCalled();
-  });
-
-  it("restituisce 409 se esiste una subscription past_due (evita sub duplicata)", async () => {
-    mockGetAuthenticatedUser.mockResolvedValue({
-      id: "user-1",
-      email: "a@b.it",
-    });
-    mockSelect.mockReturnValue(
-      makeSelectBuilder([
-        { stripeCustomerId: "cus_existing", status: "past_due" },
-      ]),
-    );
-
-    const res = await POST(makeRequest({ priceId: "price_pro" }));
-    expect(res.status).toBe(409);
-    expect(mockCustomerCreate).not.toHaveBeenCalled();
-    expect(mockSessionCreate).not.toHaveBeenCalled();
-  });
-
-  it("restituisce 409 se esiste una subscription unpaid (evita sub duplicata)", async () => {
-    mockGetAuthenticatedUser.mockResolvedValue({
-      id: "user-1",
-      email: "a@b.it",
-    });
-    mockSelect.mockReturnValue(
-      makeSelectBuilder([
-        { stripeCustomerId: "cus_existing", status: "unpaid" },
-      ]),
+      makeSelectBuilder([{ stripeCustomerId: "cus_existing", status }]),
     );
 
     const res = await POST(makeRequest({ priceId: "price_pro" }));

--- a/src/app/api/v1/receipts/route.test.ts
+++ b/src/app/api/v1/receipts/route.test.ts
@@ -215,49 +215,23 @@ describe("POST /api/v1/receipts", () => {
     );
   });
 
-  it("ritorna 400 se lotteryCode contiene caratteri non alfanumerici", async () => {
+  it.each([
+    {
+      name: "ritorna 400 se lotteryCode contiene caratteri non alfanumerici",
+      lotteryCode: "ABC-2345",
+    },
+    {
+      name: "ritorna 400 se lotteryCode è in minuscolo",
+      lotteryCode: "abc12345",
+    },
+    { name: "ritorna 400 se lotteryCode è una stringa vuota", lotteryCode: "" },
+    {
+      name: "ritorna 400 se lotteryCode è più corto di 8 caratteri",
+      lotteryCode: "ABC123",
+    },
+  ])("$name", async ({ lotteryCode }) => {
     const res = await POST(
-      makeRequest({
-        ...VALID_BODY,
-        paymentMethod: "PE",
-        lotteryCode: "ABC-2345",
-      }),
-    );
-    expect(res.status).toBe(400);
-    expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
-  });
-
-  it("ritorna 400 se lotteryCode è in minuscolo", async () => {
-    const res = await POST(
-      makeRequest({
-        ...VALID_BODY,
-        paymentMethod: "PE",
-        lotteryCode: "abc12345",
-      }),
-    );
-    expect(res.status).toBe(400);
-    expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
-  });
-
-  it("ritorna 400 se lotteryCode è una stringa vuota", async () => {
-    const res = await POST(
-      makeRequest({
-        ...VALID_BODY,
-        paymentMethod: "PE",
-        lotteryCode: "",
-      }),
-    );
-    expect(res.status).toBe(400);
-    expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
-  });
-
-  it("ritorna 400 se lotteryCode è più corto di 8 caratteri", async () => {
-    const res = await POST(
-      makeRequest({
-        ...VALID_BODY,
-        paymentMethod: "PE",
-        lotteryCode: "ABC123",
-      }),
+      makeRequest({ ...VALID_BODY, paymentMethod: "PE", lotteryCode }),
     );
     expect(res.status).toBe(400);
     expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();

--- a/src/components/billing/plan-selection.test.tsx
+++ b/src/components/billing/plan-selection.test.tsx
@@ -40,10 +40,22 @@ describe("PlanSelection", () => {
     vi.clearAllMocks();
   });
 
-  it("mostra il toggle Mensile/Annuale", () => {
+  it.each([
+    {
+      name: "mostra il toggle Mensile/Annuale",
+      first: "Mensile",
+      second: "Annuale",
+    },
+    {
+      name: "mostra i prezzi annuali nel default",
+      first: "€29.99/anno",
+      second: "€49.99/anno",
+    },
+    { name: "mostra le card Starter e Pro", first: "Starter", second: "Pro" },
+  ])("$name", ({ first, second }) => {
     renderComponent();
-    expect(screen.getByText("Mensile")).toBeInTheDocument();
-    expect(screen.getByText("Annuale")).toBeInTheDocument();
+    expect(screen.getByText(first)).toBeInTheDocument();
+    expect(screen.getByText(second)).toBeInTheDocument();
   });
 
   it("parte in modalità annuale di default", () => {
@@ -52,12 +64,6 @@ describe("PlanSelection", () => {
       screen.getByTestId("checkout-price_starter_yearly"),
     ).toBeInTheDocument();
     expect(screen.getByTestId("checkout-price_pro_yearly")).toBeInTheDocument();
-  });
-
-  it("mostra i prezzi annuali nel default", () => {
-    renderComponent();
-    expect(screen.getByText("€29.99/anno")).toBeInTheDocument();
-    expect(screen.getByText("€49.99/anno")).toBeInTheDocument();
   });
 
   it("mostra il badge -50% di default (annuale)", () => {
@@ -108,12 +114,6 @@ describe("PlanSelection", () => {
     renderComponent();
     const proBtn = screen.getByTestId("checkout-price_pro_yearly");
     expect(proBtn).not.toHaveAttribute("data-variant", "outline");
-  });
-
-  it("mostra le card Starter e Pro", () => {
-    renderComponent();
-    expect(screen.getByText("Starter")).toBeInTheDocument();
-    expect(screen.getByText("Pro")).toBeInTheDocument();
   });
 
   it("non mostra i price ID mensili in modalità annuale", () => {

--- a/src/components/cassa/numeric-keypad.test.tsx
+++ b/src/components/cassa/numeric-keypad.test.tsx
@@ -25,22 +25,62 @@ describe("NumericKeypad", () => {
     ).toBeInTheDocument();
   });
 
-  it("chiama onChange con centesimi corretti premendo una cifra (0 → 7 = 7)", () => {
+  it.each([
+    {
+      name: "chiama onChange con centesimi corretti premendo una cifra (0 → 7 = 7)",
+      value: 0,
+      button: "7",
+      expected: 7,
+    },
+    {
+      name: "aggiunge cifra al valore esistente cashier-style (13 → '5' = 135)",
+      value: 13,
+      button: "5",
+      expected: 135,
+    },
+    {
+      name: "chiama onChange con backspace cashier-style (1358 → 135)",
+      value: 1358,
+      button: /backspace|⌫|cancella/i,
+      expected: 135,
+    },
+    {
+      name: "backspace su 0 rimane 0",
+      value: 0,
+      button: /backspace|⌫|cancella/i,
+      expected: 0,
+    },
+    {
+      name: "tasto 00 aggiunge due zeri (5 → 500)",
+      value: 5,
+      button: "00",
+      expected: 500,
+    },
+    { name: "tasto 00 su 0 rimane 0", value: 0, button: "00", expected: 0 },
+    {
+      name: "non supera il massimo di 999999 centesimi",
+      value: 999999,
+      button: "1",
+      expected: 999999,
+    },
+    {
+      name: "aggiunge zero premendo il tasto 0 (10 → 100)",
+      value: 10,
+      button: "0",
+      expected: 100,
+    },
+  ] as {
+    name: string;
+    value: number;
+    button: string | RegExp;
+    expected: number;
+  }[])("$name", ({ value, button, expected }) => {
     const onChange = vi.fn();
-    render(<NumericKeypad value={0} onChange={onChange} />);
+    render(<NumericKeypad value={value} onChange={onChange} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "7" }));
+    fireEvent.click(screen.getByRole("button", { name: button }));
 
-    expect(onChange).toHaveBeenCalledWith(7);
-  });
-
-  it("aggiunge cifra al valore esistente cashier-style (13 → '5' = 135)", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={13} onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "5" }));
-
-    expect(onChange).toHaveBeenCalledWith(135);
+    expect(onChange).toHaveBeenCalledWith(expected);
   });
 
   it("sequenza 1→3→5→8 produce 1358 centesimi (€13,58)", () => {
@@ -62,63 +102,5 @@ describe("NumericKeypad", () => {
     fireEvent.click(screen.getByRole("button", { name: "8" }));
 
     expect(results).toEqual([1, 13, 135, 1358]);
-  });
-
-  it("chiama onChange con backspace cashier-style (1358 → 135)", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={1358} onChange={onChange} />);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /backspace|⌫|cancella/i }),
-    );
-
-    expect(onChange).toHaveBeenCalledWith(135);
-  });
-
-  it("backspace su 0 rimane 0", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={0} onChange={onChange} />);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /backspace|⌫|cancella/i }),
-    );
-
-    expect(onChange).toHaveBeenCalledWith(0);
-  });
-
-  it("tasto 00 aggiunge due zeri (5 → 500)", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={5} onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "00" }));
-
-    expect(onChange).toHaveBeenCalledWith(500);
-  });
-
-  it("tasto 00 su 0 rimane 0", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={0} onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "00" }));
-
-    expect(onChange).toHaveBeenCalledWith(0);
-  });
-
-  it("non supera il massimo di 999999 centesimi", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={999999} onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "1" }));
-
-    expect(onChange).toHaveBeenCalledWith(999999);
-  });
-
-  it("aggiunge zero premendo il tasto 0 (10 → 100)", () => {
-    const onChange = vi.fn();
-    render(<NumericKeypad value={10} onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "0" }));
-
-    expect(onChange).toHaveBeenCalledWith(100);
   });
 });

--- a/src/components/cassa/receipt-success.test.tsx
+++ b/src/components/cassa/receipt-success.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { ReceiptSuccess } from "./receipt-success";
@@ -54,22 +55,38 @@ describe("ReceiptSuccess", () => {
     expect(screen.getByText("trx-001")).toBeInTheDocument();
   });
 
-  it("hides AdE section when neither adeProgressive nor adeTransactionId is provided", () => {
-    render(<ReceiptSuccess {...defaultProps} />);
+  it.each([
+    {
+      name: "hides AdE section when neither adeProgressive nor adeTransactionId is provided",
+      props: {},
+      text: "Progressivo AdE",
+      present: false,
+    },
+    {
+      name: "shows share button when documentId is provided",
+      props: { documentId: "doc-uuid-123" },
+      text: "Invia ricevuta",
+      present: true,
+    },
+    {
+      name: "hides share button when documentId is not provided",
+      props: {},
+      text: "Invia ricevuta",
+      present: false,
+    },
+  ] as {
+    name: string;
+    props: Partial<ComponentProps<typeof ReceiptSuccess>>;
+    text: string;
+    present: boolean;
+  }[])("$name", ({ props, text, present }) => {
+    render(<ReceiptSuccess {...defaultProps} {...props} />);
 
-    expect(screen.queryByText("Progressivo AdE")).not.toBeInTheDocument();
-  });
-
-  it("shows share button when documentId is provided", () => {
-    render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
-
-    expect(screen.getByText("Invia ricevuta")).toBeInTheDocument();
-  });
-
-  it("hides share button when documentId is not provided", () => {
-    render(<ReceiptSuccess {...defaultProps} />);
-
-    expect(screen.queryByText("Invia ricevuta")).not.toBeInTheDocument();
+    if (present) {
+      expect(screen.getByText(text)).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText(text)).not.toBeInTheDocument();
+    }
   });
 
   it("calls onNewReceipt when 'Nuovo scontrino' is clicked", () => {

--- a/src/components/cassa/vat-selector.test.tsx
+++ b/src/components/cassa/vat-selector.test.tsx
@@ -83,33 +83,29 @@ describe("VatSelector", () => {
     ).toBeInTheDocument();
   });
 
-  it("chiama onChange con il codice IVA corretto quando si seleziona un'opzione", () => {
+  it.each([
+    {
+      name: "chiama onChange con il codice IVA corretto quando si seleziona un'opzione",
+      option: "10% – Ridotta",
+      expected: "10",
+    },
+    {
+      name: "chiama onChange con 'N2' quando si seleziona 0% – Non soggette",
+      option: "0% – Non soggette",
+      expected: "N2",
+    },
+    {
+      name: "chiama onChange con '4' quando si seleziona 4%",
+      option: "4% – Ridotta",
+      expected: "4",
+    },
+  ])("$name", ({ option, expected }) => {
     const onChange = vi.fn();
     render(<VatSelector value="22" onChange={onChange} />);
 
     fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByRole("option", { name: "10% – Ridotta" }));
+    fireEvent.click(screen.getByRole("option", { name: option }));
 
-    expect(onChange).toHaveBeenCalledWith("10");
-  });
-
-  it("chiama onChange con 'N2' quando si seleziona 0% – Non soggette", () => {
-    const onChange = vi.fn();
-    render(<VatSelector value="22" onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByRole("option", { name: "0% – Non soggette" }));
-
-    expect(onChange).toHaveBeenCalledWith("N2");
-  });
-
-  it("chiama onChange con '4' quando si seleziona 4%", () => {
-    const onChange = vi.fn();
-    render(<VatSelector value="22" onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByRole("option", { name: "4% – Ridotta" }));
-
-    expect(onChange).toHaveBeenCalledWith("4");
+    expect(onChange).toHaveBeenCalledWith(expected);
   });
 });

--- a/src/components/settings/theme-section.test.tsx
+++ b/src/components/settings/theme-section.test.tsx
@@ -53,28 +53,28 @@ describe("ThemeSection", () => {
     );
   });
 
-  it("imposta il tema chiaro al click su 'Chiaro'", () => {
+  it.each([
+    {
+      name: "imposta il tema chiaro al click su 'Chiaro'",
+      button: "Chiaro",
+      theme: "light",
+    },
+    {
+      name: "imposta il tema scuro al click su 'Scuro'",
+      button: "Scuro",
+      theme: "dark",
+    },
+    {
+      name: "imposta il tema di sistema al click su 'Sistema'",
+      button: "Sistema",
+      theme: "system",
+    },
+  ])("$name", ({ button, theme }) => {
     render(<ThemeSection />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Chiaro" }));
+    fireEvent.click(screen.getByRole("button", { name: button }));
 
-    expect(mockSetTheme).toHaveBeenCalledWith("light");
-  });
-
-  it("imposta il tema scuro al click su 'Scuro'", () => {
-    render(<ThemeSection />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Scuro" }));
-
-    expect(mockSetTheme).toHaveBeenCalledWith("dark");
-  });
-
-  it("imposta il tema di sistema al click su 'Sistema'", () => {
-    render(<ThemeSection />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Sistema" }));
-
-    expect(mockSetTheme).toHaveBeenCalledWith("system");
+    expect(mockSetTheme).toHaveBeenCalledWith(theme);
   });
 
   it("non evidenzia alcuna opzione quando il tema non è ancora risolto", () => {

--- a/src/emails/account-inactivity-warning.test.tsx
+++ b/src/emails/account-inactivity-warning.test.tsx
@@ -18,31 +18,31 @@ describe("AccountInactivityWarningEmail", () => {
     expect(html).toBeTruthy();
   });
 
-  it("saluta l'utente col nome quando presente", () => {
+  it.each([
+    {
+      name: "saluta l'utente col nome quando presente",
+      props: PROPS,
+      contains: "Mario",
+    },
+    {
+      name: "non stampa un saluto rotto quando firstName è vuoto",
+      props: { ...PROPS, firstName: "" },
+      contains: "Ciao,",
+    },
+    {
+      name: "mostra la data di cancellazione in italiano",
+      props: PROPS,
+      contains: "15 agosto 2026",
+    },
+    {
+      name: "include il link di login per mantenere l'account",
+      props: PROPS,
+      contains: "https://app.test/login",
+    },
+  ])("$name", ({ props, contains }) => {
     const html = renderToStaticMarkup(
-      createElement(AccountInactivityWarningEmail, PROPS),
+      createElement(AccountInactivityWarningEmail, props),
     );
-    expect(html).toContain("Mario");
-  });
-
-  it("non stampa un saluto rotto quando firstName è vuoto", () => {
-    const html = renderToStaticMarkup(
-      createElement(AccountInactivityWarningEmail, { ...PROPS, firstName: "" }),
-    );
-    expect(html).toContain("Ciao,");
-  });
-
-  it("mostra la data di cancellazione in italiano", () => {
-    const html = renderToStaticMarkup(
-      createElement(AccountInactivityWarningEmail, PROPS),
-    );
-    expect(html).toContain("15 agosto 2026");
-  });
-
-  it("include il link di login per mantenere l'account", () => {
-    const html = renderToStaticMarkup(
-      createElement(AccountInactivityWarningEmail, PROPS),
-    );
-    expect(html).toContain("https://app.test/login");
+    expect(html).toContain(contains);
   });
 });

--- a/src/lib/ade/cookie-jar.test.ts
+++ b/src/lib/ade/cookie-jar.test.ts
@@ -123,6 +123,24 @@ describe("CookieJar", () => {
         responses: ["GONE=x; Max-Age=0"],
         expectedSize: 0,
       },
+      {
+        name: "ignores a malformed Expires and keeps the cookie (no false delete)",
+        responses: ["SID=val; Expires=not-a-date"],
+        expectedHas: { name: "SID", present: true },
+        expectedHeaderValue: "SID=val",
+      },
+      {
+        name: "keeps an empty-valued cookie kept alive by a positive Max-Age",
+        responses: ["SID=; Max-Age=3600"],
+        expectedHas: { name: "SID", present: true },
+        expectedHeaderValue: "SID=",
+      },
+      {
+        name: "ignores a non-numeric Max-Age and falls back to value/expires",
+        responses: ["SID=val; Max-Age=abc"],
+        expectedHas: { name: "SID", present: true },
+        expectedHeaderValue: "SID=val",
+      },
     ] as {
       name: string;
       responses: string[];
@@ -182,18 +200,6 @@ describe("CookieJar", () => {
       expect(jar.has("SID")).toBe(true);
     });
 
-    it("ignores a malformed Expires and keeps the cookie (no false delete)", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Expires=not-a-date"]],
-        }),
-      );
-
-      expect(jar.has("SID")).toBe(true);
-      expect(jar.toHeaderValue()).toBe("SID=val");
-    });
-
     it("removes a cookie set with an empty value", () => {
       const jar = new CookieJar();
       jar.applyResponse(
@@ -209,18 +215,6 @@ describe("CookieJar", () => {
       );
 
       expect(jar.has("SID")).toBe(false);
-    });
-
-    it("keeps an empty-valued cookie kept alive by a positive Max-Age", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=; Max-Age=3600"]],
-        }),
-      );
-
-      expect(jar.has("SID")).toBe(true);
-      expect(jar.toHeaderValue()).toBe("SID=");
     });
 
     it("gives Max-Age precedence over a contradictory Expires (RFC 6265)", () => {
@@ -240,18 +234,6 @@ describe("CookieJar", () => {
       );
 
       expect(jar.has("SID")).toBe(false);
-    });
-
-    it("ignores a non-numeric Max-Age and falls back to value/expires", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Max-Age=abc"]],
-        }),
-      );
-
-      expect(jar.has("SID")).toBe(true);
-      expect(jar.toHeaderValue()).toBe("SID=val");
     });
   });
 

--- a/src/lib/ade/cookie-jar.test.ts
+++ b/src/lib/ade/cookie-jar.test.ts
@@ -100,64 +100,56 @@ describe("CookieJar", () => {
       expect(jar.size).toBe(0);
     });
 
-    it("keeps a cookie with a positive Max-Age", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Path=/; Max-Age=3600"]],
-        }),
-      );
+    it.each([
+      {
+        name: "keeps a cookie with a positive Max-Age",
+        responses: ["SID=val; Path=/; Max-Age=3600"],
+        expectedHas: { name: "SID", present: true },
+        expectedHeaderValue: "SID=val",
+      },
+      {
+        name: "removes a cookie deleted with Max-Age=0",
+        responses: ["SID=val; Path=/", "SID=val; Path=/; Max-Age=0"],
+        expectedHas: { name: "SID", present: false },
+        expectedSize: 0,
+      },
+      {
+        name: "removes a cookie deleted with a negative Max-Age",
+        responses: ["SID=val; Path=/", "SID=val; Max-Age=-1"],
+        expectedHas: { name: "SID", present: false },
+      },
+      {
+        name: "ignores Max-Age=0 for a cookie that does not exist (no crash)",
+        responses: ["GONE=x; Max-Age=0"],
+        expectedSize: 0,
+      },
+    ] as {
+      name: string;
+      responses: string[];
+      expectedHas?: { name: string; present: boolean };
+      expectedSize?: number;
+      expectedHeaderValue?: string;
+    }[])(
+      "$name",
+      ({ responses, expectedHas, expectedSize, expectedHeaderValue }) => {
+        const jar = new CookieJar();
+        for (const setCookie of responses) {
+          jar.applyResponse(
+            new Response("", { headers: [["Set-Cookie", setCookie]] }),
+          );
+        }
 
-      expect(jar.has("SID")).toBe(true);
-      expect(jar.toHeaderValue()).toBe("SID=val");
-    });
-
-    it("removes a cookie deleted with Max-Age=0", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Path=/"]],
-        }),
-      );
-      expect(jar.has("SID")).toBe(true);
-
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Path=/; Max-Age=0"]],
-        }),
-      );
-
-      expect(jar.has("SID")).toBe(false);
-      expect(jar.size).toBe(0);
-    });
-
-    it("removes a cookie deleted with a negative Max-Age", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Path=/"]],
-        }),
-      );
-
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "SID=val; Max-Age=-1"]],
-        }),
-      );
-
-      expect(jar.has("SID")).toBe(false);
-    });
-
-    it("ignores Max-Age=0 for a cookie that does not exist (no crash)", () => {
-      const jar = new CookieJar();
-      jar.applyResponse(
-        new Response("", {
-          headers: [["Set-Cookie", "GONE=x; Max-Age=0"]],
-        }),
-      );
-
-      expect(jar.size).toBe(0);
-    });
+        if (expectedHas) {
+          expect(jar.has(expectedHas.name)).toBe(expectedHas.present);
+        }
+        if (expectedSize !== undefined) {
+          expect(jar.size).toBe(expectedSize);
+        }
+        if (expectedHeaderValue !== undefined) {
+          expect(jar.toHeaderValue()).toBe(expectedHeaderValue);
+        }
+      },
+    );
 
     it("removes a cookie with Expires in the past", () => {
       const jar = new CookieJar();

--- a/src/lib/ade/index.test.ts
+++ b/src/lib/ade/index.test.ts
@@ -22,47 +22,67 @@ describe("getAdeMode", () => {
     vi.unstubAllEnvs();
   });
 
-  it('returns "real" when ADE_MODE=real (production)', () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("ADE_MODE", "real");
-    expect(getAdeMode()).toBe("real");
-  });
-
-  it('returns "mock" when ADE_MODE=mock (production sandbox)', () => {
-    // Sandbox runs a production build with ADE_MODE=mock — must NOT throw.
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("ADE_MODE", "mock");
-    expect(getAdeMode()).toBe("mock");
-  });
-
-  it("throws in production when ADE_MODE is absent (fail-closed)", () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("ADE_MODE", "");
-    expect(() => getAdeMode()).toThrow(/ADE_MODE non valido o assente/);
-  });
-
-  it("throws in production when ADE_MODE has an unrecognized value", () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("ADE_MODE", "REAL"); // wrong case → not recognized
-    expect(() => getAdeMode()).toThrow(/ADE_MODE non valido o assente/);
-  });
-
-  it('falls back to "mock" in test env when ADE_MODE is absent', () => {
-    vi.stubEnv("NODE_ENV", "test");
-    vi.stubEnv("ADE_MODE", "");
-    expect(getAdeMode()).toBe("mock");
-  });
-
-  it('falls back to "mock" in development when ADE_MODE has a garbage value', () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("ADE_MODE", "nonsense");
-    expect(getAdeMode()).toBe("mock");
-  });
-
-  it('honours an explicit "real" even outside production', () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("ADE_MODE", "real");
-    expect(getAdeMode()).toBe("real");
+  // Note sui casi non ovvii:
+  // - "production sandbox": sandbox gira un build di produzione con
+  //   ADE_MODE=mock — NON deve lanciare.
+  // - "unrecognized value": "REAL" (case sbagliato) non è riconosciuto.
+  it.each([
+    {
+      name: 'returns "real" when ADE_MODE=real (production)',
+      nodeEnv: "production",
+      adeMode: "real",
+      expected: "real",
+    },
+    {
+      name: 'returns "mock" when ADE_MODE=mock (production sandbox)',
+      nodeEnv: "production",
+      adeMode: "mock",
+      expected: "mock",
+    },
+    {
+      name: "throws in production when ADE_MODE is absent (fail-closed)",
+      nodeEnv: "production",
+      adeMode: "",
+      throws: /ADE_MODE non valido o assente/,
+    },
+    {
+      name: "throws in production when ADE_MODE has an unrecognized value",
+      nodeEnv: "production",
+      adeMode: "REAL",
+      throws: /ADE_MODE non valido o assente/,
+    },
+    {
+      name: 'falls back to "mock" in test env when ADE_MODE is absent',
+      nodeEnv: "test",
+      adeMode: "",
+      expected: "mock",
+    },
+    {
+      name: 'falls back to "mock" in development when ADE_MODE has a garbage value',
+      nodeEnv: "development",
+      adeMode: "nonsense",
+      expected: "mock",
+    },
+    {
+      name: 'honours an explicit "real" even outside production',
+      nodeEnv: "development",
+      adeMode: "real",
+      expected: "real",
+    },
+  ] as {
+    name: string;
+    nodeEnv: string;
+    adeMode: string;
+    expected?: string;
+    throws?: RegExp;
+  }[])("$name", ({ nodeEnv, adeMode, expected, throws }) => {
+    vi.stubEnv("NODE_ENV", nodeEnv);
+    vi.stubEnv("ADE_MODE", adeMode);
+    if (throws) {
+      expect(() => getAdeMode()).toThrow(throws);
+    } else {
+      expect(getAdeMode()).toBe(expected);
+    }
   });
 });
 

--- a/src/lib/api-auth.test.ts
+++ b/src/lib/api-auth.test.ts
@@ -102,40 +102,21 @@ describe("authenticateApiKey — format pre-check (no DB call)", () => {
     vi.useRealTimers();
   });
 
-  it("ritorna 401 senza query DB se la chiave ha prefisso errato", async () => {
+  it.each([
+    {
+      desc: "la chiave ha prefisso errato",
+      token: "sk_live_" + "A".repeat(48),
+    },
+    { desc: "la chiave è troppo corta", token: "szk_live_XXXXXXXX" },
+    { desc: "la chiave è troppo lunga", token: "szk_live_" + "A".repeat(100) },
+    {
+      desc: "il body contiene caratteri non base64url",
+      token: "szk_live_" + "+".repeat(48),
+    },
+  ])("ritorna 401 senza query DB se $desc", async ({ token }) => {
     const { authenticateApiKey } = await import("./api-auth");
     const request = new Request("https://api.scontrinozero.it/v1/receipts", {
-      headers: { authorization: "Bearer sk_live_" + "A".repeat(48) },
-    });
-    const result = await authenticateApiKey(request);
-    expect(result).toEqual({ error: "API key non valida.", status: 401 });
-    expect(mockSelectFields).not.toHaveBeenCalled();
-  });
-
-  it("ritorna 401 senza query DB se la chiave è troppo corta", async () => {
-    const { authenticateApiKey } = await import("./api-auth");
-    const request = new Request("https://api.scontrinozero.it/v1/receipts", {
-      headers: { authorization: "Bearer szk_live_XXXXXXXX" },
-    });
-    const result = await authenticateApiKey(request);
-    expect(result).toEqual({ error: "API key non valida.", status: 401 });
-    expect(mockSelectFields).not.toHaveBeenCalled();
-  });
-
-  it("ritorna 401 senza query DB se la chiave è troppo lunga", async () => {
-    const { authenticateApiKey } = await import("./api-auth");
-    const request = new Request("https://api.scontrinozero.it/v1/receipts", {
-      headers: { authorization: "Bearer szk_live_" + "A".repeat(100) },
-    });
-    const result = await authenticateApiKey(request);
-    expect(result).toEqual({ error: "API key non valida.", status: 401 });
-    expect(mockSelectFields).not.toHaveBeenCalled();
-  });
-
-  it("ritorna 401 senza query DB se il body contiene caratteri non base64url", async () => {
-    const { authenticateApiKey } = await import("./api-auth");
-    const request = new Request("https://api.scontrinozero.it/v1/receipts", {
-      headers: { authorization: "Bearer szk_live_" + "+".repeat(48) },
+      headers: { authorization: "Bearer " + token },
     });
     const result = await authenticateApiKey(request);
     expect(result).toEqual({ error: "API key non valida.", status: 401 });

--- a/src/lib/crypto.test.ts
+++ b/src/lib/crypto.test.ts
@@ -50,37 +50,20 @@ describe("crypto (AES-256-GCM)", () => {
     expect(encrypted1).not.toBe(encrypted2);
   });
 
-  it("throws on tampered ciphertext", () => {
+  // Byte offset del campo manomesso nel payload base64:
+  // - ciphertext: dopo version + IV + authTag = 29 bytes
+  // - auth tag: inizia a byte 13 (dopo version=1 + IV=12)
+  // - IV: inizia a byte 1 (dopo version=1)
+  it.each([
+    ["ciphertext", 29],
+    ["auth tag", 13],
+    ["IV", 1],
+  ])("throws on tampered %s", (_field, byteIndex) => {
     const key = makeKey();
     const encrypted = encrypt("secret data", key);
 
     const buf = Buffer.from(encrypted, "base64");
-    // Flip a byte in the ciphertext section (after version + IV + authTag = 29 bytes)
-    buf[29] ^= 0xff;
-    const tampered = buf.toString("base64");
-
-    expect(() => decrypt(tampered, makeKeyMap(key))).toThrow();
-  });
-
-  it("throws on tampered auth tag", () => {
-    const key = makeKey();
-    const encrypted = encrypt("secret data", key);
-
-    const buf = Buffer.from(encrypted, "base64");
-    // Auth tag starts at byte 13 (after version=1 + IV=12)
-    buf[13] ^= 0xff;
-    const tampered = buf.toString("base64");
-
-    expect(() => decrypt(tampered, makeKeyMap(key))).toThrow();
-  });
-
-  it("throws on tampered IV", () => {
-    const key = makeKey();
-    const encrypted = encrypt("secret data", key);
-
-    const buf = Buffer.from(encrypted, "base64");
-    // IV starts at byte 1 (after version=1)
-    buf[1] ^= 0xff;
+    buf[byteIndex] ^= 0xff;
     const tampered = buf.toString("base64");
 
     expect(() => decrypt(tampered, makeKeyMap(key))).toThrow();

--- a/src/lib/identity-env.test.ts
+++ b/src/lib/identity-env.test.ts
@@ -72,55 +72,56 @@ describe("assertIdentityEnv — failure modes in production", () => {
     vi.stubEnv("NODE_ENV", "production");
   });
 
-  it("throws when NEXT_PUBLIC_APP_URL is malformed (not a URL)", () => {
-    process.env.NEXT_PUBLIC_APP_URL = "not a url";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
-    });
-  });
-
-  it("throws when NEXT_PUBLIC_APP_URL is present-but-empty (regola 18)", () => {
-    // Dockerfile bakes ARG even when not passed -> "" -> ?? default not firing.
-    // Boot must catch this BEFORE any lazy call site (SCONTRINOZERO-F) sees it.
-    process.env.NEXT_PUBLIC_APP_URL = "";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
-    });
-  });
-
-  it("throws when NEXT_PUBLIC_APP_URL uses http (not https) in production", () => {
-    process.env.NEXT_PUBLIC_APP_URL = "http://app.scontrinozero.it";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
-    });
-  });
-
-  it("throws when APP_HOSTNAME has a scheme prefix", () => {
-    process.env.APP_HOSTNAME = "https://app.scontrinozero.it";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/APP_HOSTNAME/);
-    });
-  });
-
-  it("throws when MARKETING_HOSTNAME contains a slash", () => {
-    process.env.MARKETING_HOSTNAME = "scontrinozero.it/";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/MARKETING_HOSTNAME/);
-    });
-  });
-
-  it("throws when API_HOSTNAME is present-but-empty (regola 18)", () => {
-    process.env.API_HOSTNAME = "";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/API_HOSTNAME/);
-    });
-  });
-
-  it("throws when a NEXT_PUBLIC_*_HOSTNAME variant is malformed", () => {
-    process.env.NEXT_PUBLIC_API_HOSTNAME = "api scontrinozero.it";
-    return import("./identity-env").then(({ assertIdentityEnv }) => {
-      expect(() => assertIdentityEnv()).toThrow(/NEXT_PUBLIC_API_HOSTNAME/);
-    });
+  // present-but-empty (regola 18): il Dockerfile baka l'ARG anche quando non
+  // passato -> "" -> `?? default` non scatta. Il boot deve intercettarlo PRIMA
+  // di qualsiasi call site lazy (SCONTRINOZERO-F).
+  it.each([
+    {
+      name: "NEXT_PUBLIC_APP_URL is malformed (not a URL)",
+      key: "NEXT_PUBLIC_APP_URL",
+      value: "not a url",
+      match: /NEXT_PUBLIC_APP_URL/,
+    },
+    {
+      name: "NEXT_PUBLIC_APP_URL is present-but-empty (regola 18)",
+      key: "NEXT_PUBLIC_APP_URL",
+      value: "",
+      match: /NEXT_PUBLIC_APP_URL/,
+    },
+    {
+      name: "NEXT_PUBLIC_APP_URL uses http (not https) in production",
+      key: "NEXT_PUBLIC_APP_URL",
+      value: "http://app.scontrinozero.it",
+      match: /NEXT_PUBLIC_APP_URL/,
+    },
+    {
+      name: "APP_HOSTNAME has a scheme prefix",
+      key: "APP_HOSTNAME",
+      value: "https://app.scontrinozero.it",
+      match: /APP_HOSTNAME/,
+    },
+    {
+      name: "MARKETING_HOSTNAME contains a slash",
+      key: "MARKETING_HOSTNAME",
+      value: "scontrinozero.it/",
+      match: /MARKETING_HOSTNAME/,
+    },
+    {
+      name: "API_HOSTNAME is present-but-empty (regola 18)",
+      key: "API_HOSTNAME",
+      value: "",
+      match: /API_HOSTNAME/,
+    },
+    {
+      name: "a NEXT_PUBLIC_*_HOSTNAME variant is malformed",
+      key: "NEXT_PUBLIC_API_HOSTNAME",
+      value: "api scontrinozero.it",
+      match: /NEXT_PUBLIC_API_HOSTNAME/,
+    },
+  ])("throws when $name", async ({ key, value, match }) => {
+    process.env[key] = value;
+    const { assertIdentityEnv } = await import("./identity-env");
+    expect(() => assertIdentityEnv()).toThrow(match);
   });
 
   it("aggregates multiple failures into a single thrown message", async () => {

--- a/src/lib/marketing-to-app-href.test.ts
+++ b/src/lib/marketing-to-app-href.test.ts
@@ -119,7 +119,7 @@ describe("appHref", () => {
     }
     const { appHref } = await import("./marketing-to-app-href");
     for (const [path, expected] of cases) {
-      expect(appHref(path)).toBe(expected);
+      expect(appHref(path as `/${string}`)).toBe(expected);
     }
   });
 });

--- a/src/lib/marketing-to-app-href.test.ts
+++ b/src/lib/marketing-to-app-href.test.ts
@@ -17,92 +17,109 @@ describe("appHref", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns absolute URL on app subdomain in production", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
+  // Scenari coperti (commenti che motivano i casi non ovvii):
+  // - "baked to production" override: single Docker image buildato con prod
+  //   NEXT_PUBLIC_APP_URL e deployato in sandbox via APP_HOSTNAME; senza la
+  //   priorità APP_HOSTNAME i link /login /register punterebbero a produzione.
+  // - "unset (client bundle case)": lato server di un deploy dove solo
+  //   APP_HOSTNAME è settata (client bundle avrebbe entrambe undefined).
+  // - "scheme (typo guard)": `.env` con APP_HOSTNAME=https://... produrrebbe
+  //   `https://https://.../login` senza guard.
+  it.each([
+    {
+      name: "returns absolute URL on app subdomain in production",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://app.scontrinozero.it",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      cases: [
+        ["/login", "https://app.scontrinozero.it/login"],
+        ["/register", "https://app.scontrinozero.it/register"],
+      ],
+    },
+    {
+      name: "honours APP_HOSTNAME runtime override (sandbox)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://sandbox.scontrinozero.it",
+        APP_HOSTNAME: "sandbox.scontrinozero.it",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      cases: [["/login", "https://sandbox.scontrinozero.it/login"]],
+    },
+    {
+      name: "derives base URL from APP_HOSTNAME override even if NEXT_PUBLIC_APP_URL is baked to production",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://app.scontrinozero.it",
+        APP_HOSTNAME: "sandbox.scontrinozero.it",
+      },
+      cases: [
+        ["/login", "https://sandbox.scontrinozero.it/login"],
+        ["/register", "https://sandbox.scontrinozero.it/register"],
+      ],
+    },
+    {
+      name: "derives base URL from APP_HOSTNAME override when NEXT_PUBLIC_APP_URL is unset (client bundle case)",
+      env: { NODE_ENV: "production", APP_HOSTNAME: "custom.example.com" },
+      cases: [["/login", "https://custom.example.com/login"]],
+    },
+    {
+      name: "falls back to hardcoded default if NEXT_PUBLIC_APP_URL is malformed (never throws)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "not-a-url",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      cases: [["/login", "https://app.scontrinozero.it/login"]],
+    },
+    {
+      name: "falls back to hardcoded default if hostname is outside allowlist (never throws)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://evil.example.com",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      cases: [["/login", "https://app.scontrinozero.it/login"]],
+    },
+    {
+      name: "returns localhost URL in development when env is unset",
+      env: { NODE_ENV: "development" },
+      cases: [["/login", "http://localhost:3000/login"]],
+    },
+    {
+      name: "concatenates path with leading slash without producing double slash",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://app.scontrinozero.it/",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      cases: [["/login", "https://app.scontrinozero.it/login"]],
+    },
+    {
+      name: "falls back to hardcoded default if APP_HOSTNAME contains a scheme (typo guard)",
+      env: {
+        NODE_ENV: "production",
+        APP_HOSTNAME: "https://app.scontrinozero.it",
+      },
+      cases: [["/login", "https://app.scontrinozero.it/login"]],
+    },
+    {
+      name: "falls back to hardcoded default if APP_HOSTNAME contains a path/slash",
+      env: {
+        NODE_ENV: "production",
+        APP_HOSTNAME: "app.scontrinozero.it/redirect",
+      },
+      cases: [["/login", "https://app.scontrinozero.it/login"]],
+    },
+  ])("$name", async ({ env, cases }) => {
+    for (const [key, value] of Object.entries(env)) {
+      vi.stubEnv(key, value);
+    }
     const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
-    expect(appHref("/register")).toBe("https://app.scontrinozero.it/register");
-  });
-
-  it("honours APP_HOSTNAME runtime override (sandbox)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://sandbox.scontrinozero.it");
-    vi.stubEnv("APP_HOSTNAME", "sandbox.scontrinozero.it");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://sandbox.scontrinozero.it/login");
-  });
-
-  it("derives base URL from APP_HOSTNAME runtime override even if NEXT_PUBLIC_APP_URL is baked to production", async () => {
-    // Scenario: single Docker image built with prod NEXT_PUBLIC_APP_URL and
-    // deployed in sandbox with APP_HOSTNAME override. Without this priority,
-    // /login and /register links would point to production.
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it");
-    vi.stubEnv("APP_HOSTNAME", "sandbox.scontrinozero.it");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://sandbox.scontrinozero.it/login");
-    expect(appHref("/register")).toBe(
-      "https://sandbox.scontrinozero.it/register",
-    );
-  });
-
-  it("derives base URL from APP_HOSTNAME runtime override when NEXT_PUBLIC_APP_URL is unset (client bundle case)", async () => {
-    // In client bundles process.env.NEXT_PUBLIC_APP_URL is whatever was baked
-    // at build time. If not baked, it's undefined; APP_HOSTNAME (server-only)
-    // is also undefined client-side, so this test simulates the server side
-    // of a deployment where only APP_HOSTNAME is set.
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("APP_HOSTNAME", "custom.example.com");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://custom.example.com/login");
-  });
-
-  it("falls back to hardcoded default if NEXT_PUBLIC_APP_URL is malformed (never throws)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "not-a-url");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
-  });
-
-  it("falls back to hardcoded default if hostname is outside allowlist (never throws)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://evil.example.com");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
-  });
-
-  it("returns localhost URL in development when env is unset", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("http://localhost:3000/login");
-  });
-
-  it("concatenates path with leading slash without producing double slash", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it/");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
-  });
-
-  it("falls back to hardcoded default if APP_HOSTNAME contains a scheme (typo guard)", async () => {
-    // `.env` typo: APP_HOSTNAME=https://app.scontrinozero.it
-    // → senza guard produrrebbe `https://https://app.scontrinozero.it/login`.
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("APP_HOSTNAME", "https://app.scontrinozero.it");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
-  });
-
-  it("falls back to hardcoded default if APP_HOSTNAME contains a path/slash", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("APP_HOSTNAME", "app.scontrinozero.it/redirect");
-    const { appHref } = await import("./marketing-to-app-href");
-    expect(appHref("/login")).toBe("https://app.scontrinozero.it/login");
+    for (const [path, expected] of cases) {
+      expect(appHref(path)).toBe(expected);
+    }
   });
 });

--- a/src/lib/sentry-filters.test.ts
+++ b/src/lib/sentry-filters.test.ts
@@ -101,84 +101,84 @@ describe("isBenignFormDataParseError", () => {
 });
 
 describe("isClientNetworkFailure", () => {
-  it('filtra "Load failed" da originalException Error (iOS/Safari)', () => {
-    const event = makeEvent("/login");
-    const hint: EventHint = {
+  it.each([
+    {
+      name: 'filtra "Load failed" da originalException Error (iOS/Safari)',
+      transaction: "/login",
       originalException: new TypeError("Load failed"),
-    };
-
-    expect(isClientNetworkFailure(event, hint)).toBe(true);
-  });
-
-  it('filtra "Failed to fetch" da originalException Error (Chrome/Firefox)', () => {
-    const event = makeEvent("/login");
-    const hint: EventHint = {
+      expected: true,
+    },
+    {
+      name: 'filtra "Failed to fetch" da originalException Error (Chrome/Firefox)',
+      transaction: "/login",
       originalException: new TypeError("Failed to fetch"),
-    };
-
-    expect(isClientNetworkFailure(event, hint)).toBe(true);
-  });
-
-  it('filtra la forma arricchita col suffisso host "Failed to fetch (<host>)" (issue SCONTRINOZERO-R, estensione browser)', () => {
-    const event = makeEvent("/help/credenziali-fisconline");
-    const hint: EventHint = {
+      expected: true,
+    },
+    {
+      name: 'filtra la forma arricchita col suffisso host "Failed to fetch (<host>)" (issue SCONTRINOZERO-R, estensione browser)',
+      transaction: "/help/credenziali-fisconline",
       originalException: new TypeError("Failed to fetch (safesearchinc.com)"),
-    };
-
-    expect(isClientNetworkFailure(event, hint)).toBe(true);
-  });
-
-  it('filtra "Load failed (<host>)" arricchito dalla fetch-instrumentation', () => {
-    const event = makeEvent("/dashboard", "Load failed (example.com)");
-
-    expect(isClientNetworkFailure(event)).toBe(true);
-  });
-
-  it('non filtra un messaggio che estende la base senza il suffisso " (" (es. "Failed to fetchX")', () => {
-    const event = makeEvent("/login");
-    const hint: EventHint = {
+      expected: true,
+    },
+    {
+      name: 'filtra "Load failed (<host>)" arricchito dalla fetch-instrumentation',
+      transaction: "/dashboard",
+      exceptionValue: "Load failed (example.com)",
+      expected: true,
+    },
+    {
+      name: 'non filtra un messaggio che estende la base senza il suffisso " (" (es. "Failed to fetchX")',
+      transaction: "/login",
       originalException: new TypeError("Failed to fetchX"),
-    };
-
-    expect(isClientNetworkFailure(event, hint)).toBe(false);
-  });
-
-  it("filtra quando il messaggio è in originalException stringa", () => {
-    const event = makeEvent("/login");
-    const hint: EventHint = { originalException: "Load failed" };
-
-    expect(isClientNetworkFailure(event, hint)).toBe(true);
-  });
-
-  it("filtra quando il messaggio è nell'exception dell'evento (senza hint)", () => {
-    const event = makeEvent("/login", "Load failed");
-
-    expect(isClientNetworkFailure(event)).toBe(true);
-  });
-
-  it('non filtra "Network request failed" (messaggio non standard)', () => {
-    const event = makeEvent("/login");
-    const hint: EventHint = {
+      expected: false,
+    },
+    {
+      name: "filtra quando il messaggio è in originalException stringa",
+      transaction: "/login",
+      originalException: "Load failed",
+      expected: true,
+    },
+    {
+      name: "filtra quando il messaggio è nell'exception dell'evento (senza hint)",
+      transaction: "/login",
+      exceptionValue: "Load failed",
+      expected: true,
+    },
+    {
+      name: 'non filtra "Network request failed" (messaggio non standard)',
+      transaction: "/login",
       originalException: new TypeError("Network request failed"),
-    };
-
-    expect(isClientNetworkFailure(event, hint)).toBe(false);
-  });
-
-  it("non filtra errori applicativi diversi dai fallimenti di rete", () => {
-    const event = makeEvent("/login");
-    const hint: EventHint = {
+      expected: false,
+    },
+    {
+      name: "non filtra errori applicativi diversi dai fallimenti di rete",
+      transaction: "/login",
       originalException: new TypeError("Failed to parse body as FormData"),
-    };
+      expected: false,
+    },
+    {
+      name: "non filtra eventi senza messaggio di errore",
+      transaction: "/login",
+      expected: false,
+    },
+  ] as {
+    name: string;
+    transaction: string;
+    exceptionValue?: string;
+    originalException?: unknown;
+    expected: boolean;
+  }[])(
+    "$name",
+    ({ transaction, exceptionValue, originalException, expected }) => {
+      const event = makeEvent(transaction, exceptionValue);
+      const hint =
+        originalException !== undefined
+          ? ({ originalException } as EventHint)
+          : undefined;
 
-    expect(isClientNetworkFailure(event, hint)).toBe(false);
-  });
-
-  it("non filtra eventi senza messaggio di errore", () => {
-    const event = makeEvent("/login");
-
-    expect(isClientNetworkFailure(event)).toBe(false);
-  });
+      expect(isClientNetworkFailure(event, hint)).toBe(expected);
+    },
+  );
 });
 
 describe("isReactStreamingDomError", () => {

--- a/src/lib/services/ade-recovery.test.ts
+++ b/src/lib/services/ade-recovery.test.ts
@@ -77,28 +77,20 @@ describe("getStalePendingThresholdMs", () => {
     expect(getStalePendingThresholdMs()).toBe(0.5 * 60 * 1000);
   });
 
-  it("falls back to default on zero (avoids immediate recovery)", () => {
-    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "0");
-    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
-  });
-
-  it("falls back to default on negative values", () => {
-    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "-5");
-    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
-  });
-
-  it("falls back to default on non-numeric strings", () => {
-    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "abc");
-    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
-  });
-
-  it("falls back to default on NaN string", () => {
-    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "NaN");
-    expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
-  });
-
-  it("falls back to default when the env var is an empty string", () => {
-    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", "");
+  it.each([
+    {
+      name: "falls back to default on zero (avoids immediate recovery)",
+      value: "0",
+    },
+    { name: "falls back to default on negative values", value: "-5" },
+    { name: "falls back to default on non-numeric strings", value: "abc" },
+    { name: "falls back to default on NaN string", value: "NaN" },
+    {
+      name: "falls back to default when the env var is an empty string",
+      value: "",
+    },
+  ])("$name", ({ value }) => {
+    vi.stubEnv("STALE_PENDING_THRESHOLD_MINUTES", value);
     expect(getStalePendingThresholdMs()).toBe(30 * 60 * 1000);
   });
 });

--- a/src/lib/services/inactive-user-prune.test.ts
+++ b/src/lib/services/inactive-user-prune.test.ts
@@ -47,36 +47,51 @@ const CONFIG: PruneConfig = {
 };
 
 describe("isProtectedFromPrune", () => {
-  it("protegge unlimited sempre", async () => {
+  it.each([
+    {
+      name: "protegge unlimited sempre",
+      plan: "unlimited",
+      expiresAt: null,
+      expected: true,
+    },
+    {
+      name: "NON protegge il trial",
+      plan: "trial",
+      expiresAt: null,
+      expected: false,
+    },
+    {
+      name: "protegge un piano a pagamento ancora attivo",
+      plan: "pro",
+      expiresAt: new Date(NOW.getTime() + 30 * 86_400_000),
+      expected: true,
+    },
+    {
+      name: "protegge un piano a pagamento con scadenza sconosciuta (null) — fail-safe",
+      plan: "pro",
+      expiresAt: null,
+      expected: true,
+    },
+    {
+      name: "NON protegge un piano a pagamento scaduto oltre la grazia",
+      plan: "pro",
+      expiresAt: new Date(NOW.getTime() - 400 * 86_400_000),
+      expected: false,
+    },
+    {
+      name: "protegge un plan sconosciuto (drift schema)",
+      plan: "mystery",
+      expiresAt: null,
+      expected: true,
+    },
+  ] as {
+    name: string;
+    plan: string;
+    expiresAt: Date | null;
+    expected: boolean;
+  }[])("$name", async ({ plan, expiresAt, expected }) => {
     const { isProtectedFromPrune } = await import("./inactive-user-prune");
-    expect(isProtectedFromPrune("unlimited", null, NOW.getTime())).toBe(true);
-  });
-
-  it("NON protegge il trial", async () => {
-    const { isProtectedFromPrune } = await import("./inactive-user-prune");
-    expect(isProtectedFromPrune("trial", null, NOW.getTime())).toBe(false);
-  });
-
-  it("protegge un piano a pagamento ancora attivo", async () => {
-    const { isProtectedFromPrune } = await import("./inactive-user-prune");
-    const future = new Date(NOW.getTime() + 30 * 86_400_000);
-    expect(isProtectedFromPrune("pro", future, NOW.getTime())).toBe(true);
-  });
-
-  it("protegge un piano a pagamento con scadenza sconosciuta (null) — fail-safe", async () => {
-    const { isProtectedFromPrune } = await import("./inactive-user-prune");
-    expect(isProtectedFromPrune("pro", null, NOW.getTime())).toBe(true);
-  });
-
-  it("NON protegge un piano a pagamento scaduto oltre la grazia", async () => {
-    const { isProtectedFromPrune } = await import("./inactive-user-prune");
-    const longExpired = new Date(NOW.getTime() - 400 * 86_400_000);
-    expect(isProtectedFromPrune("pro", longExpired, NOW.getTime())).toBe(false);
-  });
-
-  it("protegge un plan sconosciuto (drift schema)", async () => {
-    const { isProtectedFromPrune } = await import("./inactive-user-prune");
-    expect(isProtectedFromPrune("mystery", null, NOW.getTime())).toBe(true);
+    expect(isProtectedFromPrune(plan, expiresAt, NOW.getTime())).toBe(expected);
   });
 });
 

--- a/src/lib/trusted-app-url.test.ts
+++ b/src/lib/trusted-app-url.test.ts
@@ -17,121 +17,135 @@ describe("getTrustedAppUrl", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns the URL when valid (production + https + allowlisted host)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("https://app.scontrinozero.it");
-  });
-
-  it("strips trailing slash", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it/");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("https://app.scontrinozero.it");
-  });
-
-  it("allows APP_HOSTNAME as runtime override (sandbox/self-hosted)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://sandbox.scontrinozero.it");
-    vi.stubEnv("APP_HOSTNAME", "sandbox.scontrinozero.it");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("https://sandbox.scontrinozero.it");
-  });
-
-  it("throws on malformed URL", async () => {
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "not-a-url");
-    const { getTrustedAppUrl, TrustedAppUrlError } =
-      await import("./trusted-app-url");
-    expect(() => getTrustedAppUrl()).toThrow(TrustedAppUrlError);
-  });
-
-  it("throws in production when protocol is not https", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://app.scontrinozero.it");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl, TrustedAppUrlError } =
-      await import("./trusted-app-url");
-    expect(() => getTrustedAppUrl()).toThrow(TrustedAppUrlError);
-    expect(() => getTrustedAppUrl()).toThrow(/https/);
-  });
-
-  it("throws in production when hostname is not allowlisted", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://evil.example.com");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl, TrustedAppUrlError } =
-      await import("./trusted-app-url");
-    expect(() => getTrustedAppUrl()).toThrow(TrustedAppUrlError);
-    expect(() => getTrustedAppUrl()).toThrow(/allowlist/);
-  });
-
-  it("does NOT allow look-alike subdomain (subdomain spoofing)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.scontrinozero.it.evil.tld");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl, TrustedAppUrlError } =
-      await import("./trusted-app-url");
-    expect(() => getTrustedAppUrl()).toThrow(TrustedAppUrlError);
-  });
-
-  it("allows http://localhost in non-production", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3000");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("http://localhost:3000");
-  });
-
-  it("does NOT allow localhost in production (forces deploy-time config)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://localhost:3000");
-    vi.stubEnv("NEXT_PUBLIC_APP_HOSTNAME", "app.scontrinozero.it");
-    const { getTrustedAppUrl, TrustedAppUrlError } =
-      await import("./trusted-app-url");
-    expect(() => getTrustedAppUrl()).toThrow(TrustedAppUrlError);
-  });
-
-  it("defaults to http://localhost:3000 when NEXT_PUBLIC_APP_URL is unset (dev only)", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("http://localhost:3000");
-  });
-
   // SCONTRINOZERO-F: il Dockerfile bakava `ENV NEXT_PUBLIC_APP_URL=` (stringa
   // vuota) quando l'ARG non veniva passato (prod/sandbox). Il `?? default`
   // NON scatta su present-but-empty → `new URL("")` lanciava → 503 su ogni
   // checkout/portal Stripe. Empty/whitespace va trattato come assente, e in
   // produzione il default deve essere l'host app (https + allowlist), non
   // localhost. (CLAUDE.md regola 18.)
-  it("defaults to the prod app URL when NEXT_PUBLIC_APP_URL is present-but-empty in production", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+  it.each([
+    {
+      name: "returns the URL when valid (production + https + allowlisted host)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://app.scontrinozero.it",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      expected: "https://app.scontrinozero.it",
+    },
+    {
+      name: "strips trailing slash",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://app.scontrinozero.it/",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      expected: "https://app.scontrinozero.it",
+    },
+    {
+      name: "allows APP_HOSTNAME as runtime override (sandbox/self-hosted)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://sandbox.scontrinozero.it",
+        APP_HOSTNAME: "sandbox.scontrinozero.it",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      expected: "https://sandbox.scontrinozero.it",
+    },
+    {
+      name: "allows http://localhost in non-production",
+      env: {
+        NODE_ENV: "development",
+        NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+      },
+      expected: "http://localhost:3000",
+    },
+    {
+      name: "defaults to http://localhost:3000 when NEXT_PUBLIC_APP_URL is unset (dev only)",
+      env: { NODE_ENV: "development" },
+      expected: "http://localhost:3000",
+    },
+    {
+      name: "defaults to the prod app URL when NEXT_PUBLIC_APP_URL is present-but-empty in production",
+      env: { NODE_ENV: "production", NEXT_PUBLIC_APP_URL: "" },
+      expected: "https://app.scontrinozero.it",
+    },
+    {
+      name: "treats a whitespace-only NEXT_PUBLIC_APP_URL as unset in production",
+      env: { NODE_ENV: "production", NEXT_PUBLIC_APP_URL: "   " },
+      expected: "https://app.scontrinozero.it",
+    },
+    {
+      name: "defaults to the prod app URL when NEXT_PUBLIC_APP_URL is unset in production",
+      env: { NODE_ENV: "production" },
+      expected: "https://app.scontrinozero.it",
+    },
+    {
+      name: "falls back to localhost when NEXT_PUBLIC_APP_URL is present-but-empty in dev",
+      env: { NODE_ENV: "development", NEXT_PUBLIC_APP_URL: "" },
+      expected: "http://localhost:3000",
+    },
+  ])("$name", async ({ env, expected }) => {
+    for (const [key, value] of Object.entries(env)) {
+      vi.stubEnv(key, value);
+    }
     const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("https://app.scontrinozero.it");
+    expect(getTrustedAppUrl()).toBe(expected);
   });
 
-  it("treats a whitespace-only NEXT_PUBLIC_APP_URL as unset in production", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "   ");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("https://app.scontrinozero.it");
-  });
-
-  it("defaults to the prod app URL when NEXT_PUBLIC_APP_URL is unset in production", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("https://app.scontrinozero.it");
-  });
-
-  it("falls back to localhost when NEXT_PUBLIC_APP_URL is present-but-empty in dev", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
-    const { getTrustedAppUrl } = await import("./trusted-app-url");
-    expect(getTrustedAppUrl()).toBe("http://localhost:3000");
-  });
+  it.each([
+    {
+      name: "throws on malformed URL",
+      env: { NEXT_PUBLIC_APP_URL: "not-a-url" },
+    },
+    {
+      name: "throws in production when protocol is not https",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "http://app.scontrinozero.it",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      messageMatch: /https/,
+    },
+    {
+      name: "throws in production when hostname is not allowlisted",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://evil.example.com",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+      messageMatch: /allowlist/,
+    },
+    {
+      name: "does NOT allow look-alike subdomain (subdomain spoofing)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://app.scontrinozero.it.evil.tld",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+    },
+    {
+      name: "does NOT allow localhost in production (forces deploy-time config)",
+      env: {
+        NODE_ENV: "production",
+        NEXT_PUBLIC_APP_URL: "https://localhost:3000",
+        NEXT_PUBLIC_APP_HOSTNAME: "app.scontrinozero.it",
+      },
+    },
+  ] as { name: string; env: Record<string, string>; messageMatch?: RegExp }[])(
+    "$name",
+    async ({ env, messageMatch }) => {
+      for (const [key, value] of Object.entries(env)) {
+        vi.stubEnv(key, value);
+      }
+      const { getTrustedAppUrl, TrustedAppUrlError } =
+        await import("./trusted-app-url");
+      expect(() => getTrustedAppUrl()).toThrow(TrustedAppUrlError);
+      if (messageMatch) {
+        expect(() => getTrustedAppUrl()).toThrow(messageMatch);
+      }
+    },
+  );
 
   it("does NOT log a critical error when env is empty in production (no false alarm)", async () => {
     vi.stubEnv("NODE_ENV", "production");

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -45,52 +45,23 @@ describe("adePinSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects empty string", () => {
-    const result = adePinSchema.safeParse("");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects 9 digits (too short by 1)", () => {
-    const result = adePinSchema.safeParse("123456789");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects 11 digits (too long by 1)", () => {
-    const result = adePinSchema.safeParse("12345678901");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects 10 characters containing a letter", () => {
-    const result = adePinSchema.safeParse("123456789a");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects 10 characters that are all letters", () => {
-    const result = adePinSchema.safeParse("abcdefghij");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects PIN with internal space (9 digits + 1 space)", () => {
-    const result = adePinSchema.safeParse("12345 6789");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects PIN with surrounding whitespace (schema does not trim)", () => {
-    // Trimming is the caller's responsibility before safeParse
-    const result = adePinSchema.safeParse(" 1234567890 ");
-    expect(result.success).toBe(false);
-    expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
-  });
-
-  it("rejects Arabic-Indic digits (\\d without /u flag matches only [0-9])", () => {
-    // U+0660–U+0669 are Arabic-Indic numerals; \d without the u flag ignores them
-    const result = adePinSchema.safeParse("٠١٢٣٤٥٦٧٨٩");
+  // Trimming is the caller's responsibility before safeParse (whitespace case).
+  // Arabic-Indic case: U+0660–U+0669 are Arabic-Indic numerals; \d without the
+  // u flag ignores them, quindi vengono respinti.
+  it.each([
+    ["empty string", ""],
+    ["9 digits (too short by 1)", "123456789"],
+    ["11 digits (too long by 1)", "12345678901"],
+    ["10 characters containing a letter", "123456789a"],
+    ["10 characters that are all letters", "abcdefghij"],
+    ["PIN with internal space (9 digits + 1 space)", "12345 6789"],
+    ["PIN with surrounding whitespace (schema does not trim)", " 1234567890 "],
+    [
+      "Arabic-Indic digits (\\d without /u flag matches only [0-9])",
+      "٠١٢٣٤٥٦٧٨٩",
+    ],
+  ])("rejects %s", (_label, input) => {
+    const result = adePinSchema.safeParse(input);
     expect(result.success).toBe(false);
     expect(result.error?.issues[0]?.message).toBe(PIN_ERROR);
   });

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -351,56 +351,61 @@ describe("proxy", () => {
       delete process.env.NEXT_PUBLIC_MARKETING_HOSTNAME;
     });
 
-    it("allows / on marketing domain (public route)", async () => {
+    it.each([
+      { name: "allows / on marketing domain (public route)", path: "/" },
+      {
+        name: "allows /privacy on marketing domain (marketing-only route)",
+        path: "/privacy",
+      },
+      {
+        name: "allows /help on marketing domain (marketing-only route)",
+        path: "/help",
+      },
+      {
+        name: "allows /help/api on marketing domain (help subroute)",
+        path: "/help/api",
+      },
+      {
+        name: "allows a dynamic marketing subroute on marketing domain (/guide/[slug])",
+        path: "/guide/regime-forfettario",
+      },
+      {
+        name: "allows /strumenti/scorporo-iva on marketing domain (tool subroute)",
+        path: "/strumenti/scorporo-iva",
+      },
+    ])("$name", async ({ path }) => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
       const { proxy } = await import("./proxy");
 
       const response = await proxy(
-        createRequestForHost("/", "scontrinozero.it"),
+        createRequestForHost(path, "scontrinozero.it"),
       );
       expect(response.status).toBe(200);
     });
 
-    it("allows /privacy on marketing domain (marketing-only route)", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
+    it.each([
+      {
+        name: "redirects /help on app domain to marketing domain",
+        path: "/help",
+      },
+      {
+        name: "redirects /strumenti/scorporo-iva on app domain to marketing domain",
+        path: "/strumenti/scorporo-iva",
+      },
+      {
+        name: "redirects /termini on app domain to marketing domain",
+        path: "/termini",
+      },
+    ])("$name", async ({ path }) => {
       const { proxy } = await import("./proxy");
 
       const response = await proxy(
-        createRequestForHost("/privacy", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(200);
-    });
-
-    it("allows /help on marketing domain (marketing-only route)", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/help", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(200);
-    });
-
-    it("allows /help/api on marketing domain (help subroute)", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/help/api", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(200);
-    });
-
-    it("redirects /help on app domain to marketing domain", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/help", "app.scontrinozero.it"),
+        createRequestForHost(path, "app.scontrinozero.it"),
       );
       expect(response.status).toBe(307);
       const location = new URL(response.headers.get("location")!);
       expect(location.hostname).toBe("scontrinozero.it");
-      expect(location.pathname).toBe("/help");
+      expect(location.pathname).toBe(path);
     });
 
     // Le pagine di contenuto marketing (oltre a privacy/termini/cookie/help)
@@ -443,48 +448,35 @@ describe("proxy", () => {
       },
     );
 
-    it("allows a dynamic marketing subroute on marketing domain (/guide/[slug])", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
+    it.each([
+      {
+        name: "redirects /dashboard on marketing domain to app domain",
+        path: "/dashboard",
+        fromHost: "scontrinozero.it",
+      },
+      {
+        name: "redirects /login on www subdomain to app domain (non-marketing route)",
+        path: "/login",
+        fromHost: "www.scontrinozero.it",
+      },
+      {
+        name: "redirects /login on bare marketing domain to app domain",
+        path: "/login",
+        fromHost: "scontrinozero.it",
+      },
+      {
+        name: "redirects /register on bare marketing domain to app domain",
+        path: "/register",
+        fromHost: "scontrinozero.it",
+      },
+    ])("$name", async ({ path, fromHost }) => {
       const { proxy } = await import("./proxy");
 
-      const response = await proxy(
-        createRequestForHost("/guide/regime-forfettario", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(200);
-    });
-
-    it("allows /strumenti/scorporo-iva on marketing domain (tool subroute)", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/strumenti/scorporo-iva", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(200);
-    });
-
-    it("redirects /strumenti/scorporo-iva on app domain to marketing domain", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/strumenti/scorporo-iva", "app.scontrinozero.it"),
-      );
-      expect(response.status).toBe(307);
-      const location = new URL(response.headers.get("location")!);
-      expect(location.hostname).toBe("scontrinozero.it");
-      expect(location.pathname).toBe("/strumenti/scorporo-iva");
-    });
-
-    it("redirects /dashboard on marketing domain to app domain", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/dashboard", "scontrinozero.it"),
-      );
+      const response = await proxy(createRequestForHost(path, fromHost));
       expect(response.status).toBe(307);
       const location = new URL(response.headers.get("location")!);
       expect(location.hostname).toBe("app.scontrinozero.it");
-      expect(location.pathname).toBe("/dashboard");
+      expect(location.pathname).toBe(path);
     });
 
     it("redirects / on app domain to /dashboard", async () => {
@@ -496,18 +488,6 @@ describe("proxy", () => {
       expect(response.status).toBe(307);
       const location = new URL(response.headers.get("location")!);
       expect(location.pathname).toBe("/dashboard");
-    });
-
-    it("redirects /termini on app domain to marketing domain", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/termini", "app.scontrinozero.it"),
-      );
-      expect(response.status).toBe(307);
-      const location = new URL(response.headers.get("location")!);
-      expect(location.hostname).toBe("scontrinozero.it");
-      expect(location.pathname).toBe("/termini");
     });
 
     it("preserves query string on app→marketing redirect", async () => {
@@ -533,42 +513,6 @@ describe("proxy", () => {
         createRequestForHost("/dashboard", "app.scontrinozero.it"),
       );
       expect(response.status).toBe(200);
-    });
-
-    it("redirects /login on www subdomain to app domain (non-marketing route)", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/login", "www.scontrinozero.it"),
-      );
-      expect(response.status).toBe(307);
-      const location = new URL(response.headers.get("location")!);
-      expect(location.hostname).toBe("app.scontrinozero.it");
-      expect(location.pathname).toBe("/login");
-    });
-
-    it("redirects /login on bare marketing domain to app domain", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/login", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(307);
-      const location = new URL(response.headers.get("location")!);
-      expect(location.hostname).toBe("app.scontrinozero.it");
-      expect(location.pathname).toBe("/login");
-    });
-
-    it("redirects /register on bare marketing domain to app domain", async () => {
-      const { proxy } = await import("./proxy");
-
-      const response = await proxy(
-        createRequestForHost("/register", "scontrinozero.it"),
-      );
-      expect(response.status).toBe(307);
-      const location = new URL(response.headers.get("location")!);
-      expect(location.hostname).toBe("app.scontrinozero.it");
-      expect(location.pathname).toBe("/register");
     });
 
     it("passes through /api/v1/receipts on api subdomain without redirect", async () => {

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -1217,45 +1217,44 @@ describe("auth-actions", () => {
       expect(mockSignUp).toHaveBeenCalled();
     });
 
-    it("accepts a captcha token whose hostname is the marketing domain (single-domain / client-side nav)", async () => {
-      // Reproduces the production bug: the widget is loaded from the marketing
-      // domain (e.g. via Next.js <Link> client-side navigation to /login) and
-      // Cloudflare therefore returns hostname=<marketing>, not <app>. Pre-fix
-      // verifyCaptcha rejected this as `captcha_hostname_mismatch`.
-      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
-      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
+    // Note sui casi non ovvii:
+    // - "marketing domain": riproduce il bug di produzione — il widget è
+    //   caricato dal dominio marketing (es. via <Link> client-side verso
+    //   /login) e Cloudflare ritorna hostname=<marketing>, non <app>. Pre-fix
+    //   verifyCaptcha lo rifiutava come `captcha_hostname_mismatch`.
+    // - "lowercase / mixed case": Turnstile ritorna data.hostname sempre
+    //   lowercase; se l'env d'identità ha maiuscole ("App.ScontrinoZero.IT")
+    //   il match esatto fallirebbe senza normalizzazione (REVIEW.md #37).
+    it.each([
+      {
+        name: "accepts a captcha token whose hostname is the marketing domain (single-domain / client-side nav)",
+        appHostname: "app.scontrinozero.it",
+        marketingHostname: "scontrinozero.it",
+        captchaHostname: "scontrinozero.it",
+      },
+      {
+        name: "accepts a captcha token whose hostname is the www variant of the marketing domain",
+        appHostname: "app.scontrinozero.it",
+        marketingHostname: "scontrinozero.it",
+        captchaHostname: "www.scontrinozero.it",
+      },
+      {
+        name: "accepts the lowercase Turnstile hostname even when the app env has mixed case",
+        appHostname: "App.ScontrinoZero.IT",
+        marketingHostname: "scontrinozero.it",
+        captchaHostname: "app.scontrinozero.it",
+      },
+      {
+        name: "accepts the marketing hostname even when its env has surrounding whitespace",
+        appHostname: "app.scontrinozero.it",
+        marketingHostname: "  scontrinozero.it  ",
+        captchaHostname: "scontrinozero.it",
+      },
+    ])("$name", async ({ appHostname, marketingHostname, captchaHostname }) => {
+      process.env.NEXT_PUBLIC_APP_HOSTNAME = appHostname;
+      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = marketingHostname;
       mockFetch.mockResolvedValueOnce(
-        captchaResponse("signup", "scontrinozero.it"),
-      );
-      mockSignUp.mockResolvedValue({
-        data: { user: { id: "user-1" } },
-        error: null,
-      });
-
-      const { signUp } = await import("./auth-actions");
-      try {
-        await signUp(
-          formData({
-            email: "test@example.com",
-            password: "Secure#99x",
-            confirmPassword: "Secure#99x",
-            termsAccepted: "true",
-            specificClausesAccepted: "true",
-            captchaToken: "valid-token",
-          }),
-        );
-      } catch (err) {
-        if (!isRedirectError(err)) throw err;
-      }
-
-      expect(mockSignUp).toHaveBeenCalled();
-    });
-
-    it("accepts a captcha token whose hostname is the www variant of the marketing domain", async () => {
-      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
-      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
-      mockFetch.mockResolvedValueOnce(
-        captchaResponse("signup", "www.scontrinozero.it"),
+        captchaResponse("signup", captchaHostname),
       );
       mockSignUp.mockResolvedValue({
         data: { user: { id: "user-1" } },
@@ -1302,70 +1301,6 @@ describe("auth-actions", () => {
 
       expect(result).toEqual({ error: "Verifica CAPTCHA fallita. Riprova." });
       expect(mockSignUp).not.toHaveBeenCalled();
-    });
-
-    it("accepts the lowercase Turnstile hostname even when the app env has mixed case", async () => {
-      // Turnstile siteverify ritorna data.hostname sempre in lowercase; se l'env
-      // d'identità è misconfigurato con maiuscole (es. "App.ScontrinoZero.IT")
-      // il match esatto fallirebbe senza normalizzazione → ogni login bloccato
-      // con captcha_hostname_mismatch (REVIEW.md #37).
-      process.env.NEXT_PUBLIC_APP_HOSTNAME = "App.ScontrinoZero.IT";
-      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "scontrinozero.it";
-      mockFetch.mockResolvedValueOnce(
-        captchaResponse("signup", "app.scontrinozero.it"),
-      );
-      mockSignUp.mockResolvedValue({
-        data: { user: { id: "user-1" } },
-        error: null,
-      });
-
-      const { signUp } = await import("./auth-actions");
-      try {
-        await signUp(
-          formData({
-            email: "test@example.com",
-            password: "Secure#99x",
-            confirmPassword: "Secure#99x",
-            termsAccepted: "true",
-            specificClausesAccepted: "true",
-            captchaToken: "valid-token",
-          }),
-        );
-      } catch (err) {
-        if (!isRedirectError(err)) throw err;
-      }
-
-      expect(mockSignUp).toHaveBeenCalled();
-    });
-
-    it("accepts the marketing hostname even when its env has surrounding whitespace", async () => {
-      process.env.NEXT_PUBLIC_APP_HOSTNAME = "app.scontrinozero.it";
-      process.env.NEXT_PUBLIC_MARKETING_HOSTNAME = "  scontrinozero.it  ";
-      mockFetch.mockResolvedValueOnce(
-        captchaResponse("signup", "scontrinozero.it"),
-      );
-      mockSignUp.mockResolvedValue({
-        data: { user: { id: "user-1" } },
-        error: null,
-      });
-
-      const { signUp } = await import("./auth-actions");
-      try {
-        await signUp(
-          formData({
-            email: "test@example.com",
-            password: "Secure#99x",
-            confirmPassword: "Secure#99x",
-            termsAccepted: "true",
-            specificClausesAccepted: "true",
-            captchaToken: "valid-token",
-          }),
-        );
-      } catch (err) {
-        if (!isRedirectError(err)) throw err;
-      }
-
-      expect(mockSignUp).toHaveBeenCalled();
     });
 
     it("falls back to the next hostname env when APP_HOSTNAME is present but empty", async () => {

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -143,35 +143,26 @@ describe("changeAdePassword", () => {
     setupDb();
   });
 
-  it("rifiuta quando la nuova password non rispetta il charset/lunghezza", async () => {
+  it.each([
+    {
+      name: "rifiuta quando la nuova password non rispetta il charset/lunghezza",
+      password: "àccented",
+    },
+    {
+      name: "rifiuta quando la nuova password è troppo corta (< 8 caratteri)",
+      password: "Short1",
+    },
+    {
+      name: "rifiuta quando la nuova password è troppo lunga (> 15 caratteri)",
+      password: "ThisIsWayTooLong1",
+    },
+  ])("$name", async ({ password }) => {
     const { changeAdePassword } = await import("@/server/onboarding-actions");
     const result = await changeAdePassword(
       BIZ_ID,
       "OldPass1",
-      "àccented",
-      "àccented",
-    );
-    expect(result.error).toMatch(/Password non valida/);
-  });
-
-  it("rifiuta quando la nuova password è troppo corta (< 8 caratteri)", async () => {
-    const { changeAdePassword } = await import("@/server/onboarding-actions");
-    const result = await changeAdePassword(
-      BIZ_ID,
-      "OldPass1",
-      "Short1",
-      "Short1",
-    );
-    expect(result.error).toMatch(/Password non valida/);
-  });
-
-  it("rifiuta quando la nuova password è troppo lunga (> 15 caratteri)", async () => {
-    const { changeAdePassword } = await import("@/server/onboarding-actions");
-    const result = await changeAdePassword(
-      BIZ_ID,
-      "OldPass1",
-      "ThisIsWayTooLong1",
-      "ThisIsWayTooLong1",
+      password,
+      password,
     );
     expect(result.error).toMatch(/Password non valida/);
   });

--- a/tests/unit/server-receipt-actions.test.ts
+++ b/tests/unit/server-receipt-actions.test.ts
@@ -164,41 +164,50 @@ describe("emitReceipt server action", () => {
       expect(result.error).toBeUndefined();
     });
 
-    it("rejects grossUnitPrice with more than 2 decimal places", async () => {
+    it.each([
+      {
+        name: "rejects grossUnitPrice with more than 2 decimal places",
+        line: {
+          id: "l",
+          description: "A",
+          quantity: 1,
+          grossUnitPrice: 1.123,
+          vatCode: "22",
+        },
+      },
+      {
+        name: "rejects quantity with more than 3 decimal places",
+        line: {
+          id: "l",
+          description: "A",
+          quantity: 1.1234,
+          grossUnitPrice: 1.0,
+          vatCode: "22",
+        },
+      },
+      {
+        name: "rejects invalid vatCode",
+        line: {
+          id: "l",
+          description: "A",
+          quantity: 1,
+          grossUnitPrice: 1.0,
+          vatCode: "99",
+        },
+      },
+      {
+        name: "rejects empty description",
+        line: {
+          id: "l",
+          description: "",
+          quantity: 1,
+          grossUnitPrice: 1.0,
+          vatCode: "22",
+        },
+      },
+    ])("$name", async ({ line }) => {
       const { emitReceipt } = await import("@/server/receipt-actions");
-      const result = await emitReceipt(
-        makeValidInput({
-          lines: [
-            {
-              id: "l",
-              description: "A",
-              quantity: 1,
-              grossUnitPrice: 1.123,
-              vatCode: "22",
-            },
-          ],
-        }),
-      );
-
-      expect(result.error).toBeDefined();
-      expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
-    });
-
-    it("rejects quantity with more than 3 decimal places", async () => {
-      const { emitReceipt } = await import("@/server/receipt-actions");
-      const result = await emitReceipt(
-        makeValidInput({
-          lines: [
-            {
-              id: "l",
-              description: "A",
-              quantity: 1.1234,
-              grossUnitPrice: 1.0,
-              vatCode: "22",
-            },
-          ],
-        }),
-      );
+      const result = await emitReceipt(makeValidInput({ lines: [line] }));
 
       expect(result.error).toBeDefined();
       expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
@@ -225,46 +234,6 @@ describe("emitReceipt server action", () => {
 
       const { emitReceipt } = await import("@/server/receipt-actions");
       const result = await emitReceipt(makeValidInput({ lines: tooManyLines }));
-
-      expect(result.error).toBeDefined();
-      expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
-    });
-
-    it("rejects invalid vatCode", async () => {
-      const { emitReceipt } = await import("@/server/receipt-actions");
-      const result = await emitReceipt(
-        makeValidInput({
-          lines: [
-            {
-              id: "l",
-              description: "A",
-              quantity: 1,
-              grossUnitPrice: 1.0,
-              vatCode: "99",
-            },
-          ],
-        }),
-      );
-
-      expect(result.error).toBeDefined();
-      expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();
-    });
-
-    it("rejects empty description", async () => {
-      const { emitReceipt } = await import("@/server/receipt-actions");
-      const result = await emitReceipt(
-        makeValidInput({
-          lines: [
-            {
-              id: "l",
-              description: "",
-              quantity: 1,
-              grossUnitPrice: 1.0,
-              vatCode: "22",
-            },
-          ],
-        }),
-      );
 
       expect(result.error).toBeDefined();
       expect(mockEmitReceiptForBusiness).not.toHaveBeenCalled();

--- a/tests/unit/server-storico-actions.test.ts
+++ b/tests/unit/server-storico-actions.test.ts
@@ -173,33 +173,24 @@ describe("searchReceipts server action", () => {
   // ── Input validation: date format + pagination clamping ──────────────────
 
   describe("input validation", () => {
-    it("returns error for dateFrom with invalid format (not yyyy-MM-dd)", async () => {
+    it.each([
+      {
+        name: "returns error for dateFrom with invalid format (not yyyy-MM-dd)",
+        dateFrom: "abc",
+      },
+      {
+        name: "returns error for dateFrom with impossible date value (e.g. 2026-99-99)",
+        dateFrom: "2026-99-99",
+      },
+      {
+        name: "returns error for dateFrom with impossible date (Feb 31 — JS normalises to March)",
+        dateFrom: "2026-02-31",
+      },
+    ])("$name", async ({ dateFrom }) => {
       const { searchReceipts } = await import("@/server/storico-actions");
       const { gte } = await import("drizzle-orm");
 
-      const result = await searchReceipts(BIZ_ID, { dateFrom: "abc" });
-
-      expect(result.error).toBeDefined();
-      expect(result.error).toMatch(/dateFrom/);
-      expect(gte).not.toHaveBeenCalled();
-    });
-
-    it("returns error for dateFrom with impossible date value (e.g. 2026-99-99)", async () => {
-      const { searchReceipts } = await import("@/server/storico-actions");
-      const { gte } = await import("drizzle-orm");
-
-      const result = await searchReceipts(BIZ_ID, { dateFrom: "2026-99-99" });
-
-      expect(result.error).toBeDefined();
-      expect(result.error).toMatch(/dateFrom/);
-      expect(gte).not.toHaveBeenCalled();
-    });
-
-    it("returns error for dateFrom with impossible date (Feb 31 — JS normalises to March)", async () => {
-      const { searchReceipts } = await import("@/server/storico-actions");
-      const { gte } = await import("drizzle-orm");
-
-      const result = await searchReceipts(BIZ_ID, { dateFrom: "2026-02-31" });
+      const result = await searchReceipts(BIZ_ID, { dateFrom });
 
       expect(result.error).toBeDefined();
       expect(result.error).toMatch(/dateFrom/);


### PR DESCRIPTION
Replace groups of near-identical it() blocks with it.each in:
marketing-to-app-href, sentry-filters, validation, crypto,
identity-env, trusted-app-url, api-auth, ade/cookie-jar, ade/index.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HKf9wTrRWHyRj6fuKwNnkW