### PR TITLE
Exclude /api/ routes from hostname redirects

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -542,6 +542,35 @@ describe("proxy", () => {
       expect(response.status).toBe(200);
     });
 
+    // API routes must NEVER be redirected cross-domain by hostnameRedirect.
+    // A server-to-server caller (Stripe webhooks, any backend POST) does NOT
+    // follow the 307, so a redirect silently drops the request/body. The
+    // Stripe dev webhook was registered on the marketing host
+    // (dev.scontrinozero.it/api/stripe/webhook) and every delivery was bounced
+    // 307 → app-dev and lost. API routes are host-agnostic (single container
+    // serves every host) and must respond on whatever host receives them.
+    it("does NOT redirect /api/stripe/webhook on marketing domain (server-to-server, no cross-domain 307)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/api/stripe/webhook", "scontrinozero.it"),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+    });
+
+    it("does NOT redirect /api/stripe/webhook on app domain either", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const { proxy } = await import("./proxy");
+
+      const response = await proxy(
+        createRequestForHost("/api/stripe/webhook", "app.scontrinozero.it"),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+    });
+
     it("strips port from Host header before comparing hostnames (e.g. scontrinozero.it:443)", async () => {
       const { proxy } = await import("./proxy");
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -93,6 +93,18 @@ function hostnameRedirect(request: NextRequest): NextResponse | null {
 
   const hostname = resolvePublicHostname(request);
   const { pathname, search } = request.nextUrl;
+
+  // API routes are host-agnostic: the single standalone container serves every
+  // host, so an API route must respond on whatever host receives it and must
+  // NEVER be redirected cross-domain. A server-to-server caller (Stripe
+  // webhooks, any backend POST) does NOT follow a 307 — a redirect silently
+  // drops the request and its body. Concretely: the Stripe webhook registered
+  // on the marketing host (`<marketing>/api/stripe/webhook`) was bounced
+  // 307 → app domain and every delivery was lost. Excluding `/api/` here keeps
+  // the domain-separation redirects for pages while leaving API endpoints
+  // reachable on any host.
+  if (pathname.startsWith("/api/")) return null;
+
   // Trusted hostnames must be parsed/validated: a malformed env var
   // (scheme leak, trailing slash, spaces, …) would otherwise alter routing
   // decisions silently. `parseTrustedHostnameEnv` fails closed to the fallback


### PR DESCRIPTION
## Summary

Prevent API routes from being redirected across domains by the `hostnameRedirect` middleware. API routes are host-agnostic (served by a single container for all hosts) and must respond on whatever host receives them. Server-to-server callers (Stripe webhooks, backend POSTs) do not follow 307 redirects, causing requests and their bodies to be silently dropped.

## Key Changes

- **src/proxy.ts**: Added early return in `hostnameRedirect()` to skip redirect logic for any request with pathname starting with `/api/`. Includes detailed comment explaining the Stripe webhook incident that motivated this fix.
- **src/proxy.test.ts**: Added two test cases to verify that `/api/stripe/webhook` requests are not redirected on either the marketing domain (`scontrinozero.it`) or the app domain (`app.scontrinozero.it`), and that no `location` header is set.

## Implementation Details

The fix is minimal and surgical: a single `if (pathname.startsWith("/api/")) return null;` check before any redirect logic is applied. This preserves domain-separation redirects for pages while keeping API endpoints reachable on any host, solving the concrete issue where Stripe webhook deliveries registered on the marketing host were bounced 307 → app domain and lost entirely.

Tests confirm the behavior on both domains to ensure the fix is robust across the multi-host setup.

https://claude.ai/code/session_01RAnHAmNJPqHR1RhJKFVg7D