### PR TITLE
Add Web Storage guard for Node ≥ 25 jsdom compatibility

### DIFF
--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -366,6 +366,23 @@ continuare") invece di throware. Test pattern speculare allo storage.
 
 Esempio canonico di copertura: `src/lib/safe-storage.test.ts`.
 
+**Gotcha Node ≥ 25 (webstorage nativo vs jsdom):** da Node 25
+`localStorage`/`sessionStorage` esistono già su `globalThis`, e
+`populateGlobal` di vitest **salta le chiavi già presenti sul global**:
+lo Storage di jsdom non viene installato e i test vedono lo stub di Node
+— che senza `--localstorage-file` è un oggetto SENZA metodi
+(`localStorage.clear is not a function` nei teardown, spy su
+`getItem`/`setItem` che falliscono con "property not defined").
+`sessionStorage` di Node invece funziona (in-memory), quindi il sintomo
+è asimmetrico: falliscono solo i test `localStorage`. Fix canonico:
+`execArgv: ["--no-experimental-webstorage"]` in `test` (top-level, i
+`poolOptions` non esistono più in vitest 4) dentro `vitest.config.ts`.
+Guard fail-fast con messaggio esplicativo:
+`tests/_helpers/assert-functional-web-storage.ts`, invocato da
+`tests/setup.ts` **solo se `typeof window !== "undefined"`** — i file
+con pragma `@vitest-environment node` caricano comunque il setup del
+progetto jsdom ma non hanno (né devono avere) Web Storage.
+
 ---
 
 ## Mock di `Sentry.withScope` + `scope.setFingerprint` (R23)

--- a/tests/_helpers/assert-functional-web-storage.ts
+++ b/tests/_helpers/assert-functional-web-storage.ts
@@ -1,0 +1,39 @@
+/**
+ * Guard fail-fast per l'environment jsdom: verifica che localStorage e
+ * sessionStorage siano Storage funzionanti (quelli di jsdom), non gli stub
+ * Web Storage di Node ≥ 25.
+ *
+ * Contesto: da Node 25 `localStorage`/`sessionStorage` esistono già su
+ * `globalThis`; `populateGlobal` di vitest salta le chiavi già presenti sul
+ * global, quindi lo Storage di jsdom non viene installato e i test vedono lo
+ * stub di Node — che senza `--localstorage-file` è un oggetto senza metodi
+ * (`localStorage.clear is not a function`). Il fix canonico è il flag
+ * `--no-experimental-webstorage` in `test.execArgv` (vitest.config.ts);
+ * questo guard trasforma un'eventuale regressione in un errore immediato e
+ * leggibile invece di decine di failure criptici.
+ */
+
+const REQUIRED_METHODS = ["getItem", "setItem", "removeItem", "clear"] as const;
+
+type StorageName = "localStorage" | "sessionStorage";
+
+export function assertFunctionalWebStorage(
+  globalLike: Partial<Record<StorageName, unknown>> = globalThis,
+): void {
+  for (const name of ["localStorage", "sessionStorage"] as const) {
+    const storage = globalLike[name] as
+      Partial<Record<string, unknown>> | undefined | null;
+    const missing = REQUIRED_METHODS.filter(
+      (method) => typeof storage?.[method] !== "function",
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `${name} non è uno Storage funzionante in questo environment jsdom ` +
+          `(metodi mancanti: ${missing.join(", ")}). Probabile stub Web ` +
+          `Storage di Node ≥ 25 non sovrascritto da jsdom: verifica che ` +
+          `vitest.config.ts passi --no-experimental-webstorage in ` +
+          `test.execArgv.`,
+      );
+    }
+  }
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,14 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
+import { assertFunctionalWebStorage } from "./_helpers/assert-functional-web-storage";
+
+// Fail-fast se lo Storage di jsdom non ha sovrascritto lo stub Web Storage
+// di Node ≥ 25 (vedi il commento nell'helper e vitest.config.ts). Solo con
+// DOM attivo: i file con pragma `@vitest-environment node` caricano comunque
+// questo setup ma non hanno (né devono avere) Web Storage.
+if (typeof window !== "undefined") {
+  assertFunctionalWebStorage();
+}
 
 afterEach(cleanup);

--- a/tests/unit/assert-functional-web-storage.test.ts
+++ b/tests/unit/assert-functional-web-storage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { assertFunctionalWebStorage } from "../_helpers/assert-functional-web-storage";
+
+function functionalStorage(): Record<string, unknown> {
+  return {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+    clear: () => undefined,
+  };
+}
+
+describe("assertFunctionalWebStorage", () => {
+  it("non lancia quando entrambi gli storage hanno tutti i metodi", () => {
+    expect(() =>
+      assertFunctionalWebStorage({
+        localStorage: functionalStorage(),
+        sessionStorage: functionalStorage(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("lancia se localStorage è lo stub rotto di Node ≥ 25 (oggetto senza metodi)", () => {
+    expect(() =>
+      assertFunctionalWebStorage({
+        localStorage: {},
+        sessionStorage: functionalStorage(),
+      }),
+    ).toThrow(/localStorage.*getItem, setItem, removeItem, clear/);
+  });
+
+  it("lancia se manca un solo metodo e lo nomina nel messaggio", () => {
+    const partial = functionalStorage();
+    delete partial.clear;
+    expect(() =>
+      assertFunctionalWebStorage({
+        localStorage: functionalStorage(),
+        sessionStorage: partial,
+      }),
+    ).toThrow(/sessionStorage.*metodi mancanti: clear/);
+  });
+
+  it("lancia se lo storage è assente (undefined)", () => {
+    expect(() =>
+      assertFunctionalWebStorage({
+        localStorage: functionalStorage(),
+        sessionStorage: undefined,
+      }),
+    ).toThrow(/sessionStorage/);
+  });
+
+  it("il messaggio d'errore indica il fix (--no-experimental-webstorage)", () => {
+    expect(() =>
+      assertFunctionalWebStorage({
+        localStorage: {},
+        sessionStorage: functionalStorage(),
+      }),
+    ).toThrow(/--no-experimental-webstorage/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
   plugins: [react()],
   test: {
     testTimeout: 15000,
+    // Node ≥ 25 espone localStorage/sessionStorage su globalThis di default,
+    // e populateGlobal di vitest salta le chiavi già presenti sul global: lo
+    // Storage di jsdom non verrebbe mai installato e i test vedrebbero lo
+    // stub di Node (senza --localstorage-file è un oggetto senza metodi →
+    // "localStorage.clear is not a function"). Il flag — accettato anche da
+    // Node 22 — riporta i worker al comportamento pre-25. Guard fail-fast:
+    // tests/setup.ts → tests/_helpers/assert-functional-web-storage.ts.
+    execArgv: ["--no-experimental-webstorage"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Summary

Adds a fail-fast guard to detect and report when jsdom's Web Storage implementation is not properly installed due to Node ≥ 25's native `localStorage`/`sessionStorage` shadowing vitest's `populateGlobal` mechanism.

## Problem

Node 25+ exposes `localStorage` and `sessionStorage` on `globalThis` by default. Vitest's `populateGlobal` skips keys already present on the global object, so jsdom's functional Storage implementation never gets installed. Tests then see Node's stub Storage (an empty object without methods), causing cryptic failures like `localStorage.clear is not a function`.

The canonical fix is `--no-experimental-webstorage` in vitest's `test.execArgv`, but without a guard, regressions manifest as dozens of confusing test failures instead of one clear error message.

## Changes

- **`tests/_helpers/assert-functional-web-storage.ts`** (new): Helper that validates both `localStorage` and `sessionStorage` have all required methods (`getItem`, `setItem`, `removeItem`, `clear`). Throws with an explicit error message naming the missing methods and pointing to the fix.

- **`tests/setup.ts`** (modified): Invokes the guard at setup time, but only when `typeof window !== "undefined"` (skips for `@vitest-environment node` files that don't need Web Storage).

- **`vitest.config.ts`** (modified): Adds `execArgv: ["--no-experimental-webstorage"]` to `test` config to disable Node's native Web Storage and allow jsdom's to take over.

- **`tests/unit/assert-functional-web-storage.test.ts`** (new): Full test coverage of the guard (happy path, missing methods, undefined storage, error message content).

- **`.claude/skills/testing-patterns/SKILL.md`** (modified): Documents the Node ≥ 25 gotcha, the fix, and the guard pattern for future reference.

## Implementation Details

- Guard runs only once at test setup, before any test executes.
- Error message includes the storage name, missing method names, and the exact flag to add to `vitest.config.ts`.
- Conditional execution prevents false positives in node-environment test files.
- All tests are in Italian to match the codebase convention.

https://claude.ai/code/session_012kfAtUezjzsPq89KpS9S3A