### PR TITLE
Add "Niente registratore di cassa" feature card to homepage

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -26,6 +26,7 @@ import {
   Undo2,
   Shield,
   CalendarRange,
+  Ban,
   ArrowRight,
   ShoppingBag,
   Scissors,
@@ -524,6 +525,12 @@ export default function Home() {
                 title: "Funziona ovunque sei",
                 description:
                   "Dal banco al furgone: basta uno smartphone con internet per gestire i tuoi corrispettivi.",
+              },
+              {
+                icon: Ban,
+                title: "Niente registratore di cassa",
+                description:
+                  "Nessun dispositivo da comprare o far installare da un tecnico. Ti bastano l'app e la tua Partita IVA.",
               },
             ].map((feature) => (
               <Card key={feature.title} className="border-border/50">


### PR DESCRIPTION
## Summary
Added a new feature card to the marketing homepage highlighting that ScontrinoZero requires no physical cash register device—only the app and a VAT number.

## Changes
- Imported the `Ban` icon from lucide-react
- Added a new feature card object with:
  - **Icon:** `Ban` (visual representation of "no device needed")
  - **Title:** "Niente registratore di cassa" (No cash register)
  - **Description:** Emphasizes that users need only the app and their VAT number, with no need to purchase or install hardware

## Implementation Details
The new card follows the existing pattern in the features array and will be rendered alongside other feature cards on the homepage. The messaging reinforces a key value proposition: ScontrinoZero eliminates the need for expensive physical hardware, reducing barriers to entry for small businesses and micro-activities.

https://claude.ai/code/session_012ESfkJQkdNZRvtH12HyUoV