### PR TITLE
Fix dark mode contrast on reauth banners (REVIEW #54)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -541,30 +541,6 @@ password, e va documentato con un commento).
 
 ---
 
-### 54. Banner reauth CIE in cassa illeggibile in dark mode
-
-- **Categoria:** UI/accessibilità · **Severità:** Low
-- **File:** `src/components/cassa/cassa-client.tsx:313-330` (banner `reauthRequired`: `border-amber-200 bg-amber-50` **senza colore testo** né varianti `dark:`); `src/components/storico/void-receipt-dialog.tsx:157-162` (ha `text-amber-800` ma nessuna variante `dark:`)
-
-**Problema.** Il dashboard usa `next-themes` con `defaultTheme="system"`
-(`src/app/dashboard/layout.tsx:49`): in dark mode il testo del banner cassa
-eredita il foreground chiaro del tema su fondo `amber-50` chiaro → contrasto
-quasi nullo proprio sul messaggio che spiega come sbloccare l'emissione. Il
-banner del dialog annullo resta leggibile (amber-800 su amber-50) ma è un
-blocco chiaro incoerente col tema scuro.
-
-**Fix (non ambiguo).**
-
-1. Cassa: `rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200`.
-2. Dialog annullo: aggiungere le stesse varianti `dark:` (`dark:bg-amber-950 dark:text-amber-200`).
-3. Ordinamento classi Tailwind via `npx prettier --write` (skill
-   `react-patterns`).
-4. Verifica visiva in entrambi i temi (nota: il banner rosso `mutationError`
-   adiacente usa `bg-red-50` + `text-destructive`, anch'esso senza `dark:` —
-   pre-esistente; allinearlo nello stesso PR è benvenuto ma opzionale).
-
----
-
 ### 55. Costruzione `WithAdeSessionParams` duplicata in receipt-service e void-service
 
 - **Categoria:** manutenibilità/duplicazione · **Severità:** Low

--- a/src/components/cassa/cassa-client.tsx
+++ b/src/components/cassa/cassa-client.tsx
@@ -313,7 +313,7 @@ export function CassaClient({
         {mutation.data?.reauthRequired && (
           <div
             role="alert"
-            className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm"
+            className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
           >
             <p>
               {

--- a/src/components/storico/void-receipt-dialog.test.tsx
+++ b/src/components/storico/void-receipt-dialog.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { VoidReceiptDialog } from "./void-receipt-dialog";
+import { voidReceipt } from "@/server/void-actions";
 import type { ReceiptListItem } from "@/types/storico";
 
 vi.mock("@/server/void-actions", () => ({
@@ -100,5 +101,40 @@ describe("VoidReceiptDialog — QR code", () => {
     // Back in detail view: the void button is visible again
     expect(screen.getByText("Annulla scontrino")).toBeInTheDocument();
     expect(screen.queryByText("Indietro")).not.toBeInTheDocument();
+  });
+});
+
+describe("VoidReceiptDialog — banner reauth CIE (REVIEW #54)", () => {
+  async function openReauthBanner() {
+    renderWithQuery(
+      <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
+    );
+    // detail → confirmingVoid
+    await act(async () => {
+      fireEvent.click(screen.getByText("Annulla scontrino"));
+    });
+    // confirmingVoid → conferma → mutation risolve reauthRequired
+    await act(async () => {
+      fireEvent.click(screen.getByText("Annulla scontrino"));
+    });
+    return screen.findByText(/Sessione CIE scaduta/);
+  }
+
+  it("mostra il banner reauth quando la server action ritorna reauthRequired", async () => {
+    vi.mocked(voidReceipt).mockResolvedValue({ reauthRequired: true });
+
+    const banner = await openReauthBanner();
+
+    expect(banner).toBeInTheDocument();
+  });
+
+  it("il banner reauth resta leggibile in dark mode (varianti dark:)", async () => {
+    vi.mocked(voidReceipt).mockResolvedValue({ reauthRequired: true });
+
+    const banner = await openReauthBanner();
+
+    // Senza le varianti dark: il testo eredita il foreground chiaro del tema
+    // su fondo amber-50 chiaro → contrasto quasi nullo (REVIEW #54).
+    expect(banner).toHaveClass("dark:bg-amber-950", "dark:text-amber-200");
   });
 });

--- a/src/components/storico/void-receipt-dialog.tsx
+++ b/src/components/storico/void-receipt-dialog.tsx
@@ -136,7 +136,7 @@ export function VoidReceiptDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <div className="rounded-md bg-amber-50 p-3 text-sm text-amber-800">
+            <div className="rounded-md bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-950 dark:text-amber-200">
               <strong>⚠️ Attenzione:</strong> L&apos;annullo è irreversibile. Lo
               scontrino verrà trasmesso all&apos;Agenzia delle Entrate come
               documento di annullo.
@@ -155,7 +155,7 @@ export function VoidReceiptDialog({
 
             {/* CIE: sessione scaduta → ricollegarsi prima di ritentare l'annullo. */}
             {mutation.data?.reauthRequired && (
-              <div className="rounded-md bg-amber-50 p-3 text-sm text-amber-800">
+              <div className="rounded-md bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-950 dark:text-amber-200">
                 {
                   "Sessione CIE scaduta. Ricollegati dalle impostazioni approvando la notifica sull'app CIE ID, poi riprova l'annullo."
                 }


### PR DESCRIPTION
## Summary

Resolves REVIEW #54 by adding dark mode color variants to reauth CIE banners in both the cassa client and void receipt dialog. The banners were illegible in dark mode due to light text on light backgrounds.

## Changes

- **`src/components/cassa/cassa-client.tsx`** (line 316): Added `text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200` to the reauth banner to ensure proper contrast in both light and dark themes.

- **`src/components/storico/void-receipt-dialog.tsx`** (lines 139, 158): Added `dark:bg-amber-950 dark:text-amber-200` to both warning banners (initial warning and reauth CIE session expired message) for consistent dark mode styling.

- **`src/components/storico/void-receipt-dialog.test.tsx`**: Added comprehensive test suite for the reauth banner behavior:
  - Test verifying the banner appears when `reauthRequired: true`
  - Test verifying dark mode classes are applied for proper contrast (`dark:bg-amber-950`, `dark:text-amber-200`)

## Implementation Details

The fix applies the same Tailwind color scheme across both components:
- Light mode: `bg-amber-50` + `text-amber-800/900`
- Dark mode: `dark:bg-amber-950` + `dark:text-amber-200`

This ensures the reauth messages remain readable when the dashboard switches to dark mode (via `next-themes` with `defaultTheme="system"`), preventing the previous issue where light foreground text inherited from the theme would become invisible on the light amber background.

Removed the corresponding REVIEW #54 entry from `REVIEW.md` as the issue is now resolved.

https://claude.ai/code/session_01MyYU5oPhjFgVUYQoeXSBhF