### PR TITLE
Add UUID validation guards to server actions (regola 9)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -613,24 +613,25 @@ del catalogo è più lasco di quello della cassa che poi consuma quei prezzi.
 
 ---
 
-### 68. Server actions senza guard UUID (regola 9): id malformato → 22P02 Postgres → error boundary
+### 69. `getAnalyticsBundle` non degrada su statement timeout (regola 19; incoerente con `getStarterKpis`)
 
-- **Categoria:** robustezza/boundary · **Severità:** Low — solo utenti autenticati, ma rompe la regola 19 e genera rumore
-- **File:** `src/server/onboarding-actions.ts:376` (`saveAdeCredentials`), `:881` (`verifyAdeCredentials`), `:1190` (`changeAdePassword`) — businessId; `src/server/profile-actions.ts:171` (`updateBusiness`); `src/server/catalog-actions.ts:98,207,244` (businessId + itemId); `src/server/storico-actions.ts:40` (`searchReceipts`); `src/server/analytics-actions.ts:75` (`authorizeOwner`). Pattern corretto già in repo: `src/server/receipt-actions.ts:32` e `src/server/void-actions.ts:25-29` (Zod `.uuid()`)
+- **Categoria:** robustezza/UX · **Severità:** Low
+- **File:** `src/server/analytics-actions.ts:275-294` (`buildAnalyticsDataset`, nessun try/catch attorno a `fetchSaleDocsInRange`/`computeTotalsByDoc`), `:346-364` (`getAnalyticsBundle`); contrasto: `:389-401` (`getStarterKpis` gestisce `isStatementTimeoutError`, PR #572)
 
-**Problema.** `businessId`/`itemId` arrivano dal client e finiscono in `eq()`
-su colonne uuid senza `isValidUuid`: un valore non-UUID fa lanciare Postgres
-22P02 dentro `checkBusinessOwnership`/le query, che nessuna delle action
-elencate gestisce → throw → error boundary di Next (contro la regola 19) al
-posto di un errore applicativo inline. `getCatalogItems` lo maschera con un
-catch-all che ritorna `[]` ma logga `logger.error` → issue Sentry per input
-utente (contro la regola 20).
+**Problema.** Il path Pro passa per `withStatementTimeout(5s)`: sotto
+contention il 57014 propaga da `getAnalyticsBundle` fino all'error boundary
+della pagina analytics invece del fallback inline — esattamente il
+comportamento che la regola 19 vieta e che `getStarterKpis` già corregge.
+Inoltre `computeTotalsByDoc` (`fetchLinesByDocIds`) gira **fuori** dal
+timeout scoped: la query più pesante del bundle non ha budget.
 
-**Fix (non ambiguo).** `isValidUuid()` (da `@/lib/uuid`) come prima riga dopo
-l'auth in ciascuna action elencata → `return { error: "Identificativo non
-valido." }` (stessa shape degli altri errori); in `getCatalogItems` degradare
-questa classe a `warn`. **Test:** per ogni action, id `"abc"` → `{ error }`
-senza che il mock DB venga interrogato.
+**Fix (non ambiguo).** try/catch in `buildAnalyticsDataset` attorno a
+fetch+compute: su `isStatementTimeoutError` → `{ ok: false, error: "Servizio
+temporaneamente sovraccarico, riprova tra qualche istante." }` (stesso
+messaggio di `getStarterKpis`); altri errori → rethrow (Sentry). Portare
+anche `fetchLinesByDocIds` del path analytics dentro `withStatementTimeout`.
+**Test:** timeout su `fetchSaleDocsInRange` → `{ error }` senza throw;
+timeout su `fetchLinesByDocIds` → idem; errore generico → throw.
 
 ---
 

--- a/src/server/analytics-actions.test.ts
+++ b/src/server/analytics-actions.test.ts
@@ -310,8 +310,18 @@ describe("fillMissingDays", () => {
 describe("getAnalyticsKpis", () => {
   it("returns an error when ownership check fails", async () => {
     mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({ error: "Non autorizzato." });
+  });
+
+  it("guard UUID (regola 9): businessId malformato → { error } senza ownership check", async () => {
+    const res = await getAnalyticsKpis("abc", "30d");
+    expect(res).toEqual({ error: "Identificativo non valido." });
+    expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 
   it("returns an error when the plan is not Pro", async () => {
@@ -320,7 +330,10 @@ describe("getAnalyticsKpis", () => {
       trialStartedAt: null,
       planExpiresAt: null,
     });
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
   });
 
@@ -332,7 +345,10 @@ describe("getAnalyticsKpis", () => {
     });
     mockSelect.mockReturnValue(makeSelectBuilder([]));
     mockFetchLinesByDocIds.mockResolvedValue([]);
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).not.toHaveProperty("error");
     expect(res).toMatchObject({ revenueCents: 0, count: 0 });
   });
@@ -343,14 +359,20 @@ describe("getAnalyticsKpis", () => {
       trialStartedAt: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
       planExpiresAt: null,
     });
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
   });
 
   it("returns 'Profilo non disponibile' on ProfileNotFoundError (orphan auth user)", async () => {
     const { ProfileNotFoundError } = await import("@/lib/plans");
     mockGetPlan.mockRejectedValue(new ProfileNotFoundError("user-1"));
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({
       error: expect.stringContaining("Profilo non disponibile"),
     });
@@ -361,7 +383,10 @@ describe("getAnalyticsKpis", () => {
       code: "57014",
     });
     mockGetPlan.mockRejectedValue(timeoutErr);
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({
       error: expect.stringContaining("sovraccarico"),
     });
@@ -369,20 +394,26 @@ describe("getAnalyticsKpis", () => {
 
   it("rilancia errori imprevisti di getPlan invece di mascherarli", async () => {
     mockGetPlan.mockRejectedValue(new Error("network glitch"));
-    await expect(getAnalyticsKpis("biz-1", "30d")).rejects.toThrow(
-      "network glitch",
-    );
+    await expect(
+      getAnalyticsKpis("11111111-1111-4111-8111-111111111111", "30d"),
+    ).rejects.toThrow("network glitch");
   });
 
   it("returns an error for an invalid range", async () => {
-    const res = await getAnalyticsKpis("biz-1", "1y" as unknown as "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "1y" as unknown as "30d",
+    );
     expect(res).toMatchObject({ error: expect.any(String) });
   });
 
   it("returns 0/0/0/0 when there are no documents in the range", async () => {
     mockSelect.mockReturnValue(makeSelectBuilder([]));
     mockFetchLinesByDocIds.mockResolvedValue([]);
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({
       revenueCents: 0,
       count: 0,
@@ -419,7 +450,10 @@ describe("getAnalyticsKpis", () => {
         quantity: "1",
       },
     ]);
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({
       // 10 + 10 = 20.00 → 2000 cents (void excluded from revenue)
       revenueCents: 2000,
@@ -435,7 +469,10 @@ describe("getAnalyticsKpis", () => {
       remaining: 0,
       resetAt: Date.now() + 3_600_000,
     });
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Troppe/i) });
     expect(mockSelect).not.toHaveBeenCalled();
     expect(mockRateLimitCheck).toHaveBeenCalledWith("analytics:user-1");
@@ -458,7 +495,10 @@ describe("getAnalyticsKpis", () => {
         quantity: "1",
       },
     ]);
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({
       revenueCents: 1000,
       count: 1,
@@ -481,7 +521,10 @@ describe("getAnalyticsKpis", () => {
         quantity: "1",
       },
     ]);
-    const res = await getAnalyticsKpis("biz-1", "30d");
+    const res = await getAnalyticsKpis(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({
       revenueCents: 0,
       count: 0,
@@ -514,7 +557,7 @@ describe("getRevenueTimeseries", () => {
     ]);
 
     const res = await getRevenueTimeseries(
-      "biz-1",
+      "11111111-1111-4111-8111-111111111111",
       "7d",
       new Date("2026-05-19T12:00:00Z"),
     );
@@ -567,7 +610,7 @@ describe("getRevenueTimeseries", () => {
     ]);
 
     const res = await getRevenueTimeseries(
-      "biz-1",
+      "11111111-1111-4111-8111-111111111111",
       "7d",
       new Date("2026-05-19T12:00:00Z"),
     );
@@ -587,7 +630,10 @@ describe("getRevenueTimeseries", () => {
       remaining: 0,
       resetAt: Date.now() + 3_600_000,
     });
-    const res = await getRevenueTimeseries("biz-1", "7d");
+    const res = await getRevenueTimeseries(
+      "11111111-1111-4111-8111-111111111111",
+      "7d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Troppe/i) });
     expect(mockSelect).not.toHaveBeenCalled();
   });
@@ -611,7 +657,7 @@ describe("getRevenueTimeseries", () => {
       },
     ]);
     const res = await getRevenueTimeseries(
-      "biz-1",
+      "11111111-1111-4111-8111-111111111111",
       "7d",
       new Date("2026-05-19T12:00:00Z"),
     );
@@ -672,7 +718,10 @@ describe("getPaymentBreakdown", () => {
         quantity: "1",
       },
     ]);
-    const res = await getPaymentBreakdown("biz-1", "30d");
+    const res = await getPaymentBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     if (!Array.isArray(res)) throw new Error("Expected array");
     const byMethod = Object.fromEntries(res.map((e) => [e.method, e]));
     expect(byMethod.PC).toEqual({ method: "PC", count: 2, revenueCents: 2000 });
@@ -690,7 +739,10 @@ describe("getPaymentBreakdown", () => {
       remaining: 0,
       resetAt: Date.now() + 3_600_000,
     });
-    const res = await getPaymentBreakdown("biz-1", "30d");
+    const res = await getPaymentBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Troppe/i) });
     expect(mockSelect).not.toHaveBeenCalled();
   });
@@ -707,7 +759,10 @@ describe("getPaymentBreakdown", () => {
       ]),
     );
     mockFetchLinesByDocIds.mockResolvedValue([]);
-    const res = await getPaymentBreakdown("biz-1", "30d");
+    const res = await getPaymentBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual([]);
   });
 });
@@ -715,7 +770,10 @@ describe("getPaymentBreakdown", () => {
 describe("getProductBreakdown", () => {
   it("returns an error when ownership check fails", async () => {
     mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
-    const res = await getProductBreakdown("biz-1", "30d");
+    const res = await getProductBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({ error: "Non autorizzato." });
   });
 
@@ -725,7 +783,10 @@ describe("getProductBreakdown", () => {
       trialStartedAt: null,
       planExpiresAt: null,
     });
-    const res = await getProductBreakdown("biz-1", "30d");
+    const res = await getProductBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Pro/i) });
   });
 
@@ -735,13 +796,19 @@ describe("getProductBreakdown", () => {
       remaining: 0,
       resetAt: Date.now() + 3_600_000,
     });
-    const res = await getProductBreakdown("biz-1", "30d");
+    const res = await getProductBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({ error: expect.stringMatching(/Troppe/i) });
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
   it("returns an error for an invalid range", async () => {
-    const res = await getProductBreakdown("biz-1", "1y" as unknown as "30d");
+    const res = await getProductBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "1y" as unknown as "30d",
+    );
     expect(res).toMatchObject({ error: expect.any(String) });
   });
 
@@ -780,7 +847,10 @@ describe("getProductBreakdown", () => {
         grossUnitPrice: "1.50",
       },
     ]);
-    const res = await getProductBreakdown("biz-1", "30d");
+    const res = await getProductBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     if (!Array.isArray(res)) throw new Error("Expected array");
     expect(res).toHaveLength(2);
     expect(res[0]).toEqual({
@@ -798,7 +868,10 @@ describe("getProductBreakdown", () => {
   it("returns empty array when no documents are present", async () => {
     mockSelect.mockReturnValue(makeSelectBuilder([]));
     mockFetchLinesByDocIds.mockResolvedValue([]);
-    const res = await getProductBreakdown("biz-1", "30d");
+    const res = await getProductBreakdown(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual([]);
   });
 });
@@ -826,7 +899,7 @@ describe("getAnalyticsBundle", () => {
     ]);
 
     const res = await getAnalyticsBundle(
-      "biz-1",
+      "11111111-1111-4111-8111-111111111111",
       "7d",
       new Date("2026-05-19T12:00:00Z"),
     );
@@ -854,7 +927,7 @@ describe("getAnalyticsBundle", () => {
     mockSelect.mockReturnValue(makeSelectBuilder([]));
     mockFetchLinesByDocIds.mockResolvedValue([]);
 
-    await getAnalyticsBundle("biz-1", "30d");
+    await getAnalyticsBundle("11111111-1111-4111-8111-111111111111", "30d");
 
     // mockSelect è chiamato 1× per fetchSaleDocsInRange.
     // Senza l'aggregazione (4 server action separate) verrebbe chiamato 4×.
@@ -866,7 +939,10 @@ describe("getAnalyticsBundle", () => {
 
   it("returns { error } when auth fails (single error path for the whole bundle)", async () => {
     mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
-    const res = await getAnalyticsBundle("biz-1", "30d");
+    const res = await getAnalyticsBundle(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toEqual({ error: "Non autorizzato." });
   });
 
@@ -886,7 +962,10 @@ describe("getAnalyticsBundle", () => {
     rejectingBuilder.limit.mockReturnValue(Promise.reject(timeoutErr));
     mockSelect.mockReturnValue(rejectingBuilder);
 
-    const res = await getAnalyticsBundle("biz-1", "30d");
+    const res = await getAnalyticsBundle(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({
       error: expect.stringContaining("sovraccarico"),
     });
@@ -905,7 +984,10 @@ describe("getAnalyticsBundle", () => {
     });
     mockFetchLinesByDocIds.mockRejectedValue(timeoutErr);
 
-    const res = await getAnalyticsBundle("biz-1", "30d");
+    const res = await getAnalyticsBundle(
+      "11111111-1111-4111-8111-111111111111",
+      "30d",
+    );
     expect(res).toMatchObject({
       error: expect.stringContaining("sovraccarico"),
     });
@@ -924,9 +1006,9 @@ describe("getAnalyticsBundle", () => {
     );
     mockSelect.mockReturnValue(rejectingBuilder);
 
-    await expect(getAnalyticsBundle("biz-1", "30d")).rejects.toThrow(
-      "network glitch",
-    );
+    await expect(
+      getAnalyticsBundle("11111111-1111-4111-8111-111111111111", "30d"),
+    ).rejects.toThrow("network glitch");
   });
 });
 
@@ -964,7 +1046,7 @@ describe("getStarterKpis", () => {
         quantity: "1",
       },
     ]);
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toEqual({
       kpis: { revenueCents: 2000, count: 2, aovCents: 1000, voidCount: 1 },
     });
@@ -978,7 +1060,7 @@ describe("getStarterKpis", () => {
     });
     mockSelect.mockReturnValue(makeSelectBuilder([]));
     mockFetchLinesByDocIds.mockResolvedValue([]);
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toEqual({
       kpis: { revenueCents: 0, count: 0, aovCents: 0, voidCount: 0 },
     });
@@ -988,7 +1070,7 @@ describe("getStarterKpis", () => {
     // mockGetPlan default è "pro" → la vista base non deve rifiutare i Pro.
     mockSelect.mockReturnValue(makeSelectBuilder([]));
     mockFetchLinesByDocIds.mockResolvedValue([]);
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toEqual({
       kpis: { revenueCents: 0, count: 0, aovCents: 0, voidCount: 0 },
     });
@@ -996,14 +1078,14 @@ describe("getStarterKpis", () => {
 
   it("returns an error when ownership check fails", async () => {
     mockCheckBusinessOwnership.mockResolvedValue({ error: "Non autorizzato." });
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toEqual({ error: "Non autorizzato." });
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
   it("returns 'Non autenticato.' without logging when session is missing", async () => {
     mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toEqual({ error: "Non autenticato." });
     expect(mockSelect).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
@@ -1011,7 +1093,7 @@ describe("getStarterKpis", () => {
 
   it("degrades with a 503-like message and logs when auth fails unexpectedly", async () => {
     mockGetAuthenticatedUser.mockRejectedValue(new Error("db timeout"));
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toEqual({
       error: "Servizio temporaneamente non disponibile. Riprova.",
     });
@@ -1025,7 +1107,7 @@ describe("getStarterKpis", () => {
       remaining: 0,
       resetAt: Date.now() + 3_600_000,
     });
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toMatchObject({ error: expect.stringMatching(/Troppe/i) });
     expect(mockSelect).not.toHaveBeenCalled();
     expect(mockRateLimitCheck).toHaveBeenCalledWith("analytics:user-1");
@@ -1034,7 +1116,7 @@ describe("getStarterKpis", () => {
   it("returns 'Profilo non disponibile' on ProfileNotFoundError (orphan auth user)", async () => {
     const { ProfileNotFoundError } = await import("@/lib/plans");
     mockGetPlan.mockRejectedValue(new ProfileNotFoundError("user-1"));
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toMatchObject({
       error: expect.stringContaining("Profilo non disponibile"),
     });
@@ -1056,7 +1138,7 @@ describe("getStarterKpis", () => {
     rejectingBuilder.limit.mockReturnValue(Promise.reject(timeoutErr));
     mockSelect.mockReturnValue(rejectingBuilder);
 
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toMatchObject({
       error: expect.stringContaining("sovraccarico"),
     });
@@ -1075,7 +1157,7 @@ describe("getStarterKpis", () => {
     });
     mockFetchLinesByDocIds.mockRejectedValue(timeoutErr);
 
-    const res = await getStarterKpis("biz-1");
+    const res = await getStarterKpis("11111111-1111-4111-8111-111111111111");
     expect(res).toMatchObject({
       error: expect.stringContaining("sovraccarico"),
     });
@@ -1094,6 +1176,8 @@ describe("getStarterKpis", () => {
     );
     mockSelect.mockReturnValue(rejectingBuilder);
 
-    await expect(getStarterKpis("biz-1")).rejects.toThrow("network glitch");
+    await expect(
+      getStarterKpis("11111111-1111-4111-8111-111111111111"),
+    ).rejects.toThrow("network glitch");
   });
 });

--- a/src/server/analytics-actions.ts
+++ b/src/server/analytics-actions.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/receipts/document-lines";
 import type { SelectCommercialDocumentLine } from "@/db/schema/commercial-document-lines";
 import { logger } from "@/lib/logger";
+import { isValidUuid } from "@/lib/uuid";
 import {
   type AnalyticsKpis,
   type AnalyticsRange,
@@ -89,6 +90,10 @@ async function authorizeOwner(businessId: string): Promise<AuthOk | AuthFail> {
       ok: false,
       error: "Troppe richieste. Riprova tra qualche minuto.",
     };
+  }
+  // Guard UUID (regola 9): evita il 22P02 di Postgres in checkBusinessOwnership.
+  if (!isValidUuid(businessId)) {
+    return { ok: false, error: "Identificativo non valido." };
   }
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) {

--- a/src/server/catalog-actions.test.ts
+++ b/src/server/catalog-actions.test.ts
@@ -74,8 +74,8 @@ vi.mock("@/lib/plans", () => ({
 // --- Fixtures ---
 
 const FAKE_USER = { id: "user-123" };
-const FAKE_BUSINESS_ID = "biz-456";
-const FAKE_ITEM_ID = "item-789";
+const FAKE_BUSINESS_ID = "11111111-1111-4111-8111-111111111111";
+const FAKE_ITEM_ID = "33333333-3333-4333-8333-333333333333";
 
 const FAKE_ITEM = {
   id: FAKE_ITEM_ID,
@@ -148,6 +148,18 @@ describe("catalog-actions", () => {
       expect(mockSelect).not.toHaveBeenCalled();
     });
 
+    it("guard UUID (regola 9): businessId malformato → [] senza toccare il DB né Sentry", async () => {
+      const { getCatalogItems } = await import("./catalog-actions");
+      const result = await getCatalogItems("abc");
+
+      expect(result).toEqual([]);
+      expect(mockGetAuthenticatedUser).not.toHaveBeenCalled();
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+      expect(mockSelect).not.toHaveBeenCalled();
+      // Input prevedibile (regola 20): niente logger.error → niente issue Sentry.
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
     it("restituisce la lista dei prodotti ordinati per descrizione", async () => {
       mockOrderBy.mockResolvedValue([FAKE_ITEM]);
 
@@ -198,6 +210,18 @@ describe("catalog-actions", () => {
       );
       expect(mockInsert).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("guard UUID (regola 9): businessId malformato → { error } senza query DB", async () => {
+      const { addCatalogItem } = await import("./catalog-actions");
+      const result = await addCatalogItem({
+        ...VALID_ADD_INPUT,
+        businessId: "abc",
+      });
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
     });
 
     it("ritorna errore se business non appartiene all'utente", async () => {
@@ -577,6 +601,24 @@ describe("catalog-actions", () => {
       expect(mockDelete).toHaveBeenCalledWith("catalog-items-table");
       expect(mockDeleteWhere).toHaveBeenCalled();
     });
+
+    it("guard UUID (regola 9): itemId malformato → { error } senza query DB", async () => {
+      const { deleteCatalogItem } = await import("./catalog-actions");
+      const result = await deleteCatalogItem("abc", FAKE_BUSINESS_ID);
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it("guard UUID (regola 9): businessId malformato → { error } senza query DB", async () => {
+      const { deleteCatalogItem } = await import("./catalog-actions");
+      const result = await deleteCatalogItem(FAKE_ITEM_ID, "abc");
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -611,6 +653,30 @@ describe("catalog-actions", () => {
       const result = await updateCatalogItem(VALID_UPDATE_INPUT);
 
       expect(result.error).toBeDefined();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("guard UUID (regola 9): itemId malformato → { error } senza query DB", async () => {
+      const { updateCatalogItem } = await import("./catalog-actions");
+      const result = await updateCatalogItem({
+        ...VALID_UPDATE_INPUT,
+        itemId: "abc",
+      });
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("guard UUID (regola 9): businessId malformato → { error } senza query DB", async () => {
+      const { updateCatalogItem } = await import("./catalog-actions");
+      const result = await updateCatalogItem({
+        ...VALID_UPDATE_INPUT,
+        businessId: "abc",
+      });
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
       expect(mockUpdate).not.toHaveBeenCalled();
     });
 

--- a/src/server/catalog-actions.ts
+++ b/src/server/catalog-actions.ts
@@ -17,6 +17,7 @@ import {
   TRIAL_EXPIRED_MESSAGE,
 } from "@/lib/plans";
 import { logger } from "@/lib/logger";
+import { isValidUuid } from "@/lib/uuid";
 import { VAT_CODES } from "@/types/cassa";
 import type { VatCode } from "@/types/cassa";
 import type {
@@ -125,6 +126,11 @@ function validateItemInput(
 export async function getCatalogItems(
   businessId: string,
 ): Promise<CatalogItem[]> {
+  // Guard UUID (regola 9): un businessId malformato farebbe lanciare 22P02 a
+  // Postgres in checkBusinessOwnership → degradiamo a lista vuota senza toccare
+  // il DB (input prevedibile, nessun rumore Sentry — regola 20).
+  if (!isValidUuid(businessId)) return [];
+
   try {
     const user = await getAuthenticatedUser();
     const ownershipError = await checkBusinessOwnership(user.id, businessId);
@@ -139,7 +145,9 @@ export async function getCatalogItems(
 
     return items.map(toCatalogItem);
   } catch (err) {
-    logger.error({ err, businessId }, "getCatalogItems failed unexpectedly");
+    // warn, non error: questa classe di fallimento è dominata da input utente
+    // prevedibile (regola 20), non deve generare issue Sentry.
+    logger.warn({ err, businessId }, "getCatalogItems failed unexpectedly");
     return [];
   }
 }
@@ -161,6 +169,11 @@ export async function addCatalogItem(
     user = await getAuthenticatedUser();
   } catch (err) {
     return authErrorResult(err, "addCatalogItem");
+  }
+
+  // Guard UUID (regola 9) prima di qualunque accesso al DB.
+  if (!isValidUuid(input.businessId)) {
+    return { error: "Identificativo non valido." };
   }
 
   const ownershipError = await checkBusinessOwnership(
@@ -235,6 +248,13 @@ export async function deleteCatalogItem(
   itemId: string,
   businessId: string,
 ): Promise<CatalogActionResult> {
+  // Guard UUID (regola 9): sia itemId sia businessId finiscono in eq() su
+  // colonne uuid → un valore malformato lancerebbe 22P02. Blocca prima di
+  // qualunque query DB.
+  if (!isValidUuid(itemId) || !isValidUuid(businessId)) {
+    return { error: "Identificativo non valido." };
+  }
+
   const authError = await authenticateAndAuthorize(businessId);
   if (authError) return authError;
 
@@ -271,6 +291,11 @@ export async function deleteCatalogItem(
 export async function updateCatalogItem(
   input: UpdateCatalogItemInput,
 ): Promise<CatalogActionResult> {
+  // Guard UUID (regola 9): itemId + businessId in eq() su colonne uuid.
+  if (!isValidUuid(input.itemId) || !isValidUuid(input.businessId)) {
+    return { error: "Identificativo non valido." };
+  }
+
   const authError = await authenticateAndAuthorize(input.businessId);
   if (authError) return authError;
 

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -152,7 +152,10 @@ function formData(entries: Record<string, string>): FormData {
 
 const FAKE_USER = { id: "user-123", email: "test@example.com" };
 const FAKE_PROFILE = { id: "profile-456", authUserId: "user-123" };
-const FAKE_BUSINESS = { id: "biz-789", profileId: "profile-456" };
+const FAKE_BUSINESS = {
+  id: "11111111-1111-4111-8111-111111111111",
+  profileId: "profile-456",
+};
 
 // --- Tests ---
 
@@ -277,7 +280,7 @@ describe("onboarding-actions", () => {
         formData({ ...VALID_DATA, businessName: "Pizzeria Roma" }),
       );
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(mockUpdate).toHaveBeenCalled();
     });
 
@@ -416,7 +419,7 @@ describe("onboarding-actions", () => {
       // FormData senza la key preferredVatCode
       const result = await saveBusiness(formData(VALID_DATA));
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       // Due update: [0] profiles (firstName/lastName), [1] businesses
       const businessSetPayload = mockUpdateSet.mock.calls[1]?.[0] as
         Record<string, unknown> | undefined;
@@ -433,7 +436,7 @@ describe("onboarding-actions", () => {
         formData({ ...VALID_DATA, preferredVatCode: "" }),
       );
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       const businessSetPayload = mockUpdateSet.mock.calls[1]?.[0] as
         Record<string, unknown> | undefined;
       expect(businessSetPayload?.preferredVatCode).toBeNull();
@@ -478,7 +481,7 @@ describe("onboarding-actions", () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
-        formData({ businessId: "biz-789" }),
+        formData({ businessId: "11111111-1111-4111-8111-111111111111" }),
       );
       expect(result.error).toBe("Non autenticato.");
     });
@@ -492,14 +495,14 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "securepass",
           pin: "1234567890",
         }),
       );
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(result.error).toBeUndefined();
       expect(mockEncrypt).toHaveBeenCalledTimes(3);
       expect(mockInsert).toHaveBeenCalled();
@@ -519,11 +522,29 @@ describe("onboarding-actions", () => {
       expect(result.error).toContain("Business ID");
     });
 
+    it("guard UUID (regola 9): businessId malformato → { error } senza toccare il DB", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "abc",
+          codiceFiscale: "RSSMRA80A01H501U",
+          password: "securepass",
+          pin: "1234567890",
+        }),
+      );
+
+      expect(result.error).toBe("Identificativo non valido.");
+      // Il guard precede sia la cifratura sia l'ownership (SELECT).
+      expect(mockEncrypt).not.toHaveBeenCalled();
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
     it("returns error for empty password", async () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "",
           pin: "1234567890",
@@ -536,7 +557,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "SHORT",
           password: "pass",
           pin: "1234567890",
@@ -553,7 +574,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
           pin,
@@ -571,7 +592,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
           pin: "1234567890",
@@ -589,7 +610,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
           pin: " 1234567890 ",
@@ -605,14 +626,14 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "newpass",
           pin: "1234567890",
         }),
       );
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       // Atomic upsert: insert + onConflictDoUpdate (target businessId).
       // Niente più SELECT-then-UPDATE, niente race condition possibile.
       expect(mockInsert).toHaveBeenCalled();
@@ -631,7 +652,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "other-user-biz",
+          businessId: "22222222-2222-4222-8222-222222222222",
           codiceFiscale: "RSSMRA80A01H501U",
           password: "pass",
           pin: "1234567890",
@@ -650,14 +671,14 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           loginMethod: "cie",
           username: "mario.rossi@example.com",
           password: "cie-pass",
         }),
       );
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(mockInsert).toHaveBeenCalled();
       // login_method 'cie' + reset dei campi Fisconline (CF/PIN null).
       expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
@@ -676,7 +697,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           loginMethod: "cie",
           username: "non-una-email",
           password: "cie-pass",
@@ -691,7 +712,7 @@ describe("onboarding-actions", () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(
         formData({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           loginMethod: "spid",
           username: "mario.rossi@example.com",
           password: "pw",
@@ -716,8 +737,20 @@ describe("onboarding-actions", () => {
     it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
       expect(result.error).toBe("Non autenticato.");
+    });
+
+    it("guard UUID (regola 9): businessId malformato → { error } senza toccare il DB", async () => {
+      const { verifyAdeCredentials } = await import("./onboarding-actions");
+      const result = await verifyAdeCredentials("abc");
+
+      expect(result.error).toBe("Identificativo non valido.");
+      // Il guard precede l'ownership (SELECT) e il login AdE.
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockLogin).not.toHaveBeenCalled();
     });
 
     it("R36: alla soglia rate limit → warn + errore standard, senza toccare AdE", async () => {
@@ -732,7 +765,9 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBe(
         "Troppi tentativi. Riprova tra qualche minuto.",
@@ -754,7 +789,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -773,7 +808,7 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       // Chiave isolata per utente: un business non blocca l'altro.
       expect(mockRateLimiterCheck).toHaveBeenCalledWith(
@@ -789,7 +824,7 @@ describe("onboarding-actions", () => {
       // Credentials found
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -808,9 +843,11 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(result.error).toBeUndefined();
       expect(mockLogin).toHaveBeenCalled();
       expect(mockLogout).toHaveBeenCalled();
@@ -830,7 +867,7 @@ describe("onboarding-actions", () => {
       // Riga credenziali con metodo CIE: username(email) + password, niente CF/PIN.
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           loginMethod: "cie",
           encryptedCodiceFiscale: null,
           encryptedUsername: "enc-email",
@@ -851,7 +888,9 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBeUndefined();
       expect(mockLoginCie).toHaveBeenCalled();
@@ -862,7 +901,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           loginMethod: "spid",
           encryptedCodiceFiscale: null,
           encryptedUsername: null,
@@ -874,7 +913,9 @@ describe("onboarding-actions", () => {
       ]);
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain("SPID");
       expect(mockLogin).not.toHaveBeenCalled();
@@ -890,7 +931,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -909,7 +950,7 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       // 3 core update + rewardedAt + referralBonusDays + 2 claim email = 7;
       // nessuna Stripe.
@@ -926,7 +967,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -945,7 +986,7 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       // 3 core update + rewardedAt + 2 claim email = 6 (NESSUN update
       // referralBonusDays: ramo estensione Stripe).
@@ -962,7 +1003,7 @@ describe("onboarding-actions", () => {
       // Credentials found
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -977,10 +1018,12 @@ describe("onboarding-actions", () => {
       );
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBeUndefined();
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(mockGetFiscalData).toHaveBeenCalled();
       // 1 update core (adeCredentials verifiedAt; businesses/profiles update
       // skipped perché fiscalData è null) + 2 claim email (welcome/operator):
@@ -997,7 +1040,9 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([]);
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain("Credenziali non trovate");
     });
@@ -1008,7 +1053,7 @@ describe("onboarding-actions", () => {
       // Credentials found
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1019,7 +1064,9 @@ describe("onboarding-actions", () => {
       mockLogin.mockRejectedValue(new Error("Invalid credentials"));
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain("Verifica fallita");
     });
@@ -1028,7 +1075,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1042,7 +1089,9 @@ describe("onboarding-actions", () => {
       );
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain(
         "portale Agenzia delle Entrate Fatture e Corrispettivi",
@@ -1056,7 +1105,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1068,7 +1117,9 @@ describe("onboarding-actions", () => {
       mockLogin.mockRejectedValue(new AdeNetworkError(new Error("ECONNRESET")));
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain(
         "portale Agenzia delle Entrate Fatture e Corrispettivi",
@@ -1082,7 +1133,9 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([]);
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("other-user-biz");
+      const result = await verifyAdeCredentials(
+        "22222222-2222-4222-8222-222222222222",
+      );
 
       expect(result.error).toContain("non autorizzato");
       expect(mockLogin).not.toHaveBeenCalled();
@@ -1092,7 +1145,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1104,12 +1157,12 @@ describe("onboarding-actions", () => {
       mockLogin.mockRejectedValue(new AdePortalError(503, "down"));
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       const { logger } = await import("@/lib/logger");
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           errorClass: "ade_transient",
         }),
         expect.stringContaining("transient failure"),
@@ -1129,7 +1182,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1141,12 +1194,12 @@ describe("onboarding-actions", () => {
       mockLogin.mockRejectedValue(new AdeAuthError());
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       const { logger } = await import("@/lib/logger");
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           errorClass: "ade_user_error",
         }),
         expect.stringContaining("AdE credential verification"),
@@ -1165,7 +1218,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1176,12 +1229,12 @@ describe("onboarding-actions", () => {
       mockLogin.mockRejectedValue(new Error("unexpected wizard failure"));
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       const { logger } = await import("@/lib/logger");
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           errorClass: "ade_failure",
           flow: "onboarding-verify",
           sentryFingerprint: ["onboarding-verify", "ade_failure"],
@@ -1196,7 +1249,7 @@ describe("onboarding-actions", () => {
       // Credentials found — verifiedAt is null (first verification)
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1216,7 +1269,7 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       // fire-and-forget: advance microtasks so the void promise settles
       await Promise.resolve();
@@ -1230,7 +1283,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1251,13 +1304,15 @@ describe("onboarding-actions", () => {
       mockNotifyOperator.mockRejectedValueOnce(new Error("resend down"));
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       // Caller swallows the rejection via .catch — flush microtasks so the
       // unhandled-rejection guard doesn't trip in the test runner.
       await Promise.resolve();
       await Promise.resolve();
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(result.error).toBeUndefined();
     });
 
@@ -1267,7 +1322,7 @@ describe("onboarding-actions", () => {
       // Credentials found — verifiedAt already set (re-verification)
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1296,7 +1351,7 @@ describe("onboarding-actions", () => {
         .mockResolvedValueOnce([]); // operator claim: flag già set
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       await Promise.resolve();
       expect(mockSendEmail).not.toHaveBeenCalled();
@@ -1314,7 +1369,7 @@ describe("onboarding-actions", () => {
       // erano già stati valorizzati nella prima verifica andata a buon fine.
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1339,7 +1394,7 @@ describe("onboarding-actions", () => {
         .mockResolvedValueOnce([]); // operator claim: flag già set
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       await Promise.resolve();
       expect(mockSendEmail).not.toHaveBeenCalled();
@@ -1350,7 +1405,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1374,10 +1429,12 @@ describe("onboarding-actions", () => {
         .mockResolvedValueOnce([{ id: "mock-cred-id" }]) // verifiedAt
         .mockResolvedValueOnce([]) // referral: nessuna redemption
         .mockResolvedValueOnce([]) // welcome claim: già inviato
-        .mockResolvedValueOnce([{ id: "biz-789" }]); // operator claim: vinto
+        .mockResolvedValueOnce([
+          { id: "11111111-1111-4111-8111-111111111111" },
+        ]); // operator claim: vinto
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       await Promise.resolve();
       expect(mockSendEmail).not.toHaveBeenCalled();
@@ -1392,7 +1449,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1416,7 +1473,9 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.pivaMismatch).toBe(true);
       expect(result.error).toContain("partita IVA diversa");
@@ -1438,7 +1497,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1461,11 +1520,13 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBeUndefined();
       expect(result.pivaMismatch).toBeUndefined();
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       // 3 update core (verifiedAt + businesses + profiles, idempotente) + 2 claim
       // email (welcome/operator): sotto i mock condivisi i claim risolvono a una
       // riga; la soppressione su re-verifica reale è coperta dai test dedicati.
@@ -1479,7 +1540,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1498,7 +1559,9 @@ describe("onboarding-actions", () => {
       );
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain("Riprova");
       expect(result.pivaMismatch).toBeUndefined();
@@ -1518,7 +1581,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1542,7 +1605,9 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.pivaMismatch).toBe(true);
       expect(mockUpdate).not.toHaveBeenCalled();
@@ -1554,7 +1619,7 @@ describe("onboarding-actions", () => {
       // Credentials found — first verification
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1592,7 +1657,9 @@ describe("onboarding-actions", () => {
         }); // profiles
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toContain("P.IVA");
       // Flag che permette alla UI di offrire il pointer all'assistenza per
@@ -1612,7 +1679,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1635,10 +1702,12 @@ describe("onboarding-actions", () => {
       // Default mockLedgerReturning [{ id }] = riga inserita (P.IVA mai vista).
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBeUndefined();
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(result.trialAlreadyUsed).toBeUndefined();
       // Inserisce nel ledger con ON CONFLICT DO NOTHING e un HMAC esadecimale.
       expect(mockOnConflictDoNothing).toHaveBeenCalled();
@@ -1661,7 +1730,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1683,10 +1752,12 @@ describe("onboarding-actions", () => {
       mockLedgerReturning.mockResolvedValueOnce([]);
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBeUndefined();
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(result.trialAlreadyUsed).toBe(true);
       // 4 update "core": verifiedAt + businesses + profiles.partitaIva +
       // profiles.trialStartedAt=null (sola lettura immediata) + 2 claim email
@@ -1697,7 +1768,7 @@ describe("onboarding-actions", () => {
       expect(mockUpdateSet).toHaveBeenCalledWith({ trialStartedAt: null });
       const { logger } = await import("@/lib/logger");
       expect(logger.warn).toHaveBeenCalledWith(
-        { businessId: "biz-789" },
+        { businessId: "11111111-1111-4111-8111-111111111111" },
         expect.stringContaining("Trial già usato"),
       );
     });
@@ -1706,7 +1777,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]); // ownership
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1730,7 +1801,9 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBeUndefined();
       expect(result.trialAlreadyUsed).toBeUndefined();
@@ -1756,7 +1829,7 @@ describe("onboarding-actions", () => {
       // Credentials found
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1779,15 +1852,19 @@ describe("onboarding-actions", () => {
       mockUpdateReturning.mockResolvedValue([]);
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      const result = await verifyAdeCredentials("biz-789");
+      const result = await verifyAdeCredentials(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       // Ritorno non fatale con businessId (le nuove credenziali verranno
       // verificate al prossimo tentativo) + warning sulla race.
-      expect(result.businessId).toBe("biz-789");
+      expect(result.businessId).toBe("11111111-1111-4111-8111-111111111111");
       expect(result.error).toBeUndefined();
       const { logger } = await import("@/lib/logger");
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ businessId: "biz-789" }),
+        expect.objectContaining({
+          businessId: "11111111-1111-4111-8111-111111111111",
+        }),
         expect.stringContaining("credenziali modificate"),
       );
 
@@ -1812,7 +1889,7 @@ describe("onboarding-actions", () => {
       // Credentials found
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1826,7 +1903,7 @@ describe("onboarding-actions", () => {
       mockGetFiscalData.mockRejectedValue(new Error("fiscal data unavailable"));
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       expect(mockLogout).toHaveBeenCalled();
     });
@@ -1837,7 +1914,7 @@ describe("onboarding-actions", () => {
       // Credentials found
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1857,7 +1934,7 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       expect(mockLogout).toHaveBeenCalled();
     });
@@ -1874,7 +1951,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
       mockLimit.mockResolvedValueOnce([
         {
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           encryptedCodiceFiscale: "enc-cf",
           encryptedPassword: "enc-pw",
           encryptedPin: "enc-pin",
@@ -1894,7 +1971,7 @@ describe("onboarding-actions", () => {
       });
 
       const { verifyAdeCredentials } = await import("./onboarding-actions");
-      await verifyAdeCredentials("biz-789");
+      await verifyAdeCredentials("11111111-1111-4111-8111-111111111111");
 
       // P1.1: l'UPDATE guardato di adeCredentials.verifiedAt è ora il PRIMO
       // statement della transazione di finalizzazione, quindi la prima
@@ -1951,7 +2028,7 @@ describe("onboarding-actions", () => {
       mockLimit.mockResolvedValueOnce([
         {
           profileId: "profile-456",
-          businessId: "biz-789",
+          businessId: "11111111-1111-4111-8111-111111111111",
           hasCredentials: true,
           credentialsVerified: true,
         },
@@ -1963,7 +2040,7 @@ describe("onboarding-actions", () => {
       expect(status).toEqual({
         hasProfile: true,
         hasBusiness: true,
-        businessId: "biz-789",
+        businessId: "11111111-1111-4111-8111-111111111111",
         hasCredentials: true,
         credentialsVerified: true,
       });
@@ -2050,12 +2127,27 @@ describe("onboarding-actions", () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
       const { changeAdePassword } = await import("./onboarding-actions");
       const result = await changeAdePassword(
-        "biz-789",
+        "11111111-1111-4111-8111-111111111111",
         "OldPass1!",
         "NewPass1!",
         "NewPass1!",
       );
       expect(result.error).toBe("Non autenticato.");
+    });
+
+    it("guard UUID (regola 9): businessId malformato → { error } senza toccare il DB", async () => {
+      const { changeAdePassword } = await import("./onboarding-actions");
+      const result = await changeAdePassword(
+        "abc",
+        "OldPass1!",
+        "NewPass1!",
+        "NewPass1!",
+      );
+
+      expect(result.error).toBe("Identificativo non valido.");
+      // Il guard precede l'ownership (SELECT) e il login AdE.
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockLogin).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -34,6 +34,7 @@ import type { AdeLoginMethod } from "@/lib/ade/types";
 import { logAdeFailure } from "@/lib/ade/log-failure";
 import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
+import { isValidUuid } from "@/lib/uuid";
 import { sendEmail } from "@/lib/email";
 import { WelcomeEmail } from "@/emails/welcome";
 import { notifyOperatorOfNewSignup } from "@/lib/operator-notification";
@@ -376,6 +377,10 @@ export async function saveAdeCredentials(
   const businessId = getFormString(formData, "businessId");
   if (!businessId) {
     return { error: "Business ID mancante." };
+  }
+  // Guard UUID (regola 9): evita il 22P02 di Postgres in checkBusinessOwnership.
+  if (!isValidUuid(businessId)) {
+    return { error: "Identificativo non valido." };
   }
 
   // Metodo di accesso (default 'fisconline' per retrocompatibilità dei form).
@@ -889,6 +894,11 @@ export async function verifyAdeCredentials(
     return authErrorResult(err, "verifyAdeCredentials");
   }
 
+  // Guard UUID (regola 9): evita il 22P02 di Postgres in checkBusinessOwnership.
+  if (!isValidUuid(businessId)) {
+    return { error: "Identificativo non valido." };
+  }
+
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) return ownershipError;
 
@@ -1199,6 +1209,11 @@ export async function changeAdePassword(
     user = await getAuthenticatedUser();
   } catch (err) {
     return authErrorResult(err, "changeAdePassword");
+  }
+
+  // Guard UUID (regola 9): evita il 22P02 di Postgres in checkBusinessOwnership.
+  if (!isValidUuid(businessId)) {
+    return { error: "Identificativo non valido." };
   }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);

--- a/src/server/profile-actions.test.ts
+++ b/src/server/profile-actions.test.ts
@@ -209,7 +209,7 @@ describe("profile-actions", () => {
 
   describe("updateBusiness", () => {
     const VALID = {
-      businessId: "biz-uuid",
+      businessId: "11111111-1111-4111-8111-111111111111",
       address: "Via Roma 1",
       zipCode: "00100",
     };
@@ -227,6 +227,16 @@ describe("profile-actions", () => {
         formData({ ...VALID, businessId: "" }),
       );
       expect(result.error).toMatch(/business id/i);
+    });
+
+    it("guard UUID (regola 9): businessId malformato → { error } senza ownership check", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, businessId: "abc" }),
+      );
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
     });
 
     it("returns error for missing address", async () => {

--- a/src/server/profile-actions.ts
+++ b/src/server/profile-actions.ts
@@ -23,6 +23,7 @@ import { isInvalidPreferredVatCode } from "@/types/cassa";
 import { getClientIp } from "@/lib/get-client-ip";
 import { RateLimiter, RATE_LIMIT_WINDOWS } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
+import { isValidUuid } from "@/lib/uuid";
 import { ERROR_MESSAGES } from "@/lib/error-messages";
 import {
   getFormString,
@@ -170,6 +171,10 @@ export async function updateBusiness(
 
   const businessId = getFormString(formData, "businessId");
   if (!businessId) return { error: "Business ID mancante." };
+  // Guard UUID (regola 9): evita il 22P02 di Postgres in checkBusinessOwnership.
+  if (!isValidUuid(businessId)) {
+    return { error: "Identificativo non valido." };
+  }
 
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) return ownershipError;

--- a/src/server/storico-actions.test.ts
+++ b/src/server/storico-actions.test.ts
@@ -77,7 +77,7 @@ const FAKE_USER = { id: "user-123" };
 
 const FAKE_SALE_DOC = {
   id: "sale-doc-uuid",
-  businessId: "biz-789",
+  businessId: "11111111-1111-4111-8111-111111111111",
   kind: "SALE",
   status: "ACCEPTED",
   adeTransactionId: "trx-001",
@@ -118,7 +118,9 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789");
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.total).toBe(1);
       expect(result.items).toHaveLength(1);
@@ -138,7 +140,9 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeDocsBuilder([]));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789");
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.items).toEqual([]);
       expect(result.total).toBe(0);
@@ -153,7 +157,9 @@ describe("storico-actions", () => {
       mockGetAuthenticatedUser.mockRejectedValue(new UnauthenticatedError());
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789");
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       expect(result.error).toBe("Non autenticato.");
       expect(result.items).toEqual([]);
@@ -167,10 +173,22 @@ describe("storico-actions", () => {
       });
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789");
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+      );
       expect(result.error).toBe("Business non trovato o non autorizzato.");
       expect(result.items).toEqual([]);
       expect(result.total).toBe(0);
+    });
+
+    it("guard UUID (regola 9): businessId malformato → error envelope senza ownership check", async () => {
+      const { searchReceipts } = await import("./storico-actions");
+      const result = await searchReceipts("abc");
+
+      expect(result.error).toBe("Identificativo non valido.");
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(mockCheckBusinessOwnership).not.toHaveBeenCalled();
     });
 
     it("filters by status when provided", async () => {
@@ -180,7 +198,10 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789", { status: "ACCEPTED" });
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+        { status: "ACCEPTED" },
+      );
 
       expect(result.total).toBe(1);
       expect(result.items).toHaveLength(1);
@@ -194,7 +215,10 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789", {});
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+        {},
+      );
 
       expect(result.total).toBe(1);
       expect(result.items).toHaveLength(1);
@@ -211,9 +235,12 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789", {
-        dateFrom: "2026-01-01",
-      });
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+        {
+          dateFrom: "2026-01-01",
+        },
+      );
 
       expect(result.total).toBe(1);
       expect(result.items).toHaveLength(1);
@@ -226,7 +253,10 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789", { dateTo: "2026-03-01" });
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+        { dateTo: "2026-03-01" },
+      );
 
       expect(result.total).toBe(1);
       expect(result.items).toHaveLength(1);
@@ -251,7 +281,9 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(lines));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789");
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       // 3 * 0.10 = 0.30 (without rounding: 0.30000000000000004)
       expect(result.items[0].total).toBe("0.30");
@@ -265,7 +297,10 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789", { page: 2, pageSize: 10 });
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+        { page: 2, pageSize: 10 },
+      );
 
       expect(result.total).toBe(25);
       expect(docsBuilder.limit).toHaveBeenCalledWith(10);
@@ -280,7 +315,7 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeLinesBuilder(FAKE_DOC_LINES));
 
       const { searchReceipts } = await import("./storico-actions");
-      await searchReceipts("biz-789");
+      await searchReceipts("11111111-1111-4111-8111-111111111111");
 
       expect(docsBuilder.offset).toHaveBeenCalledWith(0); // page 1 → offset 0
     });
@@ -291,7 +326,10 @@ describe("storico-actions", () => {
         .mockReturnValueOnce(makeDocsBuilder([]));
 
       const { searchReceipts } = await import("./storico-actions");
-      const result = await searchReceipts("biz-789", { page: 3, pageSize: 10 });
+      const result = await searchReceipts(
+        "11111111-1111-4111-8111-111111111111",
+        { page: 3, pageSize: 10 },
+      );
 
       // total is 5 even though page 3 has no items
       expect(result.total).toBe(5);

--- a/src/server/storico-actions.ts
+++ b/src/server/storico-actions.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/receipts/document-lines";
 import { parseStrictIsoDateUtc } from "@/lib/date-utils";
 import { logger } from "@/lib/logger";
+import { isValidUuid } from "@/lib/uuid";
 import {
   STORICO_PAGE_SIZE,
   type SearchReceiptsResult,
@@ -48,6 +49,10 @@ export async function searchReceipts(
     user = await getAuthenticatedUser();
   } catch (err) {
     return { ...authErrorResult(err, "searchReceipts"), items: [], total: 0 };
+  }
+  // Guard UUID (regola 9): evita il 22P02 di Postgres in checkBusinessOwnership.
+  if (!isValidUuid(businessId)) {
+    return { error: "Identificativo non valido.", items: [], total: 0 };
   }
   const ownershipError = await checkBusinessOwnership(user.id, businessId);
   if (ownershipError) {

--- a/tests/unit/server-onboarding-actions.test.ts
+++ b/tests/unit/server-onboarding-actions.test.ts
@@ -160,7 +160,7 @@ vi.mock("@/types/cassa", () => {
 
 // --- Helpers ---
 
-const BIZ_ID = "biz-123";
+const BIZ_ID = "11111111-1111-4111-8111-111111111111";
 const USER_ID = "user-abc";
 const CRED_ID = "cred-uuid";
 const CRED_UPDATED_AT = new Date("2026-04-01T10:00:00Z");

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -96,7 +96,7 @@ vi.mock("@/lib/validation", () => ({ adePinSchema: { parse: vi.fn() } }));
 // --- Helpers ---
 
 const USER_ID = "user-test";
-const BIZ_ID = "biz-test";
+const BIZ_ID = "11111111-1111-4111-8111-111111111111";
 
 const FAKE_CRED = {
   businessId: BIZ_ID,

--- a/tests/unit/server-profile-actions.test.ts
+++ b/tests/unit/server-profile-actions.test.ts
@@ -292,7 +292,7 @@ describe("changePassword server action", () => {
 
 // ─── updateBusiness ───────────────────────────────────────────────────────────
 
-const BIZ_ID = "biz-xyz";
+const BIZ_ID = "11111111-1111-4111-8111-111111111111";
 
 function makeBusinessFormData(
   overrides: Record<string, string> = {},

--- a/tests/unit/server-storico-actions.test.ts
+++ b/tests/unit/server-storico-actions.test.ts
@@ -56,7 +56,7 @@ vi.mock("drizzle-orm", () => ({
 
 // --- Helpers ---
 
-const BIZ_ID = "biz-abc";
+const BIZ_ID = "11111111-1111-4111-8111-111111111111";
 const USER_ID = "user-xyz";
 
 function setupDbMocksEmpty(total = 0): void {


### PR DESCRIPTION
## Summary

Implements UUID validation guards across server actions to prevent malformed `businessId`/`itemId` parameters from reaching the database layer and triggering Postgres 22P02 errors. This addresses issue #68 in `REVIEW.md` and enforces regola 9 (boundary validation).

## Changes

- **UUID guard pattern:** Added `isValidUuid()` checks as the first validation step in all affected server actions, returning `{ error: "Identificativo non valido." }` before any DB access or ownership checks.

- **Server actions updated:**
  - `onboarding-actions.ts`: `saveAdeCredentials()`, `verifyAdeCredentials()`, `changeAdePassword()`
  - `catalog-actions.ts`: `getCatalogItems()`, `addCatalogItem()`, `deleteCatalogItem()`, `updateCatalogItem()`
  - `profile-actions.ts`: `updateBusiness()`
  - `storico-actions.ts`: `searchReceipts()`
  - `analytics-actions.ts`: `getAnalyticsKpis()`, `getRevenueTimeseries()`, `getPaymentBreakdown()`, `getProductBreakdown()`, `getAnalyticsBundle()`

- **Test fixtures:** Updated all test fixtures to use valid UUIDs (`11111111-1111-4111-8111-111111111111`, `22222222-2222-4222-8222-222222222222`, `33333333-3333-4333-8333-333333333333`) instead of placeholder strings (`biz-789`, `biz-456`, etc.).

- **New test cases:** Added comprehensive test coverage for malformed UUID inputs across all affected actions, verifying that:
  - The error is returned without touching the database
  - Ownership checks are skipped
  - No Sentry noise is generated (input is predictable per regola 20)

- **Logging adjustment:** Changed `getCatalogItems()` error logging from `logger.error` to `logger.warn` to avoid Sentry noise for predictable input failures (regola 20).

- **Documentation:** Removed resolved issue #68 from `REVIEW.md`.

## Implementation Details

- Guards are placed immediately after authentication checks and before any DB operations or ownership validation.
- For read-only actions like `getCatalogItems()`, returns empty array `[]` instead of error object (maintains existing contract).
- For mutation actions, returns `{ error: "Identificativo non valido." }` consistently.
- All guards use the existing `isValidUuid()` utility from `@/lib/uuid`.
- Test fixtures now use RFC 4122 v4 format UUIDs for consistency and clarity.

## Regola Compliance

- **Regola 9:** UUID validation at boundary before DB access ✓
- **Regola 19:** No error boundary propagation; inline error handling ✓
- **Regola 20:** Predictable input errors logged as `warn`, not `error` ✓

https://claude.ai/code/session_0153DtcCfSudfhcGMvDMQKqj