### PR TITLE
Validate catalog prices with strict boundary rules (rule 9)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -609,32 +609,6 @@ aggiungere un test che `billing-actions.ts` non esporti più il symbol.
 
 ---
 
-### 67. Catalogo: `defaultPrice` validato con `parseFloat` ma inserito come stringa raw → 500 Postgres e valori degeneri
-
-- **Categoria:** correttezza/boundary (regola 9) · **Severità:** Low
-- **File:** `src/server/catalog-actions.ts:77-83` (`validateItemInput`), `:191` e `:278` (INSERT/UPDATE con `validated.priceStr` = input originale); colonna `numeric(10,2)` in `supabase/migrations/0000_initial.sql:84`
-
-**Problema.** La validazione fa `Number.parseFloat(priceStr)` e controlla solo
-NaN/negativo, poi inserisce la **stringa originale** nella colonna
-`numeric(10,2)`. `parseFloat` accetta prefissi numerici e valori speciali:
-`"12abc"` passa (parseFloat=12) ma l'INSERT fallisce con 22P02 → eccezione non
-gestita → error boundary; `"Infinity"` passa la validazione; `"1e7"` passa
-senza alcun tetto. Manca anche il vincolo 2 decimali/max che lo scontrino ha
-(`grossUnitPrice` ≤ 999999.99, 2 decimali, `receipt-schema.ts`): il boundary
-del catalogo è più lasco di quello della cassa che poi consuma quei prezzi.
-
-**Fix (non ambiguo).**
-
-1. Validare col criterio fiscale di `saleLineSchema`: accettare solo
-   `^\d{1,6}([.,]\d{1,2})?$` (virgola normalizzata a punto), range
-   0–999999.99; tutto il resto → `{ error: "Prezzo non valido." }`.
-2. Inserire la forma **normalizzata** (stringa canonica col punto), mai
-   l'input raw.
-3. **Test:** `"12abc"`, `"Infinity"`, `"1e7"`, `"-1"`, `"1.999"` → errore;
-   `"12,50"` → salvato `"12.50"`; `""`/null → `null` invariato.
-
----
-
 ### 68. Server actions senza guard UUID (regola 9): id malformato → 22P02 Postgres → error boundary
 
 - **Categoria:** robustezza/boundary · **Severità:** Low — solo utenti autenticati, ma rompe la regola 19 e genera rumore

--- a/src/server/catalog-actions.test.ts
+++ b/src/server/catalog-actions.test.ts
@@ -279,6 +279,68 @@ describe("catalog-actions", () => {
       expect(mockInsert).not.toHaveBeenCalled();
     });
 
+    // Regola 9 / finding #67: parseFloat accettava prefissi e valori speciali
+    // lasciando poi esplodere l'INSERT su numeric(10,2) con 22P02.
+    it.each([
+      "12abc",
+      "Infinity",
+      "-Infinity",
+      "NaN",
+      "1e7",
+      "1.999",
+      "-1",
+      "0x10",
+      "1,2,3",
+      "1_000",
+    ])(
+      "rifiuta il prezzo degenere %j senza toccare il DB",
+      async (defaultPrice) => {
+        const { addCatalogItem } = await import("./catalog-actions");
+        const result = await addCatalogItem({
+          ...VALID_ADD_INPUT,
+          defaultPrice,
+        });
+
+        expect(result.error).toMatch(/prezzo/i);
+        expect(mockInsert).not.toHaveBeenCalled();
+      },
+    );
+
+    it("rifiuta il prezzo oltre il tetto fiscale (999999.99)", async () => {
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem({
+        ...VALID_ADD_INPUT,
+        defaultPrice: "1000000",
+      });
+
+      expect(result.error).toMatch(/prezzo/i);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("normalizza la virgola decimale a punto prima dell'INSERT", async () => {
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem({
+        ...VALID_ADD_INPUT,
+        defaultPrice: "12,50",
+      });
+
+      expect(result.error).toBeUndefined();
+      const insertArg = mockInsertValues.mock.calls[0][0];
+      expect(insertArg.defaultPrice).toBe("12.50");
+    });
+
+    it("accetta il prezzo al limite fiscale (999999.99)", async () => {
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem({
+        ...VALID_ADD_INPUT,
+        defaultPrice: "999999.99",
+      });
+
+      expect(result.error).toBeUndefined();
+      const insertArg = mockInsertValues.mock.calls[0][0];
+      expect(insertArg.defaultPrice).toBe("999999.99");
+    });
+
     it("ritorna errore se il codice IVA non è valido", async () => {
       const { addCatalogItem } = await import("./catalog-actions");
       const result = await addCatalogItem({
@@ -574,6 +636,35 @@ describe("catalog-actions", () => {
       expect(result.error).toBeDefined();
       expect(result.error).toMatch(/prezzo/i);
       expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    // Regola 9 / finding #67: stesso boundary dell'INSERT anche in UPDATE.
+    it.each(["12abc", "Infinity", "1e7", "1.999", "1000000"])(
+      "rifiuta il prezzo degenere %j senza toccare il DB",
+      async (defaultPrice) => {
+        const { updateCatalogItem } = await import("./catalog-actions");
+        const result = await updateCatalogItem({
+          ...VALID_UPDATE_INPUT,
+          defaultPrice,
+        });
+
+        expect(result.error).toMatch(/prezzo/i);
+        expect(mockUpdate).not.toHaveBeenCalled();
+      },
+    );
+
+    it("normalizza la virgola decimale a punto prima dell'UPDATE", async () => {
+      mockLimit.mockResolvedValue([{ id: FAKE_ITEM_ID }]);
+
+      const { updateCatalogItem } = await import("./catalog-actions");
+      const result = await updateCatalogItem({
+        ...VALID_UPDATE_INPUT,
+        defaultPrice: "7,05",
+      });
+
+      expect(result.error).toBeUndefined();
+      const updateArg = mockUpdateSet.mock.calls[0][0];
+      expect(updateArg.defaultPrice).toBe("7.05");
     });
 
     it("ritorna errore se il codice IVA non è valido", async () => {

--- a/src/server/catalog-actions.ts
+++ b/src/server/catalog-actions.ts
@@ -62,6 +62,38 @@ async function authenticateAndAuthorize(
   return checkBusinessOwnership(user.id, businessId);
 }
 
+// Criterio fiscale allineato a `saleLineSchema` (receipt-schema.ts) e alla
+// colonna numeric(10,2): max 6 cifre intere + separatore decimale opzionale
+// (punto o virgola) con max 2 decimali. `parseFloat` accettava invece prefissi
+// numerici ("12abc" → 12), valori speciali ("Infinity", "NaN") e notazione
+// esponenziale ("1e7"), lasciando poi esplodere l'INSERT su numeric(10,2) con
+// Postgres 22P02 (error boundary invece di errore inline — regola 9/19).
+const PRICE_REGEX = /^\d{1,6}([.,]\d{1,2})?$/;
+const PRICE_MAX_CENTS = 99_999_999; // 999999.99 in centesimi
+
+/**
+ * Valida e normalizza il prezzo di catalogo al boundary (regola 9).
+ * Ritorna `{ priceStr }` con la forma canonica col punto (mai l'input raw),
+ * `null` se il prezzo è assente, o `{ error }` se degenere/fuori range.
+ */
+function normalizePrice(
+  defaultPrice: string | null,
+): { priceStr: string | null } | { error: string } {
+  const raw = defaultPrice === "" ? null : (defaultPrice ?? null);
+  if (raw === null) return { priceStr: null };
+
+  const normalized = raw.trim().replace(",", ".");
+  if (!PRICE_REGEX.test(normalized)) {
+    return { error: "Il prezzo deve essere un numero non negativo." };
+  }
+  // Range check sui centesimi interi per evitare imprecisioni IEEE-754 sul tetto.
+  const cents = Math.round(Number.parseFloat(normalized) * 100);
+  if (cents < 0 || cents > PRICE_MAX_CENTS) {
+    return { error: "Il prezzo deve essere un numero non negativo." };
+  }
+  return { priceStr: normalized };
+}
+
 /** Valida descrizione, prezzo e aliquota IVA. Ritorna { priceStr } se OK. */
 function validateItemInput(
   description: string,
@@ -74,17 +106,12 @@ function validateItemInput(
   if (description.trim().length > 200) {
     return { error: "La descrizione non può superare 200 caratteri." };
   }
-  const priceStr = defaultPrice === "" ? null : (defaultPrice ?? null);
-  if (priceStr !== null) {
-    const price = Number.parseFloat(priceStr);
-    if (Number.isNaN(price) || price < 0) {
-      return { error: "Il prezzo deve essere un numero non negativo." };
-    }
-  }
+  const priceResult = normalizePrice(defaultPrice);
+  if ("error" in priceResult) return priceResult;
   if (!VAT_CODES.includes(defaultVatCode)) {
     return { error: "Codice IVA non valido." };
   }
-  return { priceStr };
+  return { priceStr: priceResult.priceStr };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes finding #67 by implementing strict price validation in catalog actions to prevent degenerate values and database errors. Prices are now validated against a fiscal boundary (0–999999.99, max 2 decimals) matching the receipt schema, and normalized to canonical form before insertion.

## Changes

- **Added `normalizePrice()` function** in `catalog-actions.ts`:
  - Validates prices with regex `^\d{1,6}([.,]\d{1,2})?$` (aligns with `saleLineSchema`)
  - Normalizes comma to period (e.g., `"12,50"` → `"12.50"`)
  - Enforces range 0–999999.99 via centesimal integer check (avoids IEEE-754 precision issues)
  - Returns canonical normalized string or error message

- **Refactored `validateItemInput()`**:
  - Replaced `Number.parseFloat()` validation with `normalizePrice()` call
  - Now rejects degenerate inputs: `"12abc"`, `"Infinity"`, `"1e7"`, `"1.999"`, `"-1"`, `"0x10"`, `"1,2,3"`, `"1_000"`, and values > 999999.99
  - Inserts normalized form (never raw input) into database

- **Extended test coverage** in `catalog-actions.test.ts`:
  - `addCatalogItem`: 4 new test cases covering degenerate prices, boundary (999999.99), and comma normalization
  - `updateCatalogItem`: 2 new test cases for same validation rules in UPDATE path
  - All tests verify error message matches `/prezzo/i` and DB is not touched on validation failure

## Implementation Details

- **Boundary alignment**: Catalog price constraints now match receipt line item constraints (`grossUnitPrice` ≤ 999999.99, 2 decimals max)
- **Centesimal validation**: Range check uses `Math.round(parseFloat(normalized) * 100)` to avoid floating-point precision errors at the 999999.99 ceiling
- **Normalization timing**: Prices normalized immediately after validation, before any DB operation (INSERT/UPDATE)
- **Error boundary prevention** (rule 9): Rejects invalid input at validation boundary with user-facing error, preventing Postgres 22P02 exceptions from propagating to error boundary

Closes finding #67 in REVIEW.md.

https://claude.ai/code/session_01FBXboEKtszh6YcYTCXDKEJ