### PR TITLE
feat(seo): Batch D — guida stampanti termiche WiFi + help numero documento/azzeramento

### DIFF
--- a/docs/seo/content-plan.md
+++ b/docs/seo/content-plan.md
@@ -30,7 +30,7 @@ luglio). Tutto il traffico utile è dall'Italia.
 | POS 2026 (normativa, scadenza aprile, obbligo)                           | ~60     | 3–31   | Forte (pos 8,4); "scadenza collegamento pos aprile 2026" (17 impr) non intercettata esplicitamente              |
 | Scorporo IVA / calcolo da lordo                                          | ~40     | 72–100 | `/strumenti/scorporo-iva` non competitivo (SERP di calcolatori affermati)                                       |
 | Errori di accesso AdE                                                    | 111     | 6,6    | `/help/errori-ade` **CTR 0%** nonostante pos 6,6 → title non matcha l'intent (password scaduta/bloccata)        |
-| Numero azzeramento scontrino                                             | ~10     | 71–81  | Nessuna pagina dedicata                                                                                         |
+| Numero azzeramento scontrino                                             | ~10     | 71–81  | `/help/numero-documento-azzeramento` pubblicata (batch D, 12/07)                                                |
 
 ## Competitor (snapshot luglio 2026)
 
@@ -50,15 +50,6 @@ per-competitor**, resta la landing unica `/confronto` (da aggiornare
 trimestralmente: i pricing cambiano, Scontrina ha promo in corso).
 
 ## Backlog contenuti (1 batch = 1 PR, max 3 contenuti)
-
-### Batch D — P2: gap operativi (visti nei competitor e in GSC)
-
-- [ ] **Guida "Stampanti termiche WiFi per scontrino: guida alla
-      scelta"** (tutti i competitor hanno la pagina stampanti; intent
-      commerciale). Solo hardware generico compatibile, nessuna promessa di
-      feature.
-- [ ] **Help "Numero documento e azzeramento sullo scontrino"** (query a pos
-      71-81 senza pagina; richiede `page.tsx` JSX oltre al registry).
 
 ### Batch E — P3
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -47,6 +47,7 @@ sonar.coverage.exclusions=\
   src/app/(marketing)/help/intestazione-scontrino/page.tsx,\
   src/app/(marketing)/help/stampare-scontrino-termica/page.tsx,\
   src/app/(marketing)/help/registrare-pos-portale-ade/page.tsx,\
+  src/app/(marketing)/help/numero-documento-azzeramento/page.tsx,\
   src/app/(marketing)/termini/page.tsx,\
   src/app/(marketing)/cookie-policy/page.tsx,\
   src/app/(marketing)/cookie-policy/v01/page.tsx,\

--- a/src/app/(marketing)/help/numero-documento-azzeramento/page.tsx
+++ b/src/app/(marketing)/help/numero-documento-azzeramento/page.tsx
@@ -1,0 +1,224 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  JsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
+import { helpArticleMetadata } from "@/lib/help/metadata";
+import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
+
+export const metadata = helpArticleMetadata("numero-documento-azzeramento");
+
+export default function NumeroDocumentoAzzeramentoPage() {
+  return (
+    <section className="px-4 py-16">
+      <JsonLd
+        data={helpArticleBreadcrumb(
+          "numero-documento-azzeramento",
+          "Numero documento e azzeramento sullo scontrino",
+        )}
+      />
+      <HelpArticleJsonLd slug="numero-documento-azzeramento" />
+      <article className="mx-auto max-w-3xl">
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "numero-documento-azzeramento",
+            "Numero documento e azzeramento sullo scontrino",
+          )}
+        />
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Numero documento e azzeramento sullo scontrino: cosa significano
+          </h1>
+          <Badge variant="secondary">Scontrini</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Sullo scontrino di un registratore telematico il numero documento ha
+          un formato come <strong>0051-0023</strong>: la prima parte è il{" "}
+          <strong>numero di azzeramento</strong> (conta le chiusure giornaliere
+          fatte dalla cassa), la seconda è il <strong>progressivo</strong> del
+          documento, che riparte da 1 a ogni chiusura. Sul documento commerciale
+          online il numero è invece un codice unico assegnato dall&apos;Agenzia
+          delle Entrate, e l&apos;azzeramento non esiste.
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          <strong>Ultimo aggiornamento:</strong> luglio 2026
+        </p>
+
+        {/* ─── Dove si trova ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Dove si trova il numero sullo scontrino
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il numero è stampato nella parte bassa dello scontrino, di solito
+          preceduto dalla dicitura <strong>&quot;DOCUMENTO N.&quot;</strong>,
+          vicino a data e ora di emissione. Su uno scontrino emesso da
+          registratore telematico vedrai due blocchi di cifre separati da un
+          trattino (es. <em>0051-0023</em>) e, poco sotto, la matricola
+          dell&apos;apparecchio (es. <em>99MEY012345</em>). Su un documento
+          commerciale online — quello emesso dal portale Fatture e Corrispettivi
+          o da un&apos;app come ScontrinoZero — trovi invece un codice unico del
+          tipo <em>DCW2026/123456</em>, assegnato dall&apos;Agenzia delle
+          Entrate al momento della trasmissione.
+        </p>
+
+        {/* ─── Cosa significa il numero di azzeramento ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Cosa significa il numero di azzeramento
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il numero di azzeramento è il contatore delle{" "}
+          <strong>chiusure giornaliere</strong> effettuate dal registratore
+          telematico dalla sua messa in servizio. Si chiama così perché la
+          chiusura di fine giornata <em>azzera</em> il progressivo dei
+          documenti: il primo scontrino del giorno dopo riparte da 0001. Nel
+          nostro esempio, <em>0051-0023</em> significa &quot;23° documento
+          emesso nella 51ª giornata di lavoro della cassa&quot;. La coppia
+          azzeramento + progressivo, insieme alla matricola
+          dell&apos;apparecchio, identifica quindi in modo univoco ogni singolo
+          scontrino emesso da quel registratore.
+        </p>
+
+        {/* ─── A cosa serve ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          A cosa serve il numero documento
+        </h2>
+        <ul className="text-muted-foreground mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed">
+          <li>
+            <strong>Resi e annulli.</strong> Per annullare uno scontrino o
+            emettere un documento di reso bisogna identificare il documento
+            originale: numero, data e — su un RT — matricola
+            dell&apos;apparecchio. Vedi{" "}
+            <Link
+              href="/help/annullare-scontrino"
+              className="text-primary hover:underline"
+            >
+              Annullare uno scontrino: quando si può e come fare
+            </Link>
+            .
+          </li>
+          <li>
+            <strong>Garanzia e cambio merce.</strong> Il numero permette al
+            negoziante di risalire alla vendita esatta anche a distanza di mesi.
+          </li>
+          <li>
+            <strong>Controlli e contabilità.</strong> Il numero è il riferimento
+            con cui il documento compare nel cassetto fiscale e nei registri dei
+            corrispettivi: se un cliente o il commercialista ti chiede
+            &quot;quale scontrino?&quot;, la risposta è quel numero.
+          </li>
+          <li>
+            <strong>Lotteria degli scontrini.</strong> In caso di vincita, il
+            biglietto virtuale fa riferimento allo specifico documento
+            commerciale trasmesso.
+          </li>
+        </ul>
+
+        {/* ─── Come funziona col DCO ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Come funziona con il documento commerciale online
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Chi emette scontrini con il documento commerciale online non ha un
+          registratore telematico, quindi{" "}
+          <strong>
+            non ha né chiusura giornaliera né numero di azzeramento
+          </strong>
+          : ogni documento viene trasmesso all&apos;AdE nel momento stesso
+          dell&apos;emissione e non c&apos;è alcun contatore da azzerare a fine
+          giornata (per il dettaglio vedi{" "}
+          <Link
+            href="/help/chiusura-giornaliera"
+            className="text-primary hover:underline"
+          >
+            Chiusura giornaliera: è obbligatoria?
+          </Link>
+          ). Il numero documento è il progressivo assegnato direttamente
+          dall&apos;Agenzia delle Entrate alla trasmissione (formato tipo{" "}
+          <em>DCW2026/123456</em>) e in ScontrinoZero lo trovi sul PDF dello
+          scontrino, nella pagina pubblica raggiungibile dal QR code e nello{" "}
+          <Link
+            href="/help/storico-ed-esportazione"
+            className="text-primary hover:underline"
+          >
+            Storico
+          </Link>
+          . Per un reso o un annullo non devi trascrivere nulla: apri lo
+          scontrino dallo Storico e procedi da lì.
+        </p>
+
+        {/* ─── FAQ ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Domande frequenti</h2>
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-sm font-medium">
+              Il numero dello scontrino ricomincia da 1 ogni giorno?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Su un registratore telematico sì: la chiusura giornaliera azzera
+              il progressivo, ed è per questo che serve anche il numero di
+              azzeramento per identificare il documento. Sul documento
+              commerciale online no: il numero assegnato dall&apos;AdE è unico e
+              non si ripete.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Dove trovo il numero di azzeramento sul documento commerciale
+              online?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Non c&apos;è, ed è normale: l&apos;azzeramento è un concetto del
+              registratore telematico. Se un modulo o un gestionale te lo chiede
+              per uno scontrino emesso come documento commerciale online, indica
+              il numero documento completo assegnato dall&apos;AdE.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Mi serve il numero dello scontrino per fare un reso a un cliente?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              È il modo più rapido per identificare la vendita originale. In
+              ScontrinoZero però non devi cercarlo a mano: trovi lo scontrino
+              nello Storico (per data, importo o numero) e da lì avvii
+              l&apos;annullo del documento.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              Numero documento e matricola del registratore sono la stessa cosa?
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              No. La matricola (es. <em>99MEY012345</em>) identifica
+              l&apos;apparecchio e resta uguale su tutti gli scontrini di quella
+              cassa; il numero documento identifica la singola operazione e
+              cambia a ogni scontrino.
+            </p>
+          </div>
+        </div>
+
+        <RelatedHelpArticles slug="numero-documento-azzeramento" />
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -151,6 +151,10 @@ const helpCategories: HelpCategory[] = [
         title: "Come stampare lo scontrino su carta termica",
         href: "/help/stampare-scontrino-termica",
       },
+      {
+        title: "Numero documento e azzeramento sullo scontrino",
+        href: "/help/numero-documento-azzeramento",
+      },
     ],
   },
   {

--- a/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
+++ b/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
@@ -112,6 +112,18 @@ export default function StampareScontrinoTermicaPage() {
           stampante che &quot;funziona e basta&quot;. Qualsiasi alternativa con
           caratteristiche simili (ESC/POS, Bluetooth, 58 o 80 mm) andrà bene.
         </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Per un confronto approfondito tra i tipi di connessione (WiFi,
+          Bluetooth, USB), le fasce di prezzo e i criteri di acquisto vedi la
+          guida{" "}
+          <Link
+            href="/guide/stampante-termica-wifi-scontrini"
+            className="text-primary hover:underline"
+          >
+            Stampanti termiche WiFi per scontrini: guida alla scelta
+          </Link>
+          .
+        </p>
 
         {/* ─── Pairing Android ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(67);
+    expect(result).toHaveLength(69);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -113,6 +113,7 @@ describe("sitemap", () => {
       "https://scontrinozero.it/guide/lotteria-scontrini-commerciante",
       "https://scontrinozero.it/guide/scegliere-software-scontrini-elettronici",
       "https://scontrinozero.it/guide/codici-natura-iva",
+      "https://scontrinozero.it/guide/stampante-termica-wifi-scontrini",
     ];
     for (const url of expectedGuideUrls) {
       expect(allUrls).toContain(url);
@@ -124,39 +125,39 @@ describe("sitemap", () => {
     }
 
     // Legal
-    expect(result[34]).toMatchObject({
+    expect(result[35]).toMatchObject({
       url: "https://scontrinozero.it/privacy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[35]).toMatchObject({
+    expect(result[36]).toMatchObject({
       url: "https://scontrinozero.it/privacy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[36]).toMatchObject({
+    expect(result[37]).toMatchObject({
       url: "https://scontrinozero.it/termini",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[37]).toMatchObject({
+    expect(result[38]).toMatchObject({
       url: "https://scontrinozero.it/termini/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[38]).toMatchObject({
+    expect(result[39]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy",
       changeFrequency: "yearly",
       priority: 0.3,
     });
-    expect(result[39]).toMatchObject({
+    expect(result[40]).toMatchObject({
       url: "https://scontrinozero.it/cookie-policy/v01",
       changeFrequency: "yearly",
       priority: 0.3,
     });
 
     // Help center hub
-    expect(result[40]).toMatchObject({
+    expect(result[41]).toMatchObject({
       url: "https://scontrinozero.it/help",
       changeFrequency: "monthly",
       priority: 0.6,
@@ -183,12 +184,12 @@ describe("sitemap", () => {
     });
 
     // Auth pages (last two)
-    expect(result[65]).toMatchObject({
+    expect(result[67]).toMatchObject({
       url: "https://scontrinozero.it/login",
       changeFrequency: "yearly",
       priority: 0.5,
     });
-    expect(result[66]).toMatchObject({
+    expect(result[68]).toMatchObject({
       url: "https://scontrinozero.it/register",
       changeFrequency: "yearly",
       priority: 0.5,
@@ -216,8 +217,8 @@ describe("sitemap", () => {
     expect(result[23].url).toBe(
       "https://test.scontrinozero.it/guide/documento-commerciale-online",
     );
-    expect(result[34].url).toBe("https://test.scontrinozero.it/privacy");
-    expect(result[40].url).toBe("https://test.scontrinozero.it/help");
+    expect(result[35].url).toBe("https://test.scontrinozero.it/privacy");
+    expect(result[41].url).toBe("https://test.scontrinozero.it/help");
 
     vi.unstubAllEnvs();
   });

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { getGuide, guideArticles, guideSlugs, isGuideSlug } from "./articles";
 
 describe("guideSlugs", () => {
-  it("contains exactly 11 slugs", () => {
-    expect(guideSlugs).toHaveLength(11);
+  it("contains exactly 12 slugs", () => {
+    expect(guideSlugs).toHaveLength(12);
   });
 
   it("contains the expected slugs", () => {
@@ -20,6 +20,7 @@ describe("guideSlugs", () => {
         "lotteria-scontrini-commerciante",
         "scegliere-software-scontrini-elettronici",
         "codici-natura-iva",
+        "stampante-termica-wifi-scontrini",
       ]),
     );
   });
@@ -183,6 +184,60 @@ describe("scontrino-senza-registratore-di-cassa (cluster transazionale)", () => 
     expect(
       questions.some((q) => q.includes("costa") || q.includes("costo")),
     ).toBe(true);
+  });
+});
+
+describe("stampante-termica-wifi-scontrini (batch D — gap stampanti)", () => {
+  const article = guideArticles["stampante-termica-wifi-scontrini"];
+
+  it("opens with a direct answer (risposta secca GEO): no hardware fiscale", () => {
+    expect(article.heroIntro.toLowerCase()).toContain("non serve");
+  });
+
+  it("has a connection comparison table covering WiFi, Bluetooth and USB", () => {
+    const tableSection = article.sections.find((s) => s.table !== undefined);
+    expect(tableSection).toBeDefined();
+    const firstColumn = tableSection!.table!.rows.map((row) =>
+      row[0].toLowerCase(),
+    );
+    expect(firstColumn.some((c) => c.includes("wifi"))).toBe(true);
+    expect(firstColumn.some((c) => c.includes("bluetooth"))).toBe(true);
+    expect(firstColumn.some((c) => c.includes("usb"))).toBe(true);
+  });
+
+  it("has dedicated sections for paper width (58/80 mm) and ESC/POS", () => {
+    const headings = article.sections.map((s) => s.heading.toLowerCase());
+    expect(headings.some((h) => h.includes("58") && h.includes("80"))).toBe(
+      true,
+    );
+    expect(headings.some((h) => h.includes("esc/pos"))).toBe(true);
+  });
+
+  it("never promises native WiFi printing from the app (regola 8)", () => {
+    const allText = [
+      article.heroIntro,
+      ...article.sections.map((s) => s.body),
+      ...article.faq.map((f) => f.answer),
+    ]
+      .join(" ")
+      .toLowerCase();
+    // Il percorso WiFi passa dal dialogo di stampa del sistema/browser, mai
+    // da un collegamento diretto app→stampante WiFi.
+    expect(allText).not.toMatch(/app si (collega|connette) (alla|in) wifi/);
+  });
+
+  it("has FAQ covering the smartphone and fiscal-printer intents", () => {
+    const questions = article.faq.map((f) => f.question.toLowerCase());
+    expect(questions.some((q) => q.includes("smartphone"))).toBe(true);
+    expect(
+      questions.some(
+        (q) => q.includes("fiscale") || q.includes("agenzia delle entrate"),
+      ),
+    ).toBe(true);
+  });
+
+  it("links the operational help article on thermal printing", () => {
+    expect(article.relatedHelp).toContain("stampare-scontrino-termica");
   });
 });
 

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -10,6 +10,7 @@ export const guideSlugs = [
   "lotteria-scontrini-commerciante",
   "scegliere-software-scontrini-elettronici",
   "codici-natura-iva",
+  "stampante-termica-wifi-scontrini",
 ] as const;
 
 export type GuideSlug = (typeof guideSlugs)[number];
@@ -538,6 +539,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     ],
     relatedHelp: [
       "chiusura-giornaliera",
+      "numero-documento-azzeramento",
       "storico-ed-esportazione",
       "cassetto-fiscale",
     ],
@@ -602,7 +604,12 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
           "Non esiste un limite numerico esplicito, ma l'AdE può monitorare pattern anomali (es. tasso annullamento molto sopra la media di settore) come possibile indicatore di evasione. Annulla solo quando necessario e per cause documentabili; per resi a distanza usa sempre la modalità reso (DCO negativo).",
       },
     ],
-    relatedHelp: ["annullare-scontrino", "errori-ade", "primo-scontrino"],
+    relatedHelp: [
+      "annullare-scontrino",
+      "numero-documento-azzeramento",
+      "errori-ade",
+      "primo-scontrino",
+    ],
     relatedGuides: [
       "documento-commerciale-online",
       "differenza-scontrino-ricevuta-fattura",
@@ -879,6 +886,104 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "differenza-scontrino-ricevuta-fattura",
     ],
     relatedTools: ["dicitura-regime-forfettario"],
+  },
+
+  "stampante-termica-wifi-scontrini": {
+    slug: "stampante-termica-wifi-scontrini",
+    title: "Stampanti termiche WiFi per scontrini: guida alla scelta",
+    metaTitle: "Stampante termica WiFi per scontrini: guida alla scelta 2026",
+    metaDescription:
+      "Stampante termica WiFi, Bluetooth o USB per gli scontrini? Differenze, fasce di prezzo, larghezza carta 58 o 80 mm e compatibilità ESC/POS: la guida alla scelta.",
+    heroIntro:
+      "Per stampare gli scontrini non serve una stampante fiscale: basta una stampante termica generica, da 30-120 € a seconda del modello. La WiFi conviene per la postazione fissa condivisa tra più dispositivi, il Bluetooth per la cassa mobile, l'USB per chi lavora da computer. Prima di comprare verifica tre cose: linguaggio ESC/POS, larghezza carta (58 o 80 mm) e il tipo di connessione adatto a come lavori.",
+    publishedAt: "2026-07-12",
+    updatedAt: "2026-07",
+    readingMinutes: 7,
+    sections: [
+      {
+        heading: "Serve una stampante fiscale? No",
+        body: "Con il documento commerciale online lo scontrino ha già valore fiscale nel momento in cui viene trasmesso all'Agenzia delle Entrate: la stampa su carta è solo una copia di cortesia per il cliente, nemmeno obbligatoria (puoi mostrare lo scontrino a schermo o inviarlo via email). Per questo non serve un registratore telematico omologato (400-800 € di hardware più 100-200 € l'anno di manutenzione), né va dichiarato nulla all'AdE: una qualsiasi stampante termica generica, la stessa usata per le ricevute dei POS bancari, fa il lavoro. È la differenza di costo più grande rispetto alla cassa tradizionale.",
+      },
+      {
+        heading: "WiFi, Bluetooth o USB: il confronto",
+        body: "Le stampanti termiche per scontrini si collegano in tre modi, e la connessione è il primo criterio di scelta perché dipende da come lavori: banco fisso con più dispositivi, cassa mobile dal telefono o postazione singola con computer. Molti modelli combinano due o tre connessioni (es. WiFi + USB, Bluetooth + USB): a parità di prezzo, un modello multi-connessione ti lascia libero di cambiare organizzazione in futuro.",
+        table: {
+          headers: ["Connessione", "Ideale per", "Vantaggi", "Limiti"],
+          rows: [
+            [
+              "WiFi / Ethernet",
+              "Banco fisso con più dispositivi o casse",
+              "Copre tutto il locale, condivisibile tra più computer senza abbinamenti, niente cavi al banco",
+              "Richiede una rete stabile e una configurazione iniziale; prezzo un po' più alto; se cade la rete non stampa",
+            ],
+            [
+              "Bluetooth",
+              "Cassa mobile: mercati, food truck, servizio al tavolo",
+              "Si abbina direttamente a telefono o tablet, funziona senza router, modelli portatili a batteria",
+              "Portata ~10 metri, abbinata a un dispositivo per volta",
+            ],
+            [
+              "USB",
+              "Postazione fissa con computer",
+              "Collegamento plug-and-play, stabilità massima, prezzi più bassi",
+              "Vincolata dal cavo a un solo computer",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Quando conviene davvero la WiFi",
+        body: 'La stampante WiFi (o Ethernet, il cavo di rete: stessa logica) dà il meglio quando è una risorsa condivisa: un punto vendita fisso dove più operatori o più postazioni stampano sulla stessa macchina, oppure quando la stampante sta lontana dal banco e il cavo USB non arriva. Essendo collegata alla rete del locale, qualsiasi computer che la vede installata può stamparci, senza abbinamenti dispositivo per dispositivo. Non conviene invece per l\'attività ambulante o stagionale senza un router a disposizione: lì il Bluetooth, che collega telefono e stampante direttamente senza alcuna rete di mezzo, è la scelta giusta. Attenzione infine alle schede prodotto: alcune stampanti economiche vendute come "wireless" sono in realtà solo Bluetooth — se ti serve la rete, cerca esplicitamente "WiFi" o "LAN/Ethernet" tra le specifiche.',
+      },
+      {
+        heading: "58 o 80 mm: quale larghezza carta",
+        body: "Le due larghezze standard dei rotoli termici sono 58 mm e 80 mm. Il 58 mm è il formato delle mini-stampanti portatili e delle postazioni compatte: ingombro minimo, rotoli economici, perfetto in mobilità. L'80 mm è il classico formato da banco dei negozi: scontrino più largo e più leggibile, meglio se stampi molte righe. Entrambi i formati si trovano facilmente online e in cartoleria; la larghezza scelta va poi impostata uguale nel software di cassa, altrimenti il testo va a capo male o viene tagliato. Se sei indeciso e lavori da banco, l'80 mm è la scelta più comoda; in mobilità vince il 58 mm.",
+      },
+      {
+        heading: "ESC/POS: il requisito che non può mancare",
+        body: 'ESC/POS è il linguaggio standard di fatto delle stampanti termiche, sviluppato in origine da Epson e supportato dalla quasi totalità dei modelli in commercio. È quello che permette a un software di cassa qualsiasi di pilotare la stampante senza driver proprietari. Nella scheda prodotto cerca la dicitura "ESC/POS compatible": i marchi più diffusi che lo supportano sono Epson, Xprinter, Munbyn, Sunmi e Gprinter. Se la compatibilità ESC/POS non è dichiarata da nessuna parte, lascia perdere il modello — il risparmio di pochi euro non vale il rischio di una stampante che il tuo software non riconosce.',
+      },
+      {
+        heading: "Quanto costa: fasce di prezzo",
+        body: "Le portatili Bluetooth da 58 mm partono da 30-60 €. Le stampanti da banco da 80 mm con WiFi o Ethernet stanno tra 60 e 120 €. I marchi premium (Epson TM, Star Micronics) arrivano a 150-250 €, con affidabilità da uso intensivo ma nessuna funzione indispensabile in più per una micro-attività. A questi prezzi va aggiunto solo il consumabile: un rotolo termico costa 0,50-1 € e non esistono cartucce o toner, perché la stampa termica scalda la carta senza inchiostro. In totale, l'intero \"reparto stampa\" di un'attività che emette scontrini da software costa meno di un solo anno di manutenzione di un registratore telematico.",
+      },
+      {
+        heading: "Come si usa con ScontrinoZero",
+        body: "ScontrinoZero emette lo scontrino in digitale e la stampa è un passaggio opzionale. Da telefono o tablet il percorso supportato è il Bluetooth: abbini la stampante nelle impostazioni e stampi al volo, ovunque tu sia. Da computer la stampa passa dal normale dialogo di stampa del browser: funziona qualsiasi stampante installata nel sistema operativo, comprese le termiche WiFi ed Ethernet condivise in rete e i modelli USB collegati direttamente. La procedura passo-passo di abbinamento e la risoluzione dei problemi più comuni (rotolo al contrario, larghezza carta sbagliata, standby) sono nell'articolo operativo del centro assistenza, linkato in fondo.",
+      },
+    ],
+    faq: [
+      {
+        question: "Le stampanti termiche WiFi funzionano con lo smartphone?",
+        answer:
+          "In genere no, e questo è il limite principale da conoscere: le termiche WiFi economiche non supportano AirPrint (iPhone) né Mopria (Android), i sistemi di stampa nativi dei telefoni. Da smartphone la strada affidabile è il Bluetooth; la WiFi dà il meglio da computer o su postazioni fisse condivise.",
+      },
+      {
+        question:
+          "Devo comprare una stampante omologata o dichiararla all'Agenzia delle Entrate?",
+        answer:
+          "No. La stampante termica è una normale periferica, non un registratore telematico né un misuratore fiscale: il valore fiscale sta nel documento commerciale trasmesso all'AdE, non nella carta. Nessuna omologazione, nessun censimento, nessuna verifica periodica.",
+      },
+      {
+        question: "Posso usare una sola stampante WiFi con più casse?",
+        answer:
+          "Sì, è proprio il suo vantaggio: essendo collegata alla rete del locale e non a un singolo dispositivo, ogni computer che la installa può stamparci. Con il Bluetooth invece la stampante resta abbinata a un dispositivo per volta.",
+      },
+      {
+        question: "Che carta serve e come si conserva?",
+        answer:
+          "Rotoli termici da 58 o 80 mm, a seconda della stampante. Non c'è inchiostro: la carta annerisce col calore, quindi i rotoli (e gli scontrini stampati) vanno tenuti lontani da sole e fonti di calore, altrimenti sbiadiscono. Un rotolo costa 0,50-1 €.",
+      },
+    ],
+    relatedHelp: [
+      "stampare-scontrino-termica",
+      "installare-app",
+      "primo-scontrino",
+    ],
+    relatedGuides: [
+      "scontrino-senza-registratore-di-cassa",
+      "scegliere-software-scontrini-elettronici",
+    ],
   },
 };
 

--- a/src/lib/help/articles.test.ts
+++ b/src/lib/help/articles.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./articles";
 
 describe("helpArticles registry", () => {
-  it("contains at least 21 entries", () => {
-    expect(Object.keys(helpArticles).length).toBeGreaterThanOrEqual(21);
+  it("contains at least 22 entries", () => {
+    expect(Object.keys(helpArticles).length).toBeGreaterThanOrEqual(22);
   });
 
   it("each entry's key matches its slug", () => {
@@ -74,6 +74,29 @@ describe("helpArticles registry", () => {
       const unique = new Set(article.related);
       expect(unique.size).toBe(article.related.length);
     }
+  });
+});
+
+describe("numero-documento-azzeramento (batch D — query GSC senza pagina)", () => {
+  const article = helpArticles["numero-documento-azzeramento"];
+
+  it("exists in the registry", () => {
+    expect(article).toBeDefined();
+  });
+
+  it("targets the 'numero azzeramento' query in the metaTitle", () => {
+    expect(article.metaTitle.toLowerCase()).toContain("azzeramento");
+  });
+
+  it("mentions the documento commerciale online angle in the description", () => {
+    expect(article.description.toLowerCase()).toContain(
+      "documento commerciale online",
+    );
+  });
+
+  it("links the daily-closure and void cluster", () => {
+    expect(article.related).toContain("chiusura-giornaliera");
+    expect(article.related).toContain("annullare-scontrino");
   });
 });
 

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -16,7 +16,7 @@ export interface HelpArticle {
  * di revisione come `datePublished`/`dateModified` dello structured data Article.
  * Aggiornarla quando si fa una revisione complessiva dei contenuti help.
  */
-export const HELP_REVIEWED_DATE = "2026-06-15";
+export const HELP_REVIEWED_DATE = "2026-07-12";
 
 export const helpArticles: Record<string, HelpArticle> = {
   "aliquote-iva": {
@@ -35,8 +35,8 @@ export const helpArticles: Record<string, HelpArticle> = {
       "Entro quanto tempo si può annullare uno scontrino elettronico e come farlo da ScontrinoZero: la procedura, cosa succede sul portale AdE e quando emettere un reso invece dell'annullo.",
     related: [
       "primo-scontrino",
+      "numero-documento-azzeramento",
       "storico-ed-esportazione",
-      "come-collegare-ade",
     ],
   },
   api: {
@@ -142,6 +142,18 @@ export const helpArticles: Record<string, HelpArticle> = {
     description:
       "Normativa POS 2026 (Legge 207/2024): chi deve collegare POS e cassa, la scadenza del 20 aprile 2026 per la prima comunicazione, le sanzioni e come metterti in regola col Documento Commerciale Online.",
     related: ["pos-rt-obbligo", "chiusura-giornaliera", "regime-forfettario"],
+  },
+  "numero-documento-azzeramento": {
+    slug: "numero-documento-azzeramento",
+    title: "Numero documento e azzeramento sullo scontrino",
+    metaTitle: "Numero azzeramento e numero documento scontrino: cosa sono",
+    description:
+      "Cosa significano il numero documento e il numero di azzeramento stampati sullo scontrino (formato 0051-0023), dove trovarli e come cambia la numerazione con il documento commerciale online.",
+    related: [
+      "chiusura-giornaliera",
+      "annullare-scontrino",
+      "storico-ed-esportazione",
+    ],
   },
   "piani-e-prezzi": {
     slug: "piani-e-prezzi",


### PR DESCRIPTION
## Cosa

Batch D del piano contenuti SEO (`docs/seo/content-plan.md`): i due gap operativi visti nei competitor e in GSC.

### 1. Guida `/guide/stampante-termica-wifi-scontrini`
Buying guide sulla scelta della stampante termica (intent commerciale; tutti i competitor hanno la pagina stampanti):
- confronto **WiFi vs Bluetooth vs USB** con tabella comparativa
- larghezza carta 58/80 mm, requisito **ESC/POS**, fasce di prezzo
- risposta secca GEO in apertura ("non serve una stampante fiscale")
- **nessuna promessa di feature** (regola 8): il percorso WiFi è descritto solo via dialogo di stampa del sistema da computer, esattamente come già documentato nell'help operativo; da mobile il percorso indicato resta il Bluetooth. Un test dedicato blinda l'assenza di claim di collegamento WiFi nativo dall'app.

### 2. Help `/help/numero-documento-azzeramento`
Query GSC "numero azzeramento scontrino" a pos 71-81 senza pagina dedicata (registry + `page.tsx` JSX):
- formato RT `0051-0023` (azzeramento = contatore chiusure giornaliere, progressivo che riparte a ogni chiusura)
- differenza col documento commerciale online: nessun azzeramento, progressivo AdE formato `DCW2026/…` (verificato su `src/lib/ade/mock-client.ts` e `src/lib/pdf/generate-sale-receipt.ts`)
- a cosa serve il numero (resi/annulli, garanzia, cassetto fiscale, lotteria) + 4 FAQ

## Cross-link del cluster (checklist GEO punto 5)

- help `stampare-scontrino-termica` (operativo) ⇄ nuova guida (educativo): slug e metaTitle con intent distinti, si linkano a vicenda
- `relatedHelp` delle guide `chiusura-giornaliera-corrispettivi` e `annullare-scontrino-elettronico` → nuovo help
- `related` dell'help `annullare-scontrino`: `come-collegare-ade` (poco pertinente) sostituito dal nuovo help
- hub `/help` aggiornato (categoria "Emissione e gestione scontrini"); sitemap e llms.txt derivano dai registry, nessun intervento manuale

## Altro

- `HELP_REVIEWED_DATE` → `2026-07-12` (allineato all'"Ultimo aggiornamento: luglio 2026" del nuovo articolo)
- Batch D rimosso dal backlog del piano; riga GSC "numero azzeramento" marcata come pubblicata
- Sonar: coverage exclusion per la nuova pagina help (pattern delle altre pagine help)

## Test (TDD)

- `guide/articles.test.ts`: 11→12 slug + describe dedicato (tabella WiFi/BT/USB, sezioni 58-80 mm e ESC/POS, FAQ smartphone/fiscale, no claim WiFi nativo)
- `help/articles.test.ts`: ≥22 entries + describe dedicato (metaTitle con "azzeramento", cluster related)
- `sitemap.test.ts`: 67→69 entry, indici posizionali aggiornati
- Suite completa verde (225 file), type-check ok, lint ok, prettier ok, `arch:check` ok, `next build` genera entrambe le route SSG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtHX4LyMGkZVBHfoR461j2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtHX4LyMGkZVBHfoR461j2)_