### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Bump the package version from 1.4.2 to 1.5.0 in preparation for the next release.

## Changes
- Updated `package.json` version field to `1.5.0`

## Notes
This is a routine version bump. The lockfile was automatically updated as a transitive resolution artifact.

https://claude.ai/code/session_01TrvZGbyuKe59QkeffCxg1y