### PR TITLE
Handle HTTP 200 with non-JSON body in AdE API responses

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -166,48 +166,6 @@ esplicitamente, non lasciata decadere.
 
 ---
 
-### 64. Esito ignoto dopo `submitDocument` (HTTP 200 con body non-JSON) classificato come failure definitiva → mark ERROR → rischio doppio documento fiscale
-
-- **Categoria:** correttezza fiscale/robustezza · **Severità:** Medium — bassa probabilità, danno irreversibile (documento fiscale duplicato su AdE)
-- **File:** `src/lib/ade/real-client.ts:1942` (`return response.json()` finale di `submitDocument`, senza guard); gate mark-ERROR: `src/lib/services/receipt-service.ts:798-812` e `src/lib/services/void-service.ts:895-907` (`!isStatementTimeoutError && !isTransientAdeError` ⇒ status ERROR); classificazione: `isTransientAdeError` in `src/lib/ade/error-messages.ts`
-
-**Problema.** Se AdE risponde **200 con body non-JSON** (pagina di manutenzione
-HTML servita con 200, risposta troncata, proxy interposto), `response.json()`
-lancia un `SyntaxError` nudo: non è `AdeError`, non è transient, non è
-statement timeout → emit/void lo trattano come "submit sicuramente non
-arrivato" e marcano la riga **ERROR**. Ma la POST è stata consegnata e con un
-200 l'esito è **ignoto**: il documento può essere stato registrato. Con la
-riga in ERROR: (a) per il **VOID** l'indice unique parziale su
-`voided_document_id` esclude ERROR → un retry con key nuova inserisce un
-secondo VOID e ri-sottomette → **doppio annullo** su AdE; (b) per il **SALE**
-la cassa genera una idempotencyKey nuova a ogni retry → nuovo documento →
-**doppia emissione**, senza mai passare dalla riconciliazione
-`searchDocuments` che esiste proprio per gli esiti ignoti (REVIEW.md #4, che
-copre solo le righe rimaste PENDING). Lo stesso `response.json()` non guardato
-esiste su `getFiscalData`/`getDocument`/`getProducts`/`searchDocuments` — lì
-l'impatto è solo un errore opaco, non un duplicato.
-
-**Fix (non ambiguo).**
-
-1. In `submitDocument`: try/catch attorno al `response.json()` finale → throw
-   di una nuova classe `AdeUnknownOutcomeError` (in `src/lib/ade/errors.ts`),
-   messaggio con `statusCode`/`contentType` (mai il body: dati fiscali).
-2. Trattarla come **esito ignoto** = lasciare PENDING: farla riconoscere da
-   `isTransientAdeError` (documentando che il predicato significa "esito non
-   determinabile → non marcare ERROR, warn non Sentry") — così entrambi i
-   servizi restano invariati e la stale recovery riconcilia contro AdE via
-   `searchDocuments` prima di qualunque re-submit.
-3. Mappare la classe in `getUserFacingAdeErrorMessage` sullo stesso messaggio
-   "il portale non risponde… riprova" usato per i 5xx.
-4. Guard analogo (try/catch → `AdePortalError(status, …)`) sui `response.json()`
-   di `getFiscalData`/`getDocument`/`getProducts`/`searchDocuments`: nessuna
-   semantica unknown-outcome, basta un errore tipizzato invece del SyntaxError.
-5. **Test:** submit 200 + body HTML → riga resta PENDING, log warn (no Sentry);
-   retry oltre soglia stale → entra nel path `reconcileSaleBeforeResubmit` /
-   `reconcileVoidBeforeResubmit`; 200 + JSON valido → invariato.
-
----
-
 ## P3 — Bassa priorità
 
 ### 17. Key rotation zero-downtime: i caller passano sempre una sola chiave

--- a/src/lib/ade/error-messages.test.ts
+++ b/src/lib/ade/error-messages.test.ts
@@ -8,6 +8,7 @@ import {
   AdePortalError,
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
+  AdeUnknownOutcomeError,
 } from "./errors";
 import {
   getUserFacingAdeErrorMessage,
@@ -70,6 +71,17 @@ describe("getUserFacingAdeErrorMessage", () => {
       FALLBACK,
     );
     expect(result.message).toBe(FALLBACK);
+  });
+
+  it("returns the portal-down message for AdeUnknownOutcomeError (200 non-JSON, unknown outcome)", () => {
+    const result = getUserFacingAdeErrorMessage(
+      new AdeUnknownOutcomeError(200, "text/html; charset=UTF-8"),
+      FALLBACK,
+    );
+    expect(result.message).toBe(
+      "Il portale Agenzia delle Entrate Fatture e Corrispettivi non risponde al momento. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
+    );
+    expect(result.passwordExpired).toBeUndefined();
   });
 
   it("returns the SPID timeout message for AdeSpidTimeoutError", () => {
@@ -175,6 +187,12 @@ describe("isTransientAdeError", () => {
     expect(isTransientAdeError(new AdePortalError(599, "boom"))).toBe(true);
   });
 
+  it("returns true for AdeUnknownOutcomeError (unknown outcome → keep PENDING, not ERROR)", () => {
+    expect(
+      isTransientAdeError(new AdeUnknownOutcomeError(200, "text/html")),
+    ).toBe(true);
+  });
+
   it("returns false for AdePortalError with 4xx status (permanent: bad input)", () => {
     expect(isTransientAdeError(new AdePortalError(400, "bad request"))).toBe(
       false,
@@ -241,6 +259,12 @@ describe("isExpectedUserAdeError", () => {
 
   it("returns false for AdeSpidTimeoutError (transient, retry path)", () => {
     expect(isExpectedUserAdeError(new AdeSpidTimeoutError(30))).toBe(false);
+  });
+
+  it("returns false for AdeUnknownOutcomeError (unknown outcome, not user input)", () => {
+    expect(
+      isExpectedUserAdeError(new AdeUnknownOutcomeError(200, "text/html")),
+    ).toBe(false);
   });
 
   it("returns false for AdeSessionExpiredError (internal state, not user input)", () => {

--- a/src/lib/ade/error-messages.ts
+++ b/src/lib/ade/error-messages.ts
@@ -4,6 +4,7 @@ import {
   AdePasswordExpiredError,
   AdePortalError,
   AdeSpidTimeoutError,
+  AdeUnknownOutcomeError,
 } from "./errors";
 import type { AdeLoginMethod } from "./types";
 
@@ -53,7 +54,13 @@ export function getUserFacingAdeErrorMessage(
         "Il portale Agenzia delle Entrate Fatture e Corrispettivi non è raggiungibile al momento. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
     };
   }
-  if (err instanceof AdePortalError && err.statusCode >= 500) {
+  if (
+    (err instanceof AdePortalError && err.statusCode >= 500) ||
+    err instanceof AdeUnknownOutcomeError
+  ) {
+    // Esito ignoto (200 non-JSON) → stesso messaggio dei 5xx: il portale non
+    // risponde in modo utilizzabile, riprova. La riga resta PENDING e la stale
+    // recovery riconcilia (REVIEW.md #64), quindi il retry è sicuro.
     return {
       message:
         "Il portale Agenzia delle Entrate Fatture e Corrispettivi non risponde al momento. Non dipende da te né da ScontrinoZero. Riprova tra qualche minuto.",
@@ -72,19 +79,26 @@ export function getUserFacingAdeErrorMessage(
 
 /**
  * Ritorna true se l'errore è una condizione transient su cui ScontrinoZero
- * non può fare nulla (downtime AdE, rete, SPID timeout).
+ * non può fare nulla (downtime AdE, rete, SPID timeout) OPPURE un esito
+ * **ignoto** (`AdeUnknownOutcomeError`: 200 con body non-JSON dopo un submit).
  *
- * Usato dai catch site dei servizi AdE per decidere il log level: i
- * transient vanno loggati a `warn` (non `error`) per non aprire issue
- * Sentry spurie. Durante un downtime AdE da 100 utenti riceveremmo ~100
- * issue identiche e non actionable per noi — il logger.ts hook a livello
- * 50 (error) le farebbe scattare. Coerente con il downgrade di
+ * Usato dai catch site dei servizi AdE per due decisioni: (a) il log level —
+ * i transient vanno a `warn` (non `error`) per non aprire issue Sentry spurie
+ * (durante un downtime AdE da 100 utenti riceveremmo ~100 issue identiche e
+ * non actionable; il logger.ts hook a livello 50 le farebbe scattare); (b) il
+ * gate mark-ERROR di emit/void — quando true la riga resta **PENDING**, mai
+ * ERROR. Per l'esito ignoto è cruciale: la POST può aver registrato il
+ * documento su AdE, quindi marcarla ERROR la farebbe uscire dall'indice unique
+ * e dalla riconciliazione pre-resubmit → rischio doppio documento fiscale
+ * (REVIEW.md #64). Restando PENDING la stale recovery riconcilia contro AdE via
+ * `searchDocuments` prima di ogni re-submit. Coerente con il downgrade di
  * `esito:false` (rifiuto business AdE) a `warn` fatto in 8c654b5.
  */
 export function isTransientAdeError(err: unknown): boolean {
   if (err instanceof AdeNetworkError) return true;
   if (err instanceof AdeSpidTimeoutError) return true;
   if (err instanceof AdePortalError && err.statusCode >= 500) return true;
+  if (err instanceof AdeUnknownOutcomeError) return true;
   return false;
 }
 

--- a/src/lib/ade/errors.test.ts
+++ b/src/lib/ade/errors.test.ts
@@ -7,6 +7,7 @@ import {
   AdePortalError,
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
+  AdeUnknownOutcomeError,
 } from "./errors";
 
 describe("AdeError (base)", () => {
@@ -67,6 +68,29 @@ describe("AdePortalError", () => {
     expect(err.message).toBe("bad gateway");
     expect(err.code).toBe("ADE_PORTAL_ERROR");
     expect(err.name).toBe("AdePortalError");
+  });
+});
+
+describe("AdeUnknownOutcomeError", () => {
+  it("stores the status code and content type", () => {
+    const err = new AdeUnknownOutcomeError(200, "text/html; charset=UTF-8");
+    expect(err.statusCode).toBe(200);
+    expect(err.contentType).toBe("text/html; charset=UTF-8");
+    expect(err.code).toBe("ADE_UNKNOWN_OUTCOME");
+    expect(err.name).toBe("AdeUnknownOutcomeError");
+    expect(err).toBeInstanceOf(AdeError);
+  });
+
+  it("mentions the status and content type in the message but never the body", () => {
+    const err = new AdeUnknownOutcomeError(200, "text/html");
+    expect(err.message).toContain("200");
+    expect(err.message).toContain("text/html");
+  });
+
+  it("tolerates a null content type", () => {
+    const err = new AdeUnknownOutcomeError(200, null);
+    expect(err.contentType).toBeNull();
+    expect(err.message).toContain("unknown");
   });
 });
 

--- a/src/lib/ade/errors.ts
+++ b/src/lib/ade/errors.ts
@@ -57,6 +57,38 @@ export class AdePortalError extends AdeError {
   }
 }
 
+/**
+ * L'invio del documento ha ricevuto un HTTP di successo (200) ma il body non è
+ * JSON valido — pagina di manutenzione HTML servita con 200, risposta troncata,
+ * proxy interposto. La POST è stata **consegnata**: il documento fiscale può
+ * essere stato registrato su AdE o no → l'esito è **ignoto**, non una failure
+ * definitiva.
+ *
+ * Perché una classe dedicata e non un `AdePortalError`: marcare la riga ERROR
+ * la farebbe uscire dall'indice unique parziale su `voided_document_id` e dalla
+ * riconciliazione pre-resubmit, aprendo la porta a un doppio annullo / doppia
+ * emissione (documento fiscale duplicato, irreversibile). Per questo
+ * `isTransientAdeError` la riconosce: significato del predicato = "esito non
+ * determinabile → non marcare ERROR, lascia PENDING". La stale recovery
+ * riconcilia contro AdE via `searchDocuments` prima di qualunque re-submit.
+ *
+ * Mai includere il body nel messaggio: contiene dati fiscali (importi, CF).
+ */
+export class AdeUnknownOutcomeError extends AdeError {
+  readonly statusCode: number;
+  readonly contentType: string | null;
+
+  constructor(statusCode: number, contentType: string | null) {
+    super(
+      "ADE_UNKNOWN_OUTCOME",
+      `Document submission returned status ${statusCode} with a non-JSON body (content-type: ${contentType ?? "unknown"})`,
+    );
+    this.name = "AdeUnknownOutcomeError";
+    this.statusCode = statusCode;
+    this.contentType = contentType;
+  }
+}
+
 /** Network-level error (DNS, timeout, connection refused). */
 export class AdeNetworkError extends AdeError {
   override readonly cause: unknown;

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -12,6 +12,7 @@ import {
   AdePortalError,
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
+  AdeUnknownOutcomeError,
 } from "./errors";
 import { logger } from "@/lib/logger";
 import type { AdePayload, AdeResponse, SpidCredentials } from "./types";
@@ -1295,6 +1296,69 @@ describe("RealAdeClient", () => {
       );
     });
 
+    it("throws AdeUnknownOutcomeError on 200 with a non-JSON body (unknown outcome, REVIEW #64)", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      // AdE serve una pagina di manutenzione HTML con status 200: la POST è
+      // stata consegnata, l'esito è ignoto. Non è una failure definitiva.
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 200,
+          body: "<html><body>Manutenzione in corso</body></html>",
+          headers: [["Content-Type", "text/html; charset=UTF-8"]],
+        }),
+      );
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdeUnknownOutcomeError,
+      );
+    });
+
+    it("logs the unknown-outcome at warn with status/content-type but never the body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 200,
+          body: "<html>fiscal data must not leak</html>",
+          headers: [["Content-Type", "text/html; charset=UTF-8"]],
+        }),
+      );
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
+        AdeUnknownOutcomeError,
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        {
+          statusCode: 200,
+          contentType: "text/html; charset=UTF-8",
+          endpoint: "/ser/api/documenti/v1/doc/documenti/",
+        },
+        "ade:submit_non_json_success",
+      );
+      // Il body non deve mai finire in nessun log (dati fiscali).
+      const loggedNonJson = (logger.warn as ReturnType<typeof vi.fn>).mock.calls
+        .map(([ctx]) => JSON.stringify(ctx))
+        .join("");
+      expect(loggedNonJson).not.toContain("fiscal data must not leak");
+    });
+
+    it("exposes the status code on the error for an empty (non-JSON) 200 body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      // Body vuoto con status 200: json() fallisce comunque → esito ignoto.
+      fetchMock.mockResolvedValueOnce(new Response("", { status: 200 }));
+
+      await expect(client.submitSale(makeSalePayload())).rejects.toMatchObject({
+        code: "ADE_UNKNOWN_OUTCOME",
+        statusCode: 200,
+      });
+    });
+
     it("throws if not logged in", async () => {
       await expect(client.submitSale(makeSalePayload())).rejects.toThrow(
         "Not logged in",
@@ -1368,8 +1432,78 @@ describe("RealAdeClient", () => {
       await expect(client.getFiscalData()).rejects.toThrow(AdePortalError);
     });
 
+    it("throws AdePortalError (not a nude SyntaxError) on 200 with non-JSON body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      // 200 con pagina HTML: nessuna semantica unknown-outcome su una lettura,
+      // solo un errore tipizzato invece del SyntaxError opaco (REVIEW #64.4).
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          status: 200,
+          body: "<html>maintenance</html>",
+          headers: [["Content-Type", "text/html"]],
+        }),
+      );
+
+      const err = await client.getFiscalData().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(AdePortalError);
+      expect(err).not.toBeInstanceOf(SyntaxError);
+    });
+
     it("throws if not logged in", async () => {
       await expect(client.getFiscalData()).rejects.toThrow("Not logged in");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getProducts
+  // -----------------------------------------------------------------------
+
+  describe("getProducts", () => {
+    it("sends GET and returns the parsed product catalog", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      const catalog = [
+        {
+          id: 438167,
+          descrizioneProdotto: "Caffè",
+          prezzoUnitario: "100",
+          prezzoLordo: "100",
+          aliquotaIVA: "N2",
+        },
+      ];
+      fetchMock.mockResolvedValueOnce(mockResponse({ body: catalog }));
+
+      const result = await client.getProducts();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(438167);
+      expect(result[0].descrizioneProdotto).toBe("Caffè");
+    });
+
+    it("throws AdePortalError on non-200", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      fetchMock.mockResolvedValueOnce(mockResponse({ status: 500 }));
+
+      await expect(client.getProducts()).rejects.toThrow(AdePortalError);
+    });
+
+    it("throws AdePortalError on 200 with non-JSON body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ status: 200, body: "<html>maintenance</html>" }),
+      );
+
+      await expect(client.getProducts()).rejects.toThrow(AdePortalError);
+    });
+
+    it("throws if not logged in", async () => {
+      await expect(client.getProducts()).rejects.toThrow("Not logged in");
     });
   });
 
@@ -1443,6 +1577,17 @@ describe("RealAdeClient", () => {
       await client.login(mockCredentials);
 
       fetchMock.mockResolvedValueOnce(mockResponse({ status: 404 }));
+
+      await expect(client.getDocument("999")).rejects.toThrow(AdePortalError);
+    });
+
+    it("throws AdePortalError on 200 with non-JSON body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ status: 200, body: "<html>not json</html>" }),
+      );
 
       await expect(client.getDocument("999")).rejects.toThrow(AdePortalError);
     });
@@ -1534,6 +1679,17 @@ describe("RealAdeClient", () => {
       await client.login(mockCredentials);
 
       fetchMock.mockResolvedValueOnce(mockResponse({ status: 500 }));
+
+      await expect(client.searchDocuments({})).rejects.toThrow(AdePortalError);
+    });
+
+    it("throws AdePortalError on 200 with non-JSON body", async () => {
+      mockLoginSequence(fetchMock);
+      await client.login(mockCredentials);
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ status: 200, body: "<html>maintenance</html>" }),
+      );
 
       await expect(client.searchDocuments({})).rejects.toThrow(AdePortalError);
     });

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -30,6 +30,7 @@ import {
   AdePortalError,
   AdeSessionExpiredError,
   AdeSpidTimeoutError,
+  AdeUnknownOutcomeError,
 } from "./errors";
 import { logger } from "@/lib/logger";
 
@@ -1670,6 +1671,36 @@ export class RealAdeClient implements AdeClient {
     return this.submitDocument(payload);
   }
 
+  /**
+   * Parsa il body JSON di una response GET già verificata `ok`. Se il portale
+   * risponde 200 con body non-JSON (manutenzione HTML, troncamento, proxy) un
+   * `response.json()` nudo lancerebbe un SyntaxError opaco: qui lo mappiamo a un
+   * `AdePortalError` tipizzato. A differenza di `submitDocument` NON serve la
+   * semantica unknown-outcome — queste sono letture, nessuna scrittura fiscale
+   * in gioco. Mai loggare il body: dati fiscali.
+   */
+  private async parseJsonBody<T>(
+    response: Response,
+    endpoint: string,
+  ): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch {
+      logger.warn(
+        {
+          statusCode: response.status,
+          contentType: response.headers.get("content-type") ?? null,
+          endpoint,
+        },
+        "ade:non_json_body",
+      );
+      throw new AdePortalError(
+        response.status,
+        `Expected JSON body from ${endpoint} but got a non-JSON response`,
+      );
+    }
+  }
+
   async getFiscalData(): Promise<AdeCedentePrestatore> {
     this.assertLoggedIn();
 
@@ -1683,7 +1714,10 @@ export class RealAdeClient implements AdeClient {
       );
     }
 
-    return response.json();
+    return this.parseJsonBody<AdeCedentePrestatore>(
+      response,
+      "/ser/api/documenti/v1/doc/documenti/dati/fiscali",
+    );
   }
 
   /**
@@ -1706,7 +1740,10 @@ export class RealAdeClient implements AdeClient {
       );
     }
 
-    return response.json() as Promise<AdeProduct[]>;
+    return this.parseJsonBody<AdeProduct[]>(
+      response,
+      "/ser/api/documenti/v1/doc/rubrica/prodotti",
+    );
   }
 
   /**
@@ -1728,7 +1765,10 @@ export class RealAdeClient implements AdeClient {
       );
     }
 
-    return response.json() as Promise<AdeDocumentDetail>;
+    return this.parseJsonBody<AdeDocumentDetail>(
+      response,
+      "/ser/api/documenti/v1/doc/documenti/{idtrx}",
+    );
   }
 
   /**
@@ -1768,7 +1808,10 @@ export class RealAdeClient implements AdeClient {
       );
     }
 
-    return response.json() as Promise<AdeDocumentList>;
+    return this.parseJsonBody<AdeDocumentList>(
+      response,
+      "/ser/api/documenti/v1/doc/documenti/",
+    );
   }
 
   /**
@@ -1939,7 +1982,28 @@ export class RealAdeClient implements AdeClient {
       );
     }
 
-    return response.json();
+    // HTTP di successo ma body non-JSON (manutenzione HTML servita con 200,
+    // risposta troncata, proxy interposto): la POST è stata consegnata, quindi
+    // l'esito è IGNOTO, non una failure. Un SyntaxError nudo qui verrebbe
+    // classificato come "submit sicuramente non arrivato" → mark ERROR →
+    // rischio doppio documento fiscale (REVIEW.md #64). Lanciamo invece
+    // AdeUnknownOutcomeError, che isTransientAdeError riconosce per lasciare la
+    // riga PENDING e far riconciliare la stale recovery contro AdE prima di un
+    // eventuale re-submit. Mai loggare il body: dati fiscali.
+    try {
+      return await response.json();
+    } catch {
+      const contentType = response.headers.get("content-type");
+      logger.warn(
+        {
+          statusCode: response.status,
+          contentType: contentType ?? null,
+          endpoint: "/ser/api/documenti/v1/doc/documenti/",
+        },
+        "ade:submit_non_json_success",
+      );
+      throw new AdeUnknownOutcomeError(response.status, contentType);
+    }
   }
 
   private assertLoggedIn(): void {

--- a/src/lib/services/receipt-service.test.ts
+++ b/src/lib/services/receipt-service.test.ts
@@ -1080,6 +1080,22 @@ describe("emitReceiptForBusiness", () => {
     expect(updateSets).not.toContain("ERROR");
   });
 
+  it("REVIEW #64: submitSale 200 non-JSON (AdeUnknownOutcomeError) NON marca ERROR (resta PENDING)", async () => {
+    // Esito ignoto: la POST è stata consegnata con un 200, il documento può
+    // essere già su AdE. Marcare ERROR aprirebbe alla doppia emissione fiscale;
+    // la riga resta PENDING e la stale-recovery riconcilia via searchDocuments.
+    const { AdeUnknownOutcomeError } = await import("@/lib/ade/errors");
+    mockSubmitSale.mockRejectedValue(
+      new AdeUnknownOutcomeError(200, "text/html; charset=UTF-8"),
+    );
+
+    const { emitReceiptForBusiness } = await import("./receipt-service");
+    await emitReceiptForBusiness(VALID_INPUT);
+
+    const updateSets = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(updateSets).not.toContain("ERROR");
+  });
+
   it("R21: AdeAuthError (credenziali sbagliate) logga warn con errorClass ade_user_error (no Sentry noise)", async () => {
     // Credenziali Fisconline sbagliate sono input utente, non bug nostro:
     // logger.warn + errorClass ade_user_error -> niente issue Sentry.

--- a/src/lib/services/void-service.test.ts
+++ b/src/lib/services/void-service.test.ts
@@ -932,6 +932,22 @@ describe("voidReceiptForBusiness", () => {
     expect(statusUpdates).not.toContain("ERROR");
   });
 
+  it("REVIEW #64: submitVoid 200 non-JSON (AdeUnknownOutcomeError) NON marca ERROR (resta PENDING)", async () => {
+    // Esito ignoto dopo il POST di annullo: marcare ERROR permetterebbe un
+    // secondo VOID (doppio annullo su AdE). La riga resta PENDING e la
+    // stale-recovery riconcilia via searchDocuments prima di ogni re-submit.
+    const { AdeUnknownOutcomeError } = await import("@/lib/ade/errors");
+    mockSubmitVoid.mockRejectedValue(
+      new AdeUnknownOutcomeError(200, "text/html; charset=UTF-8"),
+    );
+
+    const { voidReceiptForBusiness } = await import("./void-service");
+    await voidReceiptForBusiness(VALID_INPUT);
+
+    const statusUpdates = mockUpdateSet.mock.calls.map((c) => c[0].status);
+    expect(statusUpdates).not.toContain("ERROR");
+  });
+
   it("REVIEW #35: errore pre-submit permanente (non transient) marca ancora ERROR", async () => {
     // Un errore generico non-transient e non-timeout (es. fallimento permanente
     // pre-submit) deve continuare a marcare ERROR: AdE non ha ricevuto nulla e


### PR DESCRIPTION
## Summary

Fixes REVIEW.md #64: when AdE responds with HTTP 200 but a non-JSON body (maintenance HTML, truncated response, proxy interference), the application now correctly treats this as an **unknown outcome** rather than a definitive failure. This prevents marking receipts/voids as ERROR, which would cause them to exit the unique index and reconciliation flow, risking duplicate fiscal documents.

## Key Changes

- **New error class `AdeUnknownOutcomeError`** (`src/lib/ade/errors.ts`): Represents HTTP 200 with non-JSON body after document submission. Stores `statusCode` and `contentType` (never the body, which contains fiscal data). Documented with the rationale for why it's a separate class from `AdePortalError`.

- **`submitDocument` guard** (`src/lib/ade/real-client.ts`): Wrapped the final `response.json()` in try/catch. On JSON parse failure, logs a warning with status/content-type (never the body) and throws `AdeUnknownOutcomeError`. This ensures the row stays PENDING instead of being marked ERROR.

- **`parseJsonBody` helper** (`src/lib/ade/real-client.ts`): New private method for read operations (`getFiscalData`, `getProducts`, `getDocument`, `searchDocuments`). Catches JSON parse errors and throws `AdePortalError` instead of a bare `SyntaxError`. No unknown-outcome semantics here—these are reads, not writes.

- **Error classification** (`src/lib/ade/error-messages.ts`):
  - `isTransientAdeError()` now recognizes `AdeUnknownOutcomeError` as transient (meaning "outcome indeterminate → keep PENDING, not ERROR").
  - `getUserFacingAdeErrorMessage()` maps it to the same "portal not responding" message as 5xx errors.

- **Service layer invariant** (`src/lib/services/receipt-service.ts`, `void-service.ts`): No changes needed—the existing `!isTransientAdeError && !isStatementTimeoutError` gate already prevents ERROR marking when `AdeUnknownOutcomeError` is thrown.

- **Comprehensive test coverage**:
  - `submitSale` 200 + HTML → throws `AdeUnknownOutcomeError`, logs warn with status/content-type (never body).
  - `submitSale` 200 + empty body → same behavior, exposes `statusCode` on error.
  - Read operations (`getFiscalData`, `getProducts`, `getDocument`, `searchDocuments`) 200 + non-JSON → throw `AdePortalError` (not `SyntaxError`).
  - Receipt/void service tests confirm rows stay PENDING on `AdeUnknownOutcomeError`.

## Implementation Details

- **No body in logs**: All logging explicitly avoids the response body to prevent fiscal data (amounts, tax IDs) from leaking into logs or Sentry.
- **Stale recovery integration**: By keeping the row PENDING, the existing stale recovery (`reconcileSaleBeforeResubmit`, `reconcileVoidBeforeResubmit`) will reconcile against AdE via `searchDocuments` before any re-submit, safely determining whether the document was actually registered.
- **Backward compatible**: Existing 200 + valid JSON flows are unchanged. Only the error path (previously a bare `SyntaxError`) is now typed and handled correctly.

Closes REVIEW.md #64.

https://claude.ai/code/session_017ws6HRap9B1DMjspY34rGX