### PR TITLE
Add password re-authentication gate to deleteAccount

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -674,39 +674,6 @@ finestra.
 
 ---
 
-### 62. `deleteAccount`: la conferma "ELIMINA" è solo client-side, nessuna re-autenticazione server-side
-
-- **Categoria:** sicurezza/hardening · **Severità:** Low — richiede una sessione già compromessa (XSS/device rubato), ma l'azione è la più distruttiva dell'app
-- **File:** `src/server/account-actions.ts:25-44` (unico requisito: sessione valida); `src/components/settings/account-delete-section.tsx:20-32` (la parola di conferma non lascia mai il client); pattern di re-auth già esistente: `changePassword` in `src/server/profile-actions.ts:304-311` (`signInWithPassword` con la password corrente)
-
-**Problema.** La server action di cancellazione definitiva (dati fiscali
-inclusi) è invocabile con la sola sessione: la conferma digitata esiste solo
-nel dialog React, quindi una chiamata diretta all'action (sessione rubata,
-XSS, estensione malevola) cancella l'account senza attrito. `changePassword`
-— azione meno distruttiva — richiede già la password corrente server-side.
-Nota copy contestuale: il dialog enumera solo "credenziali Fisconline" — con
-CIE live va generalizzato (stessa classe del finding #47, ma file app, non
-marketing).
-
-**Fix (non ambiguo).**
-
-1. `deleteAccount(formData)` riceve `currentPassword` (raw,
-   `getFormStringRaw`) e la verifica con
-   `supabase.auth.signInWithPassword({ email, password })` prima del purge —
-   stesso pattern e stessa sequenza di `changePassword`. Password errata →
-   `{ error: "Password non corretta." }`, `logger.warn` (regola 20, no
-   Sentry).
-2. Rate limit 5/15min per `user.id` (chiave `deleteAccount:<userId>`,
-   `RATE_LIMIT_WINDOWS.AUTH_15_MIN`) per non rendere l'action un oracle di
-   brute-force sulla password.
-3. Dialog: campo password al posto della parola "ELIMINA" (o in aggiunta);
-   aggiornare il copy "credenziali Fisconline" → "credenziali di accesso AdE
-   (Fisconline o CIE ID)".
-4. **Test:** password errata → nessun purge + errore; corretta → purge
-   invocato; 6° tentativo in 15min → rate limited.
-
----
-
 ## Rischi accettati (documentati, non da fixare)
 
 Scelte consapevoli con un trigger di riapertura. Non sono finding da pianificare.

--- a/src/components/settings/account-delete-section.test.tsx
+++ b/src/components/settings/account-delete-section.test.tsx
@@ -13,7 +13,7 @@ import { AccountDeleteSection } from "./account-delete-section";
 
 const mockDeleteAccount = vi.fn();
 vi.mock("@/server/account-actions", () => ({
-  deleteAccount: () => mockDeleteAccount(),
+  deleteAccount: (fd: FormData) => mockDeleteAccount(fd),
 }));
 
 // scrollIntoView richiesto da Radix UI Dialog
@@ -34,6 +34,13 @@ function renderWithQuery() {
       <AccountDeleteSection />
     </QueryClientProvider>,
   );
+}
+
+const PASSWORD_PLACEHOLDER = "La tua password";
+
+async function openDialog() {
+  fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
+  await screen.findByText("Eliminare l'account?");
 }
 
 // --- Tests ---
@@ -58,8 +65,7 @@ describe("AccountDeleteSection", () => {
 
   it("mostra il messaggio di recupero dati dal portale AdE nel dialog", async () => {
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
     expect(screen.getByText(/Fatture e Corrispettivi/)).toBeInTheDocument();
     expect(
@@ -67,10 +73,18 @@ describe("AccountDeleteSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("il bottone di conferma è disabilitato se il testo non è 'ELIMINA'", async () => {
+  it("il copy generalizza le credenziali AdE a Fisconline o CIE ID", async () => {
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
+
+    expect(screen.getAllByText(/Fisconline o CIE ID/).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("il bottone di conferma è disabilitato finché non si inserisce la password", async () => {
+    renderWithQuery();
+    await openDialog();
 
     const confirmBtn = screen.getByRole("button", {
       name: "Elimina definitivamente",
@@ -78,30 +92,27 @@ describe("AccountDeleteSection", () => {
     expect(confirmBtn).toBeDisabled();
   });
 
-  it("il bottone di conferma si abilita solo con la parola esatta 'ELIMINA'", async () => {
+  it("il bottone di conferma si abilita quando la password non è vuota", async () => {
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
-    const input = screen.getByPlaceholderText("ELIMINA");
+    const input = screen.getByPlaceholderText(PASSWORD_PLACEHOLDER);
     const confirmBtn = screen.getByRole("button", {
       name: "Elimina definitivamente",
     });
 
-    fireEvent.change(input, { target: { value: "elimina" } });
     expect(confirmBtn).toBeDisabled();
 
-    fireEvent.change(input, { target: { value: "ELIMINA" } });
+    fireEvent.change(input, { target: { value: "SuperSecret123!" } });
     expect(confirmBtn).not.toBeDisabled();
   });
 
-  it("chiama deleteAccount al click sul bottone di conferma", async () => {
+  it("passa la password (raw, senza trim) a deleteAccount come currentPassword", async () => {
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
-    fireEvent.change(screen.getByPlaceholderText("ELIMINA"), {
-      target: { value: "ELIMINA" },
+    fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {
+      target: { value: "  SuperSecret123!  " },
     });
 
     await act(async () => {
@@ -111,16 +122,17 @@ describe("AccountDeleteSection", () => {
     });
 
     expect(mockDeleteAccount).toHaveBeenCalledTimes(1);
+    const fd = mockDeleteAccount.mock.calls[0][0] as FormData;
+    expect(fd.get("currentPassword")).toBe("  SuperSecret123!  ");
   });
 
   it("mostra un errore se deleteAccount restituisce un errore", async () => {
-    mockDeleteAccount.mockResolvedValue({ error: "Profilo non trovato." });
+    mockDeleteAccount.mockResolvedValue({ error: "Password non corretta." });
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
-    fireEvent.change(screen.getByPlaceholderText("ELIMINA"), {
-      target: { value: "ELIMINA" },
+    fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {
+      target: { value: "wrong-password" },
     });
 
     await act(async () => {
@@ -130,18 +142,17 @@ describe("AccountDeleteSection", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Profilo non trovato.")).toBeInTheDocument();
+      expect(screen.getByText("Password non corretta.")).toBeInTheDocument();
     });
   });
 
   it("mostra errore generico se deleteAccount lancia un'eccezione", async () => {
     mockDeleteAccount.mockRejectedValue(new Error("Network error"));
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
-    fireEvent.change(screen.getByPlaceholderText("ELIMINA"), {
-      target: { value: "ELIMINA" },
+    fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {
+      target: { value: "SuperSecret123!" },
     });
 
     await act(async () => {
@@ -163,11 +174,10 @@ describe("AccountDeleteSection", () => {
     });
     mockDeleteAccount.mockRejectedValue(redirectErr);
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
-    fireEvent.change(screen.getByPlaceholderText("ELIMINA"), {
-      target: { value: "ELIMINA" },
+    fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {
+      target: { value: "SuperSecret123!" },
     });
 
     await act(async () => {
@@ -185,8 +195,7 @@ describe("AccountDeleteSection", () => {
 
   it("chiude il dialog al click su Annulla", async () => {
     renderWithQuery();
-    fireEvent.click(screen.getByRole("button", { name: "Elimina account" }));
-    await screen.findByText("Eliminare l'account?");
+    await openDialog();
 
     fireEvent.click(screen.getByRole("button", { name: "Annulla" }));
 

--- a/src/components/settings/account-delete-section.tsx
+++ b/src/components/settings/account-delete-section.tsx
@@ -17,19 +17,9 @@ import {
 import { Form, FormInputField } from "@/components/ui/form";
 import { deleteAccount } from "@/server/account-actions";
 
-const CONFIRM_WORD = "ELIMINA";
-
-const deleteSchema = z
-  .object({ confirmText: z.string() })
-  .superRefine((data, ctx) => {
-    if (data.confirmText !== CONFIRM_WORD) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Scrivi ${CONFIRM_WORD} per confermare.`,
-        path: ["confirmText"],
-      });
-    }
-  });
+const deleteSchema = z.object({
+  password: z.string().min(1, "Inserisci la tua password."),
+});
 
 type DeleteData = z.infer<typeof deleteSchema>;
 
@@ -38,16 +28,20 @@ export function AccountDeleteSection() {
 
   const form = useForm<DeleteData>({
     resolver: zodResolver(deleteSchema),
-    defaultValues: { confirmText: "" },
+    defaultValues: { password: "" },
   });
 
-  const confirmTextValue = useWatch({
+  const passwordValue = useWatch({
     control: form.control,
-    name: "confirmText",
+    name: "password",
   });
 
   const mutation = useMutation({
-    mutationFn: deleteAccount,
+    mutationFn: (data: DeleteData) => {
+      const formData = new FormData();
+      formData.set("currentPassword", data.password);
+      return deleteAccount(formData);
+    },
     onSuccess: (result) => {
       if (result.error) {
         form.setError("root", { message: result.error });
@@ -69,8 +63,8 @@ export function AccountDeleteSection() {
     setIsOpen(true);
   }
 
-  function handleSubmit() {
-    mutation.mutate();
+  function handleSubmit(data: DeleteData) {
+    mutation.mutate(data);
   }
 
   return (
@@ -98,7 +92,7 @@ export function AccountDeleteSection() {
 
           <ul className="text-muted-foreground ml-4 list-disc space-y-1 text-sm">
             <li>Il tuo profilo e i dati dell&apos;attività</li>
-            <li>Le credenziali Fisconline salvate</li>
+            <li>Le credenziali di accesso AdE salvate (Fisconline o CIE ID)</li>
             <li>Tutti gli scontrini emessi e il catalogo prodotti</li>
           </ul>
 
@@ -107,11 +101,11 @@ export function AccountDeleteSection() {
             restano disponibili sul portale{" "}
             <strong>Fatture e Corrispettivi</strong> anche dopo la cancellazione
             dell&apos;account. Puoi consultarli in qualsiasi momento accedendo
-            con le tue credenziali Fisconline.
+            con le tue credenziali AdE (Fisconline o CIE ID).
           </p>
 
           <p className="mt-2 text-sm">
-            Scrivi <strong>{CONFIRM_WORD}</strong> per confermare:
+            Inserisci la tua <strong>password</strong> per confermare:
           </p>
 
           <Form {...form}>
@@ -122,9 +116,10 @@ export function AccountDeleteSection() {
             >
               <FormInputField
                 control={form.control}
-                name="confirmText"
-                placeholder={CONFIRM_WORD}
-                autoComplete="off"
+                name="password"
+                type="password"
+                placeholder="La tua password"
+                autoComplete="current-password"
                 disabled={mutation.isPending}
               />
 
@@ -146,9 +141,7 @@ export function AccountDeleteSection() {
                 <Button
                   type="submit"
                   variant="destructive"
-                  disabled={
-                    confirmTextValue !== CONFIRM_WORD || mutation.isPending
-                  }
+                  disabled={!passwordValue || mutation.isPending}
                 >
                   {mutation.isPending
                     ? "Eliminazione…"

--- a/src/server/account-actions.test.ts
+++ b/src/server/account-actions.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UnauthenticatedError } from "@/lib/auth-errors";
 import { logger } from "@/lib/logger";
+import { ERROR_MESSAGES } from "@/lib/error-messages";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -37,10 +38,30 @@ vi.mock("@/lib/supabase/admin", () => ({
 }));
 
 const mockSignOut = vi.fn();
+const mockSignInWithPassword = vi.fn();
 vi.mock("@/lib/supabase/server", () => ({
   createServerSupabaseClient: vi.fn().mockResolvedValue({
-    auth: { signOut: mockSignOut },
+    auth: {
+      signOut: mockSignOut,
+      signInWithPassword: mockSignInWithPassword,
+    },
   }),
+}));
+
+const mockCheck = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: mockCheck };
+  }),
+  RATE_LIMIT_WINDOWS: { AUTH_15_MIN: 15 * 60 * 1000 },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/get-client-ip", () => ({
+  getClientIp: vi.fn().mockReturnValue("1.2.3.4"),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -66,6 +87,14 @@ vi.mock("next/navigation", () => ({
 // ---------------------------------------------------------------------------
 
 const FAKE_USER = { id: "user-123", email: "utente@test.it" };
+const CORRECT_PASSWORD = "SuperSecret123!";
+
+/** FormData con la password corrente, come la invia il dialog di conferma. */
+function formWithPassword(password: string = CORRECT_PASSWORD): FormData {
+  const fd = new FormData();
+  fd.set("currentPassword", password);
+  return fd;
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -78,13 +107,19 @@ describe("account-actions", () => {
     mockDeleteReturning.mockResolvedValue([{ id: "profile-456" }]);
     mockAdminDeleteUser.mockResolvedValue({ error: null });
     mockSignOut.mockResolvedValue({});
+    mockSignInWithPassword.mockResolvedValue({ error: null });
+    mockCheck.mockReturnValue({ success: true });
   });
 
   describe("deleteAccount", () => {
-    it("happy path: deletes profile, removes auth user, signs out, and redirects to /", async () => {
+    it("happy path: verifies password, deletes profile, removes auth user, signs out, and redirects to /", async () => {
       const { deleteAccount } = await import("./account-actions");
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: FAKE_USER.email,
+        password: CORRECT_PASSWORD,
+      });
       expect(mockDeleteReturning).toHaveBeenCalled();
       expect(mockAdminDeleteUser).toHaveBeenCalledWith(FAKE_USER.id);
       expect(mockSignOut).toHaveBeenCalled();
@@ -106,7 +141,7 @@ describe("account-actions", () => {
       });
 
       const { deleteAccount } = await import("./account-actions");
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
       // Auth must be deleted first so that if it fails the profile is still intact
       expect(callOrder.indexOf("deleteUser")).toBeLessThan(
@@ -122,7 +157,7 @@ describe("account-actions", () => {
       mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
 
       const { deleteAccount } = await import("./account-actions");
-      const result = await deleteAccount();
+      const result = await deleteAccount(formWithPassword());
 
       expect(result.error).toBe("Non autenticato.");
       expect(mockDeleteReturning).not.toHaveBeenCalled();
@@ -134,7 +169,7 @@ describe("account-actions", () => {
       mockGetAuthenticatedUser.mockRejectedValue(new Error("db timeout"));
 
       const { deleteAccount } = await import("./account-actions");
-      const result = await deleteAccount();
+      const result = await deleteAccount(formWithPassword());
 
       expect(result.error).toBe(
         "Servizio temporaneamente non disponibile. Riprova.",
@@ -144,13 +179,79 @@ describe("account-actions", () => {
       expect(logger.error).toHaveBeenCalledTimes(1);
     });
 
+    // ---- Re-authentication gate (REVIEW.md #62) -------------------------
+
+    it("returns an error and never purges when the password field is missing", async () => {
+      const { deleteAccount } = await import("./account-actions");
+      const result = await deleteAccount(new FormData());
+
+      expect(result.error).toBe("Inserisci la tua password.");
+      expect(mockSignInWithPassword).not.toHaveBeenCalled();
+      expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+      expect(mockDeleteReturning).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("rejects a wrong password (warn, no purge) before touching any data", async () => {
+      mockSignInWithPassword.mockResolvedValue({
+        error: { message: "Invalid login credentials" },
+      });
+
+      const { deleteAccount } = await import("./account-actions");
+      const result = await deleteAccount(formWithPassword("wrong-password"));
+
+      expect(result.error).toBe("Password non corretta.");
+      expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+      expect(mockDeleteReturning).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+      // Predictable user-input error → warn, not Sentry-bound error (regola 20)
+      expect(logger.warn).toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("passes the raw password (no trim) to signInWithPassword", async () => {
+      const { deleteAccount } = await import("./account-actions");
+      await deleteAccount(formWithPassword("  spaced pw  "));
+
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: FAKE_USER.email,
+        password: "  spaced pw  ",
+      });
+    });
+
+    it("rate-limits repeated attempts (no signIn, no purge) and warns", async () => {
+      mockCheck.mockReturnValue({ success: false });
+
+      const { deleteAccount } = await import("./account-actions");
+      const result = await deleteAccount(formWithPassword());
+
+      expect(result.error).toBe(ERROR_MESSAGES.RATE_LIMIT_AUTH_MINUTES);
+      expect(mockSignInWithPassword).not.toHaveBeenCalled();
+      expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("returns an error when the user has no email (cannot re-authenticate)", async () => {
+      mockGetAuthenticatedUser.mockResolvedValue({ id: "user-123" });
+
+      const { deleteAccount } = await import("./account-actions");
+      const result = await deleteAccount(formWithPassword());
+
+      expect(result.error).toBe("Email utente non disponibile.");
+      expect(mockSignInWithPassword).not.toHaveBeenCalled();
+      expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+    });
+
+    // ---- Purge behaviour (unchanged) ------------------------------------
+
     it("logs an error but still redirects when profile is not found after auth deletion", async () => {
       // Auth user was deleted but profile row was not found (already cleaned up or never created).
       // The function should log the anomaly and still redirect — not surface an error to the UI.
       mockDeleteReturning.mockResolvedValue([]);
 
       const { deleteAccount } = await import("./account-actions");
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
       expect(mockAdminDeleteUser).toHaveBeenCalledWith(FAKE_USER.id);
       expect(mockRedirect).toHaveBeenCalledWith("/");
@@ -163,7 +264,7 @@ describe("account-actions", () => {
       });
 
       const { deleteAccount } = await import("./account-actions");
-      const promise = deleteAccount();
+      const promise = deleteAccount(formWithPassword());
       await vi.runAllTimersAsync();
       const result = await promise;
 
@@ -182,7 +283,7 @@ describe("account-actions", () => {
         .mockResolvedValueOnce({ error: null });
 
       const { deleteAccount } = await import("./account-actions");
-      const promise = deleteAccount();
+      const promise = deleteAccount(formWithPassword());
       await vi.runAllTimersAsync();
       await promise;
 
@@ -198,7 +299,7 @@ describe("account-actions", () => {
       });
 
       const { deleteAccount } = await import("./account-actions");
-      const promise = deleteAccount();
+      const promise = deleteAccount(formWithPassword());
       await vi.runAllTimersAsync();
       const result = await promise;
 
@@ -211,7 +312,7 @@ describe("account-actions", () => {
 
     it("sends AccountDeletionEmail after successful deletion", async () => {
       const { deleteAccount } = await import("./account-actions");
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
       await Promise.resolve();
       expect(mockSendEmail).toHaveBeenCalledWith(
@@ -223,7 +324,7 @@ describe("account-actions", () => {
       mockSendEmail.mockRejectedValueOnce(new Error("Resend down"));
 
       const { deleteAccount } = await import("./account-actions");
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
       expect(mockRedirect).toHaveBeenCalledWith("/");
     });
@@ -234,7 +335,7 @@ describe("account-actions", () => {
       mockDeleteReturning.mockResolvedValue([]);
 
       const { deleteAccount } = await import("./account-actions");
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
       await Promise.resolve();
       expect(mockSendEmail).toHaveBeenCalledWith(
@@ -252,7 +353,7 @@ describe("account-actions", () => {
 
       const { deleteAccount } = await import("./account-actions");
       // Must not throw
-      await deleteAccount();
+      await deleteAccount(formWithPassword());
 
       // Auth was already deleted, so redirect still happens
       expect(mockRedirect).toHaveBeenCalledWith("/");

--- a/src/server/account-actions.ts
+++ b/src/server/account-actions.ts
@@ -2,10 +2,15 @@
 
 import { createElement } from "react";
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { getAuthenticatedUser } from "@/lib/server-auth";
 import { authErrorResult } from "@/lib/auth-errors";
+import { getClientIp } from "@/lib/get-client-ip";
+import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
+import { ERROR_MESSAGES } from "@/lib/error-messages";
+import { getFormStringRaw } from "@/lib/form-utils";
 import { sendEmail } from "@/lib/email";
 import { AccountDeletionEmail } from "@/emails/account-deletion";
 import { purgeUserById } from "@/lib/services/purge-user";
@@ -14,20 +19,74 @@ export type AccountActionResult = {
   error?: string;
 };
 
+// Rate limit per user.id (non per IP: utenti dietro lo stesso NAT non si
+// bloccano a vicenda). Impedisce che la re-autenticazione richiesta prima
+// del purge diventi un oracle di brute-force sulla password.
+const deleteAccountLimiter = new RateLimiter({
+  maxRequests: 5,
+  // stessa soglia delle altre auth action (changePassword)
+  windowMs: RATE_LIMIT_WINDOWS.AUTH_15_MIN,
+});
+
 /**
  * Permanently deletes the authenticated user's account and all associated data.
  *
  * The actual purge (auth-first delete + profile FK cascade, with retries) lives
  * in the shared `purgeUserById` helper, reused by the GDPR inactive-user prune
- * sweep. This action wraps it with the session-specific concerns: auth gate,
+ * sweep. This action wraps it with the session-specific concerns: re-auth gate,
  * sign-out, confirmation email and redirect.
+ *
+ * Re-autenticazione server-side (REVIEW.md #62): la conferma "ELIMINA" del
+ * dialog vive solo nel client, quindi una chiamata diretta alla server action
+ * (sessione rubata, XSS, estensione malevola) cancellerebbe l'account —
+ * l'azione più distruttiva dell'app — senza alcun attrito. Richiediamo la
+ * password corrente e la verifichiamo con `signInWithPassword`, stesso pattern
+ * (meno distruttivo) di `changePassword`.
  */
-export async function deleteAccount(): Promise<AccountActionResult> {
+export async function deleteAccount(
+  formData: FormData,
+): Promise<AccountActionResult> {
   let user;
   try {
     user = await getAuthenticatedUser();
   } catch (err) {
     return authErrorResult(err, "deleteAccount");
+  }
+
+  // Raw read: ogni byte della password è significativo (vedi getFormStringRaw).
+  const currentPassword = getFormStringRaw(formData, "currentPassword");
+  if (!currentPassword) return { error: "Inserisci la tua password." };
+
+  const email = user.email;
+  if (!email) return { error: "Email utente non disponibile." };
+
+  // Rate limit prima del tentativo di verifica password (anti brute-force).
+  const hdrs = await headers();
+  const ip = getClientIp(hdrs);
+  const rateLimitResult = deleteAccountLimiter.check(
+    `deleteAccount:${user.id}`,
+  );
+  if (!rateLimitResult.success) {
+    logger.warn({ userId: user.id, ip }, "deleteAccount rate limit exceeded");
+    return { error: ERROR_MESSAGES.RATE_LIMIT_AUTH_MINUTES };
+  }
+
+  // Verifica la password corrente. signInWithPassword ruota il refresh token
+  // corrente (riscritto nel cookie store SSR), ma è irrilevante qui: la
+  // sessione viene comunque distrutta dal purge subito sotto.
+  const supabase = await createServerSupabaseClient();
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email,
+    password: currentPassword,
+  });
+  if (signInError) {
+    // Password sbagliata = errore prevedibile dell'input utente: warn, non
+    // Sentry (regola 20).
+    logger.warn(
+      { userId: user.id, ip },
+      "deleteAccount: password verification failed",
+    );
+    return { error: "Password non corretta." };
   }
 
   // 1-2. Delete auth user (retry) then the profile cascade. If the auth delete
@@ -45,7 +104,6 @@ export async function deleteAccount(): Promise<AccountActionResult> {
 
   // 3. Sign out current session (best-effort: auth user is already deleted;
   //    cookies may linger but cannot be used for re-authentication).
-  const supabase = await createServerSupabaseClient();
   await supabase.auth
     .signOut()
     .catch((err) =>


### PR DESCRIPTION
## Summary

Implements server-side password verification for the `deleteAccount` action to prevent account deletion via compromised sessions (XSS, stolen device, malicious extension). Replaces the client-only "ELIMINA" confirmation with a password field, matching the existing `changePassword` pattern.

Closes REVIEW.md #62.

## Key Changes

- **Server action (`account-actions.ts`)**
  - `deleteAccount()` now accepts `FormData` with `currentPassword` field
  - Verifies password via `supabase.auth.signInWithPassword()` before purge
  - Rate-limits to 5 attempts per 15 minutes per user ID (anti-brute-force)
  - Returns `{ error: "Password non corretta." }` on auth failure (logged as warn, not Sentry)
  - Validates email presence and password field existence before verification

- **UI component (`account-delete-section.tsx`)**
  - Replaces "ELIMINA" text confirmation with password input field
  - Updates form schema: `confirmText` → `password` (min 1 char validation)
  - Passes raw password (no trim) to server action as `currentPassword` in FormData
  - Updates copy: "credenziali Fisconline" → "credenziali di accesso AdE (Fisconline o CIE ID)"
  - Button disabled until password field is non-empty

- **Tests**
  - Server action tests: password verification flow, rate limiting, missing email, missing password field
  - Component tests: password input behavior, form submission, error display
  - All existing purge behavior tests updated to pass `formWithPassword()`

## Implementation Details

- Password read via `getFormStringRaw()` to preserve whitespace (every byte significant)
- Rate limiter keyed on `deleteAccount:<userId>` (per-user, not per-IP, to avoid NAT collisions)
- Mocks added: `RateLimiter`, `headers()`, `getClientIp()`, `signInWithPassword()`
- Error messages use existing `ERROR_MESSAGES.RATE_LIMIT_AUTH_MINUTES` constant
- No session rotation needed post-verification: session destroyed by purge anyway

https://claude.ai/code/session_01Y7DQub4wuYJea8bLW464d1