### PR TITLE
Validate ADE credentials at server boundary (CIE email & password length)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -463,34 +463,6 @@ shape esatta non è verificata a runtime.
 
 ---
 
-### 53. `saveAdeCredentials` CIE: validazione server-side più debole del client
-
-- **Categoria:** correttezza/robustezza · **Severità:** Low
-- **File:** `src/server/onboarding-actions.ts:331-355` (`buildCieValues`: unico check `username.includes("@")`, nessun bound di lunghezza su username/password); client: `onboarding-form.tsx` (`z.email()`) e `edit-ade-credentials-section.tsx` (`z.email()`)
-
-**Problema.** Il client valida l'email CIE ID con `z.email()`, il server con
-un semplice `includes("@")` e nessun limite di lunghezza prima di `encrypt`:
-una chiamata diretta alla server action può memorizzare stringhe arbitrarie
-(fino al limite di body di Next) come "email" cifrata, e l'errore emergerà
-solo al login AdE. Non è un problema di sicurezza (dato cifrato, mai
-interpretato), ma il boundary server deve valere da solo (regola 9 come
-principio; NB: **non** applicare `normalizeEmail()` — è una credenziale di
-un sistema esterno, il case/spazi vanno preservati byte-per-byte come per la
-password, e va documentato con un commento).
-
-**Fix (non ambiguo).**
-
-1. In `buildCieValues`: validare l'email con lo stesso criterio del client
-   (riusare lo schema Zod `z.email()` server-side) + bound `username.length <= 254`
-   e `password.length <= 128` → `{ error }` dedicati.
-2. Simmetria: `buildFisconlineValues` ha già bound impliciti (CF 16, PIN
-   regex); aggiungere il solo cap password se assente.
-3. **Test** (in `onboarding-actions.test.ts`): username senza `@`/malformato/
-   oltre 254 char → errore; email valida con maiuscole → salvata NON
-   normalizzata (round-trip decrypt identico all'input).
-
----
-
 ### 60. `changeAdePassword` senza optimistic lock né guard sul metodo: una race con `saveAdeCredentials` può corrompere credenziali CIE
 
 - **Categoria:** correttezza/robustezza · **Severità:** Low — finestra di secondi (durata del flusso HTTP AdE di cambio password), richiede azioni concorrenti dello stesso utente

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -61,6 +61,29 @@ export const adePinSchema = z
   );
 
 /**
+ * Bound massimo per una password di credenziale AdE (Fisconline/CIE).
+ * Non è una regola AdE (Fisconline è 8–15 char), ma un cap difensivo al
+ * boundary server: la password è una credenziale opaca cifrata as-is, quindi
+ * evitiamo di cifrare/memorizzare stringhe arbitrariamente lunghe (fino al
+ * limite di body di Next) inviate bypassando il client.
+ */
+export const ADE_PASSWORD_MAX_LENGTH = 128;
+
+/**
+ * Schema Zod per l'email dell'app CIE ID (username del metodo CIE).
+ * Stesso criterio del client (`z.email()`), così il boundary server vale da
+ * solo (regola 9) e non è più debole della validazione client.
+ *
+ * NB: NON è un'email applicativa da normalizzare — è una credenziale di un
+ * sistema esterno (AdE/CIE). Case e spazi vanno preservati byte-per-byte come
+ * la password: NON applicare `normalizeEmail()`. Il bound 254 è il massimo di
+ * un indirizzo email (RFC 5321).
+ */
+export const adeCieEmailSchema = z
+  .email("Inserisci l'email dell'app CIE ID.")
+  .max(254, "Email troppo lunga.");
+
+/**
  * CAP italiano: esattamente 5 cifre numeriche.
  */
 const ITALIAN_ZIP_REGEX = /^\d{5}$/;

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -708,6 +708,88 @@ describe("onboarding-actions", () => {
       expect(mockInsert).not.toHaveBeenCalled();
     });
 
+    it.each([
+      { scenario: "senza @", username: "non-una-email" },
+      { scenario: "malformata", username: "mario@@example" },
+      {
+        scenario: "oltre 254 caratteri",
+        username: `${"a".repeat(250)}@x.com`,
+      },
+    ])(
+      "CIE: rifiuta email $scenario prima di cifrare/ownership",
+      async ({ username }) => {
+        const { saveAdeCredentials } = await import("./onboarding-actions");
+        const result = await saveAdeCredentials(
+          formData({
+            businessId: "11111111-1111-4111-8111-111111111111",
+            loginMethod: "cie",
+            username,
+            password: "cie-pass",
+          }),
+        );
+
+        expect(result.error).toBeDefined();
+        expect(mockEncrypt).not.toHaveBeenCalled();
+        expect(mockSelect).not.toHaveBeenCalled();
+        expect(mockInsert).not.toHaveBeenCalled();
+      },
+    );
+
+    it("CIE: rifiuta una password oltre il bound (128 char)", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "11111111-1111-4111-8111-111111111111",
+          loginMethod: "cie",
+          username: "mario.rossi@example.com",
+          password: "x".repeat(129),
+        }),
+      );
+
+      expect(result.error).toContain("troppo lunga");
+      expect(mockEncrypt).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("CIE: email con maiuscole salvata NON normalizzata (cifrata byte-per-byte)", async () => {
+      mockLimit.mockResolvedValueOnce([{ id: FAKE_BUSINESS.id }]);
+
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const mixedCaseEmail = "Mario.Rossi@Example.COM";
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "11111111-1111-4111-8111-111111111111",
+          loginMethod: "cie",
+          username: mixedCaseEmail,
+          password: "cie-pass",
+        }),
+      );
+
+      expect(result.error).toBeUndefined();
+      // La username viene cifrata così com'è: nessun trim/lowercase, il
+      // round-trip decrypt torna identico all'input (case preservato).
+      expect(mockEncrypt).toHaveBeenCalledWith(
+        mixedCaseEmail,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("Fisconline: rifiuta una password oltre il bound (128 char)", async () => {
+      const { saveAdeCredentials } = await import("./onboarding-actions");
+      const result = await saveAdeCredentials(
+        formData({
+          businessId: "11111111-1111-4111-8111-111111111111",
+          codiceFiscale: "RSSMRA80A01H501U",
+          password: "x".repeat(129),
+          pin: "1234567890",
+        }),
+      );
+
+      expect(result.error).toContain("troppo lunga");
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
     it("SPID: rifiutato (non supportato da PWA), nessun insert", async () => {
       const { saveAdeCredentials } = await import("./onboarding-actions");
       const result = await saveAdeCredentials(

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -44,7 +44,9 @@ import {
 } from "@/lib/server-auth";
 import { authErrorResult } from "@/lib/auth-errors";
 import {
+  adeCieEmailSchema,
   adePinSchema,
+  ADE_PASSWORD_MAX_LENGTH,
   BUSINESS_PROFILE_LIMITS,
   isValidItalianZipCode,
   ITALIAN_ZIP_MESSAGE,
@@ -315,6 +317,9 @@ function buildFisconlineValues(
   if (!password) {
     return { error: "Password Fisconline obbligatoria." };
   }
+  if (password.length > ADE_PASSWORD_MAX_LENGTH) {
+    return { error: "Password Fisconline troppo lunga." };
+  }
   const pinResult = adePinSchema.safeParse(pin);
   if (!pinResult.success) {
     return {
@@ -342,14 +347,27 @@ function buildCieValues(
   key: Buffer,
   keyVersion: number,
 ): AdeCredentialValues | { error: string } {
-  const username = getFormString(formData, "username");
+  // L'email dell'app CIE ID è una credenziale di un sistema esterno: NON
+  // normalizzare (niente trim/lowercase). Case e spazi vanno preservati
+  // byte-per-byte come la password, così il valore cifrato fa round-trip
+  // identico all'input. Uso `getFormStringRaw` + Zod `z.email()` — stesso
+  // criterio del client, il boundary server non è più debole (regola 9).
+  const username = getFormStringRaw(formData, "username");
   const password = getFormStringRaw(formData, "password");
 
-  if (!username.includes("@")) {
-    return { error: "Inserisci l'email dell'app CIE ID." };
+  const usernameResult = adeCieEmailSchema.safeParse(username);
+  if (!usernameResult.success) {
+    return {
+      error:
+        usernameResult.error.issues[0]?.message ??
+        "Inserisci l'email dell'app CIE ID.",
+    };
   }
   if (!password) {
     return { error: "Password CIE obbligatoria." };
+  }
+  if (password.length > ADE_PASSWORD_MAX_LENGTH) {
+    return { error: "Password CIE troppo lunga." };
   }
 
   return {


### PR DESCRIPTION
## Summary

Closes issue #53 from `REVIEW.md`: strengthen server-side validation of ADE credentials (CIE ID email and password length) to match client-side rules and prevent weak boundary validation.

## Changes

- **`src/lib/validation.ts`**
  - Added `ADE_PASSWORD_MAX_LENGTH = 128` constant with defensive cap rationale (opaque credential, prevent arbitrary-length encryption)
  - Added `adeCieEmailSchema` using `z.email()` + `.max(254)` to match client validation and RFC 5321 email length limit
  - Documented that CIE email is an external system credential: **not normalized** (case/spaces preserved byte-per-byte like password)

- **`src/server/onboarding-actions.ts`**
  - `buildCieValues()`: replaced weak `username.includes("@")` check with `adeCieEmailSchema.safeParse()` for proper email validation
  - Changed `getFormString()` → `getFormStringRaw()` for username to preserve case/spaces (no trim/lowercase)
  - Added password length validation (`password.length > ADE_PASSWORD_MAX_LENGTH`) with dedicated error message
  - `buildFisconlineValues()`: added symmetric password length check (Fisconline already had implicit CF/PIN bounds)
  - Added inline comment explaining why CIE email is not normalized (round-trip decrypt must match input exactly)

- **`src/server/onboarding-actions.test.ts`**
  - Added parameterized test: reject malformed CIE emails (no `@`, double `@@`, >254 chars) before encryption/ownership check
  - Added test: reject CIE password >128 chars with "troppo lunga" error
  - Added test: mixed-case email (e.g., `Mario.Rossi@Example.COM`) saved **without normalization**, round-trip decrypt identical to input
  - Added test: reject Fisconline password >128 chars with "troppo lunga" error

- **`REVIEW.md`**
  - Removed issue #53 (now fixed)

## Implementation notes

- Server boundary now validates with same criteria as client (`z.email()`), per rule 9 (boundary must stand alone)
- CIE email is treated as an opaque external credential: no `normalizeEmail()`, case/spaces preserved as-is
- Password cap (128 chars) is defensive; Fisconline spec is 8–15 chars, but cap prevents arbitrary-length encryption if client is bypassed
- Error messages match client UX ("Inserisci l'email dell'app CIE ID.", "troppo lunga")

https://claude.ai/code/session_015oubHtLh1aqhp5jV39PG5Q