### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Patch release bumping the version from 1.5.0 to 1.5.1 in `package.json`.

## Changes
- Updated `version` field in `package.json` from `1.5.0` to `1.5.1`

## Notes
This is a patch version bump. The lockfile was automatically updated as a transitive resolution artifact.

https://claude.ai/code/session_015uyq4PpPKfWs6qbm1CT13H