### PR TITLE
Move getEffectivePlan to @/lib/plans (hardening REVIEW #66)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -587,25 +587,29 @@ finestra.
 
 ---
 
-### 66. `getEffectivePlan(userId)` è una server action pubblica senza autenticazione
+### 67. Catalogo: `defaultPrice` validato con `parseFloat` ma inserito come stringa raw → 500 Postgres e valori degeneri
 
-- **Categoria:** sicurezza/hardening · **Severità:** Low — richiede l'auth UUID della vittima (non enumerabile), leak limitato al nome del piano
-- **File:** `src/server/billing-actions.ts:34` (export da modulo `"use server"`); consumer legittimo: `src/server/api-key-actions.ts:54`
+- **Categoria:** correttezza/boundary (regola 9) · **Severità:** Low
+- **File:** `src/server/catalog-actions.ts:77-83` (`validateItemInput`), `:191` e `:278` (INSERT/UPDATE con `validated.priceStr` = input originale); colonna `numeric(10,2)` in `supabase/migrations/0000_initial.sql:84`
 
-**Problema.** Ogni export async di un file `"use server"` diventa un endpoint
-POST invocabile da qualunque client con l'action ID (estraibile dal bundle).
-`getEffectivePlan` accetta un `userId` arbitrario e risponde senza chiamare
-`getAuthenticatedUser`: (a) info-leak del piano di un altro utente dato il suo
-auth UUID; (b) due query DB gratuite per invocazione non autenticata (surface
-DoS); (c) un `userId` non-UUID produce Postgres 22P02 non gestito → error
-boundary + rumore. È un helper server-side, non una action.
+**Problema.** La validazione fa `Number.parseFloat(priceStr)` e controlla solo
+NaN/negativo, poi inserisce la **stringa originale** nella colonna
+`numeric(10,2)`. `parseFloat` accetta prefissi numerici e valori speciali:
+`"12abc"` passa (parseFloat=12) ma l'INSERT fallisce con 22P02 → eccezione non
+gestita → error boundary; `"Infinity"` passa la validazione; `"1e7"` passa
+senza alcun tetto. Manca anche il vincolo 2 decimali/max che lo scontrino ha
+(`grossUnitPrice` ≤ 999999.99, 2 decimali, `receipt-schema.ts`): il boundary
+del catalogo è più lasco di quello della cassa che poi consuma quei prezzi.
 
-**Fix (non ambiguo).** Spostare `getEffectivePlan` fuori dal modulo
-`"use server"` — collocazione: `src/lib/plans.ts`, accanto a `getPlan` (già
-server-only) — e aggiornare gli import in `api-key-actions.ts` e nei test;
-in `billing-actions.ts` restano solo le action autenticate. Verificare con
-grep che nessun client component la importi. **Test:** esistenti, spostati;
-aggiungere un test che `billing-actions.ts` non esporti più il symbol.
+**Fix (non ambiguo).**
+
+1. Validare col criterio fiscale di `saleLineSchema`: accettare solo
+   `^\d{1,6}([.,]\d{1,2})?$` (virgola normalizzata a punto), range
+   0–999999.99; tutto il resto → `{ error: "Prezzo non valido." }`.
+2. Inserire la forma **normalizzata** (stringa canonica col punto), mai
+   l'input raw.
+3. **Test:** `"12abc"`, `"Infinity"`, `"1e7"`, `"-1"`, `"1.999"` → errore;
+   `"12,50"` → salvato `"12.50"`; `""`/null → `null` invariato.
 
 ---
 

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -5,14 +5,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Use vi.hoisted() to guarantee variables are available when the vi.mock
 // factory executes (vi.mock is hoisted before const declarations).
-const { mockGetDb, mockLimit, mockSelectWhere, mockFrom, mockSelect } =
-  vi.hoisted(() => ({
-    mockGetDb: vi.fn(),
-    mockLimit: vi.fn(),
-    mockSelectWhere: vi.fn(),
-    mockFrom: vi.fn(),
-    mockSelect: vi.fn(),
-  }));
+const {
+  mockGetDb,
+  mockLimit,
+  mockSelectWhere,
+  mockFrom,
+  mockSelect,
+  mockPlanFromPriceId,
+} = vi.hoisted(() => ({
+  mockGetDb: vi.fn(),
+  mockLimit: vi.fn(),
+  mockSelectWhere: vi.fn(),
+  mockFrom: vi.fn(),
+  mockSelect: vi.fn(),
+  mockPlanFromPriceId: vi.fn(),
+}));
 
 vi.mock("@/db", () => ({
   getDb: mockGetDb,
@@ -20,6 +27,11 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/db/schema", () => ({
   profiles: "profiles-table",
+  subscriptions: "subscriptions-table",
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  planFromPriceId: mockPlanFromPriceId,
 }));
 
 import {
@@ -36,6 +48,7 @@ import {
   canUseDashboardCashier,
   canUsePro,
   getApiKeyLimit,
+  getEffectivePlan,
   getPlan,
   isDeveloperPlan,
   isPaidPlanExpired,
@@ -770,5 +783,112 @@ describe("assertProPlan", () => {
     if (result.ok) {
       expect(result.plan).toBe("unlimited");
     }
+  });
+});
+
+// getEffectivePlan spostata qui da billing-actions.ts (REVIEW #66): è un
+// helper server-only, non una server action pubblica. getEffectivePlan chiama
+// il vero getPlan (query profiles), poi una query subscriptions: entrambe
+// passano dalla stessa catena select mockata, quindi si usano
+// mockResolvedValueOnce in ordine (profilo → subscription).
+describe("getEffectivePlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDb.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockSelectWhere });
+    mockSelectWhere.mockReturnValue({ limit: mockLimit });
+    mockPlanFromPriceId.mockReturnValue(null);
+  });
+
+  it("returns trial when no subscription exists", async () => {
+    mockLimit
+      .mockResolvedValueOnce([
+        { plan: "trial", trialStartedAt: new Date(), planExpiresAt: null },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const plan = await getEffectivePlan("user-123");
+
+    expect(plan).toBe("trial");
+    expect(mockPlanFromPriceId).not.toHaveBeenCalled();
+  });
+
+  it("derives plan from priceId when subscription is active (race condition)", async () => {
+    mockPlanFromPriceId.mockReturnValue("pro");
+    mockLimit
+      .mockResolvedValueOnce([
+        { plan: "trial", trialStartedAt: new Date(), planExpiresAt: null },
+      ])
+      .mockResolvedValueOnce([
+        { stripePriceId: "price_pro_monthly", status: "active" },
+      ]);
+
+    const plan = await getEffectivePlan("user-123");
+
+    expect(plan).toBe("pro");
+    expect(mockPlanFromPriceId).toHaveBeenCalledWith("price_pro_monthly");
+  });
+
+  it("keeps trial when subscription is incomplete", async () => {
+    mockPlanFromPriceId.mockReturnValue("pro");
+    mockLimit
+      .mockResolvedValueOnce([
+        { plan: "trial", trialStartedAt: new Date(), planExpiresAt: null },
+      ])
+      .mockResolvedValueOnce([
+        { stripePriceId: "price_pro_monthly", status: "incomplete" },
+      ]);
+
+    const plan = await getEffectivePlan("user-123");
+
+    expect(plan).toBe("trial");
+    expect(mockPlanFromPriceId).not.toHaveBeenCalled();
+  });
+
+  it("keeps trial when subscription is past_due", async () => {
+    mockPlanFromPriceId.mockReturnValue("pro");
+    mockLimit
+      .mockResolvedValueOnce([
+        { plan: "trial", trialStartedAt: new Date(), planExpiresAt: null },
+      ])
+      .mockResolvedValueOnce([
+        { stripePriceId: "price_pro_monthly", status: "past_due" },
+      ]);
+
+    const plan = await getEffectivePlan("user-123");
+
+    expect(plan).toBe("trial");
+    expect(mockPlanFromPriceId).not.toHaveBeenCalled();
+  });
+
+  it("keeps trial when planFromPriceId does not recognize the priceId", async () => {
+    mockPlanFromPriceId.mockReturnValue(null);
+    mockLimit
+      .mockResolvedValueOnce([
+        { plan: "trial", trialStartedAt: new Date(), planExpiresAt: null },
+      ])
+      .mockResolvedValueOnce([
+        { stripePriceId: "price_unknown", status: "active" },
+      ]);
+
+    const plan = await getEffectivePlan("user-123");
+
+    expect(plan).toBe("trial");
+  });
+
+  it("keeps profile plan when profiles.plan is not trial", async () => {
+    mockLimit
+      .mockResolvedValueOnce([
+        { plan: "starter", trialStartedAt: null, planExpiresAt: null },
+      ])
+      .mockResolvedValueOnce([
+        { stripePriceId: "price_pro_monthly", status: "active" },
+      ]);
+
+    const plan = await getEffectivePlan("user-123");
+
+    expect(plan).toBe("starter");
+    expect(mockPlanFromPriceId).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,10 +1,11 @@
 import { cache } from "react";
 import { eq } from "drizzle-orm";
 import { getDb } from "@/db";
-import { profiles } from "@/db/schema";
+import { profiles, subscriptions } from "@/db/schema";
 import { canUsePro, isPlan, type Plan } from "@/lib/plans-shared";
 import { isStatementTimeoutError } from "@/lib/api-errors";
 import { logger } from "@/lib/logger";
+import { planFromPriceId } from "@/lib/stripe";
 
 // Re-export pure helpers so existing server callers can keep importing from
 // "@/lib/plans". I client component MUST import from "@/lib/plans-shared"
@@ -120,6 +121,42 @@ async function fetchPlan(authUserId: string): Promise<PlanInfo> {
 
 export const getPlan: (authUserId: string) => Promise<PlanInfo> =
   cache(fetchPlan);
+
+/**
+ * Restituisce il piano effettivo dell'utente, applicando il fallback
+ * subscription-aware: se profiles.plan è ancora "trial" ma esiste già una
+ * subscription row con stripePriceId (set al checkout prima che arrivi il
+ * webhook), deriva il piano dal prezzo. Usato come base per tutti i feature
+ * gate che devono essere consistenti con la UI.
+ *
+ * Helper server-only (query DB): NON è una server action. Va chiamato dopo
+ * aver autenticato l'utente e passando `userId` dalla sessione, mai un valore
+ * arbitrario dal client (vedi REVIEW #66).
+ */
+export async function getEffectivePlan(userId: string): Promise<Plan> {
+  const planInfo = await getPlan(userId);
+
+  const db = getDb();
+  const [sub] = await db
+    .select({
+      stripePriceId: subscriptions.stripePriceId,
+      status: subscriptions.status,
+    })
+    .from(subscriptions)
+    .where(eq(subscriptions.userId, userId))
+    .limit(1);
+
+  // Only derive plan from subscription when payment is confirmed (active).
+  // Excluding incomplete/past_due prevents premature access on failed payments.
+  if (
+    planInfo.plan === "trial" &&
+    sub?.stripePriceId &&
+    sub.status === "active"
+  ) {
+    return planFromPriceId(sub.stripePriceId) ?? planInfo.plan;
+  }
+  return planInfo.plan;
+}
 
 export type AssertProPlanResult =
   | { ok: true; plan: Plan }

--- a/src/server/api-key-actions.test.ts
+++ b/src/server/api-key-actions.test.ts
@@ -30,11 +30,8 @@ vi.mock("@/lib/server-auth", () => ({
 vi.mock("@/lib/plans", () => ({
   canUseApi: mockCanUseApi,
   getApiKeyLimit: mockGetApiKeyLimit,
-  getPlan: mockGetPlan,
-}));
-
-vi.mock("@/server/billing-actions", () => ({
   getEffectivePlan: mockGetEffectivePlan,
+  getPlan: mockGetPlan,
 }));
 
 vi.mock("@/lib/api-keys", () => ({

--- a/src/server/api-key-actions.ts
+++ b/src/server/api-key-actions.ts
@@ -4,8 +4,12 @@ import { and, count, eq, isNull } from "drizzle-orm";
 import { getDb } from "@/db";
 import { apiKeys, businesses, profiles } from "@/db/schema";
 import { generateApiKey } from "@/lib/api-keys";
-import { canUseApi, getApiKeyLimit, getPlan } from "@/lib/plans";
-import { getEffectivePlan } from "@/server/billing-actions";
+import {
+  canUseApi,
+  getApiKeyLimit,
+  getEffectivePlan,
+  getPlan,
+} from "@/lib/plans";
 import {
   checkBusinessOwnership,
   getAuthenticatedUser,

--- a/src/server/billing-actions.test.ts
+++ b/src/server/billing-actions.test.ts
@@ -229,68 +229,15 @@ describe("billing-actions", () => {
     });
   });
 
-  describe("getEffectivePlan", () => {
-    it("ritorna il piano DB quando non è 'trial'", async () => {
-      mockGetPlan.mockResolvedValue({
-        plan: "pro",
-        trialStartedAt: null,
-        planExpiresAt: null,
-      });
-      mockSelectLimit.mockResolvedValue([]);
-
-      const { getEffectivePlan } = await import("./billing-actions");
-      const result = await getEffectivePlan("user-123");
-
-      expect(result).toBe("pro");
-      expect(mockPlanFromPriceId).not.toHaveBeenCalled();
-    });
-
-    it("ritorna il piano DB quando è 'trial' ma non esiste subscription row", async () => {
-      mockGetPlan.mockResolvedValue({
-        plan: "trial",
-        trialStartedAt: new Date(),
-        planExpiresAt: null,
-      });
-      mockSelectLimit.mockResolvedValue([]);
-
-      const { getEffectivePlan } = await import("./billing-actions");
-      const result = await getEffectivePlan("user-123");
-
-      expect(result).toBe("trial");
-    });
-
-    it("deriva il piano da stripePriceId quando DB è 'trial' ma subscription row esiste (race condition)", async () => {
-      mockGetPlan.mockResolvedValue({
-        plan: "trial",
-        trialStartedAt: new Date(),
-        planExpiresAt: null,
-      });
-      mockPlanFromPriceId.mockReturnValue("pro");
-      // status must be 'active': checkout completed + payment confirmed
-      mockSelectLimit.mockResolvedValue([
-        { stripePriceId: "price_pro_monthly", status: "active" },
-      ]);
-
-      const { getEffectivePlan } = await import("./billing-actions");
-      const result = await getEffectivePlan("user-123");
-
-      expect(result).toBe("pro");
-      expect(mockPlanFromPriceId).toHaveBeenCalledWith("price_pro_monthly");
-    });
-
-    it("mantiene 'trial' se planFromPriceId non riconosce il priceId", async () => {
-      mockGetPlan.mockResolvedValue({
-        plan: "trial",
-        trialStartedAt: new Date(),
-        planExpiresAt: null,
-      });
-      mockPlanFromPriceId.mockReturnValue(null);
-      mockSelectLimit.mockResolvedValue([{ stripePriceId: "price_unknown" }]);
-
-      const { getEffectivePlan } = await import("./billing-actions");
-      const result = await getEffectivePlan("user-123");
-
-      expect(result).toBe("trial");
+  // getEffectivePlan NON deve più essere esportata da questo modulo "use
+  // server" (REVIEW #66): ogni export async diventa un endpoint POST pubblico,
+  // e getEffectivePlan accetta uno userId arbitrario senza autenticazione. È
+  // stata spostata in "@/lib/plans" come helper server-only. I test funzionali
+  // vivono ora in src/lib/plans.test.ts.
+  describe("getEffectivePlan (hardening REVIEW #66)", () => {
+    it("non è più esportata dal modulo 'use server' billing-actions", async () => {
+      const mod = await import("./billing-actions");
+      expect("getEffectivePlan" in mod).toBe(false);
     });
   });
 });

--- a/src/server/billing-actions.ts
+++ b/src/server/billing-actions.ts
@@ -9,6 +9,9 @@ import { getPlan } from "@/lib/plans";
 import type { Plan } from "@/lib/plans";
 import { planFromPriceId } from "@/lib/stripe";
 
+// getEffectivePlan è stato spostato in "@/lib/plans" (helper server-only, non
+// una action pubblica invocabile via POST) — vedi REVIEW #66.
+
 export type ProfilePlanResult =
   | {
       plan: Plan;
@@ -23,38 +26,6 @@ export type ProfilePlanResult =
       cancelAtPeriodEnd: boolean;
     }
   | { error: string };
-
-/**
- * Restituisce il piano effettivo dell'utente, applicando il fallback
- * subscription-aware: se profiles.plan è ancora "trial" ma esiste già una
- * subscription row con stripePriceId (set al checkout prima che arrivi il
- * webhook), deriva il piano dal prezzo. Usato come base per tutti i feature
- * gate che devono essere consistenti con la UI.
- */
-export async function getEffectivePlan(userId: string): Promise<Plan> {
-  const planInfo = await getPlan(userId);
-
-  const db = getDb();
-  const [sub] = await db
-    .select({
-      stripePriceId: subscriptions.stripePriceId,
-      status: subscriptions.status,
-    })
-    .from(subscriptions)
-    .where(eq(subscriptions.userId, userId))
-    .limit(1);
-
-  // Only derive plan from subscription when payment is confirmed (active).
-  // Excluding incomplete/past_due prevents premature access on failed payments.
-  if (
-    planInfo.plan === "trial" &&
-    sub?.stripePriceId &&
-    sub.status === "active"
-  ) {
-    return planFromPriceId(sub.stripePriceId) ?? planInfo.plan;
-  }
-  return planInfo.plan;
-}
 
 /**
  * Restituisce il piano corrente dell'utente autenticato e indica

--- a/tests/unit/server-billing-actions.test.ts
+++ b/tests/unit/server-billing-actions.test.ts
@@ -43,7 +43,9 @@ vi.mock("@/db/schema", () => ({
   subscriptions: "subscriptions-table",
 }));
 
-import { getProfilePlan, getEffectivePlan } from "@/server/billing-actions";
+// getEffectivePlan spostata in "@/lib/plans" (REVIEW #66) — i suoi test vivono
+// ora in src/lib/plans.test.ts.
+import { getProfilePlan } from "@/server/billing-actions";
 
 // --- Helpers ---
 
@@ -246,69 +248,9 @@ describe("getProfilePlan", () => {
   });
 });
 
-describe("getEffectivePlan", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    mockGetPlan.mockResolvedValue({
-      plan: "trial",
-      trialStartedAt: new Date("2026-01-01"),
-      planExpiresAt: null,
-    });
-    mockPlanFromPriceId.mockReturnValue(null);
-
-    mockGetDb.mockReturnValue({ select: mockSelect });
-    mockSelect.mockReturnValue({ from: mockFrom });
-    mockFrom.mockReturnValue({ where: mockWhere });
-    mockWhere.mockReturnValue({ limit: mockLimit });
-    mockLimit.mockResolvedValue([]);
-  });
-
-  it("returns trial when no subscription exists", async () => {
-    mockLimit.mockResolvedValue([]);
-    const plan = await getEffectivePlan("user-123");
-    expect(plan).toBe("trial");
-  });
-
-  it("derives plan from priceId when subscription is active", async () => {
-    mockPlanFromPriceId.mockReturnValue("pro");
-    mockLimit.mockResolvedValue([
-      { stripePriceId: "price_pro_monthly", status: "active" },
-    ]);
-    const plan = await getEffectivePlan("user-123");
-    expect(plan).toBe("pro");
-  });
-
-  it("keeps trial when subscription is incomplete", async () => {
-    mockPlanFromPriceId.mockReturnValue("pro");
-    mockLimit.mockResolvedValue([
-      { stripePriceId: "price_pro_monthly", status: "incomplete" },
-    ]);
-    const plan = await getEffectivePlan("user-123");
-    expect(plan).toBe("trial");
-    expect(mockPlanFromPriceId).not.toHaveBeenCalled();
-  });
-
-  it("keeps trial when subscription is past_due", async () => {
-    mockPlanFromPriceId.mockReturnValue("pro");
-    mockLimit.mockResolvedValue([
-      { stripePriceId: "price_pro_monthly", status: "past_due" },
-    ]);
-    const plan = await getEffectivePlan("user-123");
-    expect(plan).toBe("trial");
-  });
-
-  it("keeps profile plan when profiles.plan is not trial", async () => {
-    mockGetPlan.mockResolvedValue({
-      plan: "starter",
-      trialStartedAt: new Date("2026-01-01"),
-      planExpiresAt: null,
-    });
-    mockLimit.mockResolvedValue([
-      { stripePriceId: "price_pro_monthly", status: "active" },
-    ]);
-    const plan = await getEffectivePlan("user-123");
-    expect(plan).toBe("starter");
-    expect(mockPlanFromPriceId).not.toHaveBeenCalled();
+describe("getEffectivePlan (hardening REVIEW #66)", () => {
+  it("non è più esportata dal modulo 'use server' billing-actions", async () => {
+    const mod = await import("@/server/billing-actions");
+    expect("getEffectivePlan" in mod).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Resolves **REVIEW #66**: `getEffectivePlan(userId)` was exported from a `"use server"` module (`billing-actions.ts`), making it a public POST endpoint invocable by any client without authentication. This created a security vulnerability allowing info-leak of another user's plan given their auth UUID, plus gratuitous DB queries (DoS surface).

**Fix:** Relocate `getEffectivePlan` from `src/server/billing-actions.ts` to `src/lib/plans.ts` as a server-only helper (not a public action), alongside the existing `getPlan` function it depends on.

## Key Changes

- **`src/lib/plans.ts`**: Added `getEffectivePlan(userId)` function with full JSDoc explaining it's a server-only helper that must be called after authentication, never with arbitrary client-supplied `userId` values.
- **`src/server/billing-actions.ts`**: Removed `getEffectivePlan` export and added clarifying comment about the move.
- **`src/server/api-key-actions.ts`**: Updated import to pull `getEffectivePlan` from `@/lib/plans` instead of `@/server/billing-actions`.
- **Test files updated:**
  - `src/lib/plans.test.ts`: Moved all functional tests for `getEffectivePlan` here; added comprehensive test suite covering trial fallback, subscription race conditions, incomplete/past_due statuses, unrecognized priceIds, and non-trial profile plans. Tests use `mockResolvedValueOnce` chaining to simulate the dual query chain (profile → subscription).
  - `tests/unit/server-billing-actions.test.ts`: Removed `getEffectivePlan` tests; added hardening test verifying the function is no longer exported from the module.
  - `src/server/api-key-actions.test.ts`: Updated mock import to source `getEffectivePlan` from `@/lib/plans`.
- **`REVIEW.md`**: Removed resolved issue #66 from the tech debt list.

## Implementation Details

- `getEffectivePlan` now calls `getPlan(userId)` (already cached) then queries `subscriptions` table for active payment status.
- Only derives plan from `stripePriceId` when subscription status is `"active"` (payment confirmed); excludes `"incomplete"` and `"past_due"` to prevent premature access on failed payments.
- Falls back to profile plan if `planFromPriceId()` doesn't recognize the price ID.
- Maintains existing behavior: returns profile plan unchanged if it's not `"trial"`.
- Mock setup in test file includes new `mockPlanFromPriceId` and `subscriptions` table mock.

## Security Impact

- Eliminates the public POST endpoint surface for `getEffectivePlan`.
- Callers must now explicitly import from `@/lib/plans` and are responsible for authentication (no implicit server action wrapping).
- Verified via hardening tests that the function is no longer exported from `billing-actions.ts`.

https://claude.ai/code/session_01LUYCnQpdby5BMW6C38Xj3f