### PR TITLE
Screenshot dell'app nella home e nel Centro assistenza

### DIFF
--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("aliquote-iva");
 
@@ -47,6 +48,19 @@ export default function AliquoteIvaPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/cassa-tastierino.png"
+            alt="Schermata Cassa di ScontrinoZero con il menu a tendina per scegliere l'aliquota IVA della riga"
+            width={900}
+            height={1944}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            In Cassa scegli l&apos;aliquota IVA della riga dal menu a tendina.
+          </figcaption>
+        </figure>
 
         {/* ─── Aliquote IVA in Italia ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("annullare-scontrino");
 
@@ -143,6 +144,19 @@ export default function AnnullareScontrinoPage() {
             scontrino originale passa a stato <strong>Annullato</strong>.
           </li>
         </ol>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/storico-dettaglio.png"
+            alt="Finestra di dettaglio di uno scontrino Emesso con il pulsante Annulla scontrino in rosso"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Dal dettaglio dello scontrino tocca «Annulla scontrino».
+          </figcaption>
+        </figure>
 
         {/* ─── Cosa succede dopo ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("cambio-piano");
 
@@ -46,6 +47,19 @@ export default function CambioPianoPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-piano.png"
+            alt="Schermata Piano e Abbonamento con il selettore mensile/annuale e i piani"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Da «Piano e Abbonamento» scegli mensile o annuale e cambia piano.
+          </figcaption>
+        </figure>
 
         {/* ─── Istruzioni ─── */}
         <h2 className="mt-10 text-xl font-semibold">Istruzioni passo-passo</h2>

--- a/src/app/(marketing)/help/come-collegare-ade/page.tsx
+++ b/src/app/(marketing)/help/come-collegare-ade/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("come-collegare-ade");
 
@@ -46,6 +47,20 @@ export default function ComeCollegareAde() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-attivita.png"
+            alt="Schermata Impostazioni con la sezione Credenziali AdE e il pulsante Verifica connessione"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Impostazioni → Credenziali AdE: collega le credenziali e verifica la
+            connessione.
+          </figcaption>
+        </figure>
 
         {/* ─── Chi può usare Fisconline ─── */}
         <div className="bg-muted/50 mt-6 rounded-md p-4 text-sm">

--- a/src/app/(marketing)/help/contatto-assistenza/page.tsx
+++ b/src/app/(marketing)/help/contatto-assistenza/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("contatto-assistenza");
 
@@ -46,6 +47,19 @@ export default function ContattoAssistenzaPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> maggio 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-preferenze.png"
+            alt="Schermata Impostazioni con la sezione Assistenza: Centro assistenza e Scrivici via email"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Impostazioni → Assistenza: Centro assistenza e contatto via email.
+          </figcaption>
+        </figure>
 
         {/* ─── Email ─── */}
         <h2 className="mt-10 text-xl font-semibold">Contatto via email</h2>

--- a/src/app/(marketing)/help/credenziali-fisconline/page.tsx
+++ b/src/app/(marketing)/help/credenziali-fisconline/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("credenziali-fisconline");
 
@@ -45,6 +46,20 @@ export default function CredenzialiPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-attivita.png"
+            alt="Schermata Impostazioni con lo stato delle credenziali AdE"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            In Impostazioni inserisci le credenziali Fisconline e ne controlli
+            lo stato.
+          </figcaption>
+        </figure>
 
         {/* ─── Cos'è Fisconline ─── */}
         <h2 className="mt-10 text-xl font-semibold">Cos&apos;è Fisconline?</h2>

--- a/src/app/(marketing)/help/errori-ade/page.tsx
+++ b/src/app/(marketing)/help/errori-ade/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("errori-ade");
 
@@ -46,6 +47,19 @@ export default function ErroriAdePage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-attivita.png"
+            alt="Schermata Impostazioni con il pulsante Verifica connessione delle credenziali AdE"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Premi «Verifica connessione» per controllare le credenziali AdE.
+          </figcaption>
+        </figure>
 
         {/* ─── Errore 1 ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/intestazione-scontrino/page.tsx
+++ b/src/app/(marketing)/help/intestazione-scontrino/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("intestazione-scontrino");
 
@@ -47,6 +48,20 @@ export default function IntestazioneScontrinoPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/documento-commerciale.png"
+            alt="Documento commerciale con l'intestazione: nome dell'attività, indirizzo e partita IVA"
+            width={661}
+            height={1188}
+            sizes="(min-width: 768px) 320px, 80vw"
+            className="mx-auto max-w-[320px] rounded-xl"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            L&apos;intestazione del documento commerciale: nome attività,
+            indirizzo e P.IVA.
+          </figcaption>
+        </figure>
 
         {/* ─── Cosa è modificabile ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/numero-documento-azzeramento/page.tsx
+++ b/src/app/(marketing)/help/numero-documento-azzeramento/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("numero-documento-azzeramento");
 
@@ -49,6 +50,20 @@ export default function NumeroDocumentoAzzeramentoPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> luglio 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/documento-commerciale.png"
+            alt="Documento commerciale con l'identificativo AdE e i dati dello scontrino"
+            width={661}
+            height={1188}
+            sizes="(min-width: 768px) 320px, 80vw"
+            className="mx-auto max-w-[320px] rounded-xl"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Sul documento compaiono l&apos;identificativo AdE e i dati dello
+            scontrino.
+          </figcaption>
+        </figure>
 
         {/* ─── Dove si trova ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("piani-e-prezzi");
 
@@ -39,6 +40,19 @@ export default function PianiEPrezziPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> maggio 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-piano.png"
+            alt="Schermata Impostazioni con i piani Starter e Pro e i relativi prezzi"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Impostazioni → Piano e Abbonamento: confronta Starter e Pro.
+          </figcaption>
+        </figure>
 
         {/* ─── Panoramica piani ─── */}
         <h2 className="mt-10 text-xl font-semibold">Panoramica dei piani</h2>

--- a/src/app/(marketing)/help/presenta-un-amico/page.tsx
+++ b/src/app/(marketing)/help/presenta-un-amico/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("presenta-un-amico");
 
@@ -44,6 +45,19 @@ export default function PresentaUnAmicoPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> giugno 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-piano.png"
+            alt="Schermata Impostazioni con la sezione Referral e il codice invito"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Il tuo codice referral nella sezione Piano e Abbonamento.
+          </figcaption>
+        </figure>
 
         {/* ─── Come funziona in breve ─── */}
         <h2 className="mt-10 text-xl font-semibold">Come funziona in breve</h2>

--- a/src/app/(marketing)/help/prima-configurazione/page.tsx
+++ b/src/app/(marketing)/help/prima-configurazione/page.tsx
@@ -10,6 +10,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("prima-configurazione");
 
@@ -46,6 +47,20 @@ export default function PrimaConfigurazioneePage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-attivita.png"
+            alt="Schermata Impostazioni con i dati dell'attività e le credenziali AdE"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Impostazioni: dati dell&apos;attività e collegamento
+            all&apos;Agenzia delle Entrate.
+          </figcaption>
+        </figure>
 
         {/* ─── Cosa ti serve ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/primo-scontrino/page.tsx
+++ b/src/app/(marketing)/help/primo-scontrino/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("primo-scontrino");
 
@@ -111,6 +112,19 @@ export default function PrimoScontrinoPage() {
           disponibili sono 4%, 5%, 10%, 22% e sei codici natura a 0% (N1–N6) per
           le operazioni non imponibili, esenti o escluse.
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/cassa-tastierino.png"
+            alt="Schermata Cassa di ScontrinoZero: tastierino numerico per inserire l'importo, con quantità e aliquota IVA"
+            width={900}
+            height={1944}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Aggiungi una riga: importo dal tastierino, quantità e aliquota IVA.
+          </figcaption>
+        </figure>
 
         <h2 className="mt-10 text-xl font-semibold">
           Passaggio 3 — Conferma il carrello e scegli il pagamento
@@ -136,6 +150,19 @@ export default function PrimoScontrinoPage() {
           <strong>Codice lotteria</strong> (8 caratteri, scontrini da almeno €1)
           per far partecipare il cliente alla Lotteria degli Scontrini.
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/riepilogo-pagamento.png"
+            alt="Schermata di riepilogo scontrino con le righe, il totale, la scelta del metodo di pagamento e il campo codice lotteria"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Il riepilogo con totale, metodo di pagamento e codice lotteria.
+          </figcaption>
+        </figure>
 
         <h2 className="mt-10 text-xl font-semibold">
           Passaggio 4 — Emetti lo scontrino
@@ -163,6 +190,19 @@ export default function PrimoScontrinoPage() {
             scontrino.
           </li>
         </ol>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/scontrino-emesso.png"
+            alt="Schermata di conferma con lo scontrino emesso e l'identificativo dell'Agenzia delle Entrate"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Emesso: identificativo AdE, invio ricevuta e QR code.
+          </figcaption>
+        </figure>
 
         <h2 className="mt-10 text-xl font-semibold">
           Passaggio 5 — Condividi lo scontrino col cliente

--- a/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
+++ b/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("sicurezza-credenziali");
 
@@ -45,6 +46,19 @@ export default function SicurezzaCredenzialiPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/impostazioni-attivita.png"
+            alt="Schermata Impostazioni con la sezione delle credenziali AdE"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Le credenziali AdE si gestiscono dalle Impostazioni.
+          </figcaption>
+        </figure>
 
         {/* ─── Perché servono ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
+++ b/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("stampare-scontrino-termica");
 
@@ -49,6 +50,19 @@ export default function StampareScontrinoTermicaPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           <strong>Ultimo aggiornamento:</strong> aprile 2026
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/documento-commerciale.png"
+            alt="Ricevuta pubblica dello scontrino con il pulsante Scarica PDF"
+            width={661}
+            height={1188}
+            sizes="(min-width: 768px) 320px, 80vw"
+            className="mx-auto max-w-[320px] rounded-xl"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Dalla ricevuta pubblica puoi scaricare il PDF e stamparlo.
+          </figcaption>
+        </figure>
 
         {/* ─── Cos'è una stampante termica ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("storico-ed-esportazione");
 
@@ -82,6 +83,20 @@ export default function StoricoEdEsportazionePage() {
           </Link>
           {"."}
         </p>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/storico-lista.png"
+            alt="Schermata Storico di ScontrinoZero con la lista degli scontrini, i filtri per periodo e stato e il pulsante Esporta CSV"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Lo Storico con i filtri per periodo e stato e l&apos;export CSV
+            (piano Pro).
+          </figcaption>
+        </figure>
 
         {/* ─── Filtri disponibili ─── */}
         <h2 className="mt-10 text-xl font-semibold">Filtri disponibili</h2>
@@ -151,6 +166,19 @@ export default function StoricoEdEsportazionePage() {
             documento di annullo.
           </li>
         </ul>
+        <figure className="mt-6">
+          <AppScreenshot
+            src="/screenshots/storico-dettaglio.png"
+            alt="Finestra di dettaglio di uno scontrino con le righe, il totale e i pulsanti Mostra QR code, Invia ricevuta e Annulla scontrino"
+            width={900}
+            height={1860}
+            sizes="(min-width: 768px) 240px, 65vw"
+            className="mx-auto max-w-[240px]"
+          />
+          <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+            Il dettaglio scontrino: QR code, invio ricevuta e annullo.
+          </figcaption>
+        </figure>
 
         {/* ─── Export CSV (Piano Pro) ─── */}
         <h2 className="mt-10 text-xl font-semibold">


### PR DESCRIPTION
## Contesto

Le pagine marketing non contenevano nessuno screenshot di prodotto (solo il logo). Questa PR introduce una libreria di screenshot dell'app (iPhone con sfondo verde rimosso → PNG trasparenti) e la usa per rendere più gradevoli la home e per illustrare le guide del Centro assistenza.

## Cosa cambia

**Asset + componente** (già su `main` dalla #726)
- `public/screenshots/` — 12 screenshot con sfondo rimosso (flood-fill dai bordi, ombra e teal UI preservati).
- `AppScreenshot` (`src/components/marketing/app-screenshot.tsx`) — wrapper `next/image` con `drop-shadow` che segue la sagoma, ok in light/dark.

**Home** (`src/app/(marketing)/page.tsx`)
- **Hero**: da colonna singola a grid 2 colonne con showcase a 3 device (scontrino emesso in primo piano, tastierino cassa e analytics angolati dietro; sul mobile solo il device principale).
- **Come funziona**: uno screenshot per passo (credenziali AdE · cassa · scontrino emesso), allineati in basso.
- **Funzionalità**: showcase a 3 righe a layout alternato (catalogo · storico con export CSV Pro · analytics); rimossa la card ridondante "Sai sempre quanto hai incassato".

**Centro assistenza** (`src/app/(marketing)/help/*`)
- Screenshot inline (pattern `<figure>` + didascalia, riusa `AppScreenshot`) in **16 articoli**: `primo-scontrino`, `storico-ed-esportazione`, `annullare-scontrino`, `aliquote-iva`, `come-collegare-ade`, `credenziali-fisconline`, `errori-ade`, `prima-configurazione`, `sicurezza-credenziali`, `intestazione-scontrino`, `numero-documento-azzeramento`, `stampare-scontrino-termica`, `piani-e-prezzi`, `cambio-piano`, `presenta-un-amico`, `contatto-assistenza`.
- Esclusi gli articoli senza uno screenshot fedele (`regime-forfettario`, `fatture-e-ricevute`, `installare-app`, `cassetto-fiscale`, normativa/POS, `api`).

## Conformità

- Copy/didascalie conformi alla skill `marketing-content`: solo feature live, export CSV citato con il gating Pro; nessuna promessa di feature non spedite.
- Nessun nuovo file/schema lato /help (pagine già escluse dalla coverage Sonar); `app-screenshot.tsx` aggiunto a `sonar.coverage.exclusions` come gli altri componenti presentazionali; props `readonly` (S6759).

## Verifica

- `prettier --check`, `type-check`, `lint`, `arch:check` verdi; suite test verde (3575).
- Verifica visiva col dev server: home (hero + come funziona + funzionalità) e pagine /help a 1280px e 390px — layout pulito, nessun overflow orizzontale, ombre ok, light/dark ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaLP9iHuxTZwwEYz7PJqqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaLP9iHuxTZwwEYz7PJqqD)_