### PR TITLE
fix(ade): decodifica entity HTML nei valori parsati + diagnostica ACS CIE

### DIFF
--- a/src/lib/ade/real-client-cie.test.ts
+++ b/src/lib/ade/real-client-cie.test.ts
@@ -123,17 +123,23 @@ function queueCiePreamble(
  */
 function mockCieHappyPath(
   fetchMock: ReturnType<typeof vi.fn>,
-  opts: { firstFormAction?: string; finalProbeAction?: string } = {},
+  opts: {
+    firstFormAction?: string;
+    finalProbeAction?: string;
+    finalProbeBody?: string;
+  } = {},
 ): void {
   queueCiePreamble(fetchMock, opts.firstFormAction);
   // 7. POST final probe → 200 SAMLResponse form verso AdE SP
   fetchMock.mockResolvedValueOnce(
     mockResponse({
-      body: samlForm(
-        opts.finalProbeAction ?? `${SP}/sp/AssertionConsumerService7`,
-        "SAMLResponse",
-        "selcie",
-      ),
+      body:
+        opts.finalProbeBody ??
+        samlForm(
+          opts.finalProbeAction ?? `${SP}/sp/AssertionConsumerService7`,
+          "SAMLResponse",
+          "selcie",
+        ),
     }),
   );
   // 8a. POST ACS → 302 make4SAM
@@ -379,6 +385,80 @@ describe("RealAdeClient.loginCie", () => {
       "ade:stale_socket_retry",
     );
   });
+
+  it("decodifica le entity HTML della pagina e1s5 (Shibboleth) prima del POST all'ACS", async () => {
+    // L'encoder di Shibboleth può codificare i non-alfanumerici degli attributi
+    // come entity numeriche: il base64 della SAMLResponse (+ / =) e l'action
+    // assoluta della form arrivano corrotti se non decodificati — il POST
+    // andrebbe all'ACS con base64 invalido (o a un URL sbagliato) → 500.
+    const encodedAction =
+      "https&#x3a;&#x2f;&#x2f;sp.agenziaentrate.gov.it&#x2f;sp&#x2f;AssertionConsumerService7";
+    const encodedSaml = "PD94bWwg&#x2b;dmVyc2lvbj&#x2f;MS4w&#x3d;&#x3d;";
+    const decodedSaml = "PD94bWwg+dmVyc2lvbj/MS4w==";
+
+    mockCieHappyPath(fetchMock, {
+      finalProbeBody: `<form action="${encodedAction}" method="post">
+        <input type="hidden" name="SAMLResponse" value="${encodedSaml}" />
+        <input type="hidden" name="RelayState" value="selcie" />
+      </form>`,
+    });
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    const session = await client.loginCie(CREDENTIALS);
+
+    expect(session.partitaIva).toBe("10872631006");
+
+    const acsCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/sp/AssertionConsumerService7"),
+    );
+    expect(acsCall).toBeDefined();
+    // L'action entity-encoded è stata decodificata in URL assoluto (host SP,
+    // non risolta per errore come path relativo sull'origin IdP).
+    expect(String(acsCall![0])).toBe(`${SP}/sp/AssertionConsumerService7`);
+    const body = new URLSearchParams(String((acsCall![1] as RequestInit).body));
+    expect(body.get("SAMLResponse")).toBe(decodedSaml);
+    expect(body.get("RelayState")).toBe("selcie");
+  });
+
+  it("logga la diagnostica dell'ACS (status, host, marker base64) quando il SP non redirige", async () => {
+    // Incidente dev 2026-07-14 (seconda occorrenza): ACS risponde 500 senza
+    // Location. Serve l'evidenza nel log per distinguere payload corrotto
+    // (samlLooksBase64 false) da errore lato SP (regola 13).
+    queueCiePreamble(fetchMock);
+    // 7. final probe → form SAMLResponse OK
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(
+          `${SP}/sp/AssertionConsumerService7`,
+          "SAMLResponse",
+          "selcie",
+        ),
+      }),
+    );
+    // 8a. POST ACS → 500 senza Location
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 500,
+        body: "<html><head><title>Errore interno</title></head></html>",
+        headers: [["Content-Type", "text/html"]],
+      }),
+    );
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    await expect(client.loginCie(CREDENTIALS)).rejects.toThrow(AdePortalError);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "cie_acs",
+        statusCode: 500,
+        acsHost: "sp.agenziaentrate.gov.it",
+        acsPath: "/sp/AssertionConsumerService7",
+        samlLooksBase64: true,
+        bodyTitle: "Errore interno",
+      }),
+      "ade:cie_acs_no_redirect",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -438,6 +518,30 @@ describe("RealAdeClient.loginCie — form action allowlist (anti-SSRF)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(13);
     const postedToAttacker = fetchMock.mock.calls.some(([url]) =>
       String(url).startsWith(ATTACKER),
+    );
+    expect(postedToAttacker).toBe(false);
+  });
+
+  it("blocks an attacker form action hidden behind HTML entities", async () => {
+    // Prima della decodifica entity, "https&#x3a;&#x2f;&#x2f;attacker…" veniva
+    // trattata come path RELATIVO sull'origin IdP (host in allowlist) — la
+    // decodifica la rivela come URL assoluto fuori allowlist: va bloccata.
+    queueCiePreamble(fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        body: samlForm(
+          "https&#x3a;&#x2f;&#x2f;attacker.example.com&#x2f;acs",
+          "SAMLResponse",
+          "selcie",
+        ),
+      }),
+    );
+
+    const client = new RealAdeClient({ ciePollIntervalMs: 0 });
+    await expect(client.loginCie(CREDENTIALS)).rejects.toThrow(AdePortalError);
+
+    const postedToAttacker = fetchMock.mock.calls.some(([url]) =>
+      String(url).includes("attacker"),
     );
     expect(postedToAttacker).toBe(false);
   });

--- a/src/lib/ade/real-client.test.ts
+++ b/src/lib/ade/real-client.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   RealAdeClient,
+  decodeHtmlEntities,
   isStaleSocketError,
   resolveAdeRedirect,
 } from "./real-client";
@@ -1998,6 +1999,46 @@ describe("isStaleSocketError", () => {
     const err = new Error("boom");
     (err as Error & { cause: unknown }).cause = err;
     expect(isStaleSocketError(err)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decodeHtmlEntities — i valori estratti dagli attributi HTML (SAMLResponse,
+// form action) vanno decodificati come farebbe un browser: Shibboleth può
+// codificare i non-alfanumerici come entity numeriche.
+// ---------------------------------------------------------------------------
+
+describe("decodeHtmlEntities", () => {
+  it("decodifica le entity esadecimali (base64 Shibboleth: + / =)", () => {
+    expect(decodeHtmlEntities("QUJD&#x2b;ZGVm&#x2f;Z2hp&#x3d;&#x3d;")).toBe(
+      "QUJD+ZGVm/Z2hp==",
+    );
+  });
+
+  it("decodifica le entity decimali", () => {
+    expect(decodeHtmlEntities("a&#43;b&#61;c")).toBe("a+b=c");
+  });
+
+  it("decodifica le entity con nome (amp, lt, gt, quot, apos)", () => {
+    expect(decodeHtmlEntities("a&lt;b&gt;c&quot;d&#39;e&apos;f&amp;g")).toBe(
+      "a<b>c\"d'e'f&g",
+    );
+  });
+
+  it("decodifica &amp; per ultimo (niente doppia decodifica)", () => {
+    // "&amp;#x2b;" è la rappresentazione HTML del testo letterale "&#x2b;":
+    // un solo passaggio di decodifica, come un browser.
+    expect(decodeHtmlEntities("&amp;#x2b;")).toBe("&#x2b;");
+  });
+
+  it("lascia intatte le stringhe senza entity (base64 tipico)", () => {
+    const base64 = "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4K+/==";
+    expect(decodeHtmlEntities(base64)).toBe(base64);
+  });
+
+  it("lascia intatta un'entity numerica fuori range Unicode", () => {
+    expect(decodeHtmlEntities("x&#x110000;y")).toBe("x&#x110000;y");
+    expect(decodeHtmlEntities("x&#1114112;y")).toBe("x&#1114112;y");
   });
 });
 

--- a/src/lib/ade/real-client.ts
+++ b/src/lib/ade/real-client.ts
@@ -166,6 +166,35 @@ function safePath(url: string): string {
 }
 
 /**
+ * Decodifica le entity HTML di un valore estratto da un attributo (hidden
+ * input value, form action) — ciò che un browser fa da spec prima di usare
+ * l'attributo. Necessario per le pagine Shibboleth dell'IdP CIE: l'encoder
+ * lato server può rappresentare i non-alfanumerici come entity numeriche,
+ * corrompendo il base64 della SAMLResponse (`+ / =` → `&#x2b; &#x2f; &#x3d;`)
+ * e le action assolute (`https&#x3a;…`) se ri-POSTati senza decodifica.
+ *
+ * Un solo passaggio (numeriche prima, `&amp;` per ultima: mai doppia
+ * decodifica); entity fuori range Unicode lasciate intatte. Esportata per
+ * testabilità.
+ */
+export function decodeHtmlEntities(value: string): string {
+  const fromCodePoint = (match: string, cp: number): string =>
+    cp <= 0x10ffff ? String.fromCodePoint(cp) : match;
+  return value
+    .replaceAll(/&#x([0-9a-f]+);/gi, (m, hex: string) =>
+      fromCodePoint(m, Number.parseInt(hex, 16)),
+    )
+    .replaceAll(/&#(\d+);/g, (m, dec: string) =>
+      fromCodePoint(m, Number.parseInt(dec, 10)),
+    )
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&amp;", "&");
+}
+
+/**
  * Riconosce il fallimento fetch da riuso di un socket keep-alive che il peer
  * ha già chiuso: undici lo riporta come `TypeError: fetch failed` con causa
  * `SocketError: other side closed` (`code: UND_ERR_SOCKET`).
@@ -816,12 +845,14 @@ export class RealAdeClient implements AdeClient {
       `value=["']([^"']*)["'][^>]*?name=["']${safePattern}["']`,
       "is",
     );
-    return (nameFirst.exec(html) ?? valueFirst.exec(html))?.[1] ?? null;
+    const raw = (nameFirst.exec(html) ?? valueFirst.exec(html))?.[1] ?? null;
+    return raw === null ? null : decodeHtmlEntities(raw);
   }
 
   /** Parse form action URL from HTML. */
   private parseFormAction(html: string): string | null {
-    return /<form[^>]+action=["']([^"']+)["']/i.exec(html)?.[1] ?? null;
+    const raw = /<form[^>]+action=["']([^"']+)["']/i.exec(html)?.[1] ?? null;
+    return raw === null ? null : decodeHtmlEntities(raw);
   }
 
   /**
@@ -1588,6 +1619,25 @@ export class RealAdeClient implements AdeClient {
     const acs = await this.request(formAction, this.cieForm(acsBody));
     const acsLoc = acs.headers.get("Location");
     if (!acsLoc) {
+      // Diagnostica prima del throw (regola 13): distingue un payload
+      // corrotto lato nostro (samlLooksBase64 false) da un errore lato SP.
+      // Mai il body né la SAMLResponse (asserzione d'identità): solo marker.
+      const bodyText = await acs.text().catch(() => "");
+      logger.warn(
+        {
+          phase: "cie_acs",
+          statusCode: acs.status,
+          contentType: acs.headers.get("content-type"),
+          bodyLen: bodyText.length,
+          bodyTitle: /<title>([^<]{0,120})/i.exec(bodyText)?.[1] ?? null,
+          acsHost: safeHost(formAction),
+          acsPath: safePath(formAction),
+          samlResponseLen: samlResponse.length,
+          samlLooksBase64: /^[A-Za-z0-9+/=]+$/.test(samlResponse),
+          relayStateLen: relayState.length,
+        },
+        "ade:cie_acs_no_redirect",
+      );
       throw new AdePortalError(acs.status, "CIE: no redirect from AdE SP ACS");
     }
 


### PR DESCRIPTION
## Problema

Secondo incidente sul flusso CIE dev (dopo il fix socket-retry di #740, che ha funzionato: il flusso ora supera la fase IdP): il POST della SAMLResponse all'AdE SP ACS risponde **500 senza Location** → `AdePortalError: CIE: no redirect from AdE SP ACS` (flow `onboarding-verify-cie`).

## Root cause (più probabile) e fix

`parseHiddenInput`/`parseFormAction` ritornavano il valore **raw** dell'attributo HTML, senza decodificare le entity — un browser le decodifica sempre, da spec. Le pagine Shibboleth dell'IdP CIE possono rappresentare i non-alfanumerici come entity numeriche: il base64 della SAMLResponse (`+ / =` → `&#x2b; &#x2f; &#x3d;`) e le action assolute (`https&#x3a;…`) arrivavano corrotti al re-POST verso l'ACS → il SP non riesce a decodificare → 500.

Fix: `decodeHtmlEntities()` (hex/dec/named, `&amp;` per ultima — un solo passaggio, niente doppia decodifica; entity fuori range Unicode lasciate intatte) applicata in entrambi i parser. È comportamento browser-equivalente, corretto a prescindere dall'encoder del server.

**Bonus sicurezza**: un'action maligna nascosta dietro entity (`https&#x3a;&#x2f;&#x2f;attacker…`) prima veniva risolta come path *relativo* su un host in allowlist; ora viene decodificata in URL assoluto e **bloccata** dall'anti-SSRF (test dedicato).

## Diagnostica (regola 13)

L'ipotesi non è verificabile offline (le pagine e1s5 esistono solo autenticati; le HAR browser non hanno catturato quei body). Quindi, oltre al fix, l'hop ACS ora logga prima del throw: status, content-type, title della pagina d'errore, host/path dell'ACS, lunghezza e marker "è base64 valido?" della SAMLResponse — mai il payload (porta l'asserzione d'identità). Se dopo il deploy il 500 persistesse, il log dirà subito se il problema è ancora lato nostro (`samlLooksBase64: false`) o lato SP.

## Test

- Unit `decodeHtmlEntities`: hex, dec, named, `&amp;` per ultimo, passthrough base64 pulito, codepoint fuori range
- E2E CIE: pagina e1s5 con action e SAMLResponse entity-encoded → login completa, ACS riceve il base64 decodificato all'URL giusto
- E2E CIE: ACS 500 senza Location → `AdePortalError` + warn `ade:cie_acs_no_redirect` con i campi diagnostici
- Anti-SSRF: action attacker dietro entity → bloccata, nessuna chiamata all'attacker

## Verifica sul campo

Dopo il merge/deploy dev: rifare la verifica CIE dalle impostazioni. Esiti possibili: ✅ login ok; ❌ ancora 500 → il log `ade:cie_acs_no_redirect` ora contiene l'evidenza per il prossimo passo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)