### PR TITLE
feat(guide): screenshot inline nelle guide educative

### DIFF
--- a/src/app/(marketing)/guide/[slug]/page.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.tsx
@@ -15,9 +15,11 @@ import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import {
   getGuide,
   guideArticles,
+  guideImageFrame,
   guideSlugs,
   isGuideSlug,
 } from "@/lib/guide/articles";
+import { AppScreenshot } from "@/components/marketing/app-screenshot";
 import { helpArticles } from "@/lib/help/articles";
 import { isToolSlug, tools } from "@/lib/strumenti/tools";
 
@@ -155,6 +157,23 @@ export default async function GuidePage({ params }: PageParams) {
                       </tbody>
                     </table>
                   </div>
+                )}
+                {section.image && (
+                  <figure className="mt-6">
+                    <AppScreenshot
+                      src={section.image.src}
+                      alt={section.image.alt}
+                      width={section.image.width}
+                      height={section.image.height}
+                      sizes={guideImageFrame(section.image.src).sizes}
+                      className={guideImageFrame(section.image.src).className}
+                    />
+                    {section.image.caption && (
+                      <figcaption className="text-muted-foreground mt-2 text-center text-xs">
+                        {section.image.caption}
+                      </figcaption>
+                    )}
+                  </figure>
                 )}
               </div>
             ))}

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { getGuide, guideArticles, guideSlugs, isGuideSlug } from "./articles";
+import {
+  getGuide,
+  guideArticles,
+  guideImageFrame,
+  guideSlugs,
+  isGuideSlug,
+} from "./articles";
 
 describe("guideSlugs", () => {
   it("contains exactly 12 slugs", () => {
@@ -119,6 +125,68 @@ describe("guideArticles dictionary", () => {
           expect(guideSlugs).toContain(guideSlug);
         }
       });
+
+      it("has well-formed inline images when present", () => {
+        for (const section of a.sections) {
+          if (!section.image) continue;
+          const { src, alt, width, height, caption } = section.image;
+          expect(src).toMatch(/^\/screenshots\/[a-z0-9-]+\.png$/);
+          expect(alt.length).toBeGreaterThan(10);
+          expect(Number.isInteger(width)).toBe(true);
+          expect(Number.isInteger(height)).toBe(true);
+          expect(width).toBeGreaterThan(0);
+          expect(height).toBeGreaterThan(0);
+          if (caption !== undefined) {
+            expect(caption.length).toBeGreaterThan(0);
+          }
+        }
+      });
+    });
+  }
+});
+
+describe("guideImageFrame", () => {
+  it("uses the wide document frame for the documento commerciale screenshot", () => {
+    const frame = guideImageFrame("/screenshots/documento-commerciale.png");
+    expect(frame.className).toContain("max-w-[320px]");
+    expect(frame.className).toContain("rounded-xl");
+    expect(frame.sizes).toContain("320px");
+  });
+
+  it("uses the narrow phone-mockup frame for any other screenshot", () => {
+    const frame = guideImageFrame("/screenshots/cassa-tastierino.png");
+    expect(frame.className).toContain("max-w-[240px]");
+    expect(frame.className).not.toContain("rounded-xl");
+    expect(frame.sizes).toContain("240px");
+  });
+});
+
+describe("guide inline screenshots", () => {
+  const cases: ReadonlyArray<{
+    readonly slug: (typeof guideSlugs)[number];
+    readonly src: string;
+  }> = [
+    {
+      slug: "documento-commerciale-online",
+      src: "/screenshots/documento-commerciale.png",
+    },
+    {
+      slug: "scontrino-senza-registratore-di-cassa",
+      src: "/screenshots/cassa-tastierino.png",
+    },
+    {
+      slug: "annullare-scontrino-elettronico",
+      src: "/screenshots/storico-dettaglio.png",
+    },
+  ];
+
+  for (const { slug, src } of cases) {
+    it(`${slug} shows the ${src} screenshot in a section`, () => {
+      const section = guideArticles[slug].sections.find(
+        (s) => s.image?.src === src,
+      );
+      expect(section).toBeDefined();
+      expect(section!.image!.alt.length).toBeGreaterThan(10);
     });
   }
 });

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -21,11 +21,29 @@ export interface GuideTable {
   readonly rows: readonly (readonly string[])[];
 }
 
+/**
+ * Screenshot inline opzionale di una sezione guida: stesso componente
+ * presentazionale del /help (AppScreenshot in un `<figure>`). `width`/`height`
+ * sono le dimensioni intrinseche del PNG in `public/screenshots/`.
+ */
+export interface GuideImage {
+  /** Percorso root-absolute (es. "/screenshots/cassa-tastierino.png"). */
+  readonly src: string;
+  /** Testo alternativo descrittivo (italiano, SEO/accessibilità). */
+  readonly alt: string;
+  readonly width: number;
+  readonly height: number;
+  /** Didascalia opzionale sotto lo screenshot. */
+  readonly caption?: string;
+}
+
 export interface GuideSection {
   readonly heading: string;
   readonly body: string;
   /** Tabella opzionale renderizzata dopo il body (es. codici natura N1-N7). */
   readonly table?: GuideTable;
+  /** Screenshot inline opzionale renderizzato dopo body/tabella. */
+  readonly image?: GuideImage;
 }
 
 export interface GuideFaq {
@@ -78,6 +96,14 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         heading: "Cosa contiene",
         body: "Un DCO riporta obbligatoriamente: ragione sociale e partita IVA dell'esercente, data e ora di emissione, numero progressivo annuale, descrizione dei beni o servizi venduti, prezzo unitario, quantità, aliquota IVA per riga, totale corrispettivo, eventuale codice lotteria del cliente. La trasmissione all'AdE avviene istantaneamente al momento della conferma di emissione.",
+        image: {
+          src: "/screenshots/documento-commerciale.png",
+          alt: "Documento commerciale online con identificativo AdE, dettaglio articoli, aliquote IVA e totale",
+          width: 661,
+          height: 1188,
+          caption:
+            "Sul documento compaiono l'identificativo AdE, gli articoli con le aliquote IVA e il totale.",
+        },
       },
       {
         heading: "Come si emette con ScontrinoZero",
@@ -145,6 +171,14 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         heading: "Procedura con un'app dedicata",
         body: 'App come ScontrinoZero automatizzano la procedura: salvi il catalogo prodotti una volta, e in fase di emissione basta toccare gli articoli, scegliere il pagamento e premere "Emetti". L\'app si occupa di autenticarsi su AdE con le tue credenziali, di trasmettere il documento e di archiviarlo. Tempo medio: 5-10 secondi per scontrino.',
+        image: {
+          src: "/screenshots/cassa-tastierino.png",
+          alt: "Schermata Cassa di ScontrinoZero: tastierino per l'importo, quantità e aliquota IVA della riga",
+          width: 900,
+          height: 1944,
+          caption:
+            "In cassa aggiungi le righe dal tastierino o dal catalogo, poi scegli pagamento ed emetti.",
+        },
       },
       {
         heading: "Quale app scegliere per lo scontrino elettronico",
@@ -576,6 +610,14 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         heading: "Procedura con software dedicato",
         body: "Un software come ScontrinoZero ti permette di annullare uno scontrino direttamente dallo storico: apri la riga del documento e selezioni \"Annulla\". L'app emette per te il DCO di annullamento con i riferimenti corretti, lo trasmette ad AdE e aggiorna lo stato. È un'operazione irreversibile: una volta annullato, lo scontrino non si recupera. Per sicurezza il sistema chiede conferma esplicita.",
+        image: {
+          src: "/screenshots/storico-dettaglio.png",
+          alt: "Dettaglio di uno scontrino nello Storico di ScontrinoZero, con l'azione per annullare il documento",
+          width: 900,
+          height: 1860,
+          caption:
+            "Dal dettaglio dello scontrino nello Storico avvii l'annullamento, con conferma esplicita.",
+        },
       },
       {
         heading: "Conservazione e tracciabilità",
@@ -998,4 +1040,30 @@ export function getGuide(slug: string): GuideArticle {
     throw new Error(`Unknown guide slug: ${slug}`);
   }
   return guideArticles[slug];
+}
+
+/** Screenshot del documento commerciale: è un foglio, non un mockup telefono. */
+const DOCUMENT_SCREENSHOT = "/screenshots/documento-commerciale.png";
+
+/**
+ * Sizing/frame di uno screenshot inline nelle guide. I mockup telefono usano
+ * una cornice stretta (`max-w-[240px]`); il documento commerciale — che è un
+ * foglio con angoli arrotondati — una più larga (`max-w-[320px] rounded-xl`).
+ * Funzione pura → coperta dai test, così la logica non vive solo nella pagina
+ * esclusa dalla coverage.
+ */
+export function guideImageFrame(src: string): {
+  readonly className: string;
+  readonly sizes: string;
+} {
+  if (src === DOCUMENT_SCREENSHOT) {
+    return {
+      className: "mx-auto max-w-[320px] rounded-xl",
+      sizes: "(min-width: 768px) 320px, 80vw",
+    };
+  }
+  return {
+    className: "mx-auto max-w-[240px]",
+    sizes: "(min-width: 768px) 240px, 65vw",
+  };
 }


### PR DESCRIPTION
Porta gli screenshot inline (già live su `/help`, PR #728) anche alle guide educative `/guide`, che finora non supportavano immagini perché sono contenuto strutturato in `src/lib/guide/articles.ts`.

## Cosa cambia

**Schema** — `GuideSection` ora ha un campo `image?: GuideImage` opzionale (`src`, `alt`, `width`, `height`, `caption?`), con la stessa forma degli screenshot `/help`.

**Renderer** — `guide/[slug]/page.tsx` emette, quando la sezione ha un'immagine, un `<figure>` con `<AppScreenshot>` + `<figcaption>`, identico allo stile del Centro assistenza. Il frame è scelto da `guideImageFrame(src)`:
- mockup telefono → `mx-auto max-w-[240px]`
- `documento-commerciale.png` (un foglio, non un telefono) → `mx-auto max-w-[320px] rounded-xl`

`guideImageFrame` è una funzione pura in `articles.ts`, così la logica di rendering vive fuori dalla pagina esclusa dalla coverage ed è coperta dai test (entrambi i rami).

**Guide popolate** — 3 abbinamenti fedeli al contenuto:
| Guida | Sezione | Screenshot |
| --- | --- | --- |
| `documento-commerciale-online` | Cosa contiene | `documento-commerciale.png` |
| `scontrino-senza-registratore-di-cassa` | Procedura con un'app dedicata | `cassa-tastierino.png` |
| `annullare-scontrino-elettronico` | Procedura con software dedicato | `storico-dettaglio.png` |

**Test** — `articles.test.ts`: validazione shape del campo `image` su tutte le guide, i due rami di `guideImageFrame`, e la presenza dello screenshot atteso nelle 3 guide popolate.

## Vincoli rispettati
- Didascalie e alt text limitati a **feature live** (skill `marketing-content`): nessuna promessa di feature non spedite.
- `npm run lint`, `tsc --noEmit`, `prettier --check`, `npm run arch:check` verdi; suite completa **3592 test passati**.
- Verifica visiva col dev server sulle 3 guide: `<figure>`/`<figcaption>` presenti, frame corretti (320px per il documento, 240px per i mockup), immagini ottimizzate servite `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkXxHngGVdJ6rxFVpuKKDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkXxHngGVdJ6rxFVpuKKDH)_