### PR TITLE
Fix #43: Validate CIE form actions against allowlist before POST

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -133,43 +133,6 @@ fatto che i payload sono statici, ma è un single point of failure.
 
 ---
 
-### 43. Flusso CIE: form action POSTate senza validazione allowlist (SAMLResponse esfiltrabile)
-
-- **Categoria:** sicurezza · **Severità:** Medium — stesso pattern del finding #28 (SPID), ma qui il flusso è **live**
-- **File:** `src/lib/ade/real-client.ts:1265` (`cieFetchSamlRequest`: `ssoUrl` da `parseFormAction` dell'HTML del SP AdE), `:1293` (`ciePostSamlRequest` POSTa a `ssoUrl` senza check), `:1463-1495` (`ciePostFinalProbe`: `formAction` da `parseFormAction` dell'HTML IdP), `:1507` (`cieSubmitSamlResponse` POSTa la `SAMLResponse` a `formAction` senza check)
-
-**Problema.** La PR #695 ha introdotto `FEDERATED_ALLOWED_HOSTS` e la valida
-correttamente su **tutti** gli header `Location` (via `resolveAdeRedirect`),
-ma le **form action estratte dall'HTML** con `parseFormAction` vengono usate
-come target di POST senza alcuna validazione: (a) `ssoUrl` dalla pagina del SP
-AdE riceve la `SAMLRequest`; (b) `formAction` dalla pagina finale dell'IdP
-riceve la **`SAMLResponse`**, che contiene l'asserzione d'identità dell'utente
-(nome, cognome, data di nascita, codice fiscale — gli attributi del consenso
-e1s4). Se l'HTML del SP/IdP fosse manomesso o servito in modo anomalo, quei
-dati verrebbero POSTati verso un host arbitrario. Le credenziali CIE non sono
-a rischio (`ciePostCredentials` usa l'URL hardcoded `CIE_IDP_BASE_URL`), e il
-TLS verso AdE/IdP mitiga in pratica — stessa classe di rischio del finding
-#28, che però copre solo il flusso SPID (non cablato).
-
-**Fix (non ambiguo).**
-
-1. Validare **ogni** output di `parseFormAction` nel flusso CIE contro
-   `FEDERATED_ALLOWED_HOSTS` prima del POST: riusare
-   `resolveAdeRedirect(currentPageUrl, action, FEDERATED_ALLOWED_HOSTS)`
-   (risolve anche i path relativi) sui tre punti: `ssoUrl` (`:1265`),
-   `formAction` (`:1480`, incluso il caso in cui vince il fallback ACS) e
-   verifica che l'unico punto già validato (`iampeAction`, `:1522`) resti
-   invariato.
-2. Errore esplicito (`AdePortalError`), mai degradare al fallback se l'action
-   parsata è fuori allowlist.
-3. **Test** (in `real-client-cie.test.ts`): form action verso host fuori
-   allowlist → throw senza che il POST parta; action relativa → risolta e
-   accettata; flusso HAR-conforme → invariato.
-4. Il finding #28 resta aperto per SPID: applicargli lo stesso helper quando
-   `loginSpid` verrà cablato.
-
----
-
 ### 47. Copy marketing/help ancora Fisconline-only: CIE è live ma il sito dice il contrario
 
 - **Categoria:** funzionalità/contenuti (regola 8) · **Severità:** Medium — TODO dichiarato nella PR #695 e rimandato, va tracciato
@@ -325,8 +288,10 @@ pratica).
    valido → flusso invariato.
 
 > **Nota.** `FEDERATED_ALLOWED_HOSTS` copre già i redirect (`Location`) del
-> flusso federato, ma le **form action** restano non validate (anche nel flusso
-> CIE): vedi finding **#43** (P2). Il fix di #43 introduce l'helper da riusare
+> flusso federato; dal fix del finding #43 anche le **form action** del flusso
+> CIE (`ssoUrl` in `cieFetchSamlRequest`, `formAction` in `ciePostFinalProbe`)
+> sono validate via `resolveAdeRedirect(currentPageUrl, action,
+FEDERATED_ALLOWED_HOSTS)`. Riusare lo stesso pattern su `parseFormAction`
 > qui quando `loginSpid` verrà cablato.
 
 ---

--- a/src/lib/ade/real-client-cie.test.ts
+++ b/src/lib/ade/real-client-cie.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RealAdeClient } from "./real-client";
-import { AdeAuthError, AdeSpidTimeoutError } from "./errors";
+import { AdeAuthError, AdePortalError, AdeSpidTimeoutError } from "./errors";
 import type { CieCredentials } from "./types";
 
 vi.mock("@/lib/logger", () => ({
@@ -55,18 +55,21 @@ const CREDENTIALS: CieCredentials = {
 };
 
 /**
- * Queue the full CIE happy-path fetch sequence (23 request() calls).
- * push approvato: il body di checkpush cambia dal baseline al secondo poll.
+ * Queue the CIE preamble (12 request() calls): dalla GET /rp/cie/sel fino alla
+ * pagina finale e1s5, ESCLUSA la response del POST final-probe che porta la
+ * SAMLResponse. Usata dai test che iniettano una response #13 su misura.
+ *
+ * `firstFormAction` è l'action della form SAMLRequest iniziale (default: IdP
+ * assoluto). I test anti-SSRF la sovrascrivono per verificarne la validazione.
  */
-function mockCieHappyPath(fetchMock: ReturnType<typeof vi.fn>): void {
+function queueCiePreamble(
+  fetchMock: ReturnType<typeof vi.fn>,
+  firstFormAction: string = `${IDP}/idp/profile/SAML2/POST/SSO`,
+): void {
   // 1. GET /rp/cie/sel → form verso l'IdP
   fetchMock.mockResolvedValueOnce(
     mockResponse({
-      body: samlForm(
-        `${IDP}/idp/profile/SAML2/POST/SSO`,
-        "SAMLRequest",
-        "selcie",
-      ),
+      body: samlForm(firstFormAction, "SAMLRequest", "selcie"),
     }),
   );
   // 2a. POST IdP SSO → 302 probe e1s1
@@ -108,11 +111,25 @@ function mockCieHappyPath(fetchMock: ReturnType<typeof vi.fn>): void {
   );
   // 6b. GET e1s5 → 200 final probe page
   fetchMock.mockResolvedValueOnce(mockResponse({}));
+}
+
+/**
+ * Queue the full CIE happy-path fetch sequence (23 request() calls).
+ * push approvato: il body di checkpush cambia dal baseline al secondo poll.
+ *
+ * `firstFormAction`/`finalProbeAction` restano parametrizzabili per i test che
+ * ne verificano la risoluzione (es. action relativa risolta contro l'origin).
+ */
+function mockCieHappyPath(
+  fetchMock: ReturnType<typeof vi.fn>,
+  opts: { firstFormAction?: string; finalProbeAction?: string } = {},
+): void {
+  queueCiePreamble(fetchMock, opts.firstFormAction);
   // 7. POST final probe → 200 SAMLResponse form verso AdE SP
   fetchMock.mockResolvedValueOnce(
     mockResponse({
       body: samlForm(
-        `${SP}/sp/AssertionConsumerService7`,
+        opts.finalProbeAction ?? `${SP}/sp/AssertionConsumerService7`,
         "SAMLResponse",
         "selcie",
       ),
@@ -322,5 +339,166 @@ describe("RealAdeClient.loginCie", () => {
     );
     // 6 richieste di preambolo + esattamente 12 checkpush, non 13.
     expect(fetchMock).toHaveBeenCalledTimes(6 + 12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #43 — form action del flusso CIE validate contro FEDERATED_ALLOWED_HOSTS
+// prima del POST (la SAMLResponse porta l'asserzione d'identità: CF, nome,
+// cognome, data di nascita). Un HTML SP/IdP manomesso non deve poter esfiltrare
+// la SAMLRequest o la SAMLResponse verso un host arbitrario.
+// ---------------------------------------------------------------------------
+describe("RealAdeClient.loginCie — form action allowlist (anti-SSRF)", () => {
+  const ATTACKER = "https://attacker.example.com";
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("blocks a SAMLRequest form action pointing outside the allowlist", async () => {
+    // Response #1: la pagina SP AdE con una form action verso un host arbitrario.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(`${ATTACKER}/sso`, "SAMLRequest", "selcie"),
+      }),
+    );
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    await expect(client.loginCie(CREDENTIALS)).rejects.toThrow(AdePortalError);
+
+    // La SAMLRequest non deve essere POSTata: solo la GET iniziale è partita.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const postedToAttacker = fetchMock.mock.calls.some(([url]) =>
+      String(url).startsWith(ATTACKER),
+    );
+    expect(postedToAttacker).toBe(false);
+  });
+
+  it("blocks a SAMLResponse form action pointing outside the allowlist", async () => {
+    // Preambolo fino alla pagina e1s5, poi la response #13 (POST final probe)
+    // porta una form SAMLResponse verso un host arbitrario.
+    queueCiePreamble(fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(`${ATTACKER}/acs`, "SAMLResponse", "selcie"),
+      }),
+    );
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    await expect(client.loginCie(CREDENTIALS)).rejects.toThrow(AdePortalError);
+
+    // Il POST della SAMLResponse (#14) non deve partire: la validazione scatta
+    // nel parsing della form (#13). Nessuna chiamata verso l'attacker.
+    expect(fetchMock).toHaveBeenCalledTimes(13);
+    const postedToAttacker = fetchMock.mock.calls.some(([url]) =>
+      String(url).startsWith(ATTACKER),
+    );
+    expect(postedToAttacker).toBe(false);
+  });
+
+  it("resolves a relative SAMLRequest form action against the SP origin and accepts it", async () => {
+    // Action relativa sulla pagina /rp/cie/sel → risolta contro sp.agenziaentrate.gov.it
+    // (in allowlist): il flusso completa e il POST parte verso l'URL assoluto risolto.
+    mockCieHappyPath(fetchMock, {
+      firstFormAction: "/idp/profile/SAML2/POST/SSO",
+    });
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    const session = await client.loginCie(CREDENTIALS);
+
+    expect(session.partitaIva).toBe("10872631006");
+    // La 2ª chiamata (POST SAMLRequest) usa l'URL assoluto risolto contro l'origin SP.
+    expect(String(fetchMock.mock.calls[1][0])).toBe(
+      `${SP}/idp/profile/SAML2/POST/SSO`,
+    );
+  });
+
+  it("resolves a relative SAMLResponse form action against the IdP origin and accepts it", async () => {
+    // Action relativa sulla pagina finale (host IdP, in allowlist): risolta e accettata.
+    mockCieHappyPath(fetchMock, {
+      finalProbeAction: "/sp/AssertionConsumerService7",
+    });
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    const session = await client.loginCie(CREDENTIALS);
+
+    expect(session.partitaIva).toBe("10872631006");
+    // La SAMLResponse è POSTata verso l'URL assoluto risolto contro l'origin IdP.
+    const acsPost = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/sp/AssertionConsumerService7") &&
+        (init as RequestInit)?.method === "POST",
+    );
+    expect(acsPost).toBeDefined();
+    expect(String(acsPost![0])).toBe(`${IDP}/sp/AssertionConsumerService7`);
+  });
+
+  it("falls back to the hardcoded ACS URL when the final page has no parsable form action", async () => {
+    // Pagina finale con SAMLResponse+RelayState ma senza attributo action:
+    // parseFormAction → null → fallback all'URL ACS AdE hardcoded (fidato),
+    // non un host arbitrario.
+    queueCiePreamble(fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: `<form method="post">
+          <input type="hidden" name="SAMLResponse" value="ABC123" />
+          <input type="hidden" name="RelayState" value="selcie" />
+        </form>`,
+      }),
+    );
+    // 8a-9f: coda happy-path invariata dopo il POST ACS.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ status: 302, location: `${SP}/make4SAM` }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(
+          `${IAMPE}/sam/Consumer/metaAlias/agenziaentrate/age-sp`,
+          "SAMLResponse",
+          `${PORTALE}/PortaleWeb/home`,
+        ),
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 302,
+        location: `${PORTALE}/PortaleWeb/home?to=FATBTB`,
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(mockResponse({ status: 501 }));
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ headers: [["x-appl", "tok"]] }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          PIva: [{ piva: "10872631006", denominazione: "DE STEFANO MARCO" }],
+          cfUidUltimo: "DSTMRC86T02H501V",
+        },
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    const session = await client.loginCie(CREDENTIALS);
+
+    expect(session.partitaIva).toBe("10872631006");
+    // Il POST della SAMLResponse è andato all'ACS AdE hardcoded.
+    const acsPost = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url) === `${SP}/sp/AssertionConsumerService7` &&
+        (init as RequestInit)?.method === "POST",
+    );
+    expect(acsPost).toBeDefined();
   });
 });

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -1285,7 +1285,15 @@ export class RealAdeClient implements AdeClient {
         "CIE: failed to parse SAMLRequest form from /rp/cie/sel",
       );
     }
-    return { ssoUrl, samlRequest, relayState };
+    // La form action è estratta dall'HTML del SP AdE: va validata contro la
+    // allowlist federata prima di usarla come target del POST SAMLRequest,
+    // esattamente come i redirect Location (REVIEW #43). Risolve anche i path
+    // relativi contro l'origin della pagina corrente.
+    return {
+      ssoUrl: resolveAdeRedirect(url, ssoUrl, FEDERATED_ALLOWED_HOSTS),
+      samlRequest,
+      relayState,
+    };
   }
 
   /**
@@ -1489,9 +1497,6 @@ export class RealAdeClient implements AdeClient {
     const html = await response.text();
     const samlResponse = this.parseHiddenInput(html, "SAMLResponse");
     const relayState = this.parseHiddenInput(html, "RelayState");
-    const formAction =
-      this.parseFormAction(html) ??
-      `${ADE_SP_BASE_URL}/sp/AssertionConsumerService7`;
 
     if (!samlResponse || !relayState) {
       throw new AdePortalError(
@@ -1499,6 +1504,17 @@ export class RealAdeClient implements AdeClient {
         "CIE: failed to parse SAMLResponse from IdP final page",
       );
     }
+
+    // La SAMLResponse porta l'asserzione d'identità (CF, nome, cognome, data di
+    // nascita): la form action estratta dall'HTML dell'IdP va validata contro la
+    // allowlist federata prima di POSTarla (REVIEW #43), mai degradare al
+    // fallback su action fuori allowlist. Il fallback ACS è un URL AdE hardcoded
+    // e fidato, usato solo quando la form non è parsabile.
+    const parsedAction = this.parseFormAction(html);
+    const formAction = parsedAction
+      ? resolveAdeRedirect(probeUrl, parsedAction, FEDERATED_ALLOWED_HOSTS)
+      : `${ADE_SP_BASE_URL}/sp/AssertionConsumerService7`;
+
     return { samlResponse, relayState, formAction };
   }
 


### PR DESCRIPTION
## Summary

Implements security fix for finding #43: validates form action URLs extracted from HTML in the CIE login flow against `FEDERATED_ALLOWED_HOSTS` before POSTing, preventing potential exfiltration of SAMLRequest/SAMLResponse to attacker-controlled hosts.

## Changes

- **`src/lib/ade/real-client.ts`**
  - `cieFetchSamlRequest()`: Validate `ssoUrl` (form action from SP AdE page) via `resolveAdeRedirect()` before returning, resolving relative paths against current page origin
  - `ciePostFinalProbe()`: Validate `formAction` (form action from IdP final page) via `resolveAdeRedirect()` before using as SAMLResponse POST target; fallback to hardcoded ACS URL only when form is unparsable, never when action is outside allowlist
  - Both validations reuse the existing `resolveAdeRedirect(currentPageUrl, action, FEDERATED_ALLOWED_HOSTS)` helper, which handles relative URL resolution and allowlist enforcement

- **`src/lib/ade/real-client-cie.test.ts`**
  - Refactored `mockCieHappyPath()` → split into `queueCiePreamble()` (12 requests up to e1s5 page) + `mockCieHappyPath()` wrapper for test reuse
  - Added parametrization (`firstFormAction`, `finalProbeAction`) to support form action validation tests
  - New test suite "form action allowlist (anti-SSRF)" with 4 cases:
    - Blocks SAMLRequest form action pointing outside allowlist
    - Blocks SAMLResponse form action pointing outside allowlist
    - Resolves relative SAMLRequest action against SP origin and accepts it
    - Resolves relative SAMLResponse action against IdP origin and accepts it
    - Falls back to hardcoded ACS URL when final page has no parsable form action
  - All tests verify no POST occurs to attacker host and correct URL is used for legitimate requests

- **`REVIEW.md`**
  - Removed finding #43 (now fixed)
  - Updated finding #28 (SPID) cross-reference to note that #43 fix provides reusable pattern for SPID when `loginSpid` is wired

## Implementation Details

- **Security model:** Form actions are treated like redirect `Location` headers — both are user-controlled HTML/response content and must be validated before use
- **Relative URL handling:** `resolveAdeRedirect()` already handles relative paths by resolving against the current page's origin, so `/idp/profile/SAML2/POST/SSO` on SP page resolves to `https://sp.agenziaentrate.gov.it/idp/profile/SAML2/POST/SSO`
- **Fallback safety:** Hardcoded ACS URL (`ADE_SP_BASE_URL/sp/AssertionConsumerService7`) is only used when form is unparsable (no `action` attribute), never as a fallback for out-of-allowlist actions
- **Error type:** Uses `AdePortalError` (consistent with other validation failures in the flow)

https://claude.ai/code/session_019MgnnzmTi1yoAjBS49oiZ2