### PR TITLE
Add dicitura regime forfettario generator tool

### DIFF
--- a/docs/seo/content-plan.md
+++ b/docs/seo/content-plan.md
@@ -66,17 +66,17 @@ trimestralmente: i pricing cambiano, Scontrina ha promo in corso).
 
 ### Batch A — P1: cluster forfettario/N2.2 (il più grande asset non sfruttato)
 
-- [ ] **Nuovo strumento `/strumenti/dicitura-regime-forfettario`**:
+- [x] **Nuovo strumento `/strumenti/dicitura-regime-forfettario`**:
       generatore copia-incolla della dicitura di esenzione (scontrino vs
       fattura) con FAQ. Intercetta "dicitura scontrino regime forfettario",
       "regime forfettario esente iva dicitura", "operazione senza
       applicazione dell'IVA art. 1 co. 54-89" (long-tail a bassissima
       competizione). Solo data file + widget semplice.
-- [ ] **Potenziare `/guide/codici-natura-iva`**: tabella N1→N7 completa, una
+- [x] **Potenziare `/guide/codici-natura-iva`**: tabella N1→N7 completa, una
       sezione per forma di query ("n2.2 cosa significa", "n2 vs n2.2",
       "codice iva n2.2 a cosa corrisponde"), risposta secca nel primo
       paragrafo di ogni sezione.
-- [ ] **Cross-link sistematico del cluster**: `help/regime-forfettario` ↔
+- [x] **Cross-link sistematico del cluster**: `help/regime-forfettario` ↔
       `guide/codici-natura-iva` ↔ `guide/scontrino-regime-forfettario` ↔
       nuovo strumento dicitura.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -125,6 +125,7 @@ sonar.coverage.exclusions=\
   src/components/marketing/tools/scorporo-iva-tool.tsx,\
   src/components/marketing/tools/verifica-lotteria-tool.tsx,\
   src/components/marketing/tools/calcolatore-risparmio-tool.tsx,\
+  src/components/marketing/tools/dicitura-forfettario-tool.tsx,\
   src/app/(marketing)/guide/page.tsx,\
   src/app/(marketing)/guide/[slug]/page.tsx
 

--- a/src/app/(marketing)/guide/[slug]/page.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
   isGuideSlug,
 } from "@/lib/guide/articles";
 import { helpArticles } from "@/lib/help/articles";
+import { isToolSlug, tools } from "@/lib/strumenti/tools";
 
 const SITE_URL = "https://scontrinozero.it";
 
@@ -73,6 +74,9 @@ export default async function GuidePage({ params }: PageParams) {
     .map((helpSlug) => helpArticles[helpSlug])
     .filter((a) => a !== undefined);
   const relatedGuides = g.relatedGuides.map((s) => guideArticles[s]);
+  const relatedTools = (g.relatedTools ?? [])
+    .filter(isToolSlug)
+    .map((s) => tools[s]);
   const crumbs = guideArticleBreadcrumbItems(g.slug, g.title);
 
   return (
@@ -113,6 +117,45 @@ export default async function GuidePage({ params }: PageParams) {
                 <p className="text-muted-foreground mt-3 leading-relaxed">
                   {section.body}
                 </p>
+                {section.table && (
+                  <div className="mt-4 overflow-x-auto rounded-xl border">
+                    <table className="w-full min-w-[36rem] text-sm">
+                      <thead>
+                        <tr className="bg-muted/50">
+                          {section.table.headers.map((header) => (
+                            <th
+                              key={header}
+                              scope="col"
+                              className="px-4 py-3 text-left font-semibold"
+                            >
+                              {header}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y">
+                        {section.table.rows.map((row) => (
+                          <tr key={row[0]}>
+                            <th
+                              scope="row"
+                              className="px-4 py-3 text-left align-top font-semibold whitespace-nowrap"
+                            >
+                              {row[0]}
+                            </th>
+                            {row.slice(1).map((cell, cellIndex) => (
+                              <td
+                                key={`${row[0]}-${section.table!.headers[cellIndex + 1]}`}
+                                className="text-muted-foreground px-4 py-3 align-top"
+                              >
+                                {cell}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -142,6 +185,26 @@ export default async function GuidePage({ params }: PageParams) {
                       className="text-primary hover:underline"
                     >
                       {article.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          {relatedTools.length > 0 && (
+            <>
+              <h2 className="mt-12 text-xl font-semibold">
+                {"Strumenti gratuiti"}
+              </h2>
+              <ul className="mt-3 space-y-1 text-sm">
+                {relatedTools.map((tool) => (
+                  <li key={tool.slug}>
+                    <Link
+                      href={`/strumenti/${tool.slug}`}
+                      className="text-primary hover:underline"
+                    >
+                      {tool.title}
                     </Link>
                   </li>
                 ))}

--- a/src/app/(marketing)/help/regime-forfettario/page.tsx
+++ b/src/app/(marketing)/help/regime-forfettario/page.tsx
@@ -249,7 +249,16 @@ export default function RegimeForfettarioPage() {
             &quot;Operazione in franchigia da IVA ai sensi dell&apos;art. 1 co.
             54-89 L. 190/2014&quot;
           </em>{" "}
-          — ma riguarda la fattura elettronica, non lo scontrino.
+          — ma riguarda la fattura elettronica, non lo scontrino. Se ti serve il
+          testo completo pronto da incollare (con clausola ritenuta
+          d&apos;acconto e controllo bollo), usa il{" "}
+          <Link
+            href="/strumenti/dicitura-regime-forfettario"
+            className="text-primary hover:underline"
+          >
+            generatore di dicitura per il regime forfettario
+          </Link>
+          {"."}
         </p>
 
         {/* ─── Soglie di ricavo ─── */}

--- a/src/app/(marketing)/strumenti/[slug]/page.tsx
+++ b/src/app/(marketing)/strumenti/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { ScorporoIvaTool } from "@/components/marketing/tools/scorporo-iva-tool";
 import { VerificaLotteriaTool } from "@/components/marketing/tools/verifica-lotteria-tool";
 import { CalcolatoreRisparmioTool } from "@/components/marketing/tools/calcolatore-risparmio-tool";
+import { DicituraForfettarioTool } from "@/components/marketing/tools/dicitura-forfettario-tool";
 import {
   tools,
   toolSlugs,
@@ -21,6 +22,7 @@ import {
   type ToolSlug,
 } from "@/lib/strumenti/tools";
 import { helpArticles } from "@/lib/help/articles";
+import { guideArticles, isGuideSlug } from "@/lib/guide/articles";
 
 const SITE_URL = "https://scontrinozero.it";
 
@@ -62,6 +64,8 @@ function ToolWidget({ slug }: { readonly slug: ToolSlug }) {
       return <VerificaLotteriaTool />;
     case "calcolatore-risparmio-rt":
       return <CalcolatoreRisparmioTool />;
+    case "dicitura-regime-forfettario":
+      return <DicituraForfettarioTool />;
   }
 }
 
@@ -75,6 +79,9 @@ export default async function ToolPage({ params }: PageParams) {
   const relatedArticles = t.relatedHelp
     .map((helpSlug) => helpArticles[helpSlug])
     .filter((a) => a !== undefined);
+  const relatedGuides = (t.relatedGuides ?? [])
+    .filter(isGuideSlug)
+    .map((s) => guideArticles[s]);
   const otherTools = toolSlugs.filter((s) => s !== t.slug);
   const crumbs = [
     { name: "Home", url: SITE_URL },
@@ -125,6 +132,26 @@ export default async function ToolPage({ params }: PageParams) {
               </div>
             ))}
           </div>
+
+          {relatedGuides.length > 0 && (
+            <>
+              <h2 className="mt-12 text-xl font-semibold">
+                {"Guide correlate"}
+              </h2>
+              <ul className="mt-3 space-y-1 text-sm">
+                {relatedGuides.map((guide) => (
+                  <li key={guide.slug}>
+                    <Link
+                      href={`/guide/${guide.slug}`}
+                      className="text-primary hover:underline"
+                    >
+                      {guide.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
 
           {relatedArticles.length > 0 && (
             <>

--- a/src/app/(marketing)/strumenti/page.tsx
+++ b/src/app/(marketing)/strumenti/page.tsx
@@ -13,11 +13,11 @@ const PAGE_URL = `${SITE_URL}/strumenti`;
 export const metadata: Metadata = {
   title: "Strumenti gratuiti",
   description:
-    "Calcolatori e verifiche gratuite per partite IVA: scorporo IVA, codice Lotteria degli Scontrini e risparmio rispetto al registratore telematico. Senza registrazione.",
+    "Calcolatori e verifiche gratuite per partite IVA: scorporo IVA, dicitura regime forfettario, codice Lotteria degli Scontrini e risparmio vs registratore telematico.",
   openGraph: {
     title: "Strumenti gratuiti | ScontrinoZero",
     description:
-      "Scorporo IVA, verifica codice Lotteria degli Scontrini e calcolatore di risparmio: strumenti gratuiti, nessuna registrazione.",
+      "Scorporo IVA, dicitura regime forfettario, verifica codice Lotteria e calcolatore di risparmio: strumenti gratuiti, nessuna registrazione.",
     url: PAGE_URL,
   },
   alternates: {

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(60);
+    expect(result).toHaveLength(61);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -82,6 +82,7 @@ describe("sitemap", () => {
       "https://scontrinozero.it/strumenti/scorporo-iva",
       "https://scontrinozero.it/strumenti/verifica-codice-lotteria",
       "https://scontrinozero.it/strumenti/calcolatore-risparmio-rt",
+      "https://scontrinozero.it/strumenti/dicitura-regime-forfettario",
     ];
     for (const url of expectedToolUrls) {
       expect(allUrls).toContain(url);
@@ -117,39 +118,39 @@ describe("sitemap", () => {
     }
 
     // Legal
-    expect(result[27]).toMatchObject({
+    expect(result[28]).toMatchObject({
       url: "https://scontrinozero.it/privacy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[28]).toMatchObject({
+    expect(result[29]).toMatchObject({
       url: "https://scontrinozero.it/privacy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[29]).toMatchObject({
+    expect(result[30]).toMatchObject({
       url: "https://scontrinozero.it/termini",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[30]).toMatchObject({
+    expect(result[31]).toMatchObject({
       url: "https://scontrinozero.it/termini/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[31]).toMatchObject({
+    expect(result[32]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[32]).toMatchObject({
+    expect(result[33]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
 
     // Help center hub
-    expect(result[33]).toMatchObject({
+    expect(result[34]).toMatchObject({
       url: "https://scontrinozero.it/help",
       changeFrequency: "monthly",
       priority: 0.6,
@@ -176,12 +177,12 @@ describe("sitemap", () => {
     });
 
     // Auth pages (last two)
-    expect(result[58]).toMatchObject({
+    expect(result[59]).toMatchObject({
       url: "https://scontrinozero.it/login",
       changeFrequency: "yearly",
       priority: 0.5,
     });
-    expect(result[59]).toMatchObject({
+    expect(result[60]).toMatchObject({
       url: "https://scontrinozero.it/register",
       changeFrequency: "yearly",
       priority: 0.5,
@@ -205,12 +206,12 @@ describe("sitemap", () => {
     expect(result[12].url).toBe(
       "https://test.scontrinozero.it/strumenti/scorporo-iva",
     );
-    expect(result[15].url).toBe("https://test.scontrinozero.it/guide");
-    expect(result[16].url).toBe(
+    expect(result[16].url).toBe("https://test.scontrinozero.it/guide");
+    expect(result[17].url).toBe(
       "https://test.scontrinozero.it/guide/documento-commerciale-online",
     );
-    expect(result[27].url).toBe("https://test.scontrinozero.it/privacy");
-    expect(result[33].url).toBe("https://test.scontrinozero.it/help");
+    expect(result[28].url).toBe("https://test.scontrinozero.it/privacy");
+    expect(result[34].url).toBe("https://test.scontrinozero.it/help");
 
     vi.unstubAllEnvs();
   });

--- a/src/components/marketing/tools/dicitura-forfettario-tool.tsx
+++ b/src/components/marketing/tools/dicitura-forfettario-tool.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useId, useMemo, useRef, useState } from "react";
+import { Check, Copy, Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  buildDicituraForfettario,
+  type DicituraDocumento,
+} from "@/lib/strumenti/dicitura-forfettario";
+import { parseItalianNumber } from "@/lib/strumenti/parse-number";
+
+const COPY_FEEDBACK_MS = 2000;
+
+export function DicituraForfettarioTool() {
+  const importoId = useId();
+  const ritenutaId = useId();
+  const [documento, setDocumento] = useState<DicituraDocumento>("fattura");
+  const [conRitenuta, setConRitenuta] = useState(false);
+  const [importoRaw, setImportoRaw] = useState("");
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const result = useMemo(() => {
+    const parsed = parseItalianNumber(importoRaw);
+    return buildDicituraForfettario({
+      documento,
+      conRitenuta,
+      importoEuro: Number.isFinite(parsed) ? parsed : null,
+    });
+  }, [documento, conRitenuta, importoRaw]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(result.testo);
+      setCopied(true);
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = setTimeout(
+        () => setCopied(false),
+        COPY_FEEDBACK_MS,
+      );
+    } catch {
+      // Clipboard non disponibile (webview, permessi negati): il testo resta
+      // selezionabile manualmente qui sotto, nessun errore da mostrare.
+    }
+  };
+
+  const documentoOptions: readonly {
+    value: DicituraDocumento;
+    label: string;
+  }[] = [
+    { value: "fattura", label: "Fattura" },
+    { value: "scontrino", label: "Scontrino" },
+  ];
+
+  return (
+    <div className="bg-card mt-6 rounded-lg border p-5">
+      <fieldset>
+        <legend className="text-sm font-medium">
+          {"Che documento devi emettere?"}
+        </legend>
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          {documentoOptions.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              variant={documento === option.value ? "default" : "outline"}
+              aria-pressed={documento === option.value}
+              onClick={() => setDocumento(option.value)}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </fieldset>
+
+      {documento === "fattura" && (
+        <div className="mt-5 space-y-4">
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id={ritenutaId}
+              checked={conRitenuta}
+              onCheckedChange={(checked) => setConRitenuta(checked === true)}
+              className="mt-0.5"
+            />
+            <Label htmlFor={ritenutaId} className="text-sm leading-snug">
+              {
+                "Aggiungi la clausola sulla ritenuta d'acconto (comma 67) — utile se il cliente è un'azienda o un professionista"
+              }
+            </Label>
+          </div>
+          <div>
+            <Label htmlFor={importoId}>
+              {"Importo della fattura (facoltativo, per il controllo bollo)"}
+            </Label>
+            <Input
+              id={importoId}
+              type="text"
+              inputMode="decimal"
+              placeholder="es. 120,00"
+              value={importoRaw}
+              onChange={(e) => setImportoRaw(e.target.value)}
+              className="mt-1 max-w-48"
+            />
+          </div>
+        </div>
+      )}
+
+      {result.obbligatoria ? (
+        <div className="mt-5">
+          <p className="text-sm font-medium">{"Dicitura da riportare:"}</p>
+          <output
+            aria-live="polite"
+            className="bg-muted/40 border-border mt-2 block rounded-md border p-4 text-sm leading-relaxed select-all"
+          >
+            {result.testo}
+          </output>
+          <Button
+            type="button"
+            onClick={handleCopy}
+            className={cn("mt-3", copied && "pointer-events-none")}
+          >
+            {copied ? (
+              <>
+                <Check className="mr-1 h-4 w-4" />
+                {"Copiato!"}
+              </>
+            ) : (
+              <>
+                <Copy className="mr-1 h-4 w-4" />
+                {"Copia la dicitura"}
+              </>
+            )}
+          </Button>
+        </div>
+      ) : null}
+
+      {result.note.map((nota) => (
+        <output
+          key={nota}
+          aria-live="polite"
+          className="border-border bg-muted/40 text-muted-foreground mt-4 flex items-start gap-3 rounded-md border p-4 text-sm leading-relaxed"
+        >
+          <Info className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+          <span>{nota}</span>
+        </output>
+      ))}
+
+      <p className="text-muted-foreground mt-4 text-xs">
+        {
+          "Il testo viene generato in locale nel browser: nessun dato viene trasmesso a server esterni."
+        }
+      </p>
+    </div>
+  );
+}

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -79,6 +79,20 @@ describe("guideArticles dictionary", () => {
         }
       });
 
+      it("has well-formed tables when present (headers + rows of equal width)", () => {
+        for (const section of a.sections) {
+          if (!section.table) continue;
+          expect(section.table.headers.length).toBeGreaterThanOrEqual(2);
+          expect(section.table.rows.length).toBeGreaterThanOrEqual(2);
+          for (const row of section.table.rows) {
+            expect(row).toHaveLength(section.table.headers.length);
+            for (const cell of row) {
+              expect(cell.length).toBeGreaterThan(0);
+            }
+          }
+        }
+      });
+
       it("has at least 3 FAQ entries with substantive question/answer", () => {
         expect(a.faq.length).toBeGreaterThanOrEqual(3);
         for (const item of a.faq) {
@@ -106,6 +120,29 @@ describe("guideArticles dictionary", () => {
       });
     });
   }
+});
+
+describe("codici-natura-iva", () => {
+  const article = guideArticles["codici-natura-iva"];
+
+  it("has a complete N1-N7 table (one row per code, sub-codes included)", () => {
+    const tableSection = article.sections.find((s) => s.table !== undefined);
+    expect(tableSection).toBeDefined();
+    const firstColumn = tableSection!.table!.rows.map((row) => row[0]);
+    for (const code of ["N1", "N2", "N2.1", "N2.2", "N4", "N5", "N7"]) {
+      expect(firstColumn).toContain(code);
+    }
+    // N3 e N6 hanno sottocodici: la riga li riporta come intervallo
+    expect(firstColumn.some((c) => c.startsWith("N3"))).toBe(true);
+    expect(firstColumn.some((c) => c.startsWith("N6"))).toBe(true);
+  });
+
+  it("has dedicated sections for the main query forms (cosa significa, N2 vs N2.2, aliquota)", () => {
+    const headings = article.sections.map((s) => s.heading.toLowerCase());
+    expect(headings.some((h) => h.includes("cosa significa"))).toBe(true);
+    expect(headings.some((h) => h.includes("n2 vs n2.2"))).toBe(true);
+    expect(headings.some((h) => h.includes("aliquota"))).toBe(true);
+  });
 });
 
 describe("getGuide", () => {
@@ -162,5 +199,28 @@ describe("relatedHelp slugs point to real help articles", () => {
         ).toContain(helpSlug);
       }
     }
+  });
+});
+
+describe("relatedTools slugs point to real tools", () => {
+  it("each related tool slug exists in the tools dictionary", async () => {
+    const { toolSlugs } = await import("@/lib/strumenti/tools");
+    for (const slug of guideSlugs) {
+      const a = guideArticles[slug];
+      for (const toolSlug of a.relatedTools ?? []) {
+        expect(toolSlugs, `guide ${slug}: toolSlug ${toolSlug}`).toContain(
+          toolSlug,
+        );
+      }
+    }
+  });
+
+  it("the forfettario/N2.2 cluster links the dicitura tool", () => {
+    expect(guideArticles["codici-natura-iva"].relatedTools).toContain(
+      "dicitura-regime-forfettario",
+    );
+    expect(
+      guideArticles["scontrino-regime-forfettario"].relatedTools,
+    ).toContain("dicitura-regime-forfettario");
   });
 });

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -14,9 +14,17 @@ export const guideSlugs = [
 
 export type GuideSlug = (typeof guideSlugs)[number];
 
+export interface GuideTable {
+  readonly headers: readonly string[];
+  /** Ogni riga deve avere lo stesso numero di celle di headers. */
+  readonly rows: readonly (readonly string[])[];
+}
+
 export interface GuideSection {
   readonly heading: string;
   readonly body: string;
+  /** Tabella opzionale renderizzata dopo il body (es. codici natura N1-N7). */
+  readonly table?: GuideTable;
 }
 
 export interface GuideFaq {
@@ -37,6 +45,8 @@ export interface GuideArticle {
   readonly faq: readonly GuideFaq[];
   readonly relatedHelp: readonly string[];
   readonly relatedGuides: readonly GuideSlug[];
+  /** Slug di /strumenti collegati (cross-link del cluster, es. forfettario). */
+  readonly relatedTools?: readonly string[];
 }
 
 export const guideArticles: Record<GuideSlug, GuideArticle> = {
@@ -363,7 +373,9 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     relatedGuides: [
       "documento-commerciale-online",
       "differenza-scontrino-ricevuta-fattura",
+      "codici-natura-iva",
     ],
+    relatedTools: ["dicitura-regime-forfettario"],
   },
 
   "migrare-da-registratore-telematico-a-software": {
@@ -703,24 +715,82 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "I codici natura IVA (N1, N2, N2.2, N3, N4, N5, N6, N7) servono a spiegare al fisco perché su un'operazione non viene addebitata l'IVA con un'aliquota ordinaria. Sono obbligatori nel tracciato della fattura elettronica e dei corrispettivi telematici. Qui vediamo cosa significano uno per uno, perché il regime forfettario usa N2.2 in fattura ma N2 sullo scontrino, e quale dicitura di esenzione indicare.",
     publishedAt: "2026-06-29",
-    updatedAt: "2026-06",
-    readingMinutes: 7,
+    updatedAt: "2026-07",
+    readingMinutes: 8,
     sections: [
       {
         heading: "Cosa sono i codici natura IVA",
         body: "Il codice natura è un'etichetta che, nel tracciato XML della fattura elettronica e nel tracciato dei corrispettivi telematici, indica il motivo per cui un'operazione non è assoggettata all'IVA ordinaria (4%, 5%, 10%, 22%). Senza un'aliquota da esporre, il sistema dell'Agenzia delle Entrate ha comunque bisogno di sapere se l'operazione è esclusa, non soggetta, non imponibile, esente, in regime del margine o in inversione contabile: il codice natura risponde proprio a questa domanda. È un dato obbligatorio: una riga a 0% senza codice natura viene scartata.",
       },
       {
-        heading: "I codici natura N1-N7 in breve",
-        body: "N1 – Operazioni escluse ex art. 15 DPR 633/72 (rimborsi e anticipazioni in nome e per conto). N2 – Operazioni non soggette, suddivise in N2.1 (mancanza del requisito di territorialità, artt. 7-7septies) e N2.2 (altri casi, tra cui il regime forfettario). N3 – Operazioni non imponibili (esportazioni, cessioni intracomunitarie, ecc.), con sottocodici N3.1-N3.6. N4 – Operazioni esenti ex art. 10 DPR 633/72 (servizi sanitari, finanziari, formativi). N5 – Regime del margine (beni usati, oggetti d'arte) e IVA non esposta. N6 – Inversione contabile (reverse charge), con sottocodici N6.1-N6.9. N7 – IVA assolta in altro Stato UE (vendite a distanza, servizi di telecomunicazione/elettronici sopra soglia).",
+        heading: "La tabella completa dei codici natura IVA (N1-N7)",
+        body: "Questi sono tutti i codici natura previsti dalle specifiche tecniche dell'Agenzia delle Entrate. Dal 1° gennaio 2021, in fattura elettronica i codici aggregati N2, N3 e N6 non sono più accettati: vanno usati i sottocodici granulari (N2.1, N2.2, N3.1-N3.6, N6.1-N6.9). Il tracciato dello scontrino elettronico, invece, usa ancora i codici aggregati.",
+        table: {
+          headers: ["Codice", "Significato", "Quando si usa"],
+          rows: [
+            [
+              "N1",
+              "Operazioni escluse ex art. 15 DPR 633/72",
+              "Rimborsi di spese anticipate in nome e per conto del cliente, interessi di mora, imballaggi a rendere",
+            ],
+            [
+              "N2",
+              "Operazioni non soggette (codice aggregato)",
+              "Solo sullo scontrino elettronico: è il codice unico per le non soggette, regime forfettario incluso",
+            ],
+            [
+              "N2.1",
+              "Non soggette per carenza di territorialità (artt. 7 - 7-septies DPR 633/72)",
+              "Prestazioni rese a soggetti esteri fuori dal campo IVA italiano",
+            ],
+            [
+              "N2.2",
+              "Non soggette - altri casi",
+              "Regime forfettario, regime di vantaggio (ex minimi), operazioni fuori campo IVA",
+            ],
+            [
+              "N3.1-N3.6",
+              "Operazioni non imponibili",
+              "Esportazioni, cessioni intracomunitarie, cessioni verso San Marino, operazioni con lettera d'intento",
+            ],
+            [
+              "N4",
+              "Operazioni esenti ex art. 10 DPR 633/72",
+              "Prestazioni sanitarie, finanziarie, assicurative, formative",
+            ],
+            [
+              "N5",
+              "Regime del margine / IVA non esposta",
+              "Beni usati, oggetti d'arte e antiquariato, agenzie di viaggio",
+            ],
+            [
+              "N6.1-N6.9",
+              "Inversione contabile (reverse charge)",
+              "Edilizia e settori connessi, rottami, elettronica, subappalti",
+            ],
+            [
+              "N7",
+              "IVA assolta in altro Stato UE",
+              "Vendite a distanza intra-UE sopra soglia, servizi elettronici a consumatori UE (regime OSS)",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "N2.2: cosa significa",
+        body: 'N2.2 significa "operazione non soggetta a IVA - altri casi": è il codice natura che nel tracciato della fattura elettronica identifica le operazioni fuori dal campo di applicazione dell\'IVA per motivi diversi dalla carenza di territorialità (coperta da N2.1). Il caso di gran lunga più frequente è la fattura emessa da un contribuente in regime forfettario; rientrano in N2.2 anche il regime di vantaggio (ex minimi) e le altre operazioni fuori campo IVA. È obbligatorio dal 1° gennaio 2021, quando le specifiche tecniche della fatturazione elettronica hanno reso inutilizzabile il codice generico N2.',
+      },
+      {
+        heading: "N2 vs N2.2: qual è la differenza",
+        body: 'N2 è il codice aggregato ("operazioni non soggette"), N2.2 è uno dei suoi due sottocodici. In fattura elettronica, dal 1° gennaio 2021, il codice N2 generico non è più accettato: si usa N2.1 (carenza di territorialità) oppure N2.2 (altri casi). Il tracciato del documento commerciale online (lo scontrino elettronico), invece, non prevede la suddivisione fine: usa ancora il codice aggregato N2. Quindi lo stesso forfettario indica N2.2 in fattura e N2 sullo scontrino. Non è una contraddizione: sono due tracciati diversi dell\'Agenzia delle Entrate, con livelli di dettaglio diversi sullo stesso concetto.',
+      },
+      {
+        heading: "Codice IVA N2.2: a quale aliquota corrisponde",
+        body: "A nessuna aliquota: N2.2 si abbina sempre ad aliquota 0%, perché segnala un'operazione fuori dal campo di applicazione dell'IVA. Non corrisponde a un'aliquota ridotta né a un'esenzione: l'operazione esente (per esempio una prestazione sanitaria) usa il codice N4, mentre N2.2 dice che l'IVA non si applica proprio, come nel regime forfettario. In pratica, nel software di fatturazione si seleziona aliquota 0% e natura N2.2 sulla stessa riga.",
       },
       {
         heading: "N2.2 e regime forfettario: il codice in fattura elettronica",
         body: "Chi è in regime forfettario non addebita l'IVA in fattura (art. 1, comma 58, Legge 190/2014). Nel tracciato della fattura elettronica questa è un'operazione \"non soggetta - altri casi\", quindi si usa il codice natura N2.2. È l'errore più comune: molti cercano un'aliquota \"esente\" (che sarebbe N4) o lasciano la riga senza codice. Per il forfettario la natura corretta in fattura è sempre N2.2, con aliquota 0%.",
-      },
-      {
-        heading: "Sullo scontrino è diverso: il forfettario usa N2",
-        body: "Il tracciato del documento commerciale online (lo scontrino elettronico) non prevede la suddivisione fine N2.1/N2.2 della fattura: usa il codice natura aggregato N2 per le operazioni non soggette. Quindi lo stesso forfettario che in fattura elettronica indica N2.2, sullo scontrino emette le righe con natura N2. Non è una contraddizione: sono due tracciati diversi dell'Agenzia delle Entrate, con livelli di dettaglio diversi sullo stesso concetto (operazione non soggetta a IVA).",
       },
       {
         heading:
@@ -759,12 +829,18 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
         answer:
           "Sì. Ogni riga a 0% deve avere un codice natura, altrimenti la trasmissione all'Agenzia delle Entrate viene scartata. Per le operazioni non soggette del forfettario il codice corretto sullo scontrino è N2.",
       },
+      {
+        question: "Che differenza c'è tra N2.1 e N2.2?",
+        answer:
+          "Sono i due sottocodici delle operazioni non soggette. N2.1 copre la carenza del requisito di territorialità (artt. 7 - 7-septies DPR 633/72, tipicamente prestazioni verso l'estero); N2.2 copre tutti gli altri casi, incluso il regime forfettario e il regime di vantaggio.",
+      },
     ],
     relatedHelp: ["regime-forfettario", "aliquote-iva", "fatture-e-ricevute"],
     relatedGuides: [
       "scontrino-regime-forfettario",
       "differenza-scontrino-ricevuta-fattura",
     ],
+    relatedTools: ["dicitura-regime-forfettario"],
   },
 };
 

--- a/src/lib/strumenti/dicitura-forfettario.test.ts
+++ b/src/lib/strumenti/dicitura-forfettario.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOLLO_IMPORTO_EURO,
+  BOLLO_SOGLIA_EURO,
+  DICITURA_FORFETTARIO_BASE,
+  DICITURA_FORFETTARIO_RITENUTA,
+  buildDicituraForfettario,
+} from "./dicitura-forfettario";
+
+describe("buildDicituraForfettario — fattura", () => {
+  it("returns the base dicitura, marked as obbligatoria", () => {
+    const result = buildDicituraForfettario({ documento: "fattura" });
+    expect(result.obbligatoria).toBe(true);
+    expect(result.testo).toBe(DICITURA_FORFETTARIO_BASE);
+  });
+
+  it("cites art. 1 commi 54-89 L. 190/2014 in the text", () => {
+    const result = buildDicituraForfettario({ documento: "fattura" });
+    expect(result.testo).toContain("articolo 1, commi da 54 a 89");
+    expect(result.testo).toContain("Legge n. 190/2014");
+  });
+
+  it("appends the ritenuta d'acconto clause (comma 67) when requested", () => {
+    const result = buildDicituraForfettario({
+      documento: "fattura",
+      conRitenuta: true,
+    });
+    expect(result.testo).toBe(
+      `${DICITURA_FORFETTARIO_BASE} ${DICITURA_FORFETTARIO_RITENUTA}`,
+    );
+    expect(result.testo).toContain("comma 67");
+  });
+
+  it("omits the ritenuta clause when conRitenuta is false or absent", () => {
+    expect(
+      buildDicituraForfettario({ documento: "fattura", conRitenuta: false })
+        .testo,
+    ).not.toContain("comma 67");
+    expect(
+      buildDicituraForfettario({ documento: "fattura" }).testo,
+    ).not.toContain("comma 67");
+  });
+
+  it("adds the marca da bollo note when importo exceeds €77,47", () => {
+    const result = buildDicituraForfettario({
+      documento: "fattura",
+      importoEuro: 100,
+    });
+    expect(result.note.some((n) => n.includes("bollo"))).toBe(true);
+    expect(result.note.some((n) => n.includes("2,00"))).toBe(true);
+  });
+
+  it("does NOT add the bollo note at exactly €77,47 (soglia non superata)", () => {
+    const result = buildDicituraForfettario({
+      documento: "fattura",
+      importoEuro: BOLLO_SOGLIA_EURO,
+    });
+    expect(result.note.some((n) => n.includes("bollo"))).toBe(false);
+  });
+
+  it("says no bollo is due when importo is at or below the threshold", () => {
+    const result = buildDicituraForfettario({
+      documento: "fattura",
+      importoEuro: 50,
+    });
+    expect(
+      result.note.some((n) => n.includes("non") && n.includes("bollo")),
+    ).toBe(false);
+    expect(result.note).toHaveLength(0);
+  });
+
+  it("treats NaN, negative and null importo as not provided (no bollo note)", () => {
+    for (const importoEuro of [Number.NaN, -5, null, undefined]) {
+      const result = buildDicituraForfettario({
+        documento: "fattura",
+        importoEuro,
+      });
+      expect(result.note.some((n) => n.includes("bollo"))).toBe(false);
+    }
+  });
+
+  it("adds bollo note just above the threshold (77,48)", () => {
+    const result = buildDicituraForfettario({
+      documento: "fattura",
+      importoEuro: 77.48,
+    });
+    expect(result.note.some((n) => n.includes("bollo"))).toBe(true);
+  });
+});
+
+describe("buildDicituraForfettario — scontrino", () => {
+  it("is not obbligatoria and returns empty text", () => {
+    const result = buildDicituraForfettario({ documento: "scontrino" });
+    expect(result.obbligatoria).toBe(false);
+    expect(result.testo).toBe("");
+  });
+
+  it("explains that natura N2 is sufficient", () => {
+    const result = buildDicituraForfettario({ documento: "scontrino" });
+    expect(result.note.some((n) => n.includes("N2"))).toBe(true);
+  });
+
+  it("never adds the bollo note, even with a high importo", () => {
+    const result = buildDicituraForfettario({
+      documento: "scontrino",
+      importoEuro: 500,
+    });
+    expect(result.note.some((n) => n.includes("bollo"))).toBe(false);
+  });
+
+  it("ignores the ritenuta flag (no clause on scontrino)", () => {
+    const result = buildDicituraForfettario({
+      documento: "scontrino",
+      conRitenuta: true,
+    });
+    expect(result.testo).toBe("");
+  });
+});
+
+describe("exported constants", () => {
+  it("BOLLO_SOGLIA_EURO is 77.47 and BOLLO_IMPORTO_EURO is 2", () => {
+    expect(BOLLO_SOGLIA_EURO).toBe(77.47);
+    expect(BOLLO_IMPORTO_EURO).toBe(2);
+  });
+
+  it("base dicitura does not mention ritenuta", () => {
+    expect(DICITURA_FORFETTARIO_BASE).not.toContain("ritenuta");
+    expect(DICITURA_FORFETTARIO_RITENUTA).toContain("ritenuta");
+  });
+});

--- a/src/lib/strumenti/dicitura-forfettario.ts
+++ b/src/lib/strumenti/dicitura-forfettario.ts
@@ -1,0 +1,64 @@
+/**
+ * Generatore della dicitura di esenzione IVA per il regime forfettario
+ * (art. 1, commi 54-89, L. 190/2014), usato dal tool
+ * /strumenti/dicitura-regime-forfettario.
+ *
+ * Fonti allineate ai contenuti del sito (guide/codici-natura-iva,
+ * help/regime-forfettario): la dicitura è obbligatoria solo sulla fattura;
+ * sullo scontrino elettronico (documento commerciale) basta la natura N2.
+ */
+
+export type DicituraDocumento = "fattura" | "scontrino";
+
+export interface DicituraInput {
+  readonly documento: DicituraDocumento;
+  /** Aggiunge la clausola di non applicazione della ritenuta d'acconto (comma 67). */
+  readonly conRitenuta?: boolean;
+  /** Importo della fattura in euro, per l'avviso marca da bollo. */
+  readonly importoEuro?: number | null;
+}
+
+export interface DicituraResult {
+  /** true = la dicitura va riportata sul documento (solo fattura). */
+  readonly obbligatoria: boolean;
+  /** Testo pronto da copiare; stringa vuota per lo scontrino. */
+  readonly testo: string;
+  readonly note: readonly string[];
+}
+
+/** Soglia oltre la quale la fattura senza IVA richiede la marca da bollo (DPR 642/1972). */
+export const BOLLO_SOGLIA_EURO = 77.47;
+export const BOLLO_IMPORTO_EURO = 2;
+
+export const DICITURA_FORFETTARIO_BASE =
+  "Operazione effettuata ai sensi dell'articolo 1, commi da 54 a 89, della Legge n. 190/2014 - Regime forfettario.";
+
+export const DICITURA_FORFETTARIO_RITENUTA =
+  "Si richiede la non applicazione della ritenuta alla fonte a titolo d'acconto ai sensi dell'articolo 1, comma 67, della Legge n. 190/2014.";
+
+const NOTA_SCONTRINO =
+  "Sullo scontrino elettronico (documento commerciale) la dicitura non è richiesta: è sufficiente emettere le righe con natura IVA N2 (operazioni non soggette). La dicitura resta obbligatoria solo sulle fatture.";
+
+const NOTA_BOLLO = `Importo superiore a ${BOLLO_SOGLIA_EURO.toFixed(2).replace(".", ",")} €: sulla fattura va assolta la marca da bollo da ${BOLLO_IMPORTO_EURO.toFixed(2).replace(".", ",")} € (in modo virtuale per la fattura elettronica).`;
+
+export function buildDicituraForfettario(input: DicituraInput): DicituraResult {
+  if (input.documento === "scontrino") {
+    return { obbligatoria: false, testo: "", note: [NOTA_SCONTRINO] };
+  }
+
+  const testo = input.conRitenuta
+    ? `${DICITURA_FORFETTARIO_BASE} ${DICITURA_FORFETTARIO_RITENUTA}`
+    : DICITURA_FORFETTARIO_BASE;
+
+  const importo = input.importoEuro;
+  const note: string[] = [];
+  if (
+    typeof importo === "number" &&
+    Number.isFinite(importo) &&
+    importo > BOLLO_SOGLIA_EURO
+  ) {
+    note.push(NOTA_BOLLO);
+  }
+
+  return { obbligatoria: true, testo, note };
+}

--- a/src/lib/strumenti/tools.test.ts
+++ b/src/lib/strumenti/tools.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { getTool, isToolSlug, tools, toolSlugs } from "./tools";
 
 describe("toolSlugs", () => {
-  it("contains exactly 3 slugs", () => {
-    expect(toolSlugs).toHaveLength(3);
+  it("contains exactly 4 slugs", () => {
+    expect(toolSlugs).toHaveLength(4);
   });
 
   it("contains the expected slugs", () => {
@@ -12,6 +12,7 @@ describe("toolSlugs", () => {
         "scorporo-iva",
         "verifica-codice-lotteria",
         "calcolatore-risparmio-rt",
+        "dicitura-regime-forfettario",
       ]),
     );
   });
@@ -26,6 +27,7 @@ describe("tools dictionary", () => {
     "scorporo-iva",
     "verifica-codice-lotteria",
     "calcolatore-risparmio-rt",
+    "dicitura-regime-forfettario",
   ] as const) {
     describe(slug, () => {
       const t = tools[slug];
@@ -107,6 +109,29 @@ describe("isToolSlug", () => {
     expect(isToolSlug("constructor")).toBe(false);
     expect(isToolSlug("toString")).toBe(false);
     expect(isToolSlug("hasOwnProperty")).toBe(false);
+  });
+});
+
+describe("relatedGuides slugs point to real guides", () => {
+  it("each related guide slug exists in the guide articles dictionary", async () => {
+    const { guideSlugs } = await import("@/lib/guide/articles");
+    for (const slug of toolSlugs) {
+      const t = tools[slug];
+      for (const guideSlug of t.relatedGuides ?? []) {
+        expect(guideSlugs, `tool ${slug}: guideSlug ${guideSlug}`).toContain(
+          guideSlug,
+        );
+      }
+    }
+  });
+
+  it("the dicitura tool links back to the forfettario/N2.2 cluster", () => {
+    expect(tools["dicitura-regime-forfettario"].relatedGuides).toEqual(
+      expect.arrayContaining([
+        "codici-natura-iva",
+        "scontrino-regime-forfettario",
+      ]),
+    );
   });
 });
 

--- a/src/lib/strumenti/tools.ts
+++ b/src/lib/strumenti/tools.ts
@@ -2,6 +2,7 @@ export const toolSlugs = [
   "scorporo-iva",
   "verifica-codice-lotteria",
   "calcolatore-risparmio-rt",
+  "dicitura-regime-forfettario",
 ] as const;
 
 export type ToolSlug = (typeof toolSlugs)[number];
@@ -20,6 +21,8 @@ export interface ToolContent {
   readonly howItWorks: readonly string[];
   readonly faq: readonly ToolFaq[];
   readonly relatedHelp: readonly string[];
+  /** Slug di /guide collegati (cross-link del cluster, es. forfettario). */
+  readonly relatedGuides?: readonly string[];
 }
 
 export const tools: Record<ToolSlug, ToolContent> = {
@@ -140,6 +143,57 @@ export const tools: Record<ToolSlug, ToolContent> = {
       },
     ],
     relatedHelp: ["pos-rt-obbligo", "normativa-pos-2026", "piani-e-prezzi"],
+  },
+  "dicitura-regime-forfettario": {
+    slug: "dicitura-regime-forfettario",
+    title: "Generatore dicitura regime forfettario",
+    metaTitle: "Dicitura regime forfettario: testo esenzione IVA da copiare",
+    metaDescription:
+      "Genera la dicitura di esenzione IVA del regime forfettario (art. 1 commi 54-89 L. 190/2014) pronta da copiare: fattura vs scontrino, ritenuta d'acconto e bollo.",
+    heroIntro:
+      "La dicitura del regime forfettario è: «Operazione effettuata ai sensi dell'articolo 1, commi da 54 a 89, della Legge n. 190/2014 - Regime forfettario». Va riportata solo sulle fatture: sullo scontrino elettronico non serve, basta la natura IVA N2. Qui sotto generi il testo completo da copiare, con la clausola sulla ritenuta d'acconto e l'avviso marca da bollo.",
+    howItWorks: [
+      "Scegli il documento che devi emettere: fattura oppure scontrino.",
+      "Per la fattura, aggiungi se serve la clausola sulla ritenuta d'acconto (comma 67) e indica l'importo per il controllo della marca da bollo.",
+      "Copia la dicitura con un tocco e incollala nel tuo software di fatturazione.",
+    ],
+    faq: [
+      {
+        question: "Qual è la dicitura per il regime forfettario?",
+        answer:
+          "La formula standard è: \"Operazione effettuata ai sensi dell'articolo 1, commi da 54 a 89, della Legge n. 190/2014 - Regime forfettario\". Se il cliente è un sostituto d'imposta si aggiunge la clausola sulla non applicazione della ritenuta d'acconto ai sensi del comma 67 della stessa legge.",
+      },
+      {
+        question:
+          "Serve la dicitura di esenzione sullo scontrino del forfettario?",
+        answer:
+          "No. Sullo scontrino elettronico (documento commerciale online) non è richiesta alcuna dicitura: è sufficiente che le righe siano emesse con natura IVA N2 (operazioni non soggette). La dicitura è obbligatoria solo sulle fatture.",
+      },
+      {
+        question:
+          "Va bene anche la formula «operazione senza applicazione dell'IVA»?",
+        answer:
+          'Sì. Varianti come "Operazione senza applicazione dell\'IVA ai sensi dell\'art. 1, commi 54-89, della Legge 190/2014" o "Operazione in franchigia da IVA" sono equivalenti: ciò che conta è il richiamo esplicito all\'articolo 1, commi da 54 a 89, della Legge 190/2014, che identifica il regime forfettario.',
+      },
+      {
+        question: "Quando serve la marca da bollo da 2 euro?",
+        answer:
+          "Sulle fatture del forfettario di importo superiore a 77,47 €: essendo operazioni senza IVA, scatta l'imposta di bollo di 2,00 € (DPR 642/1972). Per la fattura elettronica il bollo si assolve in modo virtuale, con versamento trimestrale tramite il servizio dell'Agenzia delle Entrate. Sullo scontrino il bollo non si applica.",
+      },
+      {
+        question:
+          "Cosa significa la clausola sulla ritenuta d'acconto (comma 67)?",
+        answer:
+          "I compensi del forfettario non sono soggetti a ritenuta alla fonte: l'articolo 1, comma 67, della Legge 190/2014 lo stabilisce espressamente. La clausola in fattura serve a informare il committente sostituto d'imposta (es. un'azienda) di non trattenere la ritenuta d'acconto sul pagamento.",
+      },
+      {
+        question: "Il codice natura IVA da usare è N2 o N2.2?",
+        answer:
+          "Dipende dal documento: sulla fattura elettronica il forfettario usa il codice granulare N2.2 (non soggette - altri casi), mentre sullo scontrino elettronico il tracciato prevede solo il codice aggregato N2. Stesso concetto, due tracciati diversi dell'Agenzia delle Entrate.",
+      },
+    ],
+    relatedHelp: ["regime-forfettario", "aliquote-iva", "fatture-e-ricevute"],
+    relatedGuides: ["codici-natura-iva", "scontrino-regime-forfettario"],
   },
 };
 


### PR DESCRIPTION
## Summary

Adds a new free tool `/strumenti/dicitura-regime-forfettario` that generates the mandatory IVA exemption text for the flat-rate regime (art. 1, commi 54-89, L. 190/2014), ready to copy-paste into invoices or receipts. Includes cross-linking with the forfettario/N2.2 cluster guides and expands the guide article infrastructure to support data tables.

## Key Changes

**New Tool Component & Logic**
- `src/components/marketing/tools/dicitura-forfettario-tool.tsx`: Interactive UI for selecting document type (fattura/scontrino), optional withholding tax clause, and invoice amount for stamp duty validation
- `src/lib/strumenti/dicitura-forfettario.ts`: Core generator function with constants for the base text, withholding clause, and stamp duty threshold (€77.47) and amount (€2.00)
- `src/lib/strumenti/dicitura-forfettario.test.ts`: Comprehensive test suite covering all combinations (document type, withholding flag, amount thresholds)

**Guide Infrastructure Enhancement**
- Extended `GuideSection` interface in `src/lib/guide/articles.ts` to support optional `table` field (headers + rows)
- Added `relatedTools` field to `GuideArticle` for cross-linking to `/strumenti` tools
- Updated guide page renderer (`src/app/(marketing)/guide/[slug]/page.tsx`) to render tables with proper accessibility (thead/tbody, scope attributes)
- Expanded `codici-natura-iva` guide with a complete N1-N7 reference table and updated reading time

**Tool Infrastructure**
- Added `relatedGuides` field to `ToolContent` in `src/lib/strumenti/tools.ts` for bidirectional linking
- Registered new tool in `toolSlugs` and `tools` dictionary with full metadata, FAQ, and how-it-works sections
- Updated tool page renderer to display related guides section

**Cross-Linking & Validation**
- Linked `dicitura-regime-forfettario` tool from both `codici-natura-iva` and `scontrino-regime-forfettario` guides
- Added test assertions in `src/lib/guide/articles.test.ts` and `src/lib/strumenti/tools.test.ts` to validate bidirectional references and table structure
- Updated sitemap count and help page reference to the new tool

## Implementation Details

- **Client-side generation**: All text generation happens in the browser; no data is sent to external servers (noted in UI)
- **Copy feedback**: Button shows "Copiato!" for 2 seconds after successful clipboard write, with graceful fallback if clipboard API unavailable
- **Stamp duty logic**: Automatically adds a note when invoice amount exceeds €77.47, citing DPR 642/1972
- **Document-aware**: Scontrino (receipt) path explains that natura N2 is sufficient and no dicitura is required; fattura (invoice) path shows the mandatory text
- **Table rendering**: Accessible HTML table with proper semantic markup (th scope, thead/tbody) and responsive overflow handling

https://claude.ai/code/session_01UctxYLv44XoWZDuzEpqrRm