### PR TITLE
Fix #63: Cancel Stripe subscription before account deletion

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -50,48 +50,6 @@ diventa un buco di billing al lancio della Fase B Developer API.
 
 ---
 
-### 63. `deleteAccount` non cancella l'abbonamento Stripe: l'utente cancellato continua a essere addebitato
-
-- **Categoria:** billing/GDPR · **Severità:** High — colpisce **oggi** qualunque abbonato pagante che usa la cancellazione account self-service
-- **File:** `src/server/account-actions.ts:97` (`deleteAccount` → `purgeUserById` senza alcun passo Stripe); `src/lib/services/purge-user.ts` (nessuna gestione di `subscriptions` né chiamate Stripe); `src/db/schema/subscriptions.ts:14` + `supabase/migrations/0000_initial.sql:90-104` (`subscriptions.user_id` senza FK verso `auth.users` e fuori dalla cascata `profiles` → la riga sopravvive orfana); effetto collaterale silenzioso: `src/app/api/stripe/webhook/route.ts:438-441` (`syncSubscriptionData` aggiorna `profiles` del user cancellato → 0 righe, nessun log)
-
-**Problema.** `purgeUserById` cancella auth user + profilo (con cascata su
-businesses/documenti/catalogo), ma: (a) la **subscription Stripe resta attiva**
-— Stripe continua ad addebitare la carta a ogni rinnovo di un utente che non
-può più accedere né all'app né al Billing Portal (il portal richiede login);
-(b) la riga `subscriptions` resta **orfana** nel DB (nessuna FK, nessuna
-cascata), con i webhook che continuano a sincronizzarla; l'UPDATE su
-`profiles` dentro `syncSubscriptionData` matcha 0 righe in silenzio, quindi
-nessun alert segnala l'anomalia; (c) lato GDPR i dati del customer (email)
-restano su Stripe a tempo indeterminato. Lo sweep GDPR
-(`inactive-user-prune.ts`) non è esposto perché protegge i paganti, ma il
-percorso self-service non ha alcuna guardia — né server-side né nella UI
-(`account-delete-section.tsx` non menziona l'abbonamento).
-
-**Fix (non ambiguo).**
-
-1. In `deleteAccount`, dopo la verifica password e **prima** di
-   `purgeUserById`: leggere la riga `subscriptions` per `user.id`; se
-   `stripeCustomerId` è presente → `stripe.customers.del(stripeCustomerId)`
-   in try/catch (regola 10). La delete del customer **cancella immediatamente
-   le subscription attive** e rimuove i dati anagrafici da Stripe (chiude
-   anche il punto GDPR). Su fallimento Stripe → `return { error: "Non è stato
-possibile annullare l'abbonamento. Riprova o gestiscilo dal portale prima
-di eliminare l'account." }` **senza** eseguire il purge — fail-safe: meglio
-   un account non cancellato che addebiti fantasma non più fermabili.
-2. In `purgeUserById` (condiviso col prune): `DELETE FROM subscriptions WHERE
-user_id = $authUserId` accanto alla delete del profilo — niente righe orfane
-   (per lo sweep prune gli account eleggibili non sono paganti, quindi lì la
-   riga è al più `canceled`/`pending`).
-3. UI (`account-delete-section.tsx`): menzionare nel dialog che un eventuale
-   abbonamento attivo viene annullato immediatamente (regola 8: grep copy).
-4. **Test:** account con sub attiva → `customers.del` chiamato prima del purge
-   e riga `subscriptions` rimossa; Stripe irraggiungibile → nessun purge +
-   errore dedicato; account senza riga subscriptions → flusso invariato;
-   sweep prune → riga subscriptions rimossa insieme al profilo.
-
----
-
 ## P2 — Media priorità
 
 ### 11. `getCatalogItems` senza LIMIT + autocomplete server-side

--- a/src/components/settings/account-delete-section.test.tsx
+++ b/src/components/settings/account-delete-section.test.tsx
@@ -73,6 +73,16 @@ describe("AccountDeleteSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("avvisa che un abbonamento attivo viene annullato immediatamente (REVIEW.md #63)", async () => {
+    renderWithQuery();
+    await openDialog();
+
+    expect(screen.getByText(/abbonamento attivo/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/non ti verrà addebitato alcun rinnovo/),
+    ).toBeInTheDocument();
+  });
+
   it("il copy generalizza le credenziali AdE a Fisconline o CIE ID", async () => {
     renderWithQuery();
     await openDialog();

--- a/src/components/settings/account-delete-section.tsx
+++ b/src/components/settings/account-delete-section.tsx
@@ -97,6 +97,11 @@ export function AccountDeleteSection() {
           </ul>
 
           <p className="text-muted-foreground mt-2 text-sm">
+            Se hai un <strong>abbonamento attivo</strong>, verrà annullato
+            immediatamente: non ti verrà addebitato alcun rinnovo.
+          </p>
+
+          <p className="text-muted-foreground mt-2 text-sm">
             I documenti commerciali già trasmessi all&apos;Agenzia delle Entrate
             restano disponibili sul portale{" "}
             <strong>Fatture e Corrispettivi</strong> anche dopo la cancellazione

--- a/src/lib/services/purge-user.test.ts
+++ b/src/lib/services/purge-user.test.ts
@@ -2,18 +2,27 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockDeleteReturning = vi.fn();
+// `.where()` deve servire due pattern: `.where().returning()` (profiles) e
+// `await .where()` (subscriptions, senza returning). Un Promise con `.returning`
+// attaccato soddisfa entrambi.
+const mockDbDelete = vi.fn(() => ({
+  where: () => {
+    const chain = Promise.resolve(undefined) as Promise<unknown> & {
+      returning: typeof mockDeleteReturning;
+    };
+    chain.returning = mockDeleteReturning;
+    return chain;
+  },
+}));
 vi.mock("@/db", () => ({
   getDb: vi.fn().mockReturnValue({
-    delete: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: mockDeleteReturning,
-      }),
-    }),
+    delete: mockDbDelete,
   }),
 }));
 
 vi.mock("@/db/schema", () => ({
   profiles: { authUserId: "auth_user_id" },
+  subscriptions: { userId: "user_id" },
 }));
 
 const mockAdminDeleteUser = vi.fn();
@@ -53,6 +62,18 @@ describe("purgeUserById", () => {
     expect(mockAdminDeleteUser).toHaveBeenCalledWith(USER_ID);
     expect(order).toEqual(["auth", "profile"]);
     expect(result).toEqual({ authDeleted: true, profileDeleted: true });
+  });
+
+  it("cancella anche la riga subscriptions insieme al profilo (no righe orfane, REVIEW.md #63)", async () => {
+    const { purgeUserById } = await import("./purge-user");
+    const { profiles, subscriptions } = await import("@/db/schema");
+
+    await purgeUserById(USER_ID);
+
+    // Entrambe le tabelle vengono targhettate dalla DELETE: la subscription non
+    // ha FK/cascata, quindi senza questa delete resterebbe orfana.
+    expect(mockDbDelete).toHaveBeenCalledWith(subscriptions);
+    expect(mockDbDelete).toHaveBeenCalledWith(profiles);
   });
 
   it("ritenta la delete auth fino a 3 volte poi si arrende (profilo intatto)", async () => {

--- a/src/lib/services/purge-user.ts
+++ b/src/lib/services/purge-user.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { getDb } from "@/db";
-import { profiles } from "@/db/schema";
+import { profiles, subscriptions } from "@/db/schema";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 
@@ -33,6 +33,13 @@ export type PurgeUserResult = {
  *   profiles → businesses → ade_credentials
  *                         → commercial_documents → commercial_document_lines
  *                         → catalog_items
+ *
+ * La riga `subscriptions` NON è nella cascata (nessuna FK verso auth.users né
+ * verso profiles), quindi va cancellata esplicitamente qui: senza questa DELETE
+ * resterebbe orfana e i webhook Stripe continuerebbero a sincronizzarla con un
+ * UPDATE su 0 righe, in silenzio (REVIEW.md #63). L'annullamento della
+ * subscription su Stripe è invece responsabilità del chiamante self-service
+ * (deleteAccount): lo sweep GDPR agisce solo su account non paganti.
  *
  * Ordine auth-first: l'auth user è cancellato PRIMA della riga applicativa, con
  * retry + backoff. Se la delete auth fallisce dopo i retry, `profiles` resta
@@ -87,10 +94,14 @@ export async function purgeUserById(
     return { authDeleted: false, profileDeleted: false };
   }
 
-  // 2. Delete profile — FK cascade rimuove tutto il collegato. L'auth entry è
-  //    già andata: un fallimento qui lascia un profilo orfano da pulire a mano.
+  // 2. Delete subscription (leaf, nessuna cascata) + profile (FK cascade rimuove
+  //    tutto il collegato). L'auth entry è già andata: un fallimento qui lascia
+  //    dati orfani da pulire a mano. La subscription è cancellata PRIMA così che
+  //    `profileDeleted` rifletta esattamente l'esito della delete del profilo.
   const db = getDb();
   try {
+    await db.delete(subscriptions).where(eq(subscriptions.userId, authUserId));
+
     const deleted = await db
       .delete(profiles)
       .where(eq(profiles.authUserId, authUserId))

--- a/src/server/account-actions.test.ts
+++ b/src/server/account-actions.test.ts
@@ -14,18 +14,39 @@ vi.mock("@/lib/server-auth", () => ({
 }));
 
 const mockDeleteReturning = vi.fn();
+const mockSelectLimit = vi.fn();
+// `.where()` della delete serve due pattern (profiles con `.returning()`,
+// subscriptions con `await`): un Promise con `.returning` attaccato li copre.
+const mockDbDelete = vi.fn(() => ({
+  where: () => {
+    const chain = Promise.resolve(undefined) as Promise<unknown> & {
+      returning: typeof mockDeleteReturning;
+    };
+    chain.returning = mockDeleteReturning;
+    return chain;
+  },
+}));
 vi.mock("@/db", () => ({
   getDb: vi.fn().mockReturnValue({
-    delete: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        returning: mockDeleteReturning,
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: mockSelectLimit }),
       }),
     }),
+    delete: mockDbDelete,
   }),
 }));
 
 vi.mock("@/db/schema", () => ({
   profiles: "profiles-table",
+  subscriptions: { userId: "user_id", stripeCustomerId: "stripe_customer_id" },
+}));
+
+const mockCustomersDel = vi.fn();
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn().mockReturnValue({
+    customers: { del: mockCustomersDel },
+  }),
 }));
 
 const mockAdminDeleteUser = vi.fn();
@@ -109,6 +130,10 @@ describe("account-actions", () => {
     mockSignOut.mockResolvedValue({});
     mockSignInWithPassword.mockResolvedValue({ error: null });
     mockCheck.mockReturnValue({ success: true });
+    // Default: nessuna subscription → il ramo Stripe è skippato (flusso invariato
+    // per i test preesistenti).
+    mockSelectLimit.mockResolvedValue([]);
+    mockCustomersDel.mockResolvedValue({ id: "cus_x", deleted: true });
   });
 
   describe("deleteAccount", () => {
@@ -241,6 +266,90 @@ describe("account-actions", () => {
       expect(result.error).toBe("Email utente non disponibile.");
       expect(mockSignInWithPassword).not.toHaveBeenCalled();
       expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+    });
+
+    // ---- Stripe subscription cancellation (REVIEW.md #63) ---------------
+
+    it("cancels the Stripe customer BEFORE purging when an active subscription exists", async () => {
+      mockSelectLimit.mockResolvedValue([{ stripeCustomerId: "cus_123" }]);
+      const callOrder: string[] = [];
+      mockCustomersDel.mockImplementation(async () => {
+        callOrder.push("stripeDel");
+        return { id: "cus_123", deleted: true };
+      });
+      mockAdminDeleteUser.mockImplementation(async () => {
+        callOrder.push("purge");
+        return { error: null };
+      });
+
+      const { deleteAccount } = await import("./account-actions");
+      await deleteAccount(formWithPassword());
+
+      expect(mockCustomersDel).toHaveBeenCalledWith("cus_123");
+      // La delete Stripe precede il purge: fail-safe contro addebiti fantasma.
+      expect(callOrder.indexOf("stripeDel")).toBeLessThan(
+        callOrder.indexOf("purge"),
+      );
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+    });
+
+    it("aborts the purge and returns a dedicated error when Stripe is unreachable", async () => {
+      mockSelectLimit.mockResolvedValue([{ stripeCustomerId: "cus_123" }]);
+      mockCustomersDel.mockRejectedValue(new Error("Stripe timeout"));
+
+      const { deleteAccount } = await import("./account-actions");
+      const result = await deleteAccount(formWithPassword());
+
+      expect(result.error).toBe(
+        "Non è stato possibile annullare l'abbonamento. Riprova o gestiscilo dal portale prima di eliminare l'account.",
+      );
+      // Nessun purge: né auth né profilo toccati.
+      expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+      expect(mockDeleteReturning).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+      // Fallimento SDK esterno inatteso → error (regola 10).
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("treats an already-deleted Stripe customer (404) as idempotent and proceeds with the purge", async () => {
+      mockSelectLimit.mockResolvedValue([{ stripeCustomerId: "cus_123" }]);
+      mockCustomersDel.mockRejectedValue({
+        statusCode: 404,
+        code: "resource_missing",
+      });
+
+      const { deleteAccount } = await import("./account-actions");
+      await deleteAccount(formWithPassword());
+
+      // Obiettivo raggiunto (customer già assente) → purge prosegue fino al
+      // redirect finale, nessun errore dedicato all'utente.
+      expect(mockAdminDeleteUser).toHaveBeenCalledWith(FAKE_USER.id);
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+      // Condizione attesa → warn, non Sentry-bound error (regola 20).
+      expect(logger.warn).toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("skips Stripe entirely when there is no subscription row", async () => {
+      mockSelectLimit.mockResolvedValue([]);
+
+      const { deleteAccount } = await import("./account-actions");
+      await deleteAccount(formWithPassword());
+
+      expect(mockCustomersDel).not.toHaveBeenCalled();
+      expect(mockAdminDeleteUser).toHaveBeenCalledWith(FAKE_USER.id);
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+    });
+
+    it("skips Stripe when the subscription row has no stripeCustomerId", async () => {
+      mockSelectLimit.mockResolvedValue([{ stripeCustomerId: null }]);
+
+      const { deleteAccount } = await import("./account-actions");
+      await deleteAccount(formWithPassword());
+
+      expect(mockCustomersDel).not.toHaveBeenCalled();
+      expect(mockAdminDeleteUser).toHaveBeenCalledWith(FAKE_USER.id);
+      expect(mockRedirect).toHaveBeenCalledWith("/");
     });
 
     // ---- Purge behaviour (unchanged) ------------------------------------

--- a/src/server/account-actions.ts
+++ b/src/server/account-actions.ts
@@ -3,8 +3,12 @@
 import { createElement } from "react";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { eq } from "drizzle-orm";
+import { getDb } from "@/db";
+import { subscriptions } from "@/db/schema";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
+import { getStripe } from "@/lib/stripe";
 import { getAuthenticatedUser } from "@/lib/server-auth";
 import { authErrorResult } from "@/lib/auth-errors";
 import { getClientIp } from "@/lib/get-client-ip";
@@ -14,6 +18,21 @@ import { getFormStringRaw } from "@/lib/form-utils";
 import { sendEmail } from "@/lib/email";
 import { AccountDeletionEmail } from "@/emails/account-deletion";
 import { purgeUserById } from "@/lib/services/purge-user";
+
+/**
+ * True se l'errore della Stripe SDK indica che il customer non esiste già più
+ * (già cancellato). Rende `customers.del` idempotente: se un tentativo
+ * precedente aveva cancellato il customer ma il purge era poi fallito, il retry
+ * di `deleteAccount` non deve bloccarsi su un customer inesistente.
+ */
+function isStripeCustomerAlreadyGone(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const { statusCode, code } = error as {
+    statusCode?: unknown;
+    code?: unknown;
+  };
+  return statusCode === 404 || code === "resource_missing";
+}
 
 export type AccountActionResult = {
   error?: string;
@@ -89,11 +108,52 @@ export async function deleteAccount(
     return { error: "Password non corretta." };
   }
 
-  // 1-2. Delete auth user (retry) then the profile cascade. If the auth delete
-  //      fails after retries the profile is untouched → surface an error so the
-  //      user can log in and retry. If auth succeeded but the profile delete
-  //      failed, purgeUserById has already logged a critical error; we still
-  //      proceed to sign out/redirect because the user can no longer log in.
+  // 0. Annulla l'abbonamento Stripe PRIMA del purge (REVIEW.md #63). Un utente
+  //    cancellato non può più accedere né al Billing Portal (richiede login),
+  //    quindi se lasciassimo la subscription attiva Stripe continuerebbe ad
+  //    addebitare la carta senza modo di fermarlo. `customers.del` cancella
+  //    immediatamente le subscription attive e rimuove i dati anagrafici da
+  //    Stripe (chiude anche il punto GDPR). Fail-safe: se Stripe non risponde
+  //    NON procediamo col purge — meglio un account non cancellato che un
+  //    addebito fantasma non più fermabile.
+  const db = getDb();
+  const [sub] = await db
+    .select({ stripeCustomerId: subscriptions.stripeCustomerId })
+    .from(subscriptions)
+    .where(eq(subscriptions.userId, user.id))
+    .limit(1);
+
+  if (sub?.stripeCustomerId) {
+    try {
+      await getStripe().customers.del(sub.stripeCustomerId);
+    } catch (err) {
+      if (isStripeCustomerAlreadyGone(err)) {
+        // Customer già rimosso da un tentativo precedente: obiettivo raggiunto,
+        // delete idempotente → warn (regola 20) e prosegui col purge.
+        logger.warn(
+          { userId: user.id },
+          "deleteAccount: Stripe customer già cancellato — delete idempotente, procedo col purge",
+        );
+      } else {
+        // Regola 10: SDK esterno wrappato, log strutturato, degradazione.
+        logger.error(
+          { userId: user.id, err },
+          "deleteAccount: Stripe customer deletion failed — aborting purge",
+        );
+        return {
+          error:
+            "Non è stato possibile annullare l'abbonamento. Riprova o gestiscilo dal portale prima di eliminare l'account.",
+        };
+      }
+    }
+  }
+
+  // 1-2. Delete auth user (retry) then the profile cascade (+ subscription row).
+  //      If the auth delete fails after retries the profile is untouched →
+  //      surface an error so the user can log in and retry. If auth succeeded but
+  //      the profile delete failed, purgeUserById has already logged a critical
+  //      error; we still proceed to sign out/redirect because the user can no
+  //      longer log in.
   const { authDeleted } = await purgeUserById(user.id);
   if (!authDeleted) {
     return {


### PR DESCRIPTION
## Summary

Implements the fix for REVIEW.md #63: when a user deletes their account via `deleteAccount`, the Stripe customer is now cancelled **before** the profile purge. This prevents phantom billing on already-deleted accounts that can no longer access the Billing Portal to manage their subscription.

## Key Changes

- **`src/server/account-actions.ts`**
  - Added Stripe customer deletion step before `purgeUserById`
  - Queries `subscriptions` table for active `stripeCustomerId`
  - Calls `stripe.customers.del()` with fail-safe: if Stripe is unreachable, abort the entire purge and return a dedicated error message
  - Handles idempotency: if customer already deleted (404), logs a warn and proceeds with purge
  - Added `isStripeCustomerAlreadyGone()` helper to detect 404/resource_missing errors

- **`src/lib/services/purge-user.ts`**
  - Added explicit `DELETE FROM subscriptions` before profile deletion
  - Prevents orphaned subscription rows (no FK cascade from auth.users)
  - Ensures webhook sync doesn't silently UPDATE 0 rows after user deletion

- **`src/components/settings/account-delete-section.tsx`**
  - Updated dialog copy to inform users that active subscriptions are cancelled immediately
  - Added reassurance: "non ti verrà addebitato alcun rinnovo" (no further charges)

- **Test coverage**
  - `src/server/account-actions.test.ts`: 4 new tests covering Stripe cancellation flow, error handling, and idempotency
  - `src/lib/services/purge-user.test.ts`: 1 new test verifying subscription row deletion
  - `src/components/settings/account-delete-section.test.tsx`: 1 new test for updated UI copy

## Implementation Details

- **Fail-safe ordering:** Stripe deletion happens BEFORE auth/profile purge. If Stripe fails, the account remains intact and the user can retry or manage the subscription via Billing Portal.
- **Idempotency:** Handles the case where a previous deletion attempt cancelled the customer but failed during purge—retry doesn't block on 404.
- **Logging:** Unexpected Stripe errors → `logger.error` (Sentry-bound, rule 10); expected 404 → `logger.warn` (rule 20, no Sentry noise).
- **Mock pattern:** Updated test mocks to support both `.where().returning()` (profiles) and `await .where()` (subscriptions) patterns via a Promise with attached `.returning` method.

Closes REVIEW.md #63.

https://claude.ai/code/session_011P8KH1anatw9tWZ5bCNuUp