### PR TITLE
Fix deep-link post-login redirect with open-redirect protection

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -622,36 +622,6 @@ exhaustiveness sul discriminante `method`.
 
 ---
 
-### 58. Deep-link post-login rotto: il parametro `redirect` impostato dal middleware non viene mai consumato
-
-- **Categoria:** funzionalità/UX · **Severità:** Low — l'utente atterra sempre su `/dashboard`, il deep link si perde
-- **File:** `src/proxy.ts:203-207` e `:262-266` (il middleware costruisce `/login?redirect=<pathname+search>` con commento "so a deep link … can fully restore state post-login"); `src/app/(auth)/login/page.tsx` (legge solo `error` dai searchParams, mai `redirect`); `src/server/auth-actions.ts:629` (`signIn` termina con `redirect("/dashboard")` fisso)
-
-**Problema.** La promessa codificata nel commento del middleware è morta: un
-utente con sessione scaduta che apre
-`/dashboard/storico?dateFrom=…&dateTo=…` viene mandato a `/login?redirect=…`,
-ma dopo il login `signIn` reindirizza sempre a `/dashboard` — il parametro non
-viene letto da nessuno. Con la PWA e i link condivisi (es. da un'email o da
-un secondo device) la perdita di contesto è sistematica.
-
-**Fix (non ambiguo).**
-
-1. La login page inoltra il param: campo hidden `redirect` nel form (valore da
-   `useSearchParams().get("redirect")`).
-2. `signIn` lo legge dal FormData e lo usa SOLO se supera la stessa
-   validazione anti-open-redirect del `/callback`
-   (`src/app/(auth)/callback/route.ts:36-40`): `startsWith("/")` e
-   `!startsWith("//")`; altrimenti fallback `/dashboard`. Estrarre il
-   predicato in un helper condiviso (es. `isSafeRelativeRedirect` in
-   `src/lib/validation.ts`) per non duplicarlo.
-3. Coprire anche il ramo "Supabase non configurato" del middleware (stessa
-   query, già presente).
-4. **Test:** `signIn` con `redirect=/dashboard/storico?x=1` → redirect a quel
-   path; con `//evil.com`, `https://evil.com`, stringa vuota → `/dashboard`;
-   login senza param → invariato.
-
----
-
 ### 59. PDF autenticato senza rate limit e route file-serving fuori da `getAuthenticatedUser` (regola 22 + segnale `last_seen_at`)
 
 - **Categoria:** sicurezza/hardening + osservabilità · **Severità:** Low

--- a/src/app/(auth)/callback/route.ts
+++ b/src/app/(auth)/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getTrustedAppUrl } from "@/lib/trusted-app-url";
+import { isSafeRelativeRedirect } from "@/lib/validation";
 import { logger } from "@/lib/logger";
 
 /**
@@ -31,13 +32,12 @@ export async function GET(request: Request) {
   }
 
   const code = searchParams.get("code");
-  // Only allow relative redirects to prevent open redirect attacks.
-  // Reject protocol-relative URLs like //evil.com (they inherit the protocol from origin).
+  // Only allow relative redirects to prevent open redirect attacks
+  // (predicato condiviso con `signIn` — vedi `isSafeRelativeRedirect`).
   const rawRedirect = searchParams.get("redirect") ?? "";
-  const redirect =
-    rawRedirect.startsWith("/") && !rawRedirect.startsWith("//")
-      ? rawRedirect
-      : "/dashboard";
+  const redirect = isSafeRelativeRedirect(rawRedirect)
+    ? rawRedirect
+    : "/dashboard";
 
   if (code) {
     const supabase = await createServerSupabaseClient();

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -35,7 +35,12 @@ function LoginForm() {
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
   // Messaggio impostato dal redirect del /callback (es. link di reset scaduto).
   // Suspense boundary richiesto da Next per useSearchParams nel prerender.
-  const callbackError = mapAuthCallbackError(useSearchParams().get("error"));
+  const searchParams = useSearchParams();
+  const callbackError = mapAuthCallbackError(searchParams.get("error"));
+  // Deep-link: il middleware imposta `?redirect=<path>` su una route protetta
+  // aperta senza sessione. Lo inoltriamo a `signIn`, che lo valida server-side
+  // (anti-open-redirect) prima di usarlo — vedi `isSafeRelativeRedirect`.
+  const redirectParam = searchParams.get("redirect");
   // "resend" si attiva quando il login fallisce perché l'email non è confermata:
   // mostra il messaggio dedicato e offre il re-invio della conferma. Il captcha
   // viene resettato sull'action corretta ("resend-confirmation").
@@ -70,6 +75,7 @@ function LoginForm() {
     formData.set("email", data.email);
     formData.set("password", data.password);
     if (captchaToken) formData.set("captchaToken", captchaToken);
+    if (redirectParam) formData.set("redirect", redirectParam);
 
     startTransition(async () => {
       const result = await signIn(formData);

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -6,6 +6,7 @@ import {
   isStrongPassword,
   isValidLotteryCode,
   isValidItalianZipCode,
+  isSafeRelativeRedirect,
   italianZipCodeSchema,
   normalizeEmail,
   ITALIAN_ZIP_MESSAGE,
@@ -233,6 +234,36 @@ describe("isValidItalianZipCode", () => {
 
   it("rejects empty string", () => {
     expect(isValidItalianZipCode("")).toBe(false);
+  });
+});
+
+describe("isSafeRelativeRedirect", () => {
+  it("accepts a plain relative path", () => {
+    expect(isSafeRelativeRedirect("/dashboard")).toBe(true);
+  });
+
+  it("accepts a relative path with query string (deep-link state)", () => {
+    expect(isSafeRelativeRedirect("/dashboard/storico?from=1&to=2")).toBe(true);
+  });
+
+  it("rejects protocol-relative URLs (//evil.com)", () => {
+    expect(isSafeRelativeRedirect("//evil.com")).toBe(false);
+  });
+
+  it("rejects the backslash protocol-relative bypass (/\\evil.com)", () => {
+    expect(isSafeRelativeRedirect("/\\evil.com")).toBe(false);
+  });
+
+  it("rejects absolute http(s) URLs", () => {
+    expect(isSafeRelativeRedirect("https://evil.com")).toBe(false);
+  });
+
+  it("rejects a path without a leading slash", () => {
+    expect(isSafeRelativeRedirect("evil.com/phishing")).toBe(false);
+  });
+
+  it("rejects the empty string", () => {
+    expect(isSafeRelativeRedirect("")).toBe(false);
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -130,6 +130,23 @@ export function validateBusinessOptionalFieldLengths(fields: {
 }
 
 /**
+ * True se `path` è un redirect **relativo** sicuro da seguire post-login.
+ *
+ * Difesa anti-open-redirect condivisa da `signIn` (`auth-actions.ts`) e dal
+ * callback OAuth/reset (`(auth)/callback/route.ts`): accetta solo path che
+ * iniziano con un singolo `/` e rifiuta i protocol-relative `//evil.com` e
+ * `/\evil.com` (alcuni browser normalizzano `\` in `/`, rendendoli equivalenti
+ * a `//`) — entrambi erediterebbero il protocollo dell'origin puntando a un
+ * host esterno. URL assoluti (`https://evil.com`), stringhe vuote e path senza
+ * leading slash cadono nel `false` → il caller fa fallback a `/dashboard`.
+ */
+export function isSafeRelativeRedirect(path: string): boolean {
+  if (!path.startsWith("/")) return false;
+  const second = path[1];
+  return second !== "/" && second !== "\\";
+}
+
+/**
  * Validates email format using linear-time string checks (no regex backtracking).
  * This is a structural check, not RFC 5322 compliance — real validation
  * happens when the confirmation email is delivered.

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -1468,6 +1468,62 @@ describe("auth-actions", () => {
       }
     });
 
+    it("honours a safe relative redirect param (deep-link restore)", async () => {
+      mockSignInWithPassword.mockResolvedValue({ error: null });
+
+      const { signIn } = await import("./auth-actions");
+
+      try {
+        await signIn(
+          formData({
+            email: "test@example.com",
+            password: "securepass123",
+            captchaToken: "valid-token",
+            redirect: "/dashboard/storico?from=2024-01-01&to=2024-01-31",
+          }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+        if (isRedirectError(err)) {
+          expect(err.url).toBe(
+            "/dashboard/storico?from=2024-01-01&to=2024-01-31",
+          );
+        }
+      }
+    });
+
+    it.each([
+      ["protocol-relative", "//evil.com"],
+      ["absolute URL", "https://evil.com"],
+      ["no leading slash", "evil.com/phishing"],
+      ["empty string", ""],
+    ])(
+      "falls back to /dashboard for an unsafe redirect param (%s)",
+      async (_label, redirectValue) => {
+        mockSignInWithPassword.mockResolvedValue({ error: null });
+
+        const { signIn } = await import("./auth-actions");
+
+        try {
+          await signIn(
+            formData({
+              email: "test@example.com",
+              password: "securepass123",
+              captchaToken: "valid-token",
+              redirect: redirectValue,
+            }),
+          );
+          expect.fail("Expected redirect");
+        } catch (err) {
+          expect(isRedirectError(err)).toBe(true);
+          if (isRedirectError(err)) {
+            expect(err.url).toBe("/dashboard");
+          }
+        }
+      },
+    );
+
     it("returns error on wrong credentials", async () => {
       mockSignInWithPassword.mockResolvedValue({
         error: { message: "Invalid credentials" },

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -10,6 +10,7 @@ import { profiles } from "@/db/schema";
 import {
   isValidEmail,
   isStrongPassword,
+  isSafeRelativeRedirect,
   normalizeEmail,
 } from "@/lib/validation";
 import { getClientIp, hashIp } from "@/lib/get-client-ip";
@@ -626,7 +627,12 @@ export async function signIn(formData: FormData): Promise<AuthActionResult> {
     return { error: "Email o password non corretti.", email };
   }
 
-  redirect("/dashboard");
+  // Deep-link post-login: il middleware imposta `?redirect=<pathname+search>`
+  // quando una route protetta viene aperta senza sessione (`proxy.ts`). Lo
+  // consumiamo qui, ma SOLO se supera la stessa guardia anti-open-redirect del
+  // callback OAuth/reset — altrimenti fallback a /dashboard.
+  const redirectTo = getFormString(formData, "redirect");
+  redirect(isSafeRelativeRedirect(redirectTo) ? redirectTo : "/dashboard");
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the deep-link post-login redirect feature (issue #58 in REVIEW.md) by allowing the `signIn` action to consume and validate a `redirect` parameter passed from the middleware, while maintaining strict open-redirect protection.

When a user with an expired session opens a protected route like `/dashboard/storico?dateFrom=…&dateTo=…`, the middleware redirects to `/login?redirect=<pathname+search>`. After successful login, the user is now restored to their original deep-link instead of always landing on `/dashboard`.

## Key Changes

- **New validation helper** (`src/lib/validation.ts`):
  - Added `isSafeRelativeRedirect(path)` — shared anti-open-redirect predicate that accepts only paths starting with a single `/` and rejects protocol-relative URLs (`//evil.com`), backslash bypasses (`/\evil.com`), absolute URLs, and empty strings.
  - Comprehensive JSDoc explaining the threat model (protocol inheritance in protocol-relative URLs).

- **Login form** (`src/app/(auth)/login/page.tsx`):
  - Extracts `redirect` param from `useSearchParams()`.
  - Forwards it as a hidden form field to `signIn` action.

- **Sign-in action** (`src/server/auth-actions.ts`):
  - Reads `redirect` from FormData and validates it via `isSafeRelativeRedirect()`.
  - Redirects to the validated path on success; falls back to `/dashboard` if validation fails.

- **OAuth callback** (`src/app/(auth)/callback/route.ts`):
  - Refactored to use the shared `isSafeRelativeRedirect()` helper instead of inline validation.
  - Updated comment to reference the shared predicate.

- **Test coverage** (`src/server/auth-actions.test.ts` and `src/lib/validation.test.ts`):
  - Added test for safe relative redirect with query string (deep-link state restoration).
  - Added parameterized test covering unsafe redirect variants: protocol-relative, absolute URL, no leading slash, empty string.
  - Added comprehensive unit tests for `isSafeRelativeRedirect()` including edge cases (backslash bypass).

- **Documentation** (`REVIEW.md`):
  - Removed issue #58 (now resolved).

## Implementation Details

- The validation is **server-side only** in `signIn`, preventing client-side bypass.
- The predicate rejects both `//evil.com` and `/\evil.com` (some browsers normalize backslash to forward slash, making them equivalent to protocol-relative URLs).
- Fallback to `/dashboard` is silent (no error message) — consistent with existing behavior when no redirect param is provided.
- The shared helper eliminates duplication between `signIn` and the OAuth callback route.

https://claude.ai/code/session_01316C7CHvikCtMPDdbuk53p