### PR TITLE
Add 6 guide articles, 9 category pages, and SEO feeds (RSS/llms-full)

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,8 +1,4 @@
 {
   "moderate": true,
-  "allowlist": [
-    "GHSA-67mh-4wv8-2f99",
-    "GHSA-gv7w-rqvm-qjhr",
-    "GHSA-g7r4-m6w7-qqqr"
-  ]
+  "allowlist": ["GHSA-67mh-4wv8-2f99"]
 }

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -33,6 +33,8 @@ src/
     r/              pagina pubblica scontrino (QR / link)
     sitemap.ts robots.ts manifest.ts layout.tsx global-error.tsx
     llms.txt/       route handler /llms.txt (indice markdown per crawler AI)
+    llms-full.txt/  route handler /llms-full.txt (testo completo dei registry per crawler AI)
+    feed.xml/       route handler /feed.xml (RSS 2.0 delle guide)
   components/     React. Sottocartelle per dominio (cassa, storico, analytics,
                   catalogo, billing, settings, ade, receipts, marketing, help,
                   pwa, dashboard, announcement) + ui/ (shadcn) + providers.tsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,6 +1014,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2128,13 +2129,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2229,9 +2230,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -2241,19 +2242,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -2263,19 +2264,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -2289,9 +2309,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -2305,9 +2325,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -2321,9 +2341,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -2337,9 +2357,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -2353,9 +2373,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -2369,9 +2389,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -2385,9 +2405,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -2401,9 +2421,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -2417,9 +2437,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -2433,9 +2453,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -2445,19 +2465,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -2467,19 +2487,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -2489,19 +2509,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2511,19 +2531,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -2533,19 +2553,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -2555,19 +2575,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -2577,19 +2597,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -2599,38 +2619,64 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -2640,16 +2686,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -2659,16 +2705,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -2678,7 +2724,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2889,9 +2935,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2907,9 +2950,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2927,9 +2967,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2945,9 +2982,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8664,9 +8698,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10857,9 +10891,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11522,9 +11556,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -12140,9 +12174,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13177,9 +13211,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -16607,54 +16641,59 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -90,23 +90,25 @@
   },
   "overrides": {
     "typescript-eslint": "^8.58.1",
-    "hono": "^4.12.25",
-    "@hono/node-server": "^1.19.13",
+    "hono": "^4.12.27",
+    "@hono/node-server": "^2.0.5",
     "undici": "^7.28.0",
     "path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",
     "vite": "^8.0.5",
     "yaml": ">=2.8.3",
+    "js-yaml": "^4.3.0",
+    "sharp": "^0.35.0",
     "picomatch": "4.0.4",
     "express-rate-limit": "^8.5.1",
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.4",
     "qs": "^6.15.2",
     "postcss": "^8.5.10",
-    "brace-expansion": "5.0.6",
+    "brace-expansion": "5.0.7",
     "micromatch": {
       "picomatch": "2.3.2"
     },
     "minimatch@^3.0.0": {
-      "brace-expansion": "1.1.13"
+      "brace-expansion": "1.1.16"
     },
     "minimatch@^9.0.0": {
       "brace-expansion": "2.0.3"

--- a/src/app/(marketing)/confronto/page.tsx
+++ b/src/app/(marketing)/confronto/page.tsx
@@ -11,6 +11,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { confrontoContent } from "@/lib/confronto/comparisons";
 import { helpArticles } from "@/lib/help/articles";
+import { formatDate } from "@/lib/utils";
 
 const SITE_URL = "https://scontrinozero.it";
 const PAGE_URL = `${SITE_URL}/confronto`;
@@ -197,8 +198,8 @@ export default function ConfrontoPage() {
             </table>
           </div>
           <p className="text-muted-foreground mt-3 text-xs">
-            {"Dati rilevati dai siti pubblici a "}
-            {c.lastUpdated}
+            {"Dati rilevati dai siti pubblici il "}
+            {formatDate(c.lastUpdated, "numeric", "Europe/Rome")}
             {
               ". Listini e funzionalità possono cambiare in qualsiasi momento: verifica direttamente sui siti ufficiali prima di scegliere."
             }

--- a/src/app/(marketing)/funzionalita/page.tsx
+++ b/src/app/(marketing)/funzionalita/page.tsx
@@ -15,6 +15,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { MarketingHero } from "@/components/marketing/marketing-hero";
 
+const PAGE_URL = "https://scontrinozero.it/funzionalita";
+
 export const metadata: Metadata = {
   title: "Funzionalità",
   description:
@@ -23,6 +25,10 @@ export const metadata: Metadata = {
     title: "Funzionalità ScontrinoZero | Emissione, Gestione, Compliance AdE",
     description:
       "Emissione scontrini in 5 secondi, trasmissione automatica all'AdE, annullamento, storico e condivisione digitale. Scopri tutto.",
+    url: PAGE_URL,
+  },
+  alternates: {
+    canonical: PAGE_URL,
   },
 };
 

--- a/src/app/(marketing)/guide/[slug]/page.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 import { helpArticles } from "@/lib/help/articles";
 import { isToolSlug, tools } from "@/lib/strumenti/tools";
+import { formatDate } from "@/lib/utils";
 
 const SITE_URL = "https://scontrinozero.it";
 
@@ -56,14 +57,6 @@ export async function generateMetadata({
   };
 }
 
-function lastDayOfMonth(yyyyMm: string): string {
-  const [yStr, mStr] = yyyyMm.split("-");
-  const y = Number.parseInt(yStr, 10);
-  const m = Number.parseInt(mStr, 10);
-  const lastDay = new Date(Date.UTC(y, m, 0)).getUTCDate();
-  return `${yyyyMm}-${String(lastDay).padStart(2, "0")}`;
-}
-
 export default async function GuidePage({ params }: PageParams) {
   const { slug } = await params;
   if (!isGuideSlug(slug)) {
@@ -90,7 +83,7 @@ export default async function GuidePage({ params }: PageParams) {
           description: g.metaDescription,
           url: pageUrl,
           datePublished: g.publishedAt,
-          dateModified: lastDayOfMonth(g.updatedAt),
+          dateModified: g.updatedAt,
         })}
       />
       {g.faq.length > 0 && <JsonLd data={faqPageJsonLd(g.faq)} />}
@@ -105,8 +98,8 @@ export default async function GuidePage({ params }: PageParams) {
           <p className="text-muted-foreground mt-3 flex items-center gap-1 text-xs">
             <Clock className="h-3 w-3" />
             {g.readingMinutes}
-            {" min di lettura · aggiornato "}
-            {g.updatedAt}
+            {" min di lettura · aggiornato il "}
+            {formatDate(g.updatedAt, "numeric", "Europe/Rome")}
           </p>
           <p className="text-muted-foreground mt-4 text-lg leading-relaxed">
             {g.heroIntro}

--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -1,8 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import {
   JsonLd,
+  faqPageJsonLd,
   helpArticleBreadcrumb,
   helpArticleBreadcrumbItems,
+  type FaqItem,
 } from "@/components/json-ld";
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
@@ -11,6 +13,35 @@ import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
 export const metadata = helpArticleMetadata("annullare-scontrino");
+
+/**
+ * Mirror in testo piano della FAQ visibile a video: alimenta lo structured data
+ * FAQPage (rich result Google). Tenere allineato al contenuto renderizzato sotto.
+ */
+const faqItems: readonly FaqItem[] = [
+  {
+    question: "Entro quanto tempo si può annullare uno scontrino?",
+    answer:
+      "Per il Documento Commerciale Online non esiste una finestra rigida: puoi annullare anche nei giorni successivi all'emissione. La best practice è farlo il prima possibile e comunque entro il periodo d'imposta, per non complicare la riconciliazione dei corrispettivi.",
+  },
+  {
+    question:
+      "L'annullamento deve per forza essere fatto in giornata, prima della chiusura?",
+    answer:
+      "No. Con il DCO non c'è la chiusura di cassa che blocca la giornata come sui registratori telematici fisici: l'annullo si può trasmettere anche il giorno dopo, e l'AdE rettifica i corrispettivi del giorno interessato.",
+  },
+  {
+    question:
+      "Non riesco ad annullare uno scontrino: posso comunque continuare a lavorare?",
+    answer:
+      "Sì. Con ScontrinoZero non esiste una chiusura giornaliera da completare, quindi un annullo non riuscito non blocca le vendite successive. Risolvi l'errore (di solito basta riprovare dal dettaglio dello scontrino) e ritenta l'annullo quando l'AdE è raggiungibile.",
+  },
+  {
+    question: "Come verifico che uno scontrino sia stato annullato davvero?",
+    answer:
+      "Nello Storico di ScontrinoZero lo scontrino passa allo stato «Annullato» con il progressivo del documento di annullo. In più puoi verificarlo nel portale Fatture e Corrispettivi dell'AdE: il documento originale risulta annullato con il riferimento all'annullo.",
+  },
+];
 
 export default function AnnullareScontrinoPage() {
   return (
@@ -22,6 +53,7 @@ export default function AnnullareScontrinoPage() {
         )}
       />
       <HelpArticleJsonLd slug="annullare-scontrino" />
+      <JsonLd data={faqPageJsonLd(faqItems)} />
       <article className="mx-auto max-w-3xl">
         <Breadcrumbs
           items={helpArticleBreadcrumbItems(
@@ -44,7 +76,7 @@ export default function AnnullareScontrinoPage() {
           guida spiega come farlo da ScontrinoZero e in quali casi è possibile.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
+          <strong>Ultimo aggiornamento:</strong> luglio 2026
         </p>
 
         {/* ─── Quando si può annullare ─── */}
@@ -241,6 +273,19 @@ export default function AnnullareScontrinoPage() {
               l&apos;importo corretto.
             </p>
           </div>
+        </div>
+
+        {/* ─── FAQ (mirror di faqItems: tenere allineati) ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Domande frequenti</h2>
+        <div className="mt-3 space-y-4">
+          {faqItems.map((faq) => (
+            <div key={faq.question}>
+              <p className="text-sm font-medium">{faq.question}</p>
+              <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+                {faq.answer}
+              </p>
+            </div>
+          ))}
         </div>
         <RelatedHelpArticles slug="annullare-scontrino" />
 

--- a/src/app/(marketing)/help/regime-forfettario/page.tsx
+++ b/src/app/(marketing)/help/regime-forfettario/page.tsx
@@ -83,7 +83,7 @@ export default function RegimeForfettarioPage() {
           all&apos;Agenzia delle Entrate.
         </p>
         <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> giugno 2026
+          <strong>Ultimo aggiornamento:</strong> luglio 2026
         </p>
 
         {/* ─── Cos'è il regime forfettario ─── */}
@@ -153,6 +153,14 @@ export default function RegimeForfettarioPage() {
             className="text-primary hover:underline"
           >
             Codici natura IVA: cosa sono e quando si usano
+          </Link>
+          {". Per gli obblighi normativi del forfettario (quando lo scontrino "}
+          {"è dovuto, esoneri, lotteria) c'è la guida "}
+          <Link
+            href="/guide/scontrino-regime-forfettario"
+            className="text-primary hover:underline"
+          >
+            Scontrino in regime forfettario
           </Link>
           {"."}
         </p>

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from "next";
 import { Header } from "@/components/marketing/header";
 import { Footer } from "@/components/marketing/footer";
+
+// Autodiscovery del feed RSS delle guide (crawler, aggregatori, AI).
+export const metadata: Metadata = {
+  alternates: {
+    types: {
+      "application/rss+xml": "https://scontrinozero.it/feed.xml",
+    },
+  },
+};
 
 export default function MarketingLayout({
   children,

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -251,7 +251,7 @@ export default function Home() {
               href="/guide/scontrino-senza-registratore-di-cassa"
               className="text-primary hover:underline"
             >
-              {"Scontrino senza registratore di cassa"}
+              {"Scontrino senza cassa e senza registratore"}
             </Link>
             {" · "}
             <Link

--- a/src/app/(marketing)/prezzi/page.tsx
+++ b/src/app/(marketing)/prezzi/page.tsx
@@ -2,8 +2,12 @@ import type { Metadata } from "next";
 import { ArrowRight, Check } from "lucide-react";
 import { appHref } from "@/lib/marketing-to-app-href";
 import { Button } from "@/components/ui/button";
+import { JsonLd, faqPageJsonLd } from "@/components/json-ld";
 import { MarketingHero } from "@/components/marketing/marketing-hero";
 import { PricingSection } from "@/components/marketing/pricing-section";
+
+const SITE_URL = "https://scontrinozero.it";
+const PAGE_URL = `${SITE_URL}/prezzi`;
 
 export const metadata: Metadata = {
   title: "Prezzi",
@@ -13,6 +17,10 @@ export const metadata: Metadata = {
     title: "Prezzi ScontrinoZero | Starter da €2,50/mese · Pro da €4,17/mese",
     description:
       "Starter da €2,50/mese (€29,99/anno), Pro da €4,17/mese (€49,99/anno). 30 giorni di prova gratuita, nessuna carta di credito richiesta. Disponibile anche la versione gratuita per installazione autonoma.",
+    url: PAGE_URL,
+  },
+  alternates: {
+    canonical: PAGE_URL,
   },
 };
 
@@ -85,6 +93,16 @@ const comparisonRows: ComparisonRow[] = [
 
 const pricingFaqs: { question: string; answer: string }[] = [
   {
+    question: "Serve la carta di credito per la prova gratuita?",
+    answer:
+      "No. I 30 giorni di prova non richiedono alcuna carta di credito: ti registri e inizi subito a usare il servizio. Al termine della prova scegli se attivare un piano.",
+  },
+  {
+    question: "Che differenza c'è tra Starter e Pro?",
+    answer:
+      "Starter (€29,99/anno) include scontrini illimitati, trasmissione automatica all'AdE, catalogo rapido fino a 5 prodotti e analytics base. Pro (€49,99/anno) aggiunge catalogo illimitato, analytics avanzata, export CSV e supporto prioritario.",
+  },
+  {
     question: "Posso cambiare piano in qualsiasi momento?",
     answer:
       "Sì. Puoi passare da Starter a Pro o viceversa in qualsiasi momento dal pannello di controllo. Le modifiche entrano in vigore immediatamente.",
@@ -119,6 +137,8 @@ function CellValue({ value }: Readonly<{ value: string | boolean }>) {
 export default function PrezziPage() {
   return (
     <>
+      <JsonLd data={faqPageJsonLd(pricingFaqs)} />
+
       {/* Hero */}
       <MarketingHero
         title={

--- a/src/app/feed.xml/route.test.ts
+++ b/src/app/feed.xml/route.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { guideArticles, guideSlugs } from "@/lib/guide/articles";
+
+const mockHeaderGet = vi.fn<(name: string) => string | null>();
+
+vi.mock("next/headers", () => ({
+  headers: () => Promise.resolve({ get: mockHeaderGet }),
+}));
+
+async function getResponse(): Promise<Response> {
+  const { GET } = await import("./route");
+  return GET();
+}
+
+describe("GET /feed.xml", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    mockHeaderGet.mockReset();
+  });
+
+  it("serves an RSS 2.0 feed on the production marketing apex", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const response = await getResponse();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/rss+xml; charset=utf-8",
+    );
+    const body = await response.text();
+    expect(body).toContain('<rss version="2.0"');
+    expect(body).toContain("<language>it-it</language>");
+  });
+
+  it("has one item per guide with canonical link and pubDate", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    const itemCount = (body.match(/<item>/g) ?? []).length;
+    expect(itemCount).toBe(guideSlugs.length);
+    for (const slug of guideSlugs) {
+      expect(body).toContain(
+        `<link>https://scontrinozero.it/guide/${slug}</link>`,
+      );
+    }
+    // pubDate in formato RFC 822 (richiesto da RSS 2.0)
+    expect(body).toMatch(/<pubDate>\w{3}, \d{2} \w{3} \d{4}/);
+  });
+
+  it("escapes XML entities in titles and descriptions", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    // Nessun & nudo fuori dalle entity: il feed deve restare XML valido
+    const raw = body.replaceAll(/&(amp|lt|gt|quot|apos);/g, "");
+    expect(raw).not.toContain("&");
+  });
+
+  it("orders items by publishedAt descending (newest first)", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    const links = [
+      ...body.matchAll(/<link>([^<]+\/guide\/[^<]+)<\/link>/g),
+    ].map((m) => m[1]);
+    const dates = links.map((link) => {
+      const slug = link.split("/guide/")[1] as (typeof guideSlugs)[number];
+      return guideArticles[slug].publishedAt;
+    });
+    const sorted = [...dates].toSorted((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+  });
+
+  it("returns 404 on a non-indexable host", async () => {
+    mockHeaderGet.mockReturnValue("sandbox.scontrinozero.it");
+    const response = await getResponse();
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,86 @@
+import { headers } from "next/headers";
+import { guideArticles, guideSlugs } from "@/lib/guide/articles";
+import { isIndexableHost, marketingBaseUrl } from "@/lib/seo-indexable";
+
+/**
+ * `/feed.xml`: feed RSS 2.0 delle guide editoriali. Segnale di freshness e
+ * canale di discovery per crawler, aggregatori e AI. Alimentato dallo stesso
+ * registry delle pagine (`guideArticles`), quindi non può driftare.
+ * Servito solo sull'apex marketing indicizzabile, come llms.txt.
+ */
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** RFC 822, richiesto da RSS 2.0 (es. "Tue, 22 Jul 2026 00:00:00 GMT"). */
+function toRfc822(isoDate: string): string {
+  return new Date(`${isoDate}T00:00:00Z`).toUTCString();
+}
+
+function buildFeed(baseUrl: string): string {
+  const sortedSlugs = [...guideSlugs].toSorted((a, b) => {
+    const byDate = guideArticles[b].publishedAt.localeCompare(
+      guideArticles[a].publishedAt,
+    );
+    // Chiave secondaria stabile a parità di data
+    return byDate !== 0 ? byDate : a.localeCompare(b);
+  });
+
+  const lastBuildDate = toRfc822(
+    sortedSlugs
+      .map((slug) => guideArticles[slug].updatedAt)
+      .toSorted((a, b) => a.localeCompare(b))
+      .at(-1) ?? new Date().toISOString().slice(0, 10),
+  );
+
+  const items = sortedSlugs.map((slug) => {
+    const a = guideArticles[slug];
+    const url = `${baseUrl}/guide/${slug}`;
+    return [
+      "    <item>",
+      `      <title>${escapeXml(a.title)}</title>`,
+      `      <link>${url}</link>`,
+      `      <guid isPermaLink="true">${url}</guid>`,
+      `      <description>${escapeXml(a.metaDescription)}</description>`,
+      `      <pubDate>${toRfc822(a.publishedAt)}</pubDate>`,
+      "    </item>",
+    ].join("\n");
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    "  <channel>",
+    "    <title>ScontrinoZero — Guide</title>",
+    `    <link>${baseUrl}/guide</link>`,
+    "    <description>Guide pratiche su scontrino elettronico, documento commerciale online, corrispettivi telematici e adempimenti per esercenti italiani.</description>",
+    "    <language>it-it</language>",
+    `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+    `    <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml"/>`,
+    ...items,
+    "  </channel>",
+    "</rss>",
+    "",
+  ].join("\n");
+}
+
+export async function GET(): Promise<Response> {
+  const host = (await headers()).get("host");
+
+  if (!isIndexableHost(host)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  return new Response(buildFeed(marketingBaseUrl()), {
+    status: 200,
+    headers: {
+      "content-type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/components/json-ld", () => ({
   JsonLd: () => null,
   softwareApplicationJsonLd: {},
   organizationJsonLd: {},
+  webSiteJsonLd: {},
 }));
 vi.mock("./globals.css", () => ({}));
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import {
   JsonLd,
   softwareApplicationJsonLd,
   organizationJsonLd,
+  webSiteJsonLd,
 } from "@/components/json-ld";
 import { marketingBaseUrl } from "@/lib/seo-indexable";
 import { UmamiScript } from "@/components/umami-script";
@@ -82,6 +83,7 @@ export default function RootLayout({
       >
         <JsonLd data={softwareApplicationJsonLd} />
         <JsonLd data={organizationJsonLd} />
+        <JsonLd data={webSiteJsonLd} />
         <UmamiScript />
         <Providers>{children}</Providers>
       </body>

--- a/src/app/llms-full.txt/route.test.ts
+++ b/src/app/llms-full.txt/route.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { guideArticles, guideSlugs } from "@/lib/guide/articles";
+import { helpSlugs } from "@/lib/help/articles";
+import { categorySlugs } from "@/lib/per/categories";
+import { toolSlugs } from "@/lib/strumenti/tools";
+
+const mockHeaderGet = vi.fn<(name: string) => string | null>();
+
+vi.mock("next/headers", () => ({
+  headers: () => Promise.resolve({ get: mockHeaderGet }),
+}));
+
+async function getResponse(): Promise<Response> {
+  const { GET } = await import("./route");
+  return GET();
+}
+
+describe("GET /llms-full.txt", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    mockHeaderGet.mockReset();
+  });
+
+  it("serves text/plain markdown on the production marketing apex", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const response = await getResponse();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    const body = await response.text();
+    expect(body.startsWith("# ScontrinoZero\n")).toBe(true);
+  });
+
+  it("includes the FULL text of every guide (sections and FAQ, not just links)", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    for (const slug of guideSlugs) {
+      const article = guideArticles[slug];
+      expect(body).toContain(`https://scontrinozero.it/guide/${slug}`);
+      // Testo completo: ogni sezione col suo body, ogni FAQ con la risposta
+      for (const section of article.sections) {
+        expect(body).toContain(section.heading);
+        expect(body).toContain(section.body);
+      }
+      for (const faq of article.faq) {
+        expect(body).toContain(faq.answer);
+      }
+    }
+  });
+
+  it("renders guide tables as markdown tables", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    // La tabella N1-N7 della guida codici-natura-iva deve esserci riga per riga
+    expect(body).toContain("| N2.2 |");
+  });
+
+  it("includes categories, tools and confronto content with their FAQ", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    for (const slug of categorySlugs) {
+      expect(body).toContain(`https://scontrinozero.it/per/${slug}`);
+    }
+    for (const slug of toolSlugs) {
+      expect(body).toContain(`https://scontrinozero.it/strumenti/${slug}`);
+    }
+    expect(body).toContain("https://scontrinozero.it/confronto");
+  });
+
+  it("lists help articles as links only (prose lives in the page components)", async () => {
+    mockHeaderGet.mockReturnValue("scontrinozero.it");
+    const body = await (await getResponse()).text();
+
+    for (const slug of helpSlugs) {
+      expect(body).toContain(`https://scontrinozero.it/help/${slug}`);
+    }
+  });
+
+  it("returns 404 on a non-indexable host (sandbox)", async () => {
+    mockHeaderGet.mockReturnValue("sandbox.scontrinozero.it");
+    const response = await getResponse();
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when the host header is missing", async () => {
+    mockHeaderGet.mockReturnValue(null);
+    const response = await getResponse();
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,144 @@
+import { headers } from "next/headers";
+import { guideArticles, type GuideTable } from "@/lib/guide/articles";
+import { helpArticles } from "@/lib/help/articles";
+import { categories } from "@/lib/per/categories";
+import { tools } from "@/lib/strumenti/tools";
+import { confrontoContent } from "@/lib/confronto/comparisons";
+import { isIndexableHost, marketingBaseUrl } from "@/lib/seo-indexable";
+
+/**
+ * `/llms-full.txt` (https://llmstxt.org): variante full-text di `/llms.txt`.
+ * Emette il TESTO COMPLETO dei contenuti che vivono nei registry editoriali
+ * (guide con sezioni/tabelle/FAQ, verticali /per, /confronto, strumenti),
+ * così un crawler AI può citare i contenuti senza renderizzare le pagine.
+ * Gli articoli /help compaiono solo come link: la loro prosa vive nei
+ * componenti pagina, non nel registry.
+ *
+ * Come llms.txt/robots.ts, è servito solo sull'apex marketing indicizzabile.
+ */
+
+function markdownTable(table: GuideTable): readonly string[] {
+  return [
+    `| ${table.headers.join(" | ")} |`,
+    `| ${table.headers.map(() => "---").join(" | ")} |`,
+    ...table.rows.map((row) => `| ${row.join(" | ")} |`),
+  ];
+}
+
+function faqBlock(
+  faq: readonly { readonly question: string; readonly answer: string }[],
+): readonly string[] {
+  return faq.flatMap((item) => [`**${item.question}**`, "", item.answer, ""]);
+}
+
+function buildLlmsFullTxt(baseUrl: string): string {
+  const lines: string[] = [
+    "# ScontrinoZero",
+    "",
+    '> Registratore di cassa virtuale per emettere scontrini elettronici e trasmettere i corrispettivi all\'Agenzia delle Entrate tramite la procedura "documento commerciale online", senza registratore telematico fisico. Web app (PWA) mobile-first per esercenti, micro-attività e regime forfettario in Italia.',
+    "",
+    "Piani: Starter (4,99 €/mese o 29,99 €/anno) e Pro (8,99 €/mese o 49,99 €/anno), prova gratuita di 30 giorni senza carta; versione self-hosted gratuita.",
+    "",
+    "Questo file contiene il testo completo delle guide e delle pagine editoriali. L'indice sintetico è in /llms.txt.",
+    "",
+  ];
+
+  lines.push("## Guide", "");
+  for (const a of Object.values(guideArticles)) {
+    lines.push(
+      `### ${a.title}`,
+      "",
+      `URL: ${baseUrl}/guide/${a.slug}`,
+      `Pubblicato: ${a.publishedAt} — Aggiornato: ${a.updatedAt}`,
+      "",
+      a.heroIntro,
+      "",
+    );
+    for (const section of a.sections) {
+      lines.push(`#### ${section.heading}`, "", section.body, "");
+      if (section.table) {
+        lines.push(...markdownTable(section.table), "");
+      }
+    }
+    if (a.faq.length > 0) {
+      lines.push("#### Domande frequenti", "", ...faqBlock(a.faq));
+    }
+  }
+
+  lines.push("## Per categoria di attività", "");
+  for (const c of Object.values(categories)) {
+    lines.push(
+      `### ${c.title}`,
+      "",
+      `URL: ${baseUrl}/per/${c.slug}`,
+      "",
+      c.useCase,
+      "",
+      "Obblighi principali:",
+      ...c.obligations.map((o) => `- ${o}`),
+      "",
+      ...faqBlock(c.faq),
+    );
+  }
+
+  lines.push(`## ${confrontoContent.title}`, "");
+  lines.push(
+    `URL: ${baseUrl}/confronto`,
+    `Dati verificati il: ${confrontoContent.lastUpdated}`,
+    "",
+    confrontoContent.heroIntro,
+    "",
+  );
+  for (const cat of confrontoContent.categories) {
+    lines.push(`### ${cat.title}`, "", cat.intro, "");
+  }
+  lines.push("### Software comparabili (snapshot pubblico)", "");
+  lines.push(
+    ...markdownTable({
+      headers: ["Servizio", "Prezzo", "Prova"],
+      rows: confrontoContent.saasCompetitors.map((s) => [
+        s.name,
+        s.pricing,
+        s.trial,
+      ]),
+    }),
+    "",
+    ...faqBlock(confrontoContent.faq),
+  );
+
+  lines.push("## Strumenti gratuiti", "");
+  for (const t of Object.values(tools)) {
+    lines.push(
+      `### ${t.title}`,
+      "",
+      `URL: ${baseUrl}/strumenti/${t.slug}`,
+      "",
+      t.heroIntro,
+      "",
+      ...faqBlock(t.faq),
+    );
+  }
+
+  lines.push("## Centro assistenza (solo indice)", "");
+  for (const a of Object.values(helpArticles)) {
+    lines.push(`- [${a.title}](${baseUrl}/help/${a.slug}): ${a.description}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export async function GET(): Promise<Response> {
+  const host = (await headers()).get("host");
+
+  if (!isIndexableHost(host)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  return new Response(buildLlmsFullTxt(marketingBaseUrl()), {
+    status: 200,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -107,9 +107,6 @@ function buildLlmsFullTxt(baseUrl: string): string {
     }),
     "",
     ...faqBlock(confrontoContent.faq),
-  );
-
-  lines.push(
     "## Strumenti gratuiti",
     "",
     ...Object.values(tools).flatMap((t) => [

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -81,19 +81,22 @@ function buildLlmsFullTxt(baseUrl: string): string {
     );
   }
 
-  lines.push(`## ${confrontoContent.title}`, "");
   lines.push(
+    `## ${confrontoContent.title}`,
+    "",
     `URL: ${baseUrl}/confronto`,
     `Dati verificati il: ${confrontoContent.lastUpdated}`,
     "",
     confrontoContent.heroIntro,
     "",
-  );
-  for (const cat of confrontoContent.categories) {
-    lines.push(`### ${cat.title}`, "", cat.intro, "");
-  }
-  lines.push("### Software comparabili (snapshot pubblico)", "");
-  lines.push(
+    ...confrontoContent.categories.flatMap((cat) => [
+      `### ${cat.title}`,
+      "",
+      cat.intro,
+      "",
+    ]),
+    "### Software comparabili (snapshot pubblico)",
+    "",
     ...markdownTable({
       headers: ["Servizio", "Prezzo", "Prova"],
       rows: confrontoContent.saasCompetitors.map((s) => [
@@ -106,9 +109,10 @@ function buildLlmsFullTxt(baseUrl: string): string {
     ...faqBlock(confrontoContent.faq),
   );
 
-  lines.push("## Strumenti gratuiti", "");
-  for (const t of Object.values(tools)) {
-    lines.push(
+  lines.push(
+    "## Strumenti gratuiti",
+    "",
+    ...Object.values(tools).flatMap((t) => [
       `### ${t.title}`,
       "",
       `URL: ${baseUrl}/strumenti/${t.slug}`,
@@ -116,14 +120,14 @@ function buildLlmsFullTxt(baseUrl: string): string {
       t.heroIntro,
       "",
       ...faqBlock(t.faq),
-    );
-  }
-
-  lines.push("## Centro assistenza (solo indice)", "");
-  for (const a of Object.values(helpArticles)) {
-    lines.push(`- [${a.title}](${baseUrl}/help/${a.slug}): ${a.description}`);
-  }
-  lines.push("");
+    ]),
+    "## Centro assistenza (solo indice)",
+    "",
+    ...Object.values(helpArticles).map(
+      (a) => `- [${a.title}](${baseUrl}/help/${a.slug}): ${a.description}`,
+    ),
+    "",
+  );
 
   return lines.join("\n");
 }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -42,6 +42,8 @@ function buildLlmsTxt(baseUrl: string): string {
     "",
     "Piani: Starter (4,99 €/mese o 29,99 €/anno) e Pro (8,99 €/mese o 49,99 €/anno), prova gratuita di 30 giorni senza carta; versione self-hosted gratuita.",
     "",
+    `Il testo completo delle guide e delle pagine editoriali è in ${baseUrl}/llms-full.txt.`,
+    "",
     ...section("Pagine principali", [
       `- [Funzionalità](${baseUrl}/funzionalita): cosa fa ScontrinoZero: emissione, annullo e storico degli scontrini elettronici, invio digitale o stampa termica.`,
       `- [Prezzi](${baseUrl}/prezzi): piani e prezzi aggiornati, prova gratuita.`,

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(71);
+    expect(result).toHaveLength(69);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -183,17 +183,10 @@ describe("sitemap", () => {
       priority: 0.7,
     });
 
-    // Auth pages (last two)
-    expect(result[result.length - 2]).toMatchObject({
-      url: "https://scontrinozero.it/login",
-      changeFrequency: "yearly",
-      priority: 0.5,
-    });
-    expect(result[result.length - 1]).toMatchObject({
-      url: "https://scontrinozero.it/register",
-      changeFrequency: "yearly",
-      priority: 0.5,
-    });
+    // Pagine auth: thin content, escluse dalla sitemap (restano raggiungibili
+    // e indicizzabili, ma non le pubblicizziamo ai crawler).
+    expect(allUrls).not.toContain("https://scontrinozero.it/login");
+    expect(allUrls).not.toContain("https://scontrinozero.it/register");
   });
 
   it("derives the base from NEXT_PUBLIC_MARKETING_HOSTNAME (marketing apex, not the app domain)", async () => {

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(80);
+    expect(result).toHaveLength(84);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -47,6 +47,10 @@ describe("sitemap", () => {
       "https://scontrinozero.it/per/pasticcerie-gelaterie-panifici",
       "https://scontrinozero.it/per/fioristi",
       "https://scontrinozero.it/per/lavanderie",
+      "https://scontrinozero.it/per/agriturismi-cantine",
+      "https://scontrinozero.it/per/fotografi",
+      "https://scontrinozero.it/per/toelettatura",
+      "https://scontrinozero.it/per/noleggio",
     ];
     for (const url of expectedCategoryUrls) {
       expect(allUrls).toContain(url);

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -225,4 +225,47 @@ describe("sitemap", () => {
       expect(entry.lastModified).toBeInstanceOf(Date);
     }
   });
+
+  it("uses the real registry dates as lastModified (not the build time)", async () => {
+    vi.resetModules();
+    const { default: sitemap } = await import("./sitemap");
+    const { guideArticles, guideSlugs } = await import("@/lib/guide/articles");
+    const { helpArticles } = await import("@/lib/help/articles");
+    const { confrontoContent } = await import("@/lib/confronto/comparisons");
+    const result = sitemap();
+    const byUrl = new Map(result.map((e) => [e.url, e]));
+    const isoOf = (d: unknown) =>
+      (d as Date).toISOString().slice(0, "YYYY-MM-DD".length);
+
+    // Guide: updatedAt del registry
+    for (const slug of guideSlugs) {
+      const entry = byUrl.get(`https://scontrinozero.it/guide/${slug}`);
+      expect(isoOf(entry?.lastModified)).toBe(guideArticles[slug].updatedAt);
+    }
+
+    // Help: dateModified del registry
+    for (const [slug, article] of Object.entries(helpArticles)) {
+      const entry = byUrl.get(`https://scontrinozero.it/help/${slug}`);
+      expect(isoOf(entry?.lastModified)).toBe(article.dateModified);
+    }
+
+    // Confronto: lastUpdated del registry
+    const confronto = byUrl.get("https://scontrinozero.it/confronto");
+    expect(isoOf(confronto?.lastModified)).toBe(confrontoContent.lastUpdated);
+
+    // Hub: max delle date figlie
+    const guideHub = byUrl.get("https://scontrinozero.it/guide");
+    const maxGuideDate = guideSlugs
+      .map((s) => guideArticles[s].updatedAt)
+      .toSorted((a, b) => a.localeCompare(b))
+      .at(-1);
+    expect(isoOf(guideHub?.lastModified)).toBe(maxGuideDate);
+
+    const helpHub = byUrl.get("https://scontrinozero.it/help");
+    const maxHelpDate = Object.values(helpArticles)
+      .map((a) => a.dateModified)
+      .toSorted((a, b) => a.localeCompare(b))
+      .at(-1);
+    expect(isoOf(helpHub?.lastModified)).toBe(maxHelpDate);
+  });
 });

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(77);
+    expect(result).toHaveLength(80);
 
     // Root
     expect(result[0]).toMatchObject({

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(69);
+    expect(result).toHaveLength(72);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -124,41 +124,28 @@ describe("sitemap", () => {
       });
     }
 
-    // Legal
-    expect(result[35]).toMatchObject({
-      url: "https://scontrinozero.it/privacy",
-      changeFrequency: "yearly",
-      priority: 0.3,
-    });
-    expect(result[36]).toMatchObject({
-      url: "https://scontrinozero.it/privacy/v01",
-      changeFrequency: "yearly",
-      priority: 0.3,
-    });
-    expect(result[37]).toMatchObject({
-      url: "https://scontrinozero.it/termini",
-      changeFrequency: "yearly",
-      priority: 0.3,
-    });
-    expect(result[38]).toMatchObject({
-      url: "https://scontrinozero.it/termini/v01",
-      changeFrequency: "yearly",
-      priority: 0.3,
-    });
-    expect(result[39]).toMatchObject({
-      url: "https://scontrinozero.it/cookie-policy",
-      changeFrequency: "yearly",
-      priority: 0.3,
-    });
-    expect(result[40]).toMatchObject({
-      url: "https://scontrinozero.it/cookie-policy/v01",
-      changeFrequency: "yearly",
-      priority: 0.3,
-    });
+    // Legal (lookup per URL: gli indici scorrono a ogni nuovo contenuto)
+    const legalUrls = [
+      "https://scontrinozero.it/privacy",
+      "https://scontrinozero.it/privacy/v01",
+      "https://scontrinozero.it/termini",
+      "https://scontrinozero.it/termini/v01",
+      "https://scontrinozero.it/cookie-policy",
+      "https://scontrinozero.it/cookie-policy/v01",
+    ];
+    for (const url of legalUrls) {
+      const entry = result.find((e) => e.url === url);
+      expect(entry).toMatchObject({
+        changeFrequency: "yearly",
+        priority: 0.3,
+      });
+    }
 
     // Help center hub
-    expect(result[41]).toMatchObject({
-      url: "https://scontrinozero.it/help",
+    const helpHubEntry = result.find(
+      (e) => e.url === "https://scontrinozero.it/help",
+    );
+    expect(helpHubEntry).toMatchObject({
       changeFrequency: "monthly",
       priority: 0.6,
     });
@@ -200,18 +187,20 @@ describe("sitemap", () => {
     expect(result[1].url).toBe("https://test.scontrinozero.it/prezzi");
     expect(result[2].url).toBe("https://test.scontrinozero.it/funzionalita");
     expect(result[3].url).toBe("https://test.scontrinozero.it/per");
-    expect(result[4].url).toBe("https://test.scontrinozero.it/per/ambulanti");
-    expect(result[16].url).toBe("https://test.scontrinozero.it/confronto");
-    expect(result[17].url).toBe("https://test.scontrinozero.it/strumenti");
-    expect(result[18].url).toBe(
-      "https://test.scontrinozero.it/strumenti/scorporo-iva",
-    );
-    expect(result[22].url).toBe("https://test.scontrinozero.it/guide");
-    expect(result[23].url).toBe(
-      "https://test.scontrinozero.it/guide/documento-commerciale-online",
-    );
-    expect(result[35].url).toBe("https://test.scontrinozero.it/privacy");
-    expect(result[41].url).toBe("https://test.scontrinozero.it/help");
+    // Il resto per presenza (gli indici scorrono a ogni nuovo contenuto)
+    const urls = result.map((e) => e.url);
+    for (const path of [
+      "/per/ambulanti",
+      "/confronto",
+      "/strumenti",
+      "/strumenti/scorporo-iva",
+      "/guide",
+      "/guide/documento-commerciale-online",
+      "/privacy",
+      "/help",
+    ]) {
+      expect(urls).toContain(`https://test.scontrinozero.it${path}`);
+    }
 
     vi.unstubAllEnvs();
   });

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(72);
+    expect(result).toHaveLength(77);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -42,6 +42,11 @@ describe("sitemap", () => {
       "https://scontrinozero.it/per/food-truck",
       "https://scontrinozero.it/per/ncc-taxi",
       "https://scontrinozero.it/per/tatuatori-piercer",
+      "https://scontrinozero.it/per/ristoranti-bar-asporto",
+      "https://scontrinozero.it/per/negozi",
+      "https://scontrinozero.it/per/pasticcerie-gelaterie-panifici",
+      "https://scontrinozero.it/per/fioristi",
+      "https://scontrinozero.it/per/lavanderie",
     ];
     for (const url of expectedCategoryUrls) {
       expect(allUrls).toContain(url);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -123,17 +123,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     ...helpPages,
-    {
-      url: `${baseUrl}/login`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/register`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.5,
-    },
   ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
 import { categorySlugs } from "@/lib/per/categories";
-import { guideSlugs } from "@/lib/guide/articles";
-import { helpSlugs } from "@/lib/help/articles";
+import { confrontoContent } from "@/lib/confronto/comparisons";
+import { guideArticles, guideSlugs } from "@/lib/guide/articles";
+import { helpArticles, helpSlugs } from "@/lib/help/articles";
 import { toolSlugs } from "@/lib/strumenti/tools";
 import { marketingBaseUrl } from "@/lib/seo-indexable";
 
@@ -9,116 +10,118 @@ import { marketingBaseUrl } from "@/lib/seo-indexable";
 // in sitemap devono stare sull'host indicizzabile, mai su quello in noindex.
 const baseUrl = marketingBaseUrl();
 
+// Le pagine senza data nel registry (statiche, /per, /strumenti, legal) usano
+// una data hand-maintained: bump quando il contenuto cambia davvero. Meglio una
+// data stabile e onesta di un `new Date()` a ogni build, che azzera il segnale
+// di freshness per i crawler.
+const STATIC_PAGES_UPDATED = new Date("2026-07-22");
+const LEGAL_PAGES_UPDATED = new Date("2026-07-12");
+
+/** Massimo (lessicografico, valido su date ISO) di una lista di date YYYY-MM-DD. */
+function maxIsoDate(dates: readonly string[]): Date {
+  const max = dates.toSorted((a, b) => a.localeCompare(b)).at(-1);
+  if (!max) {
+    throw new Error("maxIsoDate requires at least one date");
+  }
+  return new Date(max);
+}
+
+const guideHubLastModified = maxIsoDate(
+  guideSlugs.map((slug) => guideArticles[slug].updatedAt),
+);
+const helpHubLastModified = maxIsoDate(
+  helpSlugs.map((slug) => helpArticles[slug].dateModified),
+);
+
 const marketingPages = ["/prezzi", "/funzionalita"].map((path) => ({
   url: `${baseUrl}${path}`,
-  lastModified: new Date(),
+  lastModified: STATIC_PAGES_UPDATED,
   changeFrequency: "monthly" as const,
   priority: 0.8,
 }));
 
 const categoryLandingPages = categorySlugs.map((slug) => ({
   url: `${baseUrl}/per/${slug}`,
-  lastModified: new Date(),
+  lastModified: STATIC_PAGES_UPDATED,
   changeFrequency: "monthly" as const,
   priority: 0.7,
 }));
 
 const toolPages = toolSlugs.map((slug) => ({
   url: `${baseUrl}/strumenti/${slug}`,
-  lastModified: new Date(),
+  lastModified: STATIC_PAGES_UPDATED,
   changeFrequency: "monthly" as const,
   priority: 0.6,
 }));
 
 const guidePages = guideSlugs.map((slug) => ({
   url: `${baseUrl}/guide/${slug}`,
-  lastModified: new Date(),
+  lastModified: new Date(guideArticles[slug].updatedAt),
   changeFrequency: "monthly" as const,
   priority: 0.7,
 }));
 
 const helpPages = helpSlugs.map((slug) => ({
   url: `${baseUrl}/help/${slug}`,
-  lastModified: new Date(),
+  lastModified: new Date(helpArticles[slug].dateModified),
   changeFrequency: "monthly" as const,
   priority: 0.6,
+}));
+
+const legalPages = [
+  "/privacy",
+  "/privacy/v01",
+  "/termini",
+  "/termini/v01",
+  "/cookie-policy",
+  "/cookie-policy/v01",
+].map((path) => ({
+  url: `${baseUrl}${path}`,
+  lastModified: LEGAL_PAGES_UPDATED,
+  changeFrequency: "yearly" as const,
+  priority: 0.3,
 }));
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGES_UPDATED,
       changeFrequency: "monthly",
       priority: 1,
     },
     ...marketingPages,
     {
       url: `${baseUrl}/per`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGES_UPDATED,
       changeFrequency: "monthly",
       priority: 0.7,
     },
     ...categoryLandingPages,
     {
       url: `${baseUrl}/confronto`,
-      lastModified: new Date(),
+      lastModified: new Date(confrontoContent.lastUpdated),
       changeFrequency: "monthly",
       priority: 0.7,
     },
     {
       url: `${baseUrl}/strumenti`,
-      lastModified: new Date(),
+      lastModified: STATIC_PAGES_UPDATED,
       changeFrequency: "monthly",
       priority: 0.6,
     },
     ...toolPages,
     {
       url: `${baseUrl}/guide`,
-      lastModified: new Date(),
+      lastModified: guideHubLastModified,
       changeFrequency: "monthly",
       priority: 0.7,
     },
     ...guidePages,
-    {
-      url: `${baseUrl}/privacy`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/privacy/v01`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/termini`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/termini/v01`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/cookie-policy`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/cookie-policy/v01`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    },
+    ...legalPages,
     {
       url: `${baseUrl}/help`,
-      lastModified: new Date(),
+      lastModified: helpHubLastModified,
       changeFrequency: "monthly",
       priority: 0.6,
     },

--- a/src/components/help/article-json-ld.test.tsx
+++ b/src/components/help/article-json-ld.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { HelpArticleJsonLd } from "./article-json-ld";
-import { getHelpArticle, HELP_REVIEWED_DATE } from "@/lib/help/articles";
+import { getHelpArticle } from "@/lib/help/articles";
 
 function parseLdJson(html: string): Record<string, unknown> {
   const match = html.match(
@@ -32,14 +32,15 @@ describe("HelpArticleJsonLd", () => {
     expect(data.description).toBe(article.description);
   });
 
-  it("builds an absolute HTTPS url under /help and uses the shared review date", () => {
+  it("builds an absolute HTTPS url under /help and uses the article's own dates", () => {
+    const article = getHelpArticle("aliquote-iva");
     const html = renderToStaticMarkup(
       <HelpArticleJsonLd slug="aliquote-iva" />,
     );
     const data = parseLdJson(html);
     expect(data.url).toBe("https://scontrinozero.it/help/aliquote-iva");
-    expect(data.datePublished).toBe(HELP_REVIEWED_DATE);
-    expect(data.dateModified).toBe(HELP_REVIEWED_DATE);
+    expect(data.datePublished).toBe(article.datePublished);
+    expect(data.dateModified).toBe(article.dateModified);
   });
 
   it("throws on an unknown slug (fail-fast, mai schema vuoto)", () => {

--- a/src/components/help/article-json-ld.tsx
+++ b/src/components/help/article-json-ld.tsx
@@ -1,12 +1,12 @@
 import { JsonLd, articleJsonLd } from "@/components/json-ld";
-import { getHelpArticle, HELP_REVIEWED_DATE } from "@/lib/help/articles";
+import { getHelpArticle } from "@/lib/help/articles";
 
 const SITE_URL = "https://scontrinozero.it";
 
 /**
- * Structured data Article per un articolo del centro assistenza. Legge titolo
- * e descrizione dal registry `helpArticles` (unica fonte di verità) e usa la
- * data di revisione condivisa `HELP_REVIEWED_DATE` come datePublished/Modified.
+ * Structured data Article per un articolo del centro assistenza. Legge titolo,
+ * descrizione e date di pubblicazione/revisione per-articolo dal registry
+ * `helpArticles` (unica fonte di verità).
  * Affianca — senza sostituirlo — il BreadcrumbList già emesso da ogni pagina.
  */
 export function HelpArticleJsonLd({ slug }: { readonly slug: string }) {
@@ -17,8 +17,8 @@ export function HelpArticleJsonLd({ slug }: { readonly slug: string }) {
         headline: article.title,
         description: article.description,
         url: `${SITE_URL}/help/${slug}`,
-        datePublished: HELP_REVIEWED_DATE,
-        dateModified: HELP_REVIEWED_DATE,
+        datePublished: article.datePublished,
+        dateModified: article.dateModified,
       })}
     />
   );

--- a/src/components/json-ld.test.tsx
+++ b/src/components/json-ld.test.tsx
@@ -13,6 +13,7 @@ import {
   webApplicationJsonLd,
   guideArticleBreadcrumb,
   articleJsonLd,
+  webSiteJsonLd,
 } from "./json-ld";
 import { faqItems } from "@/components/marketing/faq-items";
 
@@ -140,6 +141,25 @@ describe("softwareApplicationJsonLd", () => {
       expect(typeof feature).toBe("string");
       expect(feature.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("webSiteJsonLd", () => {
+  it("has @type WebSite with name, url and it-IT language", () => {
+    expect(webSiteJsonLd["@type"]).toBe("WebSite");
+    expect(webSiteJsonLd.name).toBe("ScontrinoZero");
+    expect(webSiteJsonLd.url).toMatch(/^https:\/\//);
+    expect(webSiteJsonLd.inLanguage).toBe("it-IT");
+  });
+
+  it("declares an Organization publisher coherent with organizationJsonLd", () => {
+    expect(webSiteJsonLd.publisher["@type"]).toBe("Organization");
+    expect(webSiteJsonLd.publisher.name).toBe(organizationJsonLd.name);
+    expect(webSiteJsonLd.publisher.url).toBe(organizationJsonLd.url);
+  });
+
+  it("has no potentialAction (SearchAction ritirata da Google, nessuna ricerca interna)", () => {
+    expect("potentialAction" in webSiteJsonLd).toBe(false);
   });
 });
 

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -111,6 +111,23 @@ export const organizationJsonLd = {
   },
 } as const;
 
+// Niente potentialAction/SearchAction: il rich result "sitelinks searchbox" è
+// stato ritirato da Google e il sito non ha una ricerca interna — dichiararla
+// sarebbe un false claim.
+export const webSiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "ScontrinoZero",
+  alternateName: "Scontrino Zero — registratore di cassa virtuale",
+  url: SITE_URL,
+  inLanguage: "it-IT",
+  publisher: {
+    "@type": "Organization",
+    name: "ScontrinoZero",
+    url: SITE_URL,
+  },
+} as const;
+
 export interface BreadcrumbItem {
   readonly name: string;
   readonly url: string;

--- a/src/lib/confronto/comparisons.test.ts
+++ b/src/lib/confronto/comparisons.test.ts
@@ -64,8 +64,8 @@ describe("confrontoContent — categories", () => {
 });
 
 describe("confrontoContent — saasCompetitors", () => {
-  it("lists exactly the 4 verified competitors", () => {
-    expect(confrontoContent.saasCompetitors).toHaveLength(4);
+  it("lists exactly the 5 verified competitors", () => {
+    expect(confrontoContent.saasCompetitors).toHaveLength(5);
     const names = confrontoContent.saasCompetitors.map((s) => s.name);
     expect(names).toEqual(
       expect.arrayContaining([
@@ -73,6 +73,7 @@ describe("confrontoContent — saasCompetitors", () => {
         "Scontrina",
         "ScontrinoSenzaCassa (Billy)",
         "CassaDigitale",
+        "WinScontrino",
       ]),
     );
   });

--- a/src/lib/confronto/comparisons.test.ts
+++ b/src/lib/confronto/comparisons.test.ts
@@ -21,8 +21,8 @@ describe("confrontoContent — metadata", () => {
     expect(confrontoContent.heroIntro.length).toBeGreaterThanOrEqual(200);
   });
 
-  it("has lastUpdated in YYYY-MM format", () => {
-    expect(confrontoContent.lastUpdated).toMatch(/^\d{4}-\d{2}$/);
+  it("has lastUpdated in full ISO YYYY-MM-DD format", () => {
+    expect(confrontoContent.lastUpdated).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });
 

--- a/src/lib/confronto/comparisons.ts
+++ b/src/lib/confronto/comparisons.ts
@@ -42,6 +42,7 @@ export interface ConfrontoContent {
   readonly ourPositioning: OurPositioning;
   readonly faq: readonly ConfrontoFaq[];
   readonly relatedHelp: readonly string[];
+  /** Data ISO YYYY-MM-DD dell'ultima verifica dei dati competitor (refresh trimestrale). */
   readonly lastUpdated: string;
 }
 
@@ -195,5 +196,5 @@ export const confrontoContent: ConfrontoContent = {
     "come-collegare-ade",
     "credenziali-fisconline",
   ],
-  lastUpdated: "2026-05",
+  lastUpdated: "2026-05-15",
 };

--- a/src/lib/confronto/comparisons.ts
+++ b/src/lib/confronto/comparisons.ts
@@ -144,6 +144,15 @@ export const confrontoContent: ConfrontoContent = {
       notes:
         "App mobile (iOS/Android) e web. Accesso via Fisconline/SPID. Emette scontrini e fatture, gestisce chiusure di cassa.",
     },
+    {
+      name: "WinScontrino",
+      url: "https://www.wincoge.com/Scontrino%20Elettronico",
+      displayUrl: "wincoge.com",
+      pricing: "14,90 €/mese, oppure 8 €/mese con fatturazione annuale",
+      trial: "5 scontrini reali gratuiti",
+      notes:
+        "Software per PC (trasforma il computer in cassa virtuale). Emissione in tempo reale verso AdE senza hardware aggiuntivo.",
+    },
   ],
   differentiators: [
     "Open source: puoi installarlo gratis sul tuo computer o server, le credenziali AdE non transitano da noi.",
@@ -196,5 +205,5 @@ export const confrontoContent: ConfrontoContent = {
     "come-collegare-ade",
     "credenziali-fisconline",
   ],
-  lastUpdated: "2026-05-15",
+  lastUpdated: "2026-07-22",
 };

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -68,8 +68,10 @@ describe("guideArticles dictionary", () => {
         expect(a.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       });
 
-      it("has updatedAt in YYYY-MM format", () => {
-        expect(a.updatedAt).toMatch(/^\d{4}-\d{2}$/);
+      it("has updatedAt in full ISO YYYY-MM-DD format, not before publishedAt", () => {
+        expect(a.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        // Confronto lessicografico: valido per date ISO
+        expect(a.updatedAt >= a.publishedAt).toBe(true);
       });
 
       it("has positive readingMinutes", () => {

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./articles";
 
 describe("guideSlugs", () => {
-  it("contains exactly 15 slugs", () => {
-    expect(guideSlugs).toHaveLength(15);
+  it("contains exactly 18 slugs", () => {
+    expect(guideSlugs).toHaveLength(18);
   });
 
   it("contains the expected slugs", () => {
@@ -30,6 +30,9 @@ describe("guideSlugs", () => {
         "recupero-credenziali-ade-password-scaduta",
         "cassetto-fiscale-dove-trovare-scontrini",
         "obbligo-scontrino-elettronico-2026",
+        "registratore-di-cassa-prezzi",
+        "sanzioni-mancato-scontrino",
+        "registratore-telematico-vs-documento-commerciale-online",
       ]),
     );
   });
@@ -385,14 +388,15 @@ describe("obbligo-scontrino-elettronico-2026 (head term informativo)", () => {
     expect(article.heroIntro).toContain("D.Lgs. 127/2015");
   });
 
-  it("cites the citable sanction facts (90%, 500 €)", () => {
+  it("cites the citable sanction facts post-riforma (70%, 300 €, D.Lgs. 87/2024)", () => {
     const allText = [
       ...article.sections.map((s) => s.body),
       ...article.faq.map((f) => f.answer),
     ].join(" ");
-    expect(allText).toContain("90%");
-    expect(allText).toContain("500 €");
+    expect(allText).toContain("70%");
+    expect(allText).toContain("300 €");
     expect(allText).toContain("D.Lgs. 471/1997");
+    expect(allText).toContain("D.Lgs. 87/2024");
   });
 
   it("covers the 2026 POS linkage with its legal reference (L. 207/2024)", () => {
@@ -403,6 +407,99 @@ describe("obbligo-scontrino-elettronico-2026 (head term informativo)", () => {
   it("links the POS-RT cluster without duplicating its slug", () => {
     expect(article.relatedGuides).toContain("pos-rt-obbligo-2026");
     expect(article.slug).not.toBe("pos-rt-obbligo-2026");
+  });
+});
+
+describe("registratore-di-cassa-prezzi (commerciale-investigazionale)", () => {
+  const article = guideArticles["registratore-di-cassa-prezzi"];
+
+  it("opens with citable price facts (risposta secca GEO)", () => {
+    expect(article.heroIntro).toContain("400-800 €");
+  });
+
+  it("has a 3-year cost comparison table including the AdE portal", () => {
+    const tableSection = article.sections.find((s) => s.table !== undefined);
+    expect(tableSection).toBeDefined();
+    const firstColumn = tableSection!.table!.rows.map((r) =>
+      r[0].toLowerCase(),
+    );
+    expect(firstColumn.some((c) => c.includes("registratore"))).toBe(true);
+    expect(firstColumn.some((c) => c.includes("portale"))).toBe(true);
+  });
+
+  it("does not promise tax credits that are currently exhausted", () => {
+    const bonusFaq = article.faq.find((f) =>
+      f.question.toLowerCase().includes("bonus"),
+    );
+    expect(bonusFaq).toBeDefined();
+    expect(bonusFaq!.answer.toLowerCase()).toContain("esauriti");
+  });
+
+  it("links the savings calculator tool", () => {
+    expect(article.relatedTools).toContain("calcolatore-risparmio-rt");
+  });
+});
+
+describe("sanzioni-mancato-scontrino (post riforma D.Lgs. 87/2024)", () => {
+  const article = guideArticles["sanzioni-mancato-scontrino"];
+
+  it("opens with the current sanction figures (70%, 300 €)", () => {
+    expect(article.heroIntro).toContain("70%");
+    expect(article.heroIntro).toContain("300 €");
+    expect(article.heroIntro).toContain("D.Lgs. 87/2024");
+  });
+
+  it("dates the reform and mentions the previous regime", () => {
+    const bodies = article.sections.map((s) => s.body).join(" ");
+    expect(bodies).toContain("1° settembre 2024");
+    expect(bodies).toContain("90%");
+  });
+
+  it("covers the licence-suspension recidiva with its legal basis", () => {
+    const bodies = article.sections.map((s) => s.body).join(" ");
+    expect(bodies).toContain("art. 12");
+    expect(bodies).toMatch(/4 violazioni/);
+  });
+
+  it("answers the customer-fine myth in the FAQ", () => {
+    const clientFaq = article.faq.find((f) =>
+      f.question.toLowerCase().includes("cliente"),
+    );
+    expect(clientFaq).toBeDefined();
+    expect(clientFaq!.answer.startsWith("No")).toBe(true);
+  });
+});
+
+describe("registratore-telematico-vs-documento-commerciale-online", () => {
+  const article =
+    guideArticles["registratore-telematico-vs-documento-commerciale-online"];
+
+  it("opens by stating fiscal equivalence (risposta secca GEO)", () => {
+    expect(article.heroIntro).toContain("fiscalmente equivalenti");
+  });
+
+  it("has a point-by-point comparison table (costi, offline, chiusura)", () => {
+    const tableSection = article.sections.find((s) => s.table !== undefined);
+    expect(tableSection).toBeDefined();
+    const aspects = tableSection!.table!.rows.map((r) => r[0].toLowerCase());
+    expect(aspects.some((a) => a.includes("costo"))).toBe(true);
+    expect(aspects.some((a) => a.includes("connettiv"))).toBe(true);
+    expect(aspects.some((a) => a.includes("chiusura"))).toBe(true);
+  });
+
+  it("recommends the RT honestly for high-throughput counters", () => {
+    const rtSection = article.sections.find((s) =>
+      s.heading.toLowerCase().includes("registratore telematico"),
+    );
+    expect(rtSection).toBeDefined();
+    expect(rtSection!.body.toLowerCase()).toMatch(/flusso|fila|coda/);
+  });
+
+  it("links the migration guide and the pricing guide", () => {
+    expect(article.relatedGuides).toContain(
+      "migrare-da-registratore-telematico-a-software",
+    );
+    expect(article.relatedGuides).toContain("registratore-di-cassa-prezzi");
   });
 });
 

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./articles";
 
 describe("guideSlugs", () => {
-  it("contains exactly 12 slugs", () => {
-    expect(guideSlugs).toHaveLength(12);
+  it("contains exactly 15 slugs", () => {
+    expect(guideSlugs).toHaveLength(15);
   });
 
   it("contains the expected slugs", () => {
@@ -27,8 +27,20 @@ describe("guideSlugs", () => {
         "scegliere-software-scontrini-elettronici",
         "codici-natura-iva",
         "stampante-termica-wifi-scontrini",
+        "recupero-credenziali-ade-password-scaduta",
+        "cassetto-fiscale-dove-trovare-scontrini",
+        "obbligo-scontrino-elettronico-2026",
       ]),
     );
+  });
+
+  it("no guide slug collides with a help slug (canonical clash /help vs /guide)", async () => {
+    const { helpSlugs } = await import("@/lib/help/articles");
+    for (const slug of guideSlugs) {
+      expect(helpSlugs, `guide slug ${slug} duplicato in /help`).not.toContain(
+        slug,
+      );
+    }
   });
 
   it("has unique entries", () => {
@@ -308,6 +320,89 @@ describe("stampante-termica-wifi-scontrini (batch D — gap stampanti)", () => {
 
   it("links the operational help article on thermal printing", () => {
     expect(article.relatedHelp).toContain("stampare-scontrino-termica");
+  });
+});
+
+describe("recupero-credenziali-ade-password-scaduta (cluster credenziali AdE)", () => {
+  const article = guideArticles["recupero-credenziali-ade-password-scaduta"];
+
+  it("opens with the citable 90-day expiry fact (risposta secca GEO)", () => {
+    expect(article.heroIntro).toContain("90 giorni");
+  });
+
+  it("cites the dated legal reference for the Fisconline stop (DL 76/2020)", () => {
+    const allText = [
+      article.heroIntro,
+      ...article.sections.map((s) => s.body),
+      ...article.faq.map((f) => f.answer),
+    ].join(" ");
+    expect(allText).toContain("DL 76/2020");
+    expect(allText).toContain("1° marzo 2021");
+  });
+
+  it("covers SPID and CIE as alternatives", () => {
+    const headings = article.sections.map((s) => s.heading.toLowerCase());
+    expect(headings.some((h) => h.includes("spid") && h.includes("cie"))).toBe(
+      true,
+    );
+  });
+
+  it("links the operational credential help cluster", () => {
+    expect(article.relatedHelp).toContain("credenziali-fisconline");
+    expect(article.relatedHelp).toContain("collegare-ade-con-cie");
+  });
+});
+
+describe("cassetto-fiscale-dove-trovare-scontrini (cluster cassetto fiscale)", () => {
+  const article = guideArticles["cassetto-fiscale-dove-trovare-scontrini"];
+
+  it("opens by correcting the misconception (risposta secca GEO)", () => {
+    expect(article.heroIntro).toContain("Fatture e Corrispettivi");
+  });
+
+  it("gives the exact portal path in a section", () => {
+    const bodies = article.sections.map((s) => s.body).join(" ");
+    expect(bodies).toContain("Documento commerciale online");
+    expect(bodies).toContain("Ricerca");
+  });
+
+  it("answers the private-citizen intent in the FAQ", () => {
+    const questions = article.faq.map((f) => f.question.toLowerCase());
+    expect(questions.some((q) => q.includes("privato"))).toBe(true);
+  });
+
+  it("keeps a distinct slug from the operational help article", () => {
+    expect(article.slug).not.toBe("cassetto-fiscale");
+    expect(article.relatedHelp).toContain("cassetto-fiscale");
+  });
+});
+
+describe("obbligo-scontrino-elettronico-2026 (head term informativo)", () => {
+  const article = guideArticles["obbligo-scontrino-elettronico-2026"];
+
+  it("opens with the direct answer and the dated legal basis", () => {
+    expect(article.heroIntro).toContain("obbligatorio");
+    expect(article.heroIntro).toContain("D.Lgs. 127/2015");
+  });
+
+  it("cites the citable sanction facts (90%, 500 €)", () => {
+    const allText = [
+      ...article.sections.map((s) => s.body),
+      ...article.faq.map((f) => f.answer),
+    ].join(" ");
+    expect(allText).toContain("90%");
+    expect(allText).toContain("500 €");
+    expect(allText).toContain("D.Lgs. 471/1997");
+  });
+
+  it("covers the 2026 POS linkage with its legal reference (L. 207/2024)", () => {
+    const bodies = article.sections.map((s) => s.body).join(" ");
+    expect(bodies).toContain("L. 207/2024");
+  });
+
+  it("links the POS-RT cluster without duplicating its slug", () => {
+    expect(article.relatedGuides).toContain("pos-rt-obbligo-2026");
+    expect(article.slug).not.toBe("pos-rt-obbligo-2026");
   });
 });
 

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -14,6 +14,9 @@ export const guideSlugs = [
   "recupero-credenziali-ade-password-scaduta",
   "cassetto-fiscale-dove-trovare-scontrini",
   "obbligo-scontrino-elettronico-2026",
+  "registratore-di-cassa-prezzi",
+  "sanzioni-mancato-scontrino",
+  "registratore-telematico-vs-documento-commerciale-online",
 ] as const;
 
 export type GuideSlug = (typeof guideSlugs)[number];
@@ -337,7 +340,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Dal 1° gennaio 2026 è entrato in vigore l'obbligo di collegamento fra POS (terminale di pagamento) e registratore telematico, per trasmettere all'Agenzia delle Entrate gli incassi elettronici insieme ai corrispettivi. La norma ha generato molta confusione: cosa cambia davvero e cosa fare se non usi un RT fisico?",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05-14",
+    updatedAt: "2026-07-22",
     readingMinutes: 7,
     sections: [
       {
@@ -350,7 +353,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Sanzioni previste",
-        body: "Per la mancata trasmissione del singolo pagamento elettronico, la sanzione amministrativa è pari al 90% dell'IVA non documentata correttamente, con un minimo previsto. Esistono inoltre sanzioni accessorie in caso di violazioni reiterate (sospensione della licenza). I controlli sono incrociati: AdE confronta dati POS dalle banche con corrispettivi trasmessi.",
+        body: "Per la mancata trasmissione del singolo pagamento elettronico, la sanzione amministrativa è pari al 70% dell'IVA non documentata correttamente (art. 6 c. 2-bis D.Lgs. 471/1997, dopo la riforma del D.Lgs. 87/2024), con un minimo di 300 €. Esistono inoltre sanzioni accessorie in caso di violazioni reiterate (sospensione della licenza). I controlli sono incrociati: AdE confronta dati POS dalle banche con corrispettivi trasmessi.",
       },
       {
         heading: "Deroghe e casistiche particolari",
@@ -1229,7 +1232,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     title: "Obbligo di scontrino elettronico nel 2026: chi, come, sanzioni",
     metaTitle: "Obbligo scontrino elettronico 2026: chi deve emetterlo",
     metaDescription:
-      "Dal 2020 lo scontrino elettronico è obbligatorio per chi vende a privati (D.Lgs. 127/2015): esoneri, novità POS 2026, sanzioni del 90% e come adeguarsi.",
+      "Dal 2020 lo scontrino elettronico è obbligatorio per chi vende a privati (D.Lgs. 127/2015): esoneri, novità POS 2026, sanzioni del 70% e come adeguarsi.",
     heroIntro:
       "Sì, lo scontrino elettronico è obbligatorio: dal 1° gennaio 2020 ogni commerciante al minuto che vende a consumatori finali deve memorizzare e trasmettere i corrispettivi all'Agenzia delle Entrate (art. 2 D.Lgs. 127/2015). Nel 2026 si aggiunge l'obbligo di collegamento tra POS e strumento di emissione. Vediamo chi è obbligato, chi è esonerato, le sanzioni e le opzioni per adeguarsi senza comprare hardware.",
     publishedAt: "2026-07-22",
@@ -1258,7 +1261,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Le sanzioni",
-        body: "Per l'omessa, tardiva o infedele memorizzazione/trasmissione dei corrispettivi la sanzione è il 90% dell'imposta relativa (art. 6, comma 2-bis, D.Lgs. 471/1997), con minimo di 500 €. Se la violazione non incide sull'imposta, si applica la sanzione fissa di 100 € per trasmissione. Dopo 4 violazioni distinte in 5 anni può scattare la sospensione della licenza da 3 giorni a 1 mese (art. 12 D.Lgs. 471/1997). Il mancato collegamento POS-corrispettivi ha sanzioni dedicate introdotte dalla L. 207/2024.",
+        body: "Per l'omessa, tardiva o infedele memorizzazione/trasmissione dei corrispettivi la sanzione è il 70% dell'imposta relativa (art. 6, comma 2-bis, D.Lgs. 471/1997, come modificato dal D.Lgs. 87/2024 per le violazioni dal 1° settembre 2024), con minimo di 300 €. Se la violazione non incide sulla liquidazione dell'imposta, si applica la sanzione fissa di 100 € per trasmissione. Dopo 4 violazioni distinte in 5 anni può scattare la sospensione della licenza da 3 giorni a 1 mese (art. 12 D.Lgs. 471/1997). Il mancato collegamento POS-corrispettivi ha sanzioni dedicate introdotte dalla L. 207/2024.",
       },
       {
         heading: "Mettersi in regola senza comprare hardware",
@@ -1284,7 +1287,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Qual è la sanzione se non emetto lo scontrino?",
         answer:
-          "Il 90% dell'imposta relativa all'importo non memorizzato o trasmesso, con un minimo di 500 € (art. 6 c. 2-bis D.Lgs. 471/1997). Con 4 violazioni distinte in 5 anni può aggiungersi la sospensione della licenza da 3 giorni a 1 mese.",
+          "Il 70% dell'imposta relativa all'importo non memorizzato o trasmesso, con un minimo di 300 € (art. 6 c. 2-bis D.Lgs. 471/1997, dopo la riforma del D.Lgs. 87/2024). Con 4 violazioni distinte in 5 anni può aggiungersi la sospensione della licenza da 3 giorni a 1 mese.",
       },
       {
         question: "Il forfettario è esonerato dallo scontrino elettronico?",
@@ -1298,6 +1301,267 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "pos-rt-obbligo-2026",
       "scontrino-regime-forfettario",
     ],
+  },
+
+  "registratore-di-cassa-prezzi": {
+    slug: "registratore-di-cassa-prezzi",
+    title: "Quanto costa un registratore di cassa nel 2026",
+    metaTitle: "Registratore di cassa: prezzi 2026 e alternative senza costi",
+    metaDescription:
+      "Un registratore telematico costa 400-800 € più 50-100 €/anno di gestione. Le alternative software partono da 0 €: tutti i prezzi a confronto e quando conviene cosa.",
+    heroIntro:
+      "Un registratore di cassa telematico costa 400-800 € di acquisto, più l'installazione del tecnico abilitato e la verificazione periodica biennale: sui 3 anni la spesa reale supera facilmente i 1.000 €. L'alternativa software (documento commerciale online) parte da 0 € col portale AdE o da pochi euro al mese con un'app. Vediamo tutte le voci di costo e quando conviene l'una o l'altra strada.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readingMinutes: 6,
+    sections: [
+      {
+        heading: "Le voci di costo di un registratore telematico",
+        body: "Il prezzo del registratore telematico (RT) non è solo l'hardware. Le voci tipiche: acquisto del dispositivo (400-800 € per i modelli da banco più comuni, oltre 1.000 € per i sistemi touch evoluti), installazione e attivazione da parte di un tecnico abilitato (100-200 €), verificazione periodica obbligatoria ogni 2 anni (50-100 € a intervento), eventuali aggiornamenti firmware per adeguamenti normativi e i rotoli di carta termica. In caso di guasto, il fermo cassa richiede l'intervento del tecnico.",
+      },
+      {
+        heading: "Il costo reale su 3 anni",
+        body: "Mettendo insieme le voci, un RT da 600 € con installazione a 150 € e una verificazione biennale a 80 € porta la spesa del primo triennio a circa 900-1.000 €, senza contare carta, eventuali riparazioni fuori garanzia e il tempo per gli adempimenti tecnici. È il numero da confrontare con le alternative software, che su 3 anni costano da 0 € (portale AdE) a circa 90-150 € (app in abbonamento).",
+        table: {
+          headers: ["Soluzione", "Costo iniziale", "Costo 3 anni (indicativo)"],
+          rows: [
+            [
+              "Registratore telematico",
+              "500-1.000 € (acquisto + installazione)",
+              "900-1.200 € con verificazioni",
+            ],
+            [
+              "Portale AdE (DCO manuale)",
+              "0 €",
+              "0 € (ma 30-60 secondi a scontrino)",
+            ],
+            [
+              "App DCO (es. ScontrinoZero)",
+              "0 €",
+              "da ~90 € (piano annuale Starter)",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "L'obbligo non è comprare la cassa",
+        body: "L'obbligo di legge (art. 2 D.Lgs. 127/2015) riguarda la memorizzazione e trasmissione telematica dei corrispettivi, non l'acquisto di un dispositivo: il registratore telematico è uno dei modi per adempiere, insieme alla procedura web Documento Commerciale Online dell'Agenzia delle Entrate. Se apri una nuova attività a basso volume di scontrini, puoi partire senza comprare nulla e decidere dopo, sui numeri reali, se l'RT ti serve davvero.",
+      },
+      {
+        heading: "Quando conviene comunque il registratore",
+        body: "Con flussi alti alla cassa — il bar con la fila del mattino, il supermercato, il negozio con decine di battute l'ora — l'ergonomia dell'RT resta imbattibile: tasti fisici, stampa immediata, funzionamento anche offline con trasmissione differita. Il costo si ammortizza sul volume. Sotto le poche decine di scontrini al giorno, invece, il rapporto si inverte e l'hardware diventa un costo fisso difficile da giustificare.",
+      },
+      {
+        heading: "L'alternativa software nel dettaglio",
+        body: "Con la procedura DCO emetti lo scontrino elettronico dal portale AdE (gratis, ma lento: ogni documento va compilato a mano) o da un'app che automatizza la compilazione e la trasmissione. ScontrinoZero parte da 29,99 €/anno (Starter) con scontrini illimitati, prova di 30 giorni senza carta e versione self-hosted gratuita: il calcolatore di risparmio linkato sotto confronta il tuo caso specifico con i costi di un RT.",
+      },
+    ],
+    faq: [
+      {
+        question: "Quanto costa un registratore di cassa telematico?",
+        answer:
+          "I modelli da banco più comuni costano 400-800 € di acquisto, a cui aggiungere 100-200 € di installazione da tecnico abilitato e 50-100 € di verificazione ogni 2 anni. Sui 3 anni la spesa complessiva è tipicamente di 900-1.200 €.",
+      },
+      {
+        question: "È obbligatorio comprare il registratore di cassa?",
+        answer:
+          "No. L'obbligo è trasmettere i corrispettivi (art. 2 D.Lgs. 127/2015), non possedere l'hardware: la procedura Documento Commerciale Online dell'AdE — dal portale o tramite app — è un'alternativa legale con lo stesso valore fiscale.",
+      },
+      {
+        question: "Esistono bonus o crediti d'imposta per l'acquisto?",
+        answer:
+          "I crediti d'imposta per l'acquisto e l'adeguamento dei registratori telematici previsti negli anni scorsi sono a oggi esauriti; eventuali nuove agevolazioni dipendono da provvedimenti futuri. Verifica sempre con il commercialista lo stato delle agevolazioni al momento dell'acquisto.",
+      },
+      {
+        question: "Quanto costa emettere scontrini con un'app?",
+        answer:
+          "Con ScontrinoZero il piano Starter costa 29,99 €/anno (o 4,99 €/mese) con scontrini illimitati; la prova è di 30 giorni senza carta. Il portale AdE resta gratuito ma richiede la compilazione manuale di ogni documento.",
+      },
+    ],
+    relatedHelp: ["piani-e-prezzi", "primo-scontrino", "pos-rt-obbligo"],
+    relatedGuides: [
+      "scontrino-senza-registratore-di-cassa",
+      "migrare-da-registratore-telematico-a-software",
+      "registratore-telematico-vs-documento-commerciale-online",
+    ],
+    relatedTools: ["calcolatore-risparmio-rt"],
+  },
+
+  "sanzioni-mancato-scontrino": {
+    slug: "sanzioni-mancato-scontrino",
+    title: "Sanzioni per mancato scontrino: importi e regole attuali",
+    metaTitle: "Sanzioni mancato scontrino 2026: 70% dell'IVA, minimo 300 €",
+    metaDescription:
+      "La sanzione per il mancato scontrino è il 70% dell'IVA con minimo 300 € (D.Lgs. 87/2024); con 4 violazioni in 5 anni scatta la chiusura. Tutti gli importi.",
+    heroIntro:
+      "La sanzione per la mancata emissione dello scontrino è il 70% dell'imposta relativa all'importo non documentato, con un minimo di 300 € per violazione (art. 6, comma 2-bis, D.Lgs. 471/1997, come riformato dal D.Lgs. 87/2024 per le violazioni dal 1° settembre 2024). Con 4 violazioni distinte in 5 anni scatta anche la sospensione della licenza. Vediamo tutti i casi: omessa emissione, tardiva trasmissione, errori formali.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readingMinutes: 6,
+    sections: [
+      {
+        heading: "La sanzione base: 70% dell'imposta, minimo 300 €",
+        body: "Per l'omessa o infedele memorizzazione/trasmissione dei corrispettivi (cioè lo scontrino non emesso, emesso per un importo inferiore o non trasmesso) la sanzione è il 70% dell'imposta corrispondente all'importo non documentato, con un minimo di 300 € per violazione. È l'effetto della riforma delle sanzioni tributarie (D.Lgs. 87/2024), che dal 1° settembre 2024 ha ridotto la misura precedente (90% con minimo 500 €). Per le violazioni commesse prima di quella data resta applicabile il regime anteriore.",
+      },
+      {
+        heading: "Violazioni che non incidono sull'imposta: 100 €",
+        body: "Se la violazione è solo formale — la trasmissione è avvenuta in ritardo ma l'imposta è stata liquidata correttamente — si applica la sanzione fissa di 100 € per trasmissione (art. 6, comma 2-bis, ultimo periodo, D.Lgs. 471/1997), senza il minimo di 300 €. È il caso tipico del corrispettivo trasmesso oltre i 12 giorni ma contabilizzato correttamente nella liquidazione IVA del periodo.",
+      },
+      {
+        heading: "La recidiva: sospensione della licenza",
+        body: "L'art. 12, comma 2, del D.Lgs. 471/1997 prevede una sanzione accessoria pesante: se in 5 anni vengono contestate 4 violazioni distinte dell'obbligo di emettere lo scontrino (compiute in giorni diversi), scatta la sospensione della licenza o dell'autorizzazione all'esercizio, da 3 giorni a 1 mese. Sopra i 50.000 € di corrispettivi non documentati la sospensione sale da 1 a 6 mesi. È la ragione per cui la reiterazione è molto più pericolosa della singola dimenticanza.",
+      },
+      {
+        heading: "Chi rischia i controlli",
+        body: "I controlli sono sia fisici (verifiche della Guardia di Finanza sul punto vendita, spesso a ridosso della chiusura) sia incrociati: l'Agenzia delle Entrate confronta i corrispettivi trasmessi con i dati dei pagamenti elettronici comunicati dagli operatori finanziari. Dal 2026, con l'obbligo di collegamento POS-corrispettivi (L. 207/2024), l'incrocio diventa strutturale: un incasso POS senza corrispettivo corrispondente è un'anomalia immediatamente visibile.",
+      },
+      {
+        heading: "Il ravvedimento operoso",
+        body: "Se ti accorgi dell'errore prima della contestazione, puoi regolarizzare con il ravvedimento operoso (art. 13 D.Lgs. 472/1997): la sanzione si riduce in misura crescente con il tempo trascorso (da 1/10 a 1/5 del minimo a seconda di quando ravvedi). Serve trasmettere il corrispettivo omesso e versare sanzione ridotta e interessi. Per i casi concreti conviene passare dal commercialista: il calcolo dipende dai tempi e dal tipo di violazione.",
+      },
+      {
+        heading: "Come azzerare il rischio operativo",
+        body: "La quasi totalità delle violazioni nasce da dimenticanze operative: lo scontrino non battuto nella fretta, il registratore guasto, la trasmissione saltata. Con un flusso digitale (documento commerciale online via app) l'emissione e la trasmissione avvengono nello stesso gesto e ogni documento resta tracciato nello storico: niente chiusure dimenticate, niente scontrini nel cassetto. Non elimina l'obbligo, ma elimina i modi più comuni di violarlo per sbaglio.",
+      },
+    ],
+    faq: [
+      {
+        question: "Qual è la sanzione se non emetto lo scontrino?",
+        answer:
+          "Il 70% dell'IVA relativa all'importo non documentato, con un minimo di 300 € per violazione (art. 6 c. 2-bis D.Lgs. 471/1997, come modificato dal D.Lgs. 87/2024, in vigore per le violazioni dal 1° settembre 2024).",
+      },
+      {
+        question: "Cosa succede se dimentico più volte lo scontrino?",
+        answer:
+          "Con 4 violazioni distinte contestate in 5 anni, oltre alle sanzioni pecuniarie scatta la sospensione della licenza da 3 giorni a 1 mese (art. 12 c. 2 D.Lgs. 471/1997); sopra 50.000 € di corrispettivi non documentati la sospensione va da 1 a 6 mesi.",
+      },
+      {
+        question:
+          "Ho trasmesso i corrispettivi in ritardo ma l'IVA era giusta: che sanzione rischio?",
+        answer:
+          "La sanzione fissa di 100 € per trasmissione, perché la violazione non ha inciso sulla liquidazione dell'imposta. Puoi ridurla ulteriormente con il ravvedimento operoso se regolarizzi prima della contestazione.",
+      },
+      {
+        question: "Il cliente che esce senza scontrino rischia una multa?",
+        answer:
+          "No: dal 2003 non esiste più la sanzione a carico del cliente sprovvisto di scontrino. La responsabilità dell'emissione è tutta dell'esercente.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "annullare-scontrino", "errori-ade"],
+    relatedGuides: [
+      "obbligo-scontrino-elettronico-2026",
+      "chiusura-giornaliera-corrispettivi",
+      "annullare-scontrino-elettronico",
+    ],
+  },
+
+  "registratore-telematico-vs-documento-commerciale-online": {
+    slug: "registratore-telematico-vs-documento-commerciale-online",
+    title: "Registratore telematico o documento commerciale online?",
+    metaTitle: "Registratore telematico vs documento commerciale online",
+    metaDescription:
+      "RT e DCO sono fiscalmente equivalenti: cambiano costi (500-1.000 € vs 0-90 €/anno), velocità al banco e vincoli. La differenza spiegata e quando scegliere cosa.",
+    heroIntro:
+      "Registratore telematico (RT) e documento commerciale online (DCO) sono i due modi legali di certificare i corrispettivi, fiscalmente equivalenti: lo scontrino che producono ha lo stesso valore. La differenza sta nel mezzo — hardware certificato contro procedura web dell'Agenzia delle Entrate — e quindi in costi, velocità al banco e vincoli operativi. Ecco il confronto punto per punto.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readingMinutes: 6,
+    sections: [
+      {
+        heading: "Cosa sono, in una riga ciascuno",
+        body: "L'RT è una stampante fiscale certificata che memorizza i corrispettivi e li trasmette all'AdE con la chiusura giornaliera. Il DCO è la procedura web dell'Agenzia delle Entrate (Provvedimento 28 ottobre 2016 n. 182017, ex art. 2 D.Lgs. 127/2015) che genera e trasmette lo scontrino elettronico documento per documento, dal portale o tramite un software collegato.",
+      },
+      {
+        heading: "Il confronto punto per punto",
+        body: 'La tabella riassume le differenze concrete tra le due strade. Nessuna delle due è "migliore" in assoluto: dipende dal volume di scontrini, dalla mobilità dell\'attività e dal budget.',
+        table: {
+          headers: [
+            "Aspetto",
+            "Registratore telematico",
+            "Documento commerciale online",
+          ],
+          rows: [
+            ["Costo iniziale", "500-1.000 € (acquisto + installazione)", "0 €"],
+            [
+              "Costi ricorrenti",
+              "Verificazione biennale 50-100 €, carta",
+              "0 € (portale) o abbonamento app (da ~30 €/anno)",
+            ],
+            [
+              "Velocità al banco",
+              "Immediata, tasti fisici",
+              "Qualche secondo a scontrino via app; 30-60 s dal portale",
+            ],
+            [
+              "Connettività",
+              "Funziona offline, trasmette in differita",
+              "Serve connessione al momento dell'emissione",
+            ],
+            [
+              "Chiusura giornaliera",
+              "Obbligatoria (automatica sui modelli recenti)",
+              "Non esiste: ogni documento è trasmesso subito",
+            ],
+            [
+              "Mobilità",
+              "Legato al punto cassa",
+              "Ovunque: smartphone con rete 4G/5G",
+            ],
+            [
+              "Guasti",
+              "Fermo cassa, serve il tecnico abilitato",
+              "Nessun hardware: cambio dispositivo e si riparte",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Stesso valore fiscale, stessi obblighi",
+        body: "Entrambe le strade adempiono all'obbligo di memorizzazione e trasmissione dei corrispettivi (art. 2 D.Lgs. 127/2015). Il documento consegnato al cliente ha identico valore per garanzia, resi, detrazioni e Lotteria degli Scontrini. Anche il nuovo obbligo 2026 di collegamento con il POS (L. 207/2024) vale per entrambi: cambia solo la modalità tecnica dell'associazione.",
+      },
+      {
+        heading: "Quando scegliere il registratore telematico",
+        body: "Sceglie bene l'RT chi ha un punto vendita fisso con flusso continuo alla cassa: bar con la fila del mattino, minimarket, panetteria con coda. La battuta fisica è più rapida di qualunque app, l'apparecchio lavora anche senza connessione e il costo si ammortizza sul volume. Anche chi vuole lo scontrino di carta consegnato d'istinto a ogni cliente resta più comodo con l'RT.",
+      },
+      {
+        heading: "Quando scegliere il documento commerciale online",
+        body: "Il DCO vince per attività mobili, stagionali o a basso volume: ambulanti, B&B, artigiani a domicilio, professionisti, chioschi. Zero investimento iniziale, zero manutenzioni, emissione da smartphone ovunque, storico digitale sempre accessibile. Con un'app come ScontrinoZero l'emissione richiede pochi secondi e la trasmissione è automatica; il portale AdE gratuito resta l'opzione per chi emette pochissimi documenti.",
+      },
+      {
+        heading: "Si possono usare entrambi?",
+        body: "Sì: nessuna norma impone di scegliere per sempre. Puoi tenere l'RT al punto vendita e usare il DCO per il banco al mercato o la stagione estiva, o migrare gradualmente dall'uno all'altro (la guida alla migrazione linkata sotto spiega la dismissione dell'RT). L'importante è che ogni corrispettivo sia certificato con uno dei due strumenti, senza duplicazioni.",
+      },
+    ],
+    faq: [
+      {
+        question:
+          "Che differenza c'è tra registratore telematico e documento commerciale online?",
+        answer:
+          "Il valore fiscale è identico; cambia il mezzo: l'RT è hardware certificato che trasmette con la chiusura giornaliera, il DCO è la procedura web AdE che trasmette ogni scontrino al momento dell'emissione. Ne derivano differenze di costo (500-1.000 € vs 0-90 €/anno), velocità e vincoli di connessione.",
+      },
+      {
+        question: "Il DCO è legale quanto il registratore telematico?",
+        answer:
+          "Sì: è una modalità prevista dall'Agenzia delle Entrate (Provvedimento 28 ottobre 2016 n. 182017, ex art. 2 D.Lgs. 127/2015) e lo scontrino emesso ha lo stesso valore fiscale di quello dell'RT.",
+      },
+      {
+        question: "Posso passare dall'RT al DCO senza problemi?",
+        answer:
+          "Sì. Si dismette l'RT con la procedura di cessazione sul portale Fatture e Corrispettivi e si prosegue con il DCO: nessuna autorizzazione preventiva. La transizione va fatta senza lasciare corrispettivi scoperti tra i due strumenti.",
+      },
+      {
+        question: "Con il DCO devo fare la chiusura giornaliera?",
+        answer:
+          "No: la chiusura giornaliera è un adempimento del registratore telematico. Con il DCO ogni documento viene trasmesso singolarmente al momento dell'emissione e non esiste una chiusura da inviare a fine giornata.",
+      },
+    ],
+    relatedHelp: ["pos-rt-obbligo", "chiusura-giornaliera", "primo-scontrino"],
+    relatedGuides: [
+      "documento-commerciale-online",
+      "migrare-da-registratore-telematico-a-software",
+      "registratore-di-cassa-prezzi",
+    ],
+    relatedTools: ["calcolatore-risparmio-rt"],
   },
 };
 

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -11,6 +11,9 @@ export const guideSlugs = [
   "scegliere-software-scontrini-elettronici",
   "codici-natura-iva",
   "stampante-termica-wifi-scontrini",
+  "recupero-credenziali-ade-password-scaduta",
+  "cassetto-fiscale-dove-trovare-scontrini",
+  "obbligo-scontrino-elettronico-2026",
 ] as const;
 
 export type GuideSlug = (typeof guideSlugs)[number];
@@ -1067,6 +1070,233 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     relatedGuides: [
       "scontrino-senza-registratore-di-cassa",
       "scegliere-software-scontrini-elettronici",
+    ],
+  },
+
+  "recupero-credenziali-ade-password-scaduta": {
+    slug: "recupero-credenziali-ade-password-scaduta",
+    title: "Password AdE scaduta o persa: come recuperare le credenziali",
+    metaTitle: "Password AdE scaduta: recuperare le credenziali Fisconline",
+    metaDescription:
+      "La password Fisconline scade ogni 90 giorni: come recuperarla, cosa fare se l'utenza non risulta registrata (DL 76/2020) e le alternative SPID e CIE per accedere all'AdE.",
+    heroIntro:
+      "La password Fisconline scade ogni 90 giorni: se non riesci più ad accedere, puoi reimpostarla dal portale dell'Agenzia delle Entrate con la domanda segreta scelta in fase di registrazione, oppure entrare con SPID o CIE e rigenerare le credenziali. Qui trovi la procedura per ogni caso: password scaduta, PIN smarrito, utenza non registrata, credenziali di una società.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readingMinutes: 7,
+    sections: [
+      {
+        heading: "Le credenziali Fisconline: da cosa sono composte",
+        body: "Le credenziali Fisconline sono tre elementi: nome utente (per le persone fisiche coincide con il codice fiscale), password e PIN a 10 cifre. Servono tutti e tre: la password per l'accesso al portale, il PIN per autorizzare le operazioni dispositive come l'emissione del documento commerciale online. La password ha una scadenza di 90 giorni: al primo accesso dopo la scadenza il portale chiede di impostarne una nuova.",
+      },
+      {
+        heading: "Password scaduta: come reimpostarla",
+        body: "Se la password è scaduta ma la ricordi, il portale dell'Agenzia delle Entrate ti guida al cambio direttamente al login: inserisci la vecchia password e ne imposti una nuova. Se invece non la ricordi, usa la funzione \"Problemi con la password?\" nell'area di accesso: rispondi alla domanda segreta impostata in fase di registrazione e ricevi una nuova password provvisoria. Al primo accesso dovrai cambiarla.",
+      },
+      {
+        heading: "PIN smarrito: come recuperarlo",
+        body: "Il PIN si recupera dall'area riservata del portale AdE (sezione profilo utente → ripristina PIN) se accedi con SPID, CIE o CNS. In alternativa puoi recuperare le prime 4 cifre con la funzione dedicata del portale e ricevere le restanti 6 per posta al domicilio fiscale. Se hai smarrito tutto (password e PIN), la strada più rapida è accedere con SPID o CIE e rigenerare le credenziali da lì.",
+      },
+      {
+        heading:
+          '"L\'utenza indicata non ha una password associata": cosa significa',
+        body: "È l'errore tipico di chi si era registrato a Fisconline anni fa e non ha mai completato l'attivazione, oppure di chi prova a registrarsi oggi come persona fisica: dal 1° marzo 2021, per effetto del Decreto Semplificazione (DL 76/2020), l'Agenzia delle Entrate non rilascia più nuove credenziali Fisconline alle persone fisiche. Le persone fisiche — anche titolari di partita IVA — accedono con SPID, CIE o CNS. Le credenziali Fisconline restano attive per chi le aveva già e continuano a essere rilasciate a società, enti e professionisti abilitati (Entratel).",
+      },
+      {
+        heading: "Le alternative: SPID e CIE",
+        body: "SPID si richiede gratuitamente (o con costi minimi per il riconoscimento) a uno degli identity provider accreditati — Poste ID è il più diffuso — e vale per tutta la pubblica amministrazione. La CIE (Carta d'Identità Elettronica) si usa con l'app CIE ID sullo smartphone: si accede approvando una notifica push, senza ricordare password che scadono. Entrambe permettono l'accesso completo al portale Fatture e Corrispettivi e alla procedura Documento Commerciale Online.",
+      },
+      {
+        heading: "Credenziali di una società o di più attività",
+        body: "Per le società le credenziali Fisconline/Entratel vengono richieste dal rappresentante legale, che poi incarica i gestori/operatori. Se gestisci più partite IVA (es. due ditte), ogni soggetto ha le proprie credenziali: non esiste un'utenza unica multi-azienda. Il ritiro delle credenziali di una società può avvenire in ufficio AdE da parte del rappresentante legale o di un delegato con delega e documenti.",
+      },
+      {
+        heading: "Cosa serve per ScontrinoZero",
+        body: "ScontrinoZero si collega all'AdE in due modi: con le credenziali Fisconline (utente, password e PIN) oppure con la CIE tramite l'app CIE ID. Se la tua password Fisconline è scaduta, l'app te lo segnala al momento della verifica della connessione: reimpostala sul portale AdE e aggiornala nelle impostazioni. Le credenziali vengono cifrate (AES-256) e usate solo per dialogare con il portale dell'Agenzia delle Entrate.",
+      },
+    ],
+    faq: [
+      {
+        question: "Ogni quanto scade la password Fisconline?",
+        answer:
+          "Ogni 90 giorni. Alla scadenza il portale chiede di impostare una nuova password al primo accesso. Se usi un software collegato (come ScontrinoZero), ricordati di aggiornare la password anche lì dopo il cambio.",
+      },
+      {
+        question: "Non riesco più a registrarmi a Fisconline: perché?",
+        answer:
+          "Dal 1° marzo 2021 (Decreto Semplificazione, DL 76/2020) l'AdE non rilascia più nuove credenziali Fisconline alle persone fisiche: si accede con SPID, CIE o CNS. Chi aveva già le credenziali può continuare a usarle; società e professionisti abilitati continuano a riceverle.",
+      },
+      {
+        question: "Ho dimenticato sia la password che il PIN: cosa faccio?",
+        answer:
+          "La via più rapida è accedere al portale AdE con SPID o CIE e rigenerare le credenziali dall'area riservata. In alternativa puoi usare le funzioni di recupero separate (domanda segreta per la password, ripristino PIN con invio postale), ma i tempi sono più lunghi.",
+      },
+      {
+        question: "Posso usare SPID al posto delle credenziali Fisconline?",
+        answer:
+          "Per accedere al portale sì, sempre. Per i software collegati dipende dall'integrazione: ScontrinoZero supporta le credenziali Fisconline e la CIE (via app CIE ID); con la CIE approvi una notifica push e non hai password che scadono.",
+      },
+      {
+        question: "Quanti tentativi ho prima che l'utenza venga bloccata?",
+        answer:
+          "Il portale AdE blocca temporaneamente l'utenza dopo ripetuti tentativi falliti (tipicamente 5). In caso di blocco, attendi lo sblocco automatico o usa la procedura di recupero password: evita di insistere con credenziali che non ricordi.",
+      },
+    ],
+    relatedHelp: [
+      "credenziali-fisconline",
+      "collegare-ade-con-cie",
+      "errori-ade",
+      "come-collegare-ade",
+    ],
+    relatedGuides: [
+      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
+    ],
+  },
+
+  "cassetto-fiscale-dove-trovare-scontrini": {
+    slug: "cassetto-fiscale-dove-trovare-scontrini",
+    title: "Dove trovare gli scontrini emessi nel portale AdE",
+    metaTitle: "Dove trovare gli scontrini nel cassetto fiscale (portale AdE)",
+    metaDescription:
+      "Gli scontrini emessi non stanno nel cassetto fiscale ma in Fatture e Corrispettivi: il percorso per trovarli, verificarli e cosa vede il privato.",
+    heroIntro:
+      "Gli scontrini elettronici che hai emesso non si trovano nel \"cassetto fiscale\" ma nell'area Fatture e Corrispettivi del portale dell'Agenzia delle Entrate: sezione Corrispettivi → Documento commerciale online → Ricerca. Qui vediamo il percorso esatto per l'esercente, cosa può vedere il cliente privato e come verificare che una trasmissione sia andata a buon fine.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readingMinutes: 6,
+    sections: [
+      {
+        heading: "Cassetto fiscale e Fatture e Corrispettivi: due aree diverse",
+        body: "Il cassetto fiscale è l'archivio personale con dichiarazioni, versamenti, rimborsi e dati anagrafici. I documenti commerciali online (gli scontrini elettronici) vivono invece nell'area Fatture e Corrispettivi, un servizio separato dello stesso portale. È la confusione più comune: chi cerca gli scontrini nel cassetto fiscale non li trova perché sta guardando nel posto sbagliato.",
+      },
+      {
+        heading: "Il percorso esatto per l'esercente",
+        body: 'Accedi al portale dell\'Agenzia delle Entrate (SPID, CIE, CNS o credenziali Fisconline) ed entra in Fatture e Corrispettivi. Seleziona la sezione "Corrispettivi", poi "Documento commerciale online" e infine "Ricerca". Da lì filtri per data o per identificativo e vedi ogni documento emesso, con stato, dettaglio delle righe ed eventuale annullamento collegato. Ogni documento è scaricabile in PDF.',
+      },
+      {
+        heading: "Come verificare che uno scontrino sia stato trasmesso",
+        body: 'Nella Ricerca del Documento commerciale online ogni documento trasmesso compare con il suo identificativo e la data/ora di emissione. Se un documento non compare, la trasmissione non è mai arrivata all\'AdE: in ScontrinoZero lo vedi dallo stato (un documento in errore non risulta trasmesso e va riemesso). Il totale dei corrispettivi giornalieri si consulta invece nella sezione "Consultazione" dei corrispettivi.',
+      },
+      {
+        heading: "Cosa vede il cliente privato",
+        body: 'Il cliente consumatore non trova i singoli scontrini in un\'area consultabile del proprio cassetto fiscale: il documento commerciale "parlante" (con codice fiscale) confluisce nei dati della dichiarazione precompilata quando dà diritto a detrazioni (es. spese sanitarie), e i biglietti della Lotteria degli Scontrini si consultano sul portale lotteria dedicato. Per il resto, il documento del cliente è la copia che gli consegni tu: stampata, via email o QR code.',
+      },
+      {
+        heading: "Quanto restano consultabili i documenti",
+        body: "I documenti commerciali online restano consultabili nell'area Fatture e Corrispettivi per i periodi previsti dal portale; l'obbligo di conservazione dei documenti fiscali per l'esercente è di 10 anni (art. 2220 c.c.). Per non dipendere dal portale, con ScontrinoZero hai lo storico digitale sempre accessibile e l'export dei dati; l'originale fiscale resta comunque quello trasmesso all'AdE.",
+      },
+      {
+        heading: "Se usi ScontrinoZero: lo storico integrato",
+        body: "Tutto quello che emetti con ScontrinoZero è nello Storico dell'app: ogni scontrino con stato (Emesso, Annullato, Errore), identificativo AdE, dettaglio righe e ricevuta condivisibile. La verifica sul portale resta utile come controllo indipendente — è la fonte ufficiale — ma per l'operatività quotidiana non serve entrare nel portale AdE.",
+      },
+    ],
+    faq: [
+      {
+        question: "Dove trovo gli scontrini nel cassetto fiscale?",
+        answer:
+          "Non nel cassetto fiscale: gli scontrini elettronici emessi si trovano nell'area Fatture e Corrispettivi del portale AdE, sezione Corrispettivi → Documento commerciale online → Ricerca. Il cassetto fiscale contiene dichiarazioni e versamenti, non i documenti commerciali.",
+      },
+      {
+        question:
+          "Il portale ha il progressivo dei documenti commerciali emessi?",
+        answer:
+          "Sì. Ogni documento commerciale online ha un identificativo univoco e un progressivo attribuiti dal sistema AdE al momento della trasmissione: li vedi nella Ricerca del portale e sulla copia del documento consegnata al cliente.",
+      },
+      {
+        question:
+          "Sono un privato: posso vedere gli scontrini fatti a mio nome?",
+        answer:
+          'Non esiste un elenco consultabile dei singoli scontrini: i documenti "parlanti" con il tuo codice fiscale confluiscono nei dati della dichiarazione precompilata quando rilevano per le detrazioni, e i biglietti della lotteria si vedono sul portale della Lotteria degli Scontrini.',
+      },
+      {
+        question:
+          "Il commercialista può vedere i miei corrispettivi trasmessi?",
+        answer:
+          "Sì, se è tuo intermediario delegato: con la delega ai servizi di Fatture e Corrispettivi accede alla consultazione dei corrispettivi trasmessi. È il modo tipico con cui il commercialista riconcilia i corrispettivi in contabilità.",
+      },
+    ],
+    relatedHelp: ["cassetto-fiscale", "storico-ed-esportazione", "errori-ade"],
+    relatedGuides: [
+      "documento-commerciale-online",
+      "chiusura-giornaliera-corrispettivi",
+      "annullare-scontrino-elettronico",
+    ],
+  },
+
+  "obbligo-scontrino-elettronico-2026": {
+    slug: "obbligo-scontrino-elettronico-2026",
+    title: "Obbligo di scontrino elettronico nel 2026: chi, come, sanzioni",
+    metaTitle: "Obbligo scontrino elettronico 2026: chi deve emetterlo",
+    metaDescription:
+      "Dal 2020 lo scontrino elettronico è obbligatorio per chi vende a privati (D.Lgs. 127/2015): esoneri, novità POS 2026, sanzioni del 90% e come adeguarsi.",
+    heroIntro:
+      "Sì, lo scontrino elettronico è obbligatorio: dal 1° gennaio 2020 ogni commerciante al minuto che vende a consumatori finali deve memorizzare e trasmettere i corrispettivi all'Agenzia delle Entrate (art. 2 D.Lgs. 127/2015). Nel 2026 si aggiunge l'obbligo di collegamento tra POS e strumento di emissione. Vediamo chi è obbligato, chi è esonerato, le sanzioni e le opzioni per adeguarsi senza comprare hardware.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readingMinutes: 7,
+    sections: [
+      {
+        heading: "La norma base: D.Lgs. 127/2015",
+        body: "L'articolo 2 del D.Lgs. 127/2015 impone a chi effettua operazioni di commercio al minuto (art. 22 DPR 633/72) la memorizzazione elettronica e la trasmissione telematica dei corrispettivi giornalieri. L'obbligo è scattato il 1° luglio 2019 per chi superava 400.000 € di volume d'affari e il 1° gennaio 2020 per tutti gli altri. Lo scontrino di carta \"semplice\" del vecchio registratore di cassa non è più valido da allora.",
+      },
+      {
+        heading: "Chi è obbligato",
+        body: "Tutte le partite IVA che vendono beni o servizi a consumatori finali (B2C) senza emettere fattura: negozi, bar e ristoranti, artigiani con clientela privata, ambulanti, professionisti che incassano da privati, strutture ricettive per i servizi extra. Il regime fiscale non conta: anche i forfettari sono obbligati. Conta la natura dell'operazione: vendita al minuto → corrispettivo telematico.",
+      },
+      {
+        heading: "Chi è esonerato",
+        body: "Gli esoneri sono elencati dal DM 10 maggio 2019: tra i principali, le operazioni già esonerate dall'obbligo di certificazione ex art. 2 DPR 696/1996 (es. vendita di giornali, alcune cessioni di tabacchi e generi di monopolio), le prestazioni di trasporto pubblico con biglietti, e le operazioni per cui si emette comunque fattura. Chi rientra negli esoneri può comunque scegliere di emettere il documento commerciale volontariamente.",
+      },
+      {
+        heading: "Come adempiere: le tre strade",
+        body: '1) Registratore telematico (RT): hardware certificato, 400-800 € di acquisto più il canone di verifica biennale — ha senso per volumi alti al banco. 2) Procedura web "Documento Commerciale Online" dell\'AdE: gratuita, dal portale Fatture e Corrispettivi, ma richiede 30-60 secondi a scontrino. 3) Software collegato alla procedura DCO (come ScontrinoZero): stessa validità fiscale, emissione in pochi secondi dallo smartphone, senza hardware.',
+      },
+      {
+        heading: "La novità 2026: collegamento POS-corrispettivi",
+        body: "La Legge di Bilancio 2025 (L. 207/2024, art. 1 commi 74-77) ha introdotto l'obbligo di collegamento tecnico tra gli strumenti di pagamento elettronico (POS) e lo strumento di memorizzazione dei corrispettivi. Da gennaio 2026 il POS deve risultare associato allo strumento di emissione, così l'AdE può incrociare incassi elettronici e corrispettivi trasmessi. Chi usa il DCO registra il POS nel portale Fatture e Corrispettivi: la procedura è guidata e non richiede hardware.",
+      },
+      {
+        heading: "Le sanzioni",
+        body: "Per l'omessa, tardiva o infedele memorizzazione/trasmissione dei corrispettivi la sanzione è il 90% dell'imposta relativa (art. 6, comma 2-bis, D.Lgs. 471/1997), con minimo di 500 €. Se la violazione non incide sull'imposta, si applica la sanzione fissa di 100 € per trasmissione. Dopo 4 violazioni distinte in 5 anni può scattare la sospensione della licenza da 3 giorni a 1 mese (art. 12 D.Lgs. 471/1997). Il mancato collegamento POS-corrispettivi ha sanzioni dedicate introdotte dalla L. 207/2024.",
+      },
+      {
+        heading: "Mettersi in regola senza comprare hardware",
+        body: "Se apri ora o vuoi dismettere il registratore, la strada più economica è la procedura DCO: zero hardware, zero collaudi. Con ScontrinoZero emetti dallo smartphone in pochi secondi, trasmetti in automatico a ogni scontrino e hai lo storico digitale; la prova è di 30 giorni senza carta di credito. Se il tuo flusso al banco è molto alto, valuta onestamente un RT: la nostra guida al confronto spiega quando conviene l'uno o l'altro.",
+      },
+    ],
+    faq: [
+      {
+        question: "Lo scontrino elettronico è obbligatorio per tutti?",
+        answer:
+          "Per tutti quelli che vendono a consumatori finali senza fattura, sì: l'obbligo vale dal 1° gennaio 2020 (art. 2 D.Lgs. 127/2015), indipendentemente dal regime fiscale. Restano fuori solo le operazioni esonerate dal DM 10 maggio 2019 e chi emette sempre fattura.",
+      },
+      {
+        question: "Serve per forza comprare un registratore telematico?",
+        answer:
+          "No. Il registratore telematico è una delle opzioni, non l'unica: la procedura Documento Commerciale Online dell'AdE (usata direttamente dal portale o tramite un software come ScontrinoZero) ha la stessa validità fiscale e non richiede alcun hardware.",
+      },
+      {
+        question: "Cosa cambia nel 2026 con il POS?",
+        answer:
+          "Dal 2026 gli strumenti di pagamento elettronico devono risultare collegati allo strumento che memorizza i corrispettivi (L. 207/2024, art. 1 commi 74-77). Chi usa il DCO registra il POS nel portale Fatture e Corrispettivi; chi ha un RT deve associarlo tecnicamente al dispositivo.",
+      },
+      {
+        question: "Qual è la sanzione se non emetto lo scontrino?",
+        answer:
+          "Il 90% dell'imposta relativa all'importo non memorizzato o trasmesso, con un minimo di 500 € (art. 6 c. 2-bis D.Lgs. 471/1997). Con 4 violazioni distinte in 5 anni può aggiungersi la sospensione della licenza da 3 giorni a 1 mese.",
+      },
+      {
+        question: "Il forfettario è esonerato dallo scontrino elettronico?",
+        answer:
+          "No. Il regime forfettario esonera dall'IVA, non dalla certificazione dei corrispettivi: per le vendite a privati anche il forfettario emette il documento commerciale, con natura N2 al posto dell'aliquota.",
+      },
+    ],
+    relatedHelp: ["pos-rt-obbligo", "normativa-pos-2026", "primo-scontrino"],
+    relatedGuides: [
+      "scontrino-senza-registratore-di-cassa",
+      "pos-rt-obbligo-2026",
+      "scontrino-regime-forfettario",
     ],
   },
 };

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -57,7 +57,9 @@ export interface GuideArticle {
   readonly metaTitle: string;
   readonly metaDescription: string;
   readonly heroIntro: string;
+  /** Data ISO YYYY-MM-DD: finisce in Article JSON-LD e sitemap, mai troncarla al mese. */
   readonly publishedAt: string;
+  /** Data ISO YYYY-MM-DD dell'ultima revisione sostanziale (>= publishedAt). */
   readonly updatedAt: string;
   readonly readingMinutes: number;
   readonly sections: readonly GuideSection[];
@@ -78,7 +80,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       'Il documento commerciale online (DCO) è la versione digitale dello scontrino: lo si emette dal portale Agenzia delle Entrate "Fatture e Corrispettivi" senza bisogno di un registratore telematico fisico. È fiscalmente equivalente allo scontrino stampato e trasmette i corrispettivi all\'AdE in tempo reale.',
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-14",
     readingMinutes: 6,
     sections: [
       {
@@ -153,7 +155,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Sì, si può: da gennaio 2020 qualunque partita IVA può emettere lo scontrino elettronico senza registratore di cassa fisico, gratis dal portale \"Fatture e Corrispettivi\" dell'Agenzia delle Entrate oppure in pochi secondi con un'app dal telefono. Vediamo cosa serve, quanto costa e come scegliere l'app giusta.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-07",
+    updatedAt: "2026-07-13",
     readingMinutes: 8,
     sections: [
       {
@@ -266,7 +268,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Scontrino, ricevuta fiscale e fattura sono tre documenti diversi con regole diverse. Saper distinguere quando emettere l'uno o l'altro è la base per non sbagliare adempimenti. Vediamo le differenze pratiche con esempi concreti per chi lavora al pubblico.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-14",
     readingMinutes: 5,
     sections: [
       {
@@ -331,7 +333,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Dal 1° gennaio 2026 è entrato in vigore l'obbligo di collegamento fra POS (terminale di pagamento) e registratore telematico, per trasmettere all'Agenzia delle Entrate gli incassi elettronici insieme ai corrispettivi. La norma ha generato molta confusione: cosa cambia davvero e cosa fare se non usi un RT fisico?",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-14",
     readingMinutes: 7,
     sections: [
       {
@@ -395,7 +397,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Il regime forfettario semplifica molti adempimenti (IVA, ritenute, gestione contabile), ma NON esonera dall'obbligo di emettere scontrino al consumatore finale per le vendite B2C. Vediamo come gestire correttamente l'emissione, l'IVA \"a zero\" e gli aspetti operativi tipici del forfettario.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-14",
     readingMinutes: 6,
     sections: [
       {
@@ -460,7 +462,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Hai un registratore telematico ma vorresti dismetterlo per passare al documento commerciale online via software? Il passaggio è legittimo e in molti casi conviene, ma richiede alcune verifiche preliminari e attenzione agli adempimenti formali. Vediamo cosa serve, passo per passo.",
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-15",
     readingMinutes: 7,
     sections: [
       {
@@ -528,7 +530,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       'La "chiusura giornaliera" era l\'operazione classica di fine giornata con il registratore di cassa: si stampava lo scontrino di chiusura (la storica "Z") e si trasmettevano i corrispettivi. Con il documento commerciale online la logica è diversa, e in molti casi più semplice. Vediamo cosa devi davvero fare a fine giornata.',
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-15",
     readingMinutes: 5,
     sections: [
       {
@@ -592,7 +594,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       'Dopo aver emesso uno scontrino elettronico ti accorgi di un errore, oppure il cliente cambia idea e chiede il rimborso: si può annullare? Sì, ma con regole precise. Lo "scontrino di annullamento" è un documento dedicato che cancella fiscalmente il precedente. Vediamo procedura, termini e casi pratici tipici.',
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-15",
     readingMinutes: 6,
     sections: [
       {
@@ -667,7 +669,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "La Lotteria degli Scontrini è un sistema premio per i consumatori che presentano un codice al momento dell'acquisto. Per il commerciante è un'attività operativa semplice: contrariamente a quanto si legge in giro, oggi non esiste una sanzione amministrativa per il rifiuto del codice — la previsione iniziale del decreto fiscale 2020 fu eliminata in sede di conversione. Resta però un meccanismo di segnalazione del cliente sul Portale Lotteria, che alimenta l'analisi del rischio dell'Agenzia delle Entrate.",
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-15",
     readingMinutes: 6,
     sections: [
       {
@@ -735,7 +737,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Il mercato dei software per scontrini elettronici è cresciuto rapidamente: web app, app mobile, gestionali integrati, soluzioni self-hosted. Scegliere quello giusto significa risparmiare ore di lavoro mensili ed evitare incidenti fiscali. Vediamo 6 criteri pratici per orientarti senza farti convincere dal marketing.",
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05",
+    updatedAt: "2026-05-15",
     readingMinutes: 7,
     sections: [
       {
@@ -802,7 +804,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "I codici natura IVA (N1, N2, N2.2, N3, N4, N5, N6, N7) servono a spiegare al fisco perché su un'operazione non viene addebitata l'IVA con un'aliquota ordinaria. Sono obbligatori nel tracciato della fattura elettronica e dei corrispettivi telematici. Qui vediamo cosa significano uno per uno, perché il regime forfettario usa N2.2 in fattura ma N2 sullo scontrino, e quale dicitura di esenzione indicare.",
     publishedAt: "2026-06-29",
-    updatedAt: "2026-07",
+    updatedAt: "2026-07-12",
     readingMinutes: 8,
     sections: [
       {
@@ -939,7 +941,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Per stampare gli scontrini non serve una stampante fiscale: basta una stampante termica generica, da 30-120 € a seconda del modello. La WiFi conviene per la postazione fissa condivisa tra più dispositivi, il Bluetooth per la cassa mobile, l'USB per chi lavora da computer. Prima di comprare verifica tre cose: linguaggio ESC/POS, larghezza carta (58 o 80 mm) e il tipo di connessione adatto a come lavori.",
     publishedAt: "2026-07-12",
-    updatedAt: "2026-07",
+    updatedAt: "2026-07-12",
     readingMinutes: 7,
     sections: [
       {

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -149,13 +149,14 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "scontrino-senza-registratore-di-cassa": {
     slug: "scontrino-senza-registratore-di-cassa",
     title: "Emettere scontrino senza registratore di cassa: si può?",
-    metaTitle: "Scontrino elettronico senza registratore di cassa: guida 2026",
+    metaTitle:
+      "Scontrino senza cassa: come emetterlo senza registratore (2026)",
     metaDescription:
-      "Sì, si può: dal 2020 emetti scontrini elettronici senza registratore telematico, dal portale AdE o con un'app dal telefono. Cosa serve, costi e come iniziare.",
+      "Sì, si può: dal 2020 emetti lo scontrino senza cassa né registratore telematico, dal portale AdE o con un'app dal telefono. Cosa serve, costi e come iniziare.",
     heroIntro:
       "Sì, si può: da gennaio 2020 qualunque partita IVA può emettere lo scontrino elettronico senza registratore di cassa fisico, gratis dal portale \"Fatture e Corrispettivi\" dell'Agenzia delle Entrate oppure in pochi secondi con un'app dal telefono. Vediamo cosa serve, quanto costa e come scegliere l'app giusta.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-07-13",
+    updatedAt: "2026-07-22",
     readingMinutes: 8,
     sections: [
       {
@@ -391,13 +392,14 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "scontrino-regime-forfettario": {
     slug: "scontrino-regime-forfettario",
     title: "Scontrino in regime forfettario: cosa devi sapere",
-    metaTitle: "Scontrino elettronico regime forfettario 2026: come emetterlo",
+    metaTitle:
+      "Scontrino regime forfettario 2026: quando è obbligatorio e come",
     metaDescription:
-      "Anche i forfettari devono emettere scontrino ai privati: come farlo senza registratore di cassa, natura IVA N2, dicitura di esenzione e lotteria. Guida 2026.",
+      "Sì, anche in regime forfettario lo scontrino ai privati è obbligatorio: si emette senza IVA con natura N2, anche senza registratore di cassa. Errori tipici e lotteria.",
     heroIntro:
-      "Il regime forfettario semplifica molti adempimenti (IVA, ritenute, gestione contabile), ma NON esonera dall'obbligo di emettere scontrino al consumatore finale per le vendite B2C. Vediamo come gestire correttamente l'emissione, l'IVA \"a zero\" e gli aspetti operativi tipici del forfettario.",
+      "Sì: anche in regime forfettario devi emettere lo scontrino (documento commerciale) per ogni vendita al consumatore finale. Il forfettario semplifica IVA, ritenute e contabilità, ma NON esonera dalla certificazione dei corrispettivi B2C. Vediamo come gestire l'emissione, l'IVA \"a zero\" (natura N2) e gli aspetti operativi tipici del forfettario.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05-14",
+    updatedAt: "2026-07-22",
     readingMinutes: 6,
     sections: [
       {
@@ -442,6 +444,17 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
           "Come gestisco i contanti vs i pagamenti elettronici da forfettario?",
         answer:
           "Allo stesso modo di qualunque altro esercente: in fase di emissione indichi il metodo di pagamento (contanti, carta, misto). L'informazione finisce nel DCO trasmesso all'AdE. Non c'è una gestione speciale per il forfettario su questo punto.",
+      },
+      {
+        question: "Nello scontrino del forfettario c'è l'IVA?",
+        answer:
+          "No. L'operazione del forfettario è in franchigia da IVA (art. 1 c. 54-89 L. 190/2014): sullo scontrino le righe escono ad aliquota 0% con natura N2 al posto dell'imposta. Il totale che paga il cliente è quindi il prezzo pieno, senza IVA esposta.",
+      },
+      {
+        question:
+          "Ho emesso scontrini con IVA al 22% per errore: come rimedio?",
+        answer:
+          "Annulla ogni scontrino errato ed emettilo di nuovo con la natura N2 corretta: i documenti già trasmessi all'AdE non si possono modificare retroattivamente. Se l'errore si è protratto per settimane o mesi, coinvolgi il commercialista per sistemare anche i corrispettivi già liquidati.",
       },
     ],
     relatedHelp: ["regime-forfettario", "aliquote-iva", "primo-scontrino"],
@@ -592,9 +605,9 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     metaDescription:
       "Come annullare un documento commerciale elettronico già trasmesso all'AdE: termini, procedura tecnica, differenza fra annullamento e reso, casi pratici.",
     heroIntro:
-      'Dopo aver emesso uno scontrino elettronico ti accorgi di un errore, oppure il cliente cambia idea e chiede il rimborso: si può annullare? Sì, ma con regole precise. Lo "scontrino di annullamento" è un documento dedicato che cancella fiscalmente il precedente. Vediamo procedura, termini e casi pratici tipici.',
+      'Sì, uno scontrino elettronico si può annullare, anche nei giorni successivi all\'emissione: lo "scontrino di annullamento" è un documento dedicato che cancella fiscalmente il precedente. Vediamo procedura, termini e casi pratici tipici, e quando invece è più corretto gestire un reso.',
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05-15",
+    updatedAt: "2026-07-22",
     readingMinutes: 6,
     sections: [
       {
@@ -646,6 +659,22 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
           "Quanti annullamenti posso fare? Esiste un limite o vengo monitorato?",
         answer:
           "Non esiste un limite numerico esplicito, ma l'AdE può monitorare pattern anomali (es. tasso annullamento molto sopra la media di settore) come possibile indicatore di evasione. Annulla solo quando necessario e per cause documentabili; per resi a distanza usa sempre la modalità reso (DCO negativo).",
+      },
+      {
+        question: "Entro quanti giorni si può annullare uno scontrino?",
+        answer:
+          "La normativa non fissa un termine perentorio per il documento commerciale online: l'annullamento è possibile anche nei giorni successivi all'emissione. La best practice è annullare il prima possibile — idealmente entro la giornata — e comunque entro il periodo d'imposta: più passa il tempo, più complessa è la riconciliazione dei corrispettivi.",
+      },
+      {
+        question: "Posso annullare uno scontrino dopo la chiusura giornaliera?",
+        answer:
+          'Con il documento commerciale online sì: non esiste la "chiusura di cassa" del registratore telematico che blocca la giornata, quindi puoi annullare anche il giorno dopo. I corrispettivi del giorno interessato vengono rettificati dall\'AdE con il documento di annullo.',
+      },
+      {
+        question:
+          "Ho battuto uno scontrino errato mesi fa (es. a gennaio): posso stornarlo ora?",
+        answer:
+          "Meglio di no: a mesi di distanza l'annullamento complica la riconciliazione dei corrispettivi già liquidati. Il caso va gestito con il commercialista, tipicamente con una rettifica in sede di liquidazione, non con un annullo tardivo del documento.",
       },
     ],
     relatedHelp: [
@@ -798,13 +827,14 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "codici-natura-iva": {
     slug: "codici-natura-iva",
     title: "Codici natura IVA: cosa sono e quando si usano",
-    metaTitle: "Natura IVA N2.2: cosa significa e dicitura forfettari",
+    metaTitle:
+      "Codice natura IVA N2.2: significato, forfettario e tabella N1-N7",
     metaDescription:
-      "Cosa sono i codici natura IVA N1-N7, cosa significa N2.2 per il regime forfettario in fattura elettronica, perché sullo scontrino si usa N2 e quale dicitura indicare.",
+      'N2.2 significa "operazione non soggetta a IVA - altri casi": il codice del forfettario in fattura elettronica. Tabella N1-N7, differenza con N2 e dicitura.',
     heroIntro:
       "I codici natura IVA (N1, N2, N2.2, N3, N4, N5, N6, N7) servono a spiegare al fisco perché su un'operazione non viene addebitata l'IVA con un'aliquota ordinaria. Sono obbligatori nel tracciato della fattura elettronica e dei corrispettivi telematici. Qui vediamo cosa significano uno per uno, perché il regime forfettario usa N2.2 in fattura ma N2 sullo scontrino, e quale dicitura di esenzione indicare.",
     publishedAt: "2026-06-29",
-    updatedAt: "2026-07-12",
+    updatedAt: "2026-07-22",
     readingMinutes: 8,
     sections: [
       {
@@ -922,6 +952,16 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
         question: "Che differenza c'è tra N2.1 e N2.2?",
         answer:
           "Sono i due sottocodici delle operazioni non soggette. N2.1 copre la carenza del requisito di territorialità (artt. 7 - 7-septies DPR 633/72, tipicamente prestazioni verso l'estero); N2.2 copre tutti gli altri casi, incluso il regime forfettario e il regime di vantaggio.",
+      },
+      {
+        question: "Il codice IVA N2.2 a cosa corrisponde?",
+        answer:
+          'Corrisponde alle operazioni "non soggette a IVA - altri casi" del tracciato della fattura elettronica: soprattutto il regime forfettario, il regime di vantaggio (ex minimi) e le operazioni fuori campo IVA diverse dalla carenza di territorialità. Si abbina sempre ad aliquota 0%, mai a un\'aliquota ridotta.',
+      },
+      {
+        question: "N2.2 vuol dire fuori campo IVA?",
+        answer:
+          "Sì, in senso lato: N2.2 identifica operazioni fuori dal campo di applicazione dell'IVA per motivi diversi dalla territorialità (quella è N2.1). Non va confuso con l'esenzione: le operazioni esenti ex art. 10 DPR 633/72 usano il codice N4, non N2.2.",
       },
     ],
     relatedHelp: ["regime-forfettario", "aliquote-iva", "fatture-e-ricevute"],

--- a/src/lib/help/articles.test.ts
+++ b/src/lib/help/articles.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   helpArticles,
   helpSlugs,
-  HELP_REVIEWED_DATE,
   getRelatedArticles,
   getHelpArticle,
 } from "./articles";
@@ -121,13 +120,29 @@ describe("analytics-e-report (KPI, grafici e gating Pro)", () => {
   });
 });
 
-describe("HELP_REVIEWED_DATE", () => {
-  it("is an ISO date in YYYY-MM-DD form (accettata da articleJsonLd)", () => {
-    expect(HELP_REVIEWED_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+describe("per-article dates", () => {
+  it("every article has datePublished and dateModified in ISO YYYY-MM-DD form", () => {
+    for (const article of Object.values(helpArticles)) {
+      expect(article.datePublished).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(article.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
   });
 
-  it("is a real, parseable calendar date", () => {
-    expect(Number.isNaN(Date.parse(HELP_REVIEWED_DATE))).toBe(false);
+  it("every date is a real, parseable calendar date", () => {
+    for (const article of Object.values(helpArticles)) {
+      expect(Number.isNaN(Date.parse(article.datePublished))).toBe(false);
+      expect(Number.isNaN(Date.parse(article.dateModified))).toBe(false);
+    }
+  });
+
+  it("dateModified is never before datePublished", () => {
+    for (const article of Object.values(helpArticles)) {
+      // Confronto lessicografico: valido per date ISO
+      expect(
+        article.dateModified >= article.datePublished,
+        `${article.slug}: ${article.dateModified} < ${article.datePublished}`,
+      ).toBe(true);
+    }
   });
 });
 

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -6,21 +6,19 @@ export interface HelpArticle {
   readonly metaTitle: string;
   /** Descrizione SEO, riusata sia nei metadata di pagina sia nello structured data Article. */
   readonly description: string;
+  /** Data ISO YYYY-MM-DD di prima pubblicazione (finisce in Article JSON-LD e sitemap). */
+  readonly datePublished: string;
+  /** Data ISO YYYY-MM-DD dell'ultima revisione sostanziale del page.tsx (>= datePublished).
+   * Bump manuale a ogni modifica di contenuto — è il segnale di freshness per Google/AI. */
+  readonly dateModified: string;
   readonly related: readonly [string, string, string];
 }
-
-/**
- * Data condivisa di "ultima revisione" del centro assistenza. Gli articoli help
- * sono documentazione viva, allineata alla versione corrente del prodotto: non
- * tracciamo una data di pubblicazione per-articolo, quindi usiamo un'unica data
- * di revisione come `datePublished`/`dateModified` dello structured data Article.
- * Aggiornarla quando si fa una revisione complessiva dei contenuti help.
- */
-export const HELP_REVIEWED_DATE = "2026-07-12";
 
 export const helpArticles: Record<string, HelpArticle> = {
   "aliquote-iva": {
     slug: "aliquote-iva",
+    datePublished: "2026-04-17",
+    dateModified: "2026-07-13",
     title: "Aliquote IVA, catalogo e metodi di pagamento",
     metaTitle: "Come gestire aliquote IVA, catalogo e metodi di pagamento",
     description:
@@ -29,6 +27,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "annullare-scontrino": {
     slug: "annullare-scontrino",
+    datePublished: "2026-04-11",
+    dateModified: "2026-07-13",
     title: "Annullare uno scontrino: quando si può e come fare",
     metaTitle: "Annullare scontrino elettronico: come fare ed entro quando",
     description:
@@ -41,6 +41,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "analytics-e-report": {
     slug: "analytics-e-report",
+    datePublished: "2026-07-13",
+    dateModified: "2026-07-13",
     title: "Analytics e report: ricavi, scontrini e prodotti",
     metaTitle: "Analytics e report: ricavi, scontrini e prodotti più venduti",
     description:
@@ -49,6 +51,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   api: {
     slug: "api",
+    datePublished: "2026-04-02",
+    dateModified: "2026-06-26",
     title: "API per sviluppatori",
     metaTitle: "API per sviluppatori",
     description:
@@ -61,6 +65,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "cambio-piano": {
     slug: "cambio-piano",
+    datePublished: "2026-04-20",
+    dateModified: "2026-07-13",
     title: "Come passare da mensile ad annuale",
     metaTitle: "Come passare da mensile ad annuale",
     description:
@@ -69,6 +75,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "cassetto-fiscale": {
     slug: "cassetto-fiscale",
+    datePublished: "2026-04-17",
+    dateModified: "2026-06-21",
     title: "Verificare i corrispettivi nel cassetto fiscale",
     metaTitle: "Dove verificare i corrispettivi nel cassetto fiscale",
     description:
@@ -77,6 +85,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "chiusura-giornaliera": {
     slug: "chiusura-giornaliera",
+    datePublished: "2026-04-17",
+    dateModified: "2026-06-21",
     title: "Chiusura giornaliera: è obbligatoria?",
     metaTitle: "Chiusura giornaliera: è obbligatoria?",
     description:
@@ -85,6 +95,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "come-collegare-ade": {
     slug: "come-collegare-ade",
+    datePublished: "2026-04-11",
+    dateModified: "2026-07-15",
     title: "Collegare ScontrinoZero all'Agenzia delle Entrate",
     metaTitle: "Come collegare ScontrinoZero all'Agenzia delle Entrate",
     description:
@@ -93,6 +105,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "collegare-ade-con-cie": {
     slug: "collegare-ade-con-cie",
+    datePublished: "2026-07-15",
+    dateModified: "2026-07-15",
     title: "Collegare l'AdE con CIE (app CIE ID)",
     metaTitle: "Collegare ScontrinoZero all'AdE con CIE (app CIE ID)",
     description:
@@ -101,6 +115,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "contatto-assistenza": {
     slug: "contatto-assistenza",
+    datePublished: "2026-04-20",
+    dateModified: "2026-07-13",
     title: "Come contattare l'assistenza",
     metaTitle: "Come contattare l'assistenza",
     description:
@@ -109,6 +125,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "credenziali-fisconline": {
     slug: "credenziali-fisconline",
+    datePublished: "2026-04-11",
+    dateModified: "2026-07-13",
     title: "Credenziali Fisconline: dove trovarle e verificarle",
     metaTitle: "Credenziali Fisconline: dove trovarle e come verificarle",
     description:
@@ -117,6 +135,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "errori-ade": {
     slug: "errori-ade",
+    datePublished: "2026-04-16",
+    dateModified: "2026-07-15",
     title: "Errori comuni di accesso AdE e come risolverli",
     metaTitle: "Password AdE scaduta o accesso bloccato: come risolvere",
     description:
@@ -129,6 +149,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "fatture-e-ricevute": {
     slug: "fatture-e-ricevute",
+    datePublished: "2026-04-20",
+    dateModified: "2026-06-21",
     title: "Dove trovare fatture e ricevute di pagamento",
     metaTitle: "Dove trovare fatture e ricevute di pagamento",
     description:
@@ -137,6 +159,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "installare-app": {
     slug: "installare-app",
+    datePublished: "2026-04-16",
+    dateModified: "2026-06-21",
     title: "Installare ScontrinoZero come app sul dispositivo",
     metaTitle: "Come installare ScontrinoZero come app sul tuo dispositivo",
     description:
@@ -145,6 +169,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "intestazione-scontrino": {
     slug: "intestazione-scontrino",
+    datePublished: "2026-04-20",
+    dateModified: "2026-07-13",
     title: "Personalizzare intestazione e dati dello scontrino",
     metaTitle: "Personalizzare intestazione e dati dello scontrino",
     description:
@@ -153,6 +179,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "normativa-pos-2026": {
     slug: "normativa-pos-2026",
+    datePublished: "2026-04-17",
+    dateModified: "2026-06-21",
     title: "Collegamento POS-cassa 2026: cosa cambia",
     metaTitle: "Normativa POS 2026: obbligo, scadenze e sanzioni POS-cassa",
     description:
@@ -161,6 +189,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "numero-documento-azzeramento": {
     slug: "numero-documento-azzeramento",
+    datePublished: "2026-07-12",
+    dateModified: "2026-07-13",
     title: "Numero documento e azzeramento sullo scontrino",
     metaTitle: "Numero azzeramento e numero documento scontrino: cosa sono",
     description:
@@ -173,6 +203,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "piani-e-prezzi": {
     slug: "piani-e-prezzi",
+    datePublished: "2026-04-17",
+    dateModified: "2026-07-15",
     title: "Piani disponibili: Starter, Pro e self-hosted",
     metaTitle: "Piani disponibili: Starter, Pro e self-hosted gratuito",
     description:
@@ -181,6 +213,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "pos-rt-obbligo": {
     slug: "pos-rt-obbligo",
+    datePublished: "2026-04-20",
+    dateModified: "2026-06-21",
     title: "Collegamento POS-RT: obbligo e scadenze 2026",
     metaTitle: "Collegamento POS-RT: chi è obbligato e scadenze 2026",
     description:
@@ -189,6 +223,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "prima-configurazione": {
     slug: "prima-configurazione",
+    datePublished: "2026-04-16",
+    dateModified: "2026-07-15",
     title: "Prima configurazione passo-passo",
     metaTitle: "Prima configurazione passo-passo",
     description:
@@ -197,6 +233,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "presenta-un-amico": {
     slug: "presenta-un-amico",
+    datePublished: "2026-06-26",
+    dateModified: "2026-07-13",
     title: "Presenta un amico: come funziona il bonus referral",
     metaTitle:
       "Presenta un amico: bonus referral e quando arriva il mese gratis",
@@ -206,6 +244,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "primo-scontrino": {
     slug: "primo-scontrino",
+    datePublished: "2026-04-11",
+    dateModified: "2026-07-15",
     title: "Come emettere il primo scontrino elettronico",
     metaTitle: "Come emettere il primo scontrino elettronico",
     description:
@@ -218,6 +258,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "regime-forfettario": {
     slug: "regime-forfettario",
+    datePublished: "2026-04-11",
+    dateModified: "2026-07-12",
     title: "Regime forfettario: configurazione IVA corretta",
     metaTitle: "Codice IVA regime forfettario: N2 scontrino, N2.2 fattura",
     description:
@@ -226,6 +268,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "registrare-pos-portale-ade": {
     slug: "registrare-pos-portale-ade",
+    datePublished: "2026-05-21",
+    dateModified: "2026-06-21",
     title: "Registrare un POS nel portale Fatture e Corrispettivi",
     metaTitle: "Come registrare un POS nel portale Fatture e Corrispettivi",
     description:
@@ -234,6 +278,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "sicurezza-credenziali": {
     slug: "sicurezza-credenziali",
+    datePublished: "2026-04-16",
+    dateModified: "2026-07-15",
     title: "Sicurezza e privacy delle credenziali",
     metaTitle: "Sicurezza e privacy: come proteggiamo le tue credenziali",
     description:
@@ -242,6 +288,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "stampare-scontrino-termica": {
     slug: "stampare-scontrino-termica",
+    datePublished: "2026-05-21",
+    dateModified: "2026-07-13",
     title: "Stampare lo scontrino su carta termica",
     metaTitle: "Come stampare lo scontrino su carta termica",
     description:
@@ -254,6 +302,8 @@ export const helpArticles: Record<string, HelpArticle> = {
   },
   "storico-ed-esportazione": {
     slug: "storico-ed-esportazione",
+    datePublished: "2026-04-17",
+    dateModified: "2026-07-13",
     title: "Storico scontrini: filtri, ricerca ed esportazione",
     metaTitle: "Storico scontrini: filtri, ricerca ed esportazione",
     description:

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -28,7 +28,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "annullare-scontrino": {
     slug: "annullare-scontrino",
     datePublished: "2026-04-11",
-    dateModified: "2026-07-13",
+    dateModified: "2026-07-22",
     title: "Annullare uno scontrino: quando si può e come fare",
     metaTitle: "Annullare scontrino elettronico: come fare ed entro quando",
     description:
@@ -259,11 +259,13 @@ export const helpArticles: Record<string, HelpArticle> = {
   "regime-forfettario": {
     slug: "regime-forfettario",
     datePublished: "2026-04-11",
-    dateModified: "2026-07-12",
+    dateModified: "2026-07-22",
     title: "Regime forfettario: configurazione IVA corretta",
-    metaTitle: "Codice IVA regime forfettario: N2 scontrino, N2.2 fattura",
+    // Intent operativo in-app: le query informative su N2/N2.2 sono territorio
+    // della guida codici-natura-iva (regola slug separati /help vs /guide).
+    metaTitle: "Configurare l'IVA del regime forfettario in ScontrinoZero",
     description:
-      "Il codice IVA del regime forfettario è natura N2 sullo scontrino elettronico e N2.2 in fattura, con dicitura art. 1 commi 54-89 L. 190/2014: ecco come configurarlo in ScontrinoZero senza errori.",
+      "Come impostare la natura N2 negli scontrini del forfettario in ScontrinoZero: aliquota prevalente «0% – Non soggette», catalogo prodotti e correzione degli errori più comuni.",
     related: ["aliquote-iva", "primo-scontrino", "annullare-scontrino"],
   },
   "registrare-pos-portale-ade": {

--- a/src/lib/per/categories.test.ts
+++ b/src/lib/per/categories.test.ts
@@ -7,8 +7,8 @@ import {
 } from "./categories";
 
 describe("categorySlugs", () => {
-  it("contains exactly 12 slugs", () => {
-    expect(categorySlugs).toHaveLength(12);
+  it("contains exactly 17 slugs", () => {
+    expect(categorySlugs).toHaveLength(17);
   });
 
   it("contains the expected slugs", () => {
@@ -26,6 +26,11 @@ describe("categorySlugs", () => {
         "food-truck",
         "ncc-taxi",
         "tatuatori-piercer",
+        "ristoranti-bar-asporto",
+        "negozi",
+        "pasticcerie-gelaterie-panifici",
+        "fioristi",
+        "lavanderie",
       ]),
     );
   });
@@ -36,20 +41,7 @@ describe("categorySlugs", () => {
 });
 
 describe("categories dictionary", () => {
-  for (const slug of [
-    "ambulanti",
-    "parrucchieri-estetisti",
-    "artigiani",
-    "b-and-b",
-    "regime-forfettario",
-    "professionisti",
-    "officine-meccanici",
-    "eventi-mercatini-hobbisti",
-    "palestre-personal-trainer",
-    "food-truck",
-    "ncc-taxi",
-    "tatuatori-piercer",
-  ] as const) {
+  for (const slug of categorySlugs) {
     describe(slug, () => {
       const c = categories[slug];
 
@@ -115,6 +107,21 @@ describe("categories dictionary", () => {
       });
     });
   }
+});
+
+describe("ristoranti-bar-asporto (framing onesto sui limiti)", () => {
+  const c = categories["ristoranti-bar-asporto"];
+
+  it("states the high-throughput limit honestly instead of overpromising", () => {
+    const allText = [c.useCase, ...c.faq.map((f) => f.answer)].join(" ");
+    // La pagina deve dichiarare che il DCO non è adatto ai banconi ad alto
+    // flusso e targettizzare chioschi/stagionali/asporto (decisione utente).
+    expect(allText.toLowerCase()).toMatch(/non è (adatt|pensat)/);
+  });
+
+  it("targets the low-volume segment in the audience", () => {
+    expect(c.audience.toLowerCase()).toMatch(/chiosch|stagional|asporto/);
+  });
 });
 
 describe("getCategory", () => {

--- a/src/lib/per/categories.test.ts
+++ b/src/lib/per/categories.test.ts
@@ -7,8 +7,8 @@ import {
 } from "./categories";
 
 describe("categorySlugs", () => {
-  it("contains exactly 17 slugs", () => {
-    expect(categorySlugs).toHaveLength(17);
+  it("contains exactly 21 slugs", () => {
+    expect(categorySlugs).toHaveLength(21);
   });
 
   it("contains the expected slugs", () => {
@@ -31,6 +31,10 @@ describe("categorySlugs", () => {
         "pasticcerie-gelaterie-panifici",
         "fioristi",
         "lavanderie",
+        "agriturismi-cantine",
+        "fotografi",
+        "toelettatura",
+        "noleggio",
       ]),
     );
   });

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -29,7 +29,12 @@ export type CategorySlug =
   | "palestre-personal-trainer"
   | "food-truck"
   | "ncc-taxi"
-  | "tatuatori-piercer";
+  | "tatuatori-piercer"
+  | "ristoranti-bar-asporto"
+  | "negozi"
+  | "pasticcerie-gelaterie-panifici"
+  | "fioristi"
+  | "lavanderie";
 
 export const categorySlugs: readonly CategorySlug[] = [
   "ambulanti",
@@ -44,6 +49,11 @@ export const categorySlugs: readonly CategorySlug[] = [
   "food-truck",
   "ncc-taxi",
   "tatuatori-piercer",
+  "ristoranti-bar-asporto",
+  "negozi",
+  "pasticcerie-gelaterie-panifici",
+  "fioristi",
+  "lavanderie",
 ];
 
 export const categories: Record<CategorySlug, CategoryContent> = {
@@ -582,6 +592,228 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "primo-scontrino",
       "annullare-scontrino",
       "regime-forfettario",
+    ],
+  },
+  "ristoranti-bar-asporto": {
+    slug: "ristoranti-bar-asporto",
+    title: "Scontrino elettronico per chioschi, asporto e bar stagionali",
+    metaTitle: "Scontrino elettronico per chioschi, asporto e bar stagionali",
+    metaDescription:
+      "Chiosco, asporto, bar stagionale: emetti scontrini elettronici dallo smartphone senza registratore telematico. Da €2,50/mese, prova 30 giorni gratis.",
+    heroSubtitle:
+      "Per chioschi, asporto, delivery e attività stagionali della ristorazione: scontrini dallo smartphone, senza registratore sul bancone.",
+    audience:
+      "chioschi, bar e attività di ristorazione stagionali, asporto e delivery, piccole somministrazioni a basso volume",
+    useCase:
+      "Siamo onesti: se hai un bar o un ristorante con fila alla cassa e decine di battute l'ora, il registratore telematico fisico resta più ergonomico — l'emissione del Documento Commerciale Online richiede qualche secondo per scontrino e non è pensata per il bancone ad alto flusso. ScontrinoZero è invece la scelta giusta per il segmento a basso volume della ristorazione: il chiosco estivo, il bar stagionale, l'asporto e il delivery, il food service a eventi. Lì elimini l'hardware (400-800 € più canoni) e fai tutto dallo smartphone.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni vendita o somministrazione B2C (art. 22 DPR 633/72).",
+      "Aliquota IVA corretta: 10% per la somministrazione di alimenti e bevande, 22% per alcune vendite accessorie.",
+      "Trasmissione telematica dei corrispettivi all'Agenzia delle Entrate entro 12 giorni dall'operazione.",
+      "Dal 2026, registrazione del POS collegato ai corrispettivi (L. 207/2024).",
+    ],
+    benefits: [
+      "Perfetto per l'attività stagionale: paghi il periodo in cui lavori, senza ammortizzare un registratore.",
+      "Asporto e delivery: emetti lo scontrino al momento dell'ordine e lo invii via link o WhatsApp col sacchetto.",
+      "Zero hardware sul chiosco: basta lo smartphone, anche con sola connessione 4G.",
+      "Storico digitale di tutte le vendite, consultabile dal commercialista.",
+    ],
+    faq: [
+      {
+        question: "È adatto a un bar con molti scontrini l'ora?",
+        answer:
+          "No, non è pensato per quello: con un flusso continuo alla cassa il registratore telematico fisico resta la soluzione più ergonomica, perché il DCO richiede qualche secondo per emissione. ScontrinoZero dà il meglio su chioschi, stagionali, asporto e volumi bassi o medi.",
+      },
+      {
+        question: "Che aliquota IVA uso per l'asporto?",
+        answer:
+          "La cessione di alimenti e bevande da asporto sconta in generale l'IVA del 10% (somministrazione); alcuni prodotti confezionati seguono l'aliquota propria del bene. In ScontrinoZero configuri le aliquote per prodotto nel catalogo e le richiami in due tap.",
+      },
+      {
+        question: "Posso usarlo solo per la stagione estiva?",
+        answer:
+          "Sì: il piano mensile (da €4,99/mese) si attiva e disattiva quando vuoi, senza penali. Alla disattivazione l'account passa in sola lettura e lo storico resta consultabile — utile per la dichiarazione dei redditi.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "aliquote-iva", "installare-app"],
+  },
+  negozi: {
+    slug: "negozi",
+    title: "Scontrino elettronico per piccoli negozi al dettaglio",
+    metaTitle:
+      "Scontrino elettronico per negozi al dettaglio senza registratore",
+    metaDescription:
+      "Piccolo negozio, atelier o showroom: emetti scontrini elettronici senza registratore telematico, da smartphone o tablet. Da €2,50/mese, prova gratis.",
+    heroSubtitle:
+      "Per il piccolo dettaglio — abbigliamento, artigianato, showroom — dove ogni vendita conta ma le battute al giorno sono poche.",
+    audience:
+      "piccoli negozi di abbigliamento e accessori, atelier, boutique, showroom, negozi con vendite poco frequenti ma di valore",
+    useCase:
+      "In un piccolo negozio di abbigliamento, un atelier o uno showroom si fanno poche vendite al giorno, spesso di importo alto: tenere un registratore telematico per 5-10 scontrini quotidiani significa hardware sul banco, canoni di verifica e un costo fisso sproporzionato. Con ScontrinoZero emetti il Documento Commerciale Online dal tablet o dallo smartphone, con il catalogo dei tuoi articoli configurato, e trasmetti automaticamente i corrispettivi. Se il cliente vuole la carta, stampi su una termica Bluetooth; altrimenti invii lo scontrino via email o QR.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni vendita B2C (art. 22 DPR 633/72).",
+      "Applicazione dell'aliquota IVA propria dei beni venduti (22% per abbigliamento e accessori).",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+      "Gestione di resi e cambi merce con annullo o documento di reso.",
+    ],
+    benefits: [
+      "Niente registratore sul banco: il negozio resta pulito, la vendita si chiude dal tablet.",
+      "Catalogo articoli con prezzi e aliquote: scontrino in due tap anche con più capi.",
+      "Resi e annulli gestiti dallo storico, con tracciabilità completa verso AdE.",
+      "Scontrino digitale via email o QR: comodo per chi spedisce o consegna a domicilio.",
+    ],
+    faq: [
+      {
+        question: "Come gestisco un reso o un cambio merce?",
+        answer:
+          "Per un errore o un ripensamento immediato annulli lo scontrino dallo storico e, se serve, ne emetti uno corretto. Per il cambio con differenza di prezzo emetti un nuovo scontrino per la differenza. La catena resta tracciata verso l'Agenzia delle Entrate.",
+      },
+      {
+        question: "Posso emettere fattura se il cliente la chiede?",
+        answer:
+          "La fattura B2B/B2C su richiesta si emette con un software di fatturazione elettronica via SDI, non con il documento commerciale: sono adempimenti diversi. ScontrinoZero copre gli scontrini; molti negozi lo affiancano a un gestionale di fatturazione per le (rare) fatture.",
+      },
+      {
+        question: "Il cliente può avere lo scontrino per la garanzia?",
+        answer:
+          "Sì: il documento commerciale vale come prova d'acquisto ai fini della garanzia legale di 26 mesi. Puoi stamparlo su termica o inviarlo via email/QR: la copia digitale ha lo stesso valore di quella cartacea.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "annullare-scontrino", "aliquote-iva"],
+  },
+  "pasticcerie-gelaterie-panifici": {
+    slug: "pasticcerie-gelaterie-panifici",
+    title: "Scontrino elettronico per pasticcerie, gelaterie e panifici",
+    metaTitle: "Scontrino elettronico per pasticcerie, gelaterie e panifici",
+    metaDescription:
+      "Pasticceria, gelateria o panificio a conduzione familiare: scontrini elettronici senza registratore telematico, dallo smartphone. Da €2,50/mese, prova gratis.",
+    heroSubtitle:
+      "Per il laboratorio con vendita diretta: banco ordinato, scontrini dallo smartphone e aliquote alimentari già configurate nel catalogo.",
+    audience:
+      "pasticcerie, gelaterie, panifici e laboratori artigianali con vendita al banco a volumi bassi o medi, banchi a mercati ed eventi",
+    useCase:
+      "Nel laboratorio artigianale con vendita diretta — la pasticceria su ordinazione, il panificio di paese, la gelateria stagionale — il flusso alla cassa è gestibile e il registratore telematico è spesso un costo sproporzionato. Con ScontrinoZero configuri il catalogo con le aliquote alimentari corrette (4% sul pane comune, 10% su pasticceria e gelato) ed emetti il Documento Commerciale Online in pochi secondi, anche al banco del mercato o alla fiera con il solo smartphone. Se il tuo banco ha coda continua tutto il giorno, valuta onestamente un registratore fisico.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni vendita B2C (art. 22 DPR 633/72).",
+      "Aliquote IVA alimentari corrette per riga: 4% per pane e prodotti da forno di base, 10% per pasticceria, gelato e altri alimenti.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+      "Tracciabilità e conservazione dei documenti per 10 anni.",
+    ],
+    benefits: [
+      "Catalogo con aliquote per prodotto: il 4% e il 10% escono giusti senza pensarci a ogni battuta.",
+      "Righe multiple con aliquote diverse nello stesso scontrino (pane + torta + bibita).",
+      "Al mercato o alla fiera emetti dallo smartphone come al banco.",
+      "Per le torte su ordinazione: scontrino al ritiro, inviato anche via WhatsApp.",
+    ],
+    faq: [
+      {
+        question: "Che aliquota IVA metto su pane, dolci e gelato?",
+        answer:
+          "Il pane comune e i prodotti da forno di base scontano il 4%; pasticceria fresca, gelato e la maggior parte degli alimenti trasformati il 10%; alcune bevande e prodotti accessori il 22%. Nel catalogo di ScontrinoZero assegni l'aliquota a ogni prodotto una volta sola.",
+      },
+      {
+        question:
+          "Posso emettere un solo scontrino con prodotti ad aliquote diverse?",
+        answer:
+          "Sì: ogni riga dello scontrino porta la sua aliquota (es. pane al 4% e torta al 10% nello stesso documento) e la trasmissione all'AdE riporta il dettaglio corretto per aliquota.",
+      },
+      {
+        question: "Va bene per il banco della gelateria in alta stagione?",
+        answer:
+          "Dipende dal flusso: per una gelateria con coda continua il registratore fisico resta più rapido, perché il DCO richiede qualche secondo per emissione. Per la stagionale con volumi moderati, il piano mensile senza hardware è spesso la scelta più economica.",
+      },
+    ],
+    relatedHelp: ["aliquote-iva", "primo-scontrino", "installare-app"],
+  },
+  fioristi: {
+    slug: "fioristi",
+    title: "Scontrino elettronico per fioristi e garden",
+    metaTitle: "Scontrino elettronico per fioristi senza registratore di cassa",
+    metaDescription:
+      "Fioreria o banco fiori: emetti scontrini elettronici dallo smartphone, anche a domicilio o al mercato, senza registratore telematico. Da €2,50/mese.",
+    heroSubtitle:
+      "Dal negozio al banco del mercato alle consegne a domicilio: lo scontrino ti segue, non il registratore.",
+    audience:
+      "fioristi, fiorerie, banchi fiori ai mercati, piccoli garden e vivai con vendita al dettaglio",
+    useCase:
+      "Il lavoro del fiorista non sta solo dietro al banco: c'è il mercato del sabato, la consegna a domicilio, l'allestimento per la cerimonia. Con ScontrinoZero emetti il Documento Commerciale Online dove ti trovi, dallo smartphone: al negozio, al banco o alla consegna. Le aliquote dei fiori (10% sui fiori recisi e piante ornamentali, 22% su vasi e accessori) stanno nel catalogo, e per gli ordini telefonici lo scontrino parte via email o WhatsApp insieme alla conferma.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni vendita B2C (art. 22 DPR 633/72).",
+      "Aliquote IVA corrette per riga: 10% per fiori recisi e piante, 22% per vasi, accessori e articoli regalo.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+      "Per gli allestimenti fatturati a imprese (B2B): fattura elettronica via SDI, non scontrino.",
+    ],
+    benefits: [
+      "Scontrino a domicilio: lo emetti alla consegna del mazzo, senza tornare in negozio.",
+      "Righe con aliquote miste (fiori al 10% + vaso al 22%) nello stesso documento.",
+      "Al mercato basta lo smartphone: niente registratore da alimentare sul banco.",
+      "Per ordini telefonici o via social, scontrino digitale via link insieme alla conferma.",
+    ],
+    faq: [
+      {
+        question: "Che aliquota IVA applico ai fiori?",
+        answer:
+          "I fiori recisi e le piante ornamentali scontano in generale l'IVA al 10%; vasi, accessori e articoli regalo il 22%. In ScontrinoZero assegni l'aliquota a ogni voce del catalogo e il documento esce con il dettaglio corretto per riga.",
+      },
+      {
+        question:
+          "Per un matrimonio o un allestimento aziendale serve lo scontrino?",
+        answer:
+          "Se il cliente è un privato puoi emettere il documento commerciale; se è un'azienda o chiede fattura, si emette fattura elettronica via SDI con un software di fatturazione — lo scontrino non la sostituisce. Molti fioristi usano entrambi gli strumenti.",
+      },
+      {
+        question: "Posso emettere lo scontrino alla consegna a domicilio?",
+        answer:
+          "Sì, è il caso d'uso ideale: emetti dallo smartphone al momento dell'incasso e invii la copia digitale via email o WhatsApp. Serve solo la connessione dati del telefono.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "aliquote-iva", "installare-app"],
+  },
+  lavanderie: {
+    slug: "lavanderie",
+    title: "Scontrino elettronico per lavanderie e sartorie",
+    metaTitle: "Scontrino elettronico per lavanderie e sartorie senza cassa",
+    metaDescription:
+      "Lavanderia artigiana o sartoria: scontrini elettronici senza registratore telematico, con catalogo dei servizi e ritiro/consegna. Da €2,50/mese, prova gratis.",
+    heroSubtitle:
+      "Per lavanderie artigiane e sartorie: catalogo servizi, scontrino al ritiro e banco libero dal registratore.",
+    audience:
+      "lavanderie artigiane, stirerie, sartorie e servizi di riparazione capi con clientela privata",
+    useCase:
+      "Nella lavanderia artigiana o nella sartoria il flusso di cassa è fatto di tanti piccoli incassi al ritiro dei capi. Con ScontrinoZero configuri il listino dei servizi (lavaggio, stiratura, riparazioni) nel catalogo ed emetti il Documento Commerciale Online in due tap quando il cliente ritira. Niente registratore telematico da comprare e revisionare: bastano lo smartphone o un tablet al banco, e la stampante termica Bluetooth se il cliente vuole la copia cartacea.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni servizio B2C incassato (art. 22 DPR 633/72).",
+      "Applicazione dell'aliquota IVA al 22% sui servizi di lavanderia e sartoria.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+      "Conservazione dei documenti emessi per 10 anni.",
+    ],
+    benefits: [
+      "Listino servizi nel catalogo: lavaggio camicia, piumone, orlo — scontrino in due tap.",
+      "Incassi misti (contanti + carta) gestiti nello stesso documento.",
+      "Scontrino al momento del ritiro, anche con acconto alla consegna dei capi.",
+      "Storico digitale per il commercialista, senza rotoli da archiviare.",
+    ],
+    faq: [
+      {
+        question: "Quando emetto lo scontrino: alla consegna o al ritiro?",
+        answer:
+          "Al momento del pagamento. Se il cliente paga al ritiro dei capi, emetti allora; se lascia un acconto alla consegna, certifichi l'acconto quando lo incassi e il saldo al ritiro. Il documento commerciale segue sempre l'incasso.",
+      },
+      {
+        question: "Che aliquota IVA hanno i servizi di lavanderia?",
+        answer:
+          "I servizi di lavanderia, stireria e sartoria scontano l'IVA ordinaria al 22%. Configuri l'aliquota una volta sola nel catalogo servizi e ogni scontrino esce corretto.",
+      },
+      {
+        question: "Serve la stampante o basta lo scontrino digitale?",
+        answer:
+          "Il documento commerciale digitale (email, SMS o QR) ha pieno valore fiscale: la stampa non è obbligatoria. Molte lavanderie tengono comunque una termica Bluetooth per i clienti che preferiscono la carta.",
+      },
+    ],
+    relatedHelp: [
+      "primo-scontrino",
+      "stampare-scontrino-termica",
+      "aliquote-iva",
     ],
   },
 };

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -34,7 +34,11 @@ export type CategorySlug =
   | "negozi"
   | "pasticcerie-gelaterie-panifici"
   | "fioristi"
-  | "lavanderie";
+  | "lavanderie"
+  | "agriturismi-cantine"
+  | "fotografi"
+  | "toelettatura"
+  | "noleggio";
 
 export const categorySlugs: readonly CategorySlug[] = [
   "ambulanti",
@@ -54,6 +58,10 @@ export const categorySlugs: readonly CategorySlug[] = [
   "pasticcerie-gelaterie-panifici",
   "fioristi",
   "lavanderie",
+  "agriturismi-cantine",
+  "fotografi",
+  "toelettatura",
+  "noleggio",
 ];
 
 export const categories: Record<CategorySlug, CategoryContent> = {
@@ -815,6 +823,180 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "stampare-scontrino-termica",
       "aliquote-iva",
     ],
+  },
+  "agriturismi-cantine": {
+    slug: "agriturismi-cantine",
+    title: "Scontrino elettronico per agriturismi e cantine",
+    metaTitle: "Scontrino elettronico per agriturismi e cantine senza cassa",
+    metaDescription:
+      "Degustazioni, vendita diretta e ospitalità in agriturismo o cantina: scontrini elettronici dallo smartphone, senza registratore. Da €2,50/mese, prova gratis.",
+    heroSubtitle:
+      "Dalla sala degustazione al punto vendita in vigna: lo scontrino esce dallo smartphone, anche dove il registratore non arriverebbe.",
+    audience:
+      "agriturismi, cantine con vendita diretta e degustazioni, aziende agricole con spaccio, frantoi e apicoltori con vendita al pubblico",
+    useCase:
+      "In un agriturismo o in una cantina la vendita non avviene a un banco fisso: la degustazione si chiude in sala, la cassetta di prodotti si vende in cortile, il pernottamento si salda alla partenza. Con ScontrinoZero emetti il Documento Commerciale Online dove sei, dallo smartphone, e trasmetti automaticamente i corrispettivi. Il catalogo tiene le aliquote giuste per ogni prodotto (vino al 22%, olio e miele al 4-10%) e per i servizi di ospitalità e ristorazione al 10%.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni vendita o servizio B2C incassato (art. 22 DPR 633/72).",
+      "Aliquote IVA corrette per riga: 22% sul vino, 4-10% su olio, miele e conserve, 10% su alloggio e somministrazione.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+      "Per i produttori agricoli in regime speciale (art. 34 DPR 633/72), verifica col commercialista il corretto inquadramento delle vendite.",
+    ],
+    benefits: [
+      "Funziona in vigna e in campagna: basta la connessione 4G dello smartphone.",
+      "Aliquote miste nello stesso scontrino (vino 22% + olio 4% + degustazione 10%).",
+      "Scontrino digitale via email al turista straniero, senza stampante.",
+      "Storico digitale a disposizione del commercialista per la contabilità.",
+    ],
+    faq: [
+      {
+        question: "Che aliquote IVA uso per vino, olio e degustazioni?",
+        answer:
+          "Il vino sconta il 22%, l'olio d'oliva il 4%, il miele il 10%, le conserve in genere il 10%; la degustazione con somministrazione segue il 10% della ristorazione. Nel catalogo assegni l'aliquota a ogni voce una volta sola e lo scontrino esce con il dettaglio corretto per riga.",
+      },
+      {
+        question: "Per il pernottamento serve scontrino o ricevuta?",
+        answer:
+          "Al cliente privato puoi emettere il documento commerciale al saldo; se l'ospite chiede fattura (es. trasferta di lavoro), quella si emette via SDI con un software di fatturazione. Con ScontrinoZero gestisci gli scontrini; la fattura resta un flusso separato.",
+      },
+      {
+        question: "Il regime speciale agricolo cambia qualcosa?",
+        answer:
+          "Il regime speciale IVA agricolo (art. 34 DPR 633/72) riguarda la detrazione, non l'obbligo di certificare i corrispettivi: le vendite al dettaglio a privati vanno comunque documentate. L'inquadramento corretto delle singole attività (agricola, connessa, commerciale) va verificato col commercialista.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "aliquote-iva", "installare-app"],
+  },
+  fotografi: {
+    slug: "fotografi",
+    title: "Scontrino elettronico per fotografi",
+    metaTitle:
+      "Scontrino elettronico per fotografi senza registratore di cassa",
+    metaDescription:
+      "Servizi fotografici, stampe ed eventi: emetti lo scontrino elettronico dallo smartphone al momento dell'incasso, senza registratore. Da €2,50/mese.",
+    heroSubtitle:
+      "Dallo studio al matrimonio al mini-shooting in piazza: lo scontrino segue te e la macchina fotografica, non un registratore.",
+    audience:
+      "fotografi con clientela privata: ritratti, cerimonie, eventi, stampe e album, mini-shooting stagionali",
+    useCase:
+      "Il fotografo incassa quasi sempre fuori da un negozio: l'acconto alla prenotazione del servizio, il saldo alla consegna dell'album, il mini-shooting a tema pagato sul posto. Con ScontrinoZero emetti il Documento Commerciale Online dallo smartphone al momento dell'incasso, ovunque sia, e lo invii al cliente via email o WhatsApp insieme alle foto. Per i lavori fatturati ad aziende (eventi corporate, shooting commerciali) resta la fattura elettronica: i due flussi convivono.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni incasso da cliente privato (art. 22 DPR 633/72).",
+      "Certificazione di acconti e saldi al momento dell'incasso, non alla consegna.",
+      "Aliquota IVA al 22% su servizi fotografici, stampe e album.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+    ],
+    benefits: [
+      "Acconto e saldo certificati sul momento, anche a domicilio o in location.",
+      "Scontrino digitale via email o WhatsApp insieme alla consegna delle foto.",
+      "Catalogo con i tuoi pacchetti (servizio, stampa, album) per emettere in due tap.",
+      "Per il forfettario: natura N2 preimpostata, scontrini senza IVA.",
+    ],
+    faq: [
+      {
+        question: "Devo emettere scontrino per l'acconto del matrimonio?",
+        answer:
+          "Sì: ogni incasso da cliente privato va certificato al momento in cui lo ricevi, acconto compreso. Emetti un documento commerciale per l'acconto e uno per il saldo; se il cliente preferisce la fattura, va emessa via SDI con un software di fatturazione.",
+      },
+      {
+        question: "Sono fotografo in regime forfettario: cambia qualcosa?",
+        answer:
+          "Solo l'IVA: gli scontrini escono con natura N2 (operazioni non soggette) e senza imposta. L'obbligo di certificare gli incassi da privati resta identico. In ScontrinoZero imposti l'aliquota prevalente su «0% – Non soggette» una volta sola.",
+      },
+      {
+        question: "Come consegno lo scontrino al cliente?",
+        answer:
+          "Via email, SMS, WhatsApp o QR code: il documento digitale ha pieno valore fiscale. È il canale naturale per chi già consegna le foto online; la stampa termica resta possibile ma raramente serve.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "regime-forfettario", "installare-app"],
+  },
+  toelettatura: {
+    slug: "toelettatura",
+    title: "Scontrino elettronico per toelettature e pet service",
+    metaTitle:
+      "Scontrino elettronico per toelettatura cani e gatti senza cassa",
+    metaDescription:
+      "Toelettatura, pet sitting e servizi per animali: scontrini elettronici senza registratore, con listino servizi nel catalogo. Da €2,50/mese, prova gratis.",
+    heroSubtitle:
+      "Per toelettature e pet service: listino nel catalogo, scontrino in due tap a fine seduta, banco libero dal registratore.",
+    audience:
+      "toelettature per cani e gatti, pet sitter e dog sitter con incassi da privati, servizi di pet care a domicilio",
+    useCase:
+      "Nella toelettatura la giornata è fatta di appuntamenti: bagno e tosatura, ritiro a fine seduta, incasso singolo per cliente. Con ScontrinoZero configuri il listino dei servizi (bagno taglia piccola, tosatura completa, unghie) nel catalogo ed emetti il Documento Commerciale Online in due tap al ritiro dell'animale, dallo smartphone o dal tablet. Chi lavora a domicilio emette direttamente dal telefono a fine servizio. Il registratore telematico, per pochi incassi al giorno, è un costo che puoi evitare.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni servizio B2C incassato (art. 22 DPR 633/72).",
+      "Aliquota IVA al 22% sui servizi di toelettatura e sulla vendita di prodotti per animali.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+      "Conservazione dei documenti emessi per 10 anni.",
+    ],
+    benefits: [
+      "Listino servizi per taglia e trattamento: scontrino pronto in due tap.",
+      "Servizio + prodotto (shampoo, antiparassitario) nello stesso documento.",
+      "A domicilio emetti dallo smartphone a fine servizio, senza attrezzatura.",
+      "Storico incassi per appuntamento, comodo per la contabilità di fine mese.",
+    ],
+    faq: [
+      {
+        question: "Serve il registratore di cassa per aprire una toelettatura?",
+        answer:
+          "No: serve certificare i corrispettivi, e puoi farlo con il Documento Commerciale Online senza hardware. Per un'attività su appuntamento con qualche decina di incassi a settimana è in genere la soluzione più economica: zero acquisto, zero verificazioni.",
+      },
+      {
+        question: "Posso vendere prodotti insieme al servizio?",
+        answer:
+          "Sì, nello stesso scontrino: righe separate per il servizio di toelettatura e per i prodotti venduti, ciascuna con la propria aliquota (in genere 22% per entrambi). Il documento trasmesso all'AdE riporta il dettaglio per riga.",
+      },
+      {
+        question: "Faccio anche pet sitting a domicilio: come mi regolo?",
+        answer:
+          "Uguale: ogni incasso da cliente privato va certificato al momento. Emetti il documento commerciale dallo smartphone a fine servizio e lo invii via WhatsApp o email al proprietario. Se sei in regime forfettario, gli scontrini escono con natura N2 senza IVA.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "aliquote-iva", "regime-forfettario"],
+  },
+  noleggio: {
+    slug: "noleggio",
+    title: "Scontrino elettronico per noleggio bici, attrezzature e sport",
+    metaTitle: "Scontrino elettronico per attività di noleggio senza cassa",
+    metaDescription:
+      "Noleggio bici, sup, sci o attrezzature: scontrini elettronici dallo smartphone, perfetti per attività stagionali. Da €2,50/mese, prova 30 giorni gratis.",
+    heroSubtitle:
+      "Per il noleggio stagionale — bici, sup, sci, attrezzature — dove la cassa deve stare in un marsupio, non su un banco.",
+    audience:
+      "noleggi di bici ed e-bike, sup e attrezzature da spiaggia, sci e ciaspole, attrezzature per eventi e giardinaggio, attività stagionali",
+    useCase:
+      "Il noleggio è spesso un'attività stagionale e all'aperto: il banco è un gazebo in spiaggia, un container alla pista o un furgone all'evento. Con ScontrinoZero emetti il Documento Commerciale Online dallo smartphone al momento dell'incasso — tariffa oraria, mezza giornata, giornata intera nel catalogo — e trasmetti automaticamente i corrispettivi. Il piano mensile si attiva per la stagione e si sospende quando chiudi, e la cauzione non incassata non va certificata: solo il corrispettivo del noleggio.",
+    obligations: [
+      "Emissione del Documento Commerciale Online per ogni noleggio B2C incassato (art. 22 DPR 633/72).",
+      "Aliquota IVA al 22% sui corrispettivi di noleggio di beni mobili.",
+      "La cauzione restituibile non è un corrispettivo: si certifica solo l'importo del noleggio effettivamente incassato.",
+      "Trasmissione telematica dei corrispettivi entro 12 giorni dall'operazione.",
+    ],
+    benefits: [
+      "Tariffe orarie e giornaliere nel catalogo: scontrino in due tap al ritiro.",
+      "Attività stagionale: piano mensile attivabile solo nei mesi di apertura.",
+      "Scontrino via QR o WhatsApp al turista, anche straniero, senza stampante.",
+      "Storico incassi per giornata, utile per capire le punte di stagione.",
+    ],
+    faq: [
+      {
+        question: "La cauzione va nello scontrino?",
+        answer:
+          "No, se è una cauzione restituibile: non è un corrispettivo ma una garanzia, e va gestita a parte (contante trattenuto o pre-autorizzazione carta). Nello scontrino certifichi solo l'importo del noleggio. Se tratterrai la cauzione per un danno, quella somma andrà documentata al momento dell'incasso definitivo.",
+      },
+      {
+        question: "Apro solo 4 mesi l'anno: conviene comunque?",
+        answer:
+          "È il caso ideale: attivi il piano mensile (da €4,99/mese) per i mesi di apertura e lo sospendi a fine stagione, senza ammortizzare un registratore che resta fermo 8 mesi. Alla riapertura ritrovi catalogo e storico.",
+      },
+      {
+        question: "Il turista straniero può ricevere lo scontrino?",
+        answer:
+          "Sì: gli invii il documento via QR code, email o WhatsApp al momento del noleggio. Il documento commerciale è valido a prescindere dalla nazionalità del cliente; per il noleggio B2C a consumatori UE si applica l'IVA italiana del 22%.",
+      },
+    ],
+    relatedHelp: ["primo-scontrino", "cambio-piano", "installare-app"],
   },
 };
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -414,8 +414,10 @@ describe("proxy", () => {
     // app.scontrinozero.it perché assenti da MARKETING_ONLY_ROUTES.
     const MARKETING_CONTENT_ROUTES = [
       "/confronto",
+      "/feed.xml",
       "/funzionalita",
       "/guide",
+      "/llms-full.txt",
       "/llms.txt",
       "/per",
       "/prezzi",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -38,9 +38,11 @@ function pathNeedsAuthSession(pathname: string): boolean {
 const MARKETING_ONLY_ROUTES = [
   "/confronto",
   "/cookie-policy",
+  "/feed.xml",
   "/funzionalita",
   "/guide",
   "/help",
+  "/llms-full.txt",
   "/llms.txt",
   "/per",
   "/prezzi",


### PR DESCRIPTION
## Summary

Expands editorial content with 6 new guide articles (credential recovery, cassetto fiscale, 2026 obligations, pricing, sanctions, registratore comparison), 9 new category landing pages for vertical markets (restaurants, shops, bakeries, florists, laundries, agritourism, photographers, grooming, rentals), and introduces two new SEO distribution channels: RSS 2.0 feed (`/feed.xml`) and full-text markdown for AI crawlers (`/llms-full.txt`).

## Key Changes

**Guide Articles (6 new)**
- Added slugs to `guideSlugs` array and updated test expectations (12 → 18)
- Fixed `updatedAt` format from `YYYY-MM` to full `YYYY-MM-DD` across all existing guides (per comment: "mai troncarla al mese")
- Added per-article comments documenting `publishedAt` and `updatedAt` semantics
- Updated guide content: meta titles, descriptions, hero intros, FAQ entries, and section bodies for improved SEO and accuracy
  - `scontrino-senza-registratore-di-cassa`: refined meta title/description, added 3 new FAQ items on IVA handling
  - `pos-registratore-telematico`: corrected sanction percentage (90% → 70%, citing D.Lgs. 87/2024)
  - `scontrino-regime-forfettario`: improved hero intro clarity, added 3 new FAQ items on IVA and error recovery
  - `annullare-scontrino`: expanded hero intro, added 3 new FAQ items on timing and retroactive annulments

**Category Pages (9 new)**
- Added 9 new category slugs to `categorySlugs` and updated test (12 → 21)
- Populated `categories` registry with full content for each vertical: title, meta, hero subtitle, audience, use case, obligations, benefits, FAQ
- Categories: ristoranti-bar-asporto, negozi, pasticcerie-gelaterie-panifici, fioristi, lavanderie, agriturismi-cantine, fotografi, toelettatura, noleggio

**Help Articles (per-article dates)**
- Replaced global `HELP_REVIEWED_DATE` constant with per-article `datePublished` and `dateModified` fields
- Updated all help article entries with explicit dates (e.g., "aliquote-iva": published 2026-04-17, modified 2026-07-13)
- Updated test to validate `dateModified >= datePublished` and full `YYYY-MM-DD` format

**SEO Feeds**
- Added `/feed.xml` route: RSS 2.0 feed of all guide articles, sorted by `publishedAt` descending, with RFC 822 dates
- Added `/llms-full.txt` route: full-text markdown dump of guides, categories, tools, and comparisons for AI crawler indexing
- Both routes serve only on production marketing apex (via `isIndexableHost()` check)
- Added comprehensive tests for both routes

**Sitemap & Indexing**
- Updated `sitemap.ts` to use per-article `updatedAt` dates (guides) and `dateModified` (help) instead of `new Date()`
- Introduced `STATIC_PAGES_UPDATED` and `LEGAL_PAGES_UPDATED` hand-maintained dates for non-registry pages
- Added `maxIsoDate()` helper to compute freshness from registry dates
- Updated sitemap test expectations (71 → 84 entries) and refactored legal page assertions to use URL lookup instead of hardcoded indices
- Updated `proxy.ts` and `proxy.test.ts` to route `/feed.xml` and `/llms-full.txt` to marketing only

**Metadata & Structured Data**
- Added `webSiteJsonLd` export to `json-ld.tsx` (no SearchAction, as sitelinks searchbox is deprecated)
- Updated `layout.tsx` to include WebSite JSON-LD and RSS autodiscov

https://claude.ai/code/session_01RECZwfoFY7GtnuNipXZVUp