### PR TITLE
Filter benign Server Action not-found errors from Sentry

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,5 +1,8 @@
 import * as Sentry from "@sentry/nextjs";
-import { isBenignFormDataParseError } from "@/lib/sentry-filters";
+import {
+  isBenignFormDataParseError,
+  isBenignServerActionNotFound,
+} from "@/lib/sentry-filters";
 import { getAppRelease } from "@/lib/version";
 
 Sentry.init({
@@ -24,6 +27,10 @@ Sentry.init({
   beforeSend(event, hint) {
     // Rumore da bot che fanno POST a path inesistenti (issue SCONTRINOZERO-E)
     if (isBenignFormDataParseError(event, hint)) {
+      return null;
+    }
+    // Scanner che fanno POST alla route not-found (issue SCONTRINOZERO-T)
+    if (isBenignServerActionNotFound(event, hint)) {
       return null;
     }
     return event;

--- a/src/lib/sentry-filters.test.ts
+++ b/src/lib/sentry-filters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ErrorEvent, EventHint } from "@sentry/nextjs";
 import {
   isBenignFormDataParseError,
+  isBenignServerActionNotFound,
   isClientNetworkFailure,
   isReactStreamingDomError,
 } from "./sentry-filters";
@@ -97,6 +98,68 @@ describe("isBenignFormDataParseError", () => {
     const event = makeEvent("POST /_not-found/page");
 
     expect(isBenignFormDataParseError(event)).toBe(false);
+  });
+});
+
+describe("isBenignServerActionNotFound", () => {
+  const message =
+    "Failed to find Server Action. This request might be from an older or newer deployment.";
+
+  it("scarta l'errore Server Action sulla route not-found (sonda bot)", () => {
+    const event = makeEvent("POST /_not-found/page");
+    const hint: EventHint = {
+      originalException: new Error(message),
+    };
+
+    expect(isBenignServerActionNotFound(event, hint)).toBe(true);
+  });
+
+  it("legge il messaggio dall'exception dell'evento se manca originalException", () => {
+    const event = makeEvent("POST /_not-found/page", message);
+
+    expect(isBenignServerActionNotFound(event)).toBe(true);
+  });
+
+  it("non scarta lo stesso errore su una Server Action reale (possibile deploy skew)", () => {
+    const event = makeEvent("POST /dashboard/receipts");
+    const hint: EventHint = {
+      originalException: new Error(message),
+    };
+
+    expect(isBenignServerActionNotFound(event, hint)).toBe(false);
+  });
+
+  it("non scarta altri errori sulla route not-found", () => {
+    const event = makeEvent("POST /_not-found/page");
+    const hint: EventHint = {
+      originalException: new Error("Database connection refused"),
+    };
+
+    expect(isBenignServerActionNotFound(event, hint)).toBe(false);
+  });
+
+  it("gestisce transaction mancante senza lanciare", () => {
+    const event = makeEvent(undefined);
+    const hint: EventHint = {
+      originalException: new Error(message),
+    };
+
+    expect(isBenignServerActionNotFound(event, hint)).toBe(false);
+  });
+
+  it("gestisce originalException stringa", () => {
+    const event = makeEvent("POST /_not-found/page");
+    const hint: EventHint = {
+      originalException: message,
+    };
+
+    expect(isBenignServerActionNotFound(event, hint)).toBe(true);
+  });
+
+  it("non scarta eventi senza messaggio di errore", () => {
+    const event = makeEvent("POST /_not-found/page");
+
+    expect(isBenignServerActionNotFound(event)).toBe(false);
   });
 });
 

--- a/src/lib/sentry-filters.ts
+++ b/src/lib/sentry-filters.ts
@@ -117,3 +117,35 @@ export function isBenignFormDataParseError(
   const transaction = event.transaction ?? "";
   return transaction.includes("/_not-found");
 }
+
+/**
+ * Messaggio lanciato dall'App Router di Next.js quando un POST con body
+ * colpisce la route not-found: non trovando una Server Action registrata,
+ * l'handler lancia questo errore. Come per il FormData sopra, è generato solo
+ * da bot/scanner che sondano path inesistenti con POST (es. Python Requests su
+ * `/index.php?option=com_sppagebuilder&task=asset.uploadCustomIcon`, uno
+ * scanner di vulnerabilità Joomla). Non è mai un flusso legittimo dell'app: la
+ * richiesta finisce comunque in 404 e l'errore non è azionabile. Lo filtriamo
+ * per non inquinare Sentry (issue SCONTRINOZERO-T).
+ */
+const SERVER_ACTION_NOT_FOUND_MESSAGE = "Failed to find Server Action";
+
+/**
+ * True se l'evento è il benigno `Failed to find Server Action` generato da un
+ * POST verso la route not-found (sonda bot). Lo scope è volutamente limitato
+ * alla transaction `/_not-found`: sulle Server Action reali lo stesso messaggio
+ * può segnalare un deploy skew genuino (client vecchio verso build nuova) e va
+ * lasciato passare per essere investigato.
+ */
+export function isBenignServerActionNotFound(
+  event: ErrorEvent,
+  hint?: EventHint,
+): boolean {
+  const message = extractErrorMessage(event, hint);
+  if (!message.includes(SERVER_ACTION_NOT_FOUND_MESSAGE)) {
+    return false;
+  }
+
+  const transaction = event.transaction ?? "";
+  return transaction.includes("/_not-found");
+}


### PR DESCRIPTION
## Summary

Adds a new Sentry error filter to suppress the benign "Failed to find Server Action" error that occurs when bots/scanners POST to the `/_not-found` route. This error is generated by Next.js App Router when a POST request with a body hits the not-found page but no Server Action is registered—a common pattern for vulnerability scanners probing non-existent paths. The error is not actionable and only pollutes Sentry.

## Changes

- **`src/lib/sentry-filters.ts`**: Added `isBenignServerActionNotFound()` filter function that:
  - Checks if the error message contains "Failed to find Server Action"
  - Verifies the transaction is the `/_not-found` route (to avoid filtering legitimate deploy skew errors on real Server Actions)
  - Handles both `Error` objects and string exceptions in the hint
  - Gracefully handles missing transaction/message data

- **`src/lib/sentry-filters.test.ts`**: Added comprehensive test suite covering:
  - Filtering the error on the `/_not-found` route (bot probe scenario)
  - Fallback to event message when `originalException` is missing
  - Not filtering the same error on real Server Actions (potential deploy skew)
  - Not filtering other errors on the `/_not-found` route
  - Edge cases: missing transaction, string exceptions, missing error message

- **`sentry.server.config.ts`**: Integrated the new filter into the Sentry `beforeSend` hook (after the existing `isBenignFormDataParseError` check)

## Implementation Details

The filter follows the same pattern as the existing `isBenignFormDataParseError` filter: it's scoped to the `/_not-found` transaction to avoid suppressing genuine errors. On real Server Actions, the same message can indicate a legitimate client/server version mismatch (deploy skew) and must be reported for investigation.

The implementation reuses the existing `extractErrorMessage()` helper to handle both `Error` objects and string exceptions consistently.

Addresses issue SCONTRINOZERO-T.

https://claude.ai/code/session_01JPfv1c6eBmN5Th7AVgpcnh