### PR TITLE
Handle DB statement timeouts in analytics bundle (finding #69)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -656,28 +656,6 @@ senza che il mock DB venga interrogato.
 
 ---
 
-### 69. `getAnalyticsBundle` non degrada su statement timeout (regola 19; incoerente con `getStarterKpis`)
-
-- **Categoria:** robustezza/UX · **Severità:** Low
-- **File:** `src/server/analytics-actions.ts:275-294` (`buildAnalyticsDataset`, nessun try/catch attorno a `fetchSaleDocsInRange`/`computeTotalsByDoc`), `:346-364` (`getAnalyticsBundle`); contrasto: `:389-401` (`getStarterKpis` gestisce `isStatementTimeoutError`, PR #572)
-
-**Problema.** Il path Pro passa per `withStatementTimeout(5s)`: sotto
-contention il 57014 propaga da `getAnalyticsBundle` fino all'error boundary
-della pagina analytics invece del fallback inline — esattamente il
-comportamento che la regola 19 vieta e che `getStarterKpis` già corregge.
-Inoltre `computeTotalsByDoc` (`fetchLinesByDocIds`) gira **fuori** dal
-timeout scoped: la query più pesante del bundle non ha budget.
-
-**Fix (non ambiguo).** try/catch in `buildAnalyticsDataset` attorno a
-fetch+compute: su `isStatementTimeoutError` → `{ ok: false, error: "Servizio
-temporaneamente sovraccarico, riprova tra qualche istante." }` (stesso
-messaggio di `getStarterKpis`); altri errori → rethrow (Sentry). Portare
-anche `fetchLinesByDocIds` del path analytics dentro `withStatementTimeout`.
-**Test:** timeout su `fetchSaleDocsInRange` → `{ error }` senza throw;
-timeout su `fetchLinesByDocIds` → idem; errore generico → throw.
-
----
-
 ### 70. Webhook `invoice.paid`: `currentPeriodEnd` scritto con `invoice.period_end` (semantica Stripe sbagliata)
 
 - **Categoria:** correttezza/billing · **Severità:** Low — oggi il campo non ha consumer runtime, il danno è latente

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -869,6 +869,65 @@ describe("getAnalyticsBundle", () => {
     const res = await getAnalyticsBundle("biz-1", "30d");
     expect(res).toEqual({ error: "Non autorizzato." });
   });
+
+  it("degrades to { error } on a DB statement timeout during the docs fetch (57014)", async () => {
+    // Il 57014 su fetchSaleDocsInRange deve degradare inline (regola 19), non
+    // propagare fino all'error boundary come faceva prima del finding #69.
+    const timeoutErr = Object.assign(new Error("statement timeout"), {
+      code: "57014",
+    });
+    const rejectingBuilder = {
+      from: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn(),
+    };
+    rejectingBuilder.from.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.where.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.limit.mockReturnValue(Promise.reject(timeoutErr));
+    mockSelect.mockReturnValue(rejectingBuilder);
+
+    const res = await getAnalyticsBundle("biz-1", "30d");
+    expect(res).toMatchObject({
+      error: expect.stringContaining("sovraccarico"),
+    });
+  });
+
+  it("degrades to { error } on a DB statement timeout during the lines fetch (57014)", async () => {
+    // fetchLinesByDocIds ora gira dentro withStatementTimeout (finding #69):
+    // un 57014 sulla query piu' pesante del bundle degrada come quello sui docs.
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { id: "d1", status: "ACCEPTED", createdAt: new Date() },
+      ]),
+    );
+    const timeoutErr = Object.assign(new Error("statement timeout"), {
+      code: "57014",
+    });
+    mockFetchLinesByDocIds.mockRejectedValue(timeoutErr);
+
+    const res = await getAnalyticsBundle("biz-1", "30d");
+    expect(res).toMatchObject({
+      error: expect.stringContaining("sovraccarico"),
+    });
+  });
+
+  it("rethrows unexpected fetch errors instead of masking them", async () => {
+    const rejectingBuilder = {
+      from: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn(),
+    };
+    rejectingBuilder.from.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.where.mockReturnValue(rejectingBuilder);
+    rejectingBuilder.limit.mockReturnValue(
+      Promise.reject(new Error("network glitch")),
+    );
+    mockSelect.mockReturnValue(rejectingBuilder);
+
+    await expect(getAnalyticsBundle("biz-1", "30d")).rejects.toThrow(
+      "network glitch",
+    );
+  });
 });
 
 describe("getStarterKpis", () => {
@@ -996,6 +1055,25 @@ describe("getStarterKpis", () => {
     rejectingBuilder.where.mockReturnValue(rejectingBuilder);
     rejectingBuilder.limit.mockReturnValue(Promise.reject(timeoutErr));
     mockSelect.mockReturnValue(rejectingBuilder);
+
+    const res = await getStarterKpis("biz-1");
+    expect(res).toMatchObject({
+      error: expect.stringContaining("sovraccarico"),
+    });
+  });
+
+  it("degrades to { error } on a DB statement timeout during the lines fetch (57014)", async () => {
+    // computeTotalsByDoc esegue fetchLinesByDocIds dentro withStatementTimeout
+    // (finding #69): un 57014 qui deve degradare come quello sui docs.
+    mockSelect.mockReturnValue(
+      makeSelectBuilder([
+        { id: "d1", status: "ACCEPTED", createdAt: new Date() },
+      ]),
+    );
+    const timeoutErr = Object.assign(new Error("statement timeout"), {
+      code: "57014",
+    });
+    mockFetchLinesByDocIds.mockRejectedValue(timeoutErr);
 
     const res = await getStarterKpis("biz-1");
     expect(res).toMatchObject({

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -249,7 +249,17 @@ async function computeTotalsByDoc(
   if (docs.length === 0) {
     return { totalsByDoc: new Map(), linesByDoc: new Map() };
   }
-  const lines = await fetchLinesByDocIds(docs.map((d) => d.id));
+  // `fetchLinesByDocIds` e' la query piu' pesante del bundle (una riga per
+  // articolo su tutti i documenti del range). Eseguirla dentro
+  // `withStatementTimeout` le da' lo stesso budget di `fetchSaleDocsInRange`:
+  // senza, la query piu' costosa girava fuori budget e un 57014 sotto
+  // contention pinnava la connessione invece di degradare (finding #69).
+  const lines = await withStatementTimeout(ANALYTICS_QUERY_TIMEOUT_MS, (tx) =>
+    fetchLinesByDocIds(
+      docs.map((d) => d.id),
+      tx,
+    ),
+  );
   const linesByDoc = groupLinesByDocId(lines);
   const totalsByDoc = new Map<string, number>();
   for (const doc of docs) {
@@ -286,11 +296,26 @@ async function buildAnalyticsDataset(
   // Includiamo sempre publicRequest: il dataset condiviso serve KPI +
   // timeseries (che non lo usano) e breakdown (che lo usa). Pagare un campo
   // jsonb in piu' una volta sola e' molto piu' economico di 3 fetch separate.
-  const docs = await fetchSaleDocsInRange(businessId, from, to, {
-    includePublicRequest: true,
-  });
-  const { totalsByDoc, linesByDoc } = await computeTotalsByDoc(docs);
-  return { ok: true, docs, totalsByDoc, linesByDoc, from, to };
+  try {
+    const docs = await fetchSaleDocsInRange(businessId, from, to, {
+      includePublicRequest: true,
+    });
+    const { totalsByDoc, linesByDoc } = await computeTotalsByDoc(docs);
+    return { ok: true, docs, totalsByDoc, linesByDoc, from, to };
+  } catch (err) {
+    // Un timeout DB (57014) sotto contention deve degradare inline (il
+    // fallback della pagina analytics), non propagare fino all'error boundary
+    // di Next (regola 19, stesso comportamento di getStarterKpis). Gli errori
+    // imprevisti restano visibili (rethrow → Sentry).
+    if (isStatementTimeoutError(err)) {
+      return {
+        ok: false,
+        error:
+          "Servizio temporaneamente sovraccarico, riprova tra qualche istante.",
+      };
+    }
+    throw err;
+  }
 }
 
 // Cached path: deduplicato per (businessId, range) nello stesso render RSC.


### PR DESCRIPTION
## Summary

Fixes finding #69 by implementing graceful degradation for database statement timeouts (error code 57014) in the analytics bundle, bringing it in line with the existing behavior in `getStarterKpis` (rule 19).

## Changes

- **`buildAnalyticsDataset`:** Added try-catch around `fetchSaleDocsInRange` and `computeTotalsByDoc` to catch statement timeout errors and return a user-friendly error message instead of propagating to the error boundary.

- **`computeTotalsByDoc`:** Wrapped `fetchLinesByDocIds` call in `withStatementTimeout` to ensure the heaviest query in the bundle (`fetchLinesByDocIds`) runs within the same 5-second budget as `fetchSaleDocsInRange`. Previously it ran outside the timeout scope, causing contention-induced 57014 errors to pin the connection instead of degrading gracefully.

- **Tests:** Added three new test cases:
  - Timeout during docs fetch (57014) → returns `{ error: "sovraccarico..." }`
  - Timeout during lines fetch (57014) → returns `{ error: "sovraccarico..." }`
  - Unexpected errors (e.g., network glitch) → rethrows to Sentry
  
  Added equivalent test for `getStarterKpis` to verify timeout handling in `computeTotalsByDoc` path.

- **REVIEW.md:** Removed finding #69 (now resolved).

## Implementation Details

- Uses existing `isStatementTimeoutError()` helper to distinguish 57014 from other errors.
- Returns the same user-facing message as `getStarterKpis` for consistency.
- Unexpected errors are rethrown to maintain observability (Sentry).
- Follows rule 19: server actions degrade inline on read failures, never propagate to error boundary.

https://claude.ai/code/session_012X8xmNJHWGjmHWRPBWUBa2