### PR TITLE
fix(auth): previeni cancellazione dell'auth user legittimo nella race del doppio signUp

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -208,43 +208,6 @@ l'impatto è solo un errore opaco, non un duplicato.
 
 ---
 
-### 65. Race sul doppio `signUp`: il compensating delete può cancellare l'auth user legittimo → email bloccata per sempre
-
-- **Categoria:** correttezza/auth · **Severità:** Medium — trigger realistico (doppio click/retry di rete sul form), esito permanente senza cleanup manuale
-- **File:** `src/server/auth-actions.ts:330-382` (`insertProfileOrRollback`: compensating delete su **ogni** failure dell'insert), `:304-328` (`compensatingDeleteAuthUser`), `:505-529` (pre-check email); schema: `profiles.auth_user_id` **senza FK** verso `auth.users` (`supabase/migrations/0000_initial.sql:5,18`) → nessuna cascata ripulisce il profilo orfano
-
-**Problema.** Due submit ravvicinati della stessa registrazione passano
-entrambi il pre-check email (il profilo non esiste ancora). R1:
-`auth.signUp` crea l'utente A e committa il profilo. R2: `auth.signUp` sulla
-stessa email — per un utente esistente **non confermato** Supabase non crea
-un nuovo utente: reinvia la conferma e ritorna **lo stesso id A**. L'insert
-profilo di R2 fallisce con unique violation e il catch esegue
-`compensatingDeleteAuthUser(A)`: cancella l'auth user della registrazione
-legittima di R1. Risultato: profilo orfano (nessuna FK → nessuna cascata),
-link di conferma morto, login impossibile, ri-registrazione bloccata dal
-pre-check (il profilo esiste) — l'email è inutilizzabile finché non si
-interviene a mano. Il commento nel codice assume che il duplicato crei
-"un nuovo auth user con UUID diverso", ma per gli unconfirmed non è così.
-
-**Fix (non ambiguo).**
-
-1. In `insertProfileOrRollback`, nel catch e **prima** del compensating
-   delete: `SELECT id FROM profiles WHERE auth_user_id = $authUserId`. Se la
-   riga esiste, l'auth user appartiene a una registrazione già completata
-   dall'altra richiesta → **non** cancellare, procedere col solo
-   `redirect("/verify-email")`. (Determinismo: la unique violation viene
-   sollevata solo dopo il commit della transazione vincente, quindi la SELECT
-   vede sempre la riga.)
-2. Difesa aggiuntiva a monte: dopo `auth.signUp`, se `data.user.identities`
-   è assente/vuoto (utente obfuscato anti-enumeration di Supabase) trattare
-   come email già registrata → redirect `/verify-email` senza insert.
-3. **Test:** unique violation con profilo già presente per lo stesso
-   authUserId → `deleteUser` mai chiamato; unique violation senza profilo
-   (fallimento genuino) → compensating delete invariato; `identities: []` →
-   redirect senza insert.
-
----
-
 ## P3 — Bassa priorità
 
 ### 17. Key rotation zero-downtime: i caller passano sempre una sola chiave

--- a/src/server/auth-actions.test.ts
+++ b/src/server/auth-actions.test.ts
@@ -965,6 +965,161 @@ describe("auth-actions", () => {
       );
     });
 
+    // --- REVIEW #65: race sul doppio signUp ---
+
+    it("NON cancella l'auth user quando un profilo esiste già per lo stesso authUserId (race doppio signUp)", async () => {
+      // R2 del doppio signUp: Supabase riusa lo stesso auth user id, l'insert
+      // fallisce con unique violation, ma l'auth user appartiene alla
+      // registrazione R1 già committata → NON deve essere cancellato.
+      mockSignUp.mockResolvedValue({
+        // identities non vuoto: bypassa il guard obfuscated (isoliamo il guard
+        // in insertProfileOrRollback).
+        data: { user: { id: "shared-auth-id", identities: [{ id: "i1" }] } },
+        error: null,
+      });
+      const uniqueErr = Object.assign(new Error("duplicate key"), {
+        code: "23505",
+      });
+      mockInsert.mockReturnValueOnce({
+        values: vi.fn().mockRejectedValueOnce(uniqueErr),
+      });
+      // 1ª SELECT = pre-check email (nessun profilo → signup procede);
+      // 2ª SELECT = guard esistenza profilo per authUserId (riga presente).
+      mockLimit.mockResolvedValueOnce([]);
+      mockLimit.mockResolvedValueOnce([{ id: "r1-profile-id" }]);
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+        if (isRedirectError(err)) {
+          expect(err.url).toBe("/verify-email");
+        }
+      }
+
+      // L'auth user legittimo di R1 NON deve essere toccato.
+      expect(mockDeleteUser).not.toHaveBeenCalled();
+    });
+
+    it("redirect a /verify-email senza insert quando signUp ritorna un utente obfuscato (identities vuoto)", async () => {
+      // Email già registrata e non confermata: Supabase ritorna un utente
+      // obfuscato con identities: [] riusando l'id esistente.
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "existing-auth-id", identities: [] } },
+        error: null,
+      });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+        expect.fail("Expected redirect");
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+        if (isRedirectError(err)) {
+          expect(err.url).toBe("/verify-email");
+        }
+      }
+
+      // Nessun tentativo di insert e nessuna cancellazione dell'auth user.
+      expect(mockInsert).not.toHaveBeenCalled();
+      expect(mockDeleteUser).not.toHaveBeenCalled();
+    });
+
+    it("cancella l'auth user orfano quando l'insert fallisce e NESSUN profilo esiste per l'authUserId (fallimento genuino)", async () => {
+      // Nessun profilo per l'authUserId (guard → []): l'auth user è davvero
+      // orfano e il compensating delete deve procedere (comportamento storico).
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "genuine-orphan", identities: [{ id: "i1" }] } },
+        error: null,
+      });
+      const uniqueErr = Object.assign(new Error("duplicate key"), {
+        code: "23505",
+      });
+      mockInsert.mockReturnValueOnce({
+        values: vi.fn().mockRejectedValueOnce(uniqueErr),
+      });
+      // Pre-check email [] e guard esistenza profilo [] → orfano genuino.
+      mockLimit.mockResolvedValueOnce([]);
+      mockLimit.mockResolvedValueOnce([]);
+      mockDeleteUser.mockResolvedValue({ error: null });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+      }
+
+      expect(mockDeleteUser).toHaveBeenCalledWith("genuine-orphan");
+    });
+
+    it("degrada al compensating delete quando il guard di esistenza profilo fallisce (regola 19)", async () => {
+      // Se anche la query di guard fallisce non possiamo confermare l'esistenza
+      // del profilo: torniamo al comportamento storico (compensating delete)
+      // invece di propagare l'errore.
+      mockSignUp.mockResolvedValue({
+        data: { user: { id: "orphan-guard-fail", identities: [{ id: "i1" }] } },
+        error: null,
+      });
+      const uniqueErr = Object.assign(new Error("duplicate key"), {
+        code: "23505",
+      });
+      mockInsert.mockReturnValueOnce({
+        values: vi.fn().mockRejectedValueOnce(uniqueErr),
+      });
+      // Pre-check email [] poi guard che rigetta → profileExistsForAuthUser=false.
+      mockLimit.mockResolvedValueOnce([]);
+      mockLimit.mockRejectedValueOnce(new Error("guard DB error"));
+      mockDeleteUser.mockResolvedValue({ error: null });
+
+      const { signUp } = await import("./auth-actions");
+      try {
+        await signUp(
+          formData({
+            email: "test@example.com",
+            password: "Secure#99x",
+            confirmPassword: "Secure#99x",
+            termsAccepted: "true",
+            specificClausesAccepted: "true",
+            captchaToken: "valid-token",
+          }),
+        );
+      } catch (err) {
+        expect(isRedirectError(err)).toBe(true);
+      }
+
+      expect(mockDeleteUser).toHaveBeenCalledWith("orphan-guard-fail");
+    });
+
     it("returns captcha error when token is missing", async () => {
       const { signUp } = await import("./auth-actions");
       const result = await signUp(

--- a/src/server/auth-actions.ts
+++ b/src/server/auth-actions.ts
@@ -345,6 +345,57 @@ async function compensatingDeleteAuthUser(authUserId: string): Promise<void> {
   }
 }
 
+/**
+ * True quando `supabase.auth.signUp` ha ritornato l'oggetto utente "obfuscato"
+ * che Supabase produce per un'email GIÀ registrata ma non confermata (feature
+ * anti-enumeration di GoTrue): l'utente esiste, quindi `identities` è un array
+ * **presente ma vuoto** (`[]`). In quel caso l'`id` ritornato è quello
+ * dell'utente esistente, non di uno nuovo — inserire un profilo qui rischia la
+ * unique violation il cui compensating delete cancellerebbe l'auth user
+ * legittimo dell'altra registrazione (REVIEW #65).
+ *
+ * Controlliamo SOLO l'array vuoto esplicito, mai `undefined`/`null`: un
+ * `identities` assente non è una response reale di Supabase per un signup
+ * andato a buon fine, e trattarlo come "già registrato" bloccherebbe
+ * registrazioni genuine (fail-open sul dubbio, il guard vero è in
+ * `insertProfileOrRollback`).
+ */
+function isObfuscatedExistingUser(
+  user: { identities?: unknown[] | null } | null | undefined,
+): boolean {
+  return Array.isArray(user?.identities) && user.identities.length === 0;
+}
+
+/**
+ * Guard della race del doppio signUp (REVIEW #65): esiste già un profilo per
+ * questo `authUserId`? In caso affermativo l'auth user appartiene a una
+ * registrazione concorrente GIÀ committata e NON va cancellato (nessuna FK
+ * `profiles → auth.users` ripulisce un eventuale orfano: cancellarlo
+ * renderebbe l'email inutilizzabile per sempre).
+ *
+ * Su errore della query di guard degradiamo a `false` (regola 19: non
+ * propagare) tornando al comportamento storico del compensating delete: la
+ * SELECT vede sempre la riga committata quando il DB è sano, quindi il caso
+ * race resta coperto.
+ */
+async function profileExistsForAuthUser(authUserId: string): Promise<boolean> {
+  try {
+    const db = getDb();
+    const [row] = await db
+      .select({ id: profiles.id })
+      .from(profiles)
+      .where(sql`${profiles.authUserId} = ${authUserId}`)
+      .limit(1);
+    return Boolean(row);
+  } catch (err) {
+    logger.warn(
+      { err },
+      "insertProfileOrRollback: profile existence guard query failed",
+    );
+    return false;
+  }
+}
+
 async function insertProfileOrRollback(
   authUserId: string,
   email: string,
@@ -384,10 +435,19 @@ async function insertProfileOrRollback(
     });
     return null;
   } catch (err) {
-    // Any insert failure means the auth user just created has no matching
-    // profile and must be removed to avoid orphans (CLAUDE.md regola #17).
-    // This covers both the UNIQUE-constraint race (two concurrent signups for
-    // the same email) and transient DB errors.
+    // Doppio signUp race (REVIEW #65): per un'email esistente NON confermata
+    // Supabase ritorna lo STESSO auth user id, quindi questo insert può fallire
+    // con unique violation mentre l'auth user appartiene già a una
+    // registrazione committata dall'altra richiesta. Prima di cancellare
+    // verifichiamo se esiste già un profilo per questo authUserId: se sì, NON
+    // cancellare (romperebbe l'email per sempre) → solo redirect anti-enum.
+    if (await profileExistsForAuthUser(authUserId)) {
+      redirect("/verify-email");
+    }
+
+    // Nessun profilo per questo authUserId: l'auth user appena creato è orfano
+    // (unique violation su email di un altro utente o errore DB transitorio) e
+    // va rimosso per non lasciare zombie auth users (CLAUDE.md regola #17).
     await compensatingDeleteAuthUser(authUserId);
 
     if (isUniqueConstraintViolation(err)) {
@@ -571,6 +631,15 @@ export async function signUp(formData: FormData): Promise<AuthActionResult> {
   if (error) {
     logger.error({ error: error.message }, "signUp failed");
     return { error: "Registrazione fallita. Riprova." };
+  }
+
+  // Anti-enumeration Supabase (REVIEW #65): se l'email esiste già ed è non
+  // confermata, signUp non crea un nuovo utente e ritorna un oggetto obfuscato
+  // con `identities: []` riusando l'id dell'utente esistente. Trattiamo come
+  // "già registrato" → redirect senza insert, così non tentiamo un profilo il
+  // cui rollback cancellerebbe l'auth user legittimo.
+  if (isObfuscatedExistingUser(data.user)) {
+    redirect("/verify-email");
   }
 
   // Create profile in our DB (mandatory: records terms acceptance for compliance)


### PR DESCRIPTION
Due submit ravvicinati della stessa registrazione: R1 crea l'auth user A e
committa il profilo; R2, su email esistente non confermata, riceve da Supabase
lo STESSO id A (reinvio conferma, nessun nuovo utente). L'insert profilo di R2
falliva con unique violation e il compensating delete cancellava A — l'auth
user della registrazione legittima di R1 — lasciando un profilo orfano (nessuna
FK profiles→auth.users) e l'email inutilizzabile per sempre (REVIEW #65).

- insertProfileOrRollback: prima del compensating delete, guard
  profileExistsForAuthUser(authUserId); se un profilo esiste già l'auth user
  appartiene alla registrazione concorrente committata → solo redirect
  anti-enum, nessuna cancellazione. Su errore del guard degrada al
  comportamento storico (regola 19).
- signUp: se signUp ritorna l'utente obfuscato (identities: []) tratta come
  email già registrata → redirect senza insert.
- Test: race con profilo presente → deleteUser mai chiamato; identities vuoto
  → redirect senza insert; orfano genuino → compensating delete invariato;
  guard in errore → degrada al delete.
- REVIEW.md: rimosso il finding #65 risolto.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CDdMio4UmzZdaYn9wLJZ4e