### PR TITLE
Bump version to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scontrinozero",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scontrinozero",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@marsidev/react-turnstile": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scontrinozero",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary
Patch release bumping the version from 1.5.1 to 1.5.2 in `package.json`.

## Changes
- Updated `package.json` version field from `1.5.1` to `1.5.2`

## Notes
This is a patch version bump. The lockfile has been automatically updated with transitive dependency resolution.

https://claude.ai/code/session_01Pxu2P5ahjd4XeZzjxy1j3C