### PR TITLE
API v1: map NOT_FOUND error code to 404 HTTP status

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -124,13 +124,14 @@ con Stripe standard (no Metered Billing). Raggiunto il limite: `429` con invito 
 Autenticazione: `Authorization: Bearer szk_live_XXXX` (business key)
 Base URL: `https://api.scontrinozero.it/v1` (stesso container, Cloudflare Tunnel hostname separato)
 
-| Metodo | Path                     | Descrizione                         |
-| ------ | ------------------------ | ----------------------------------- |
-| `POST` | `/v1/receipts`           | Emetti scontrino (SALE)             |
-| `POST` | `/v1/receipts/{id}/void` | Annulla scontrino                   |
-| `GET`  | `/v1/receipts/{id}`      | Stato scontrino / idempotency check |
+| Metodo | Path                     | Descrizione                                                               |
+| ------ | ------------------------ | ------------------------------------------------------------------------- |
+| `POST` | `/v1/receipts`           | Emetti scontrino (SALE)                                                   |
+| `GET`  | `/v1/receipts`           | Lista paginata per intervallo di date (`from`/`to`/`page`/`limit`/`kind`) |
+| `POST` | `/v1/receipts/{id}/void` | Annulla scontrino                                                         |
+| `GET`  | `/v1/receipts/{id}`      | Stato/dettaglio scontrino / idempotency check                             |
 
-Post-MVP: `GET /v1/receipts` (lista paginata), `GET /v1/receipts/{id}/pdf`
+Post-MVP: `GET /v1/receipts/{id}/pdf`
 
 **Esempio richiesta:**
 
@@ -200,19 +201,40 @@ curl https://api.scontrinozero.it/v1/receipts/550e8400-e29b-41d4-a716-4466554400
 > `lotteryCode` è `null` se non fornito o se il metodo di pagamento è `"PC"` (contanti).
 > `quantity` e `grossUnitPrice` sono stringhe con precisione fissa (3 e 2 decimali rispettivamente).
 
+**Risposta annullo (200) — `POST /v1/receipts/{id}/void`:**
+
+```json
+{
+  "voidDocumentId": "uuid",
+  "adeTransactionId": "151086012",
+  "adeProgressive": "DCW2026/5111-2611"
+}
+```
+
 **Errori standard:**
 
-- `400` — validazione input
-- `401` — API key mancante, non valida, o revocata
+Tutte le risposte d'errore hanno l'envelope `{ "error": "<messaggio>" }`; gli
+errori con un `code` machine-readable lo includono anche nel body (`{ "code":
+"…", "error": "…" }`). **Non esiste un campo `adeErrors`.**
+
+- `400` — validazione input (corpo malformato, UUID non valido)
+- `401` — API key mancante, non valida, revocata o scaduta
 - `402` — piano non supporta API access (upgrade a Pro/Developer)
+- `403` — chiave di tipo sbagliato (es. management key su un endpoint business)
+- `404` — scontrino non trovato (ID inesistente o di un altro esercente); vale
+  sia per `GET /v1/receipts/{id}` sia per `POST /v1/receipts/{id}/void`
 - `409` — conflitto idempotency (body include `code`): `PENDING_IN_PROGRESS` /
   `VOID_PENDING_IN_PROGRESS` (richiesta in corso, ritenta), `ALREADY_REJECTED`,
   `IDEMPOTENCY_PAYLOAD_MISMATCH` (key riusata con payload diverso **o**
   cross-operazione), `ALREADY_VOIDED` (la key identifica uno scontrino già
-  annullato)
-- `422` — scontrino rifiutato dall'AdE (body include `adeErrors`)
+  annullato), `VOID_ALREADY_TARGETED` (annullo concorrente sullo stesso SALE)
+- `422` — rifiuto funzionale AdE o altro errore di logica senza `code` (es.
+  documento non annullabile, dati AdE mancanti). Body: solo `{ "error": "…" }`
 - `429` — rate limit superato (header `Retry-After`)
-- `500` — errore interno
+- `500` — errore interno (incl. `VOID_SYNC_FAILED`: annullo su AdE riuscito ma
+  sync DB fallita, richiede intervento)
+- `503` — servizio temporaneamente sovraccarico / timeout DB (`code: "DB_TIMEOUT"`,
+  header `Retry-After`); è **retryable**
 
 > ⚠️ **La idempotency key deve essere unica per operazione.** Emissione e
 > annullo non condividono mai la stessa `idempotencyKey`: riusarla tra le due
@@ -316,13 +338,15 @@ WHERE b.profile_id = $developer_profile_id
 
 ### Rate Limits API
 
-| Key pattern           | Limite  | Finestra |
-| --------------------- | ------- | -------- |
-| `api:emit:{apiKeyId}` | 120/ora | 1h       |
-| `api:void:{apiKeyId}` | 20/ora  | 1h       |
-| `api:get:{apiKeyId}`  | 300/ora | 1h       |
+| Key pattern           | Endpoint                      | Limite  | Finestra |
+| --------------------- | ----------------------------- | ------- | -------- |
+| `api:emit:{apiKeyId}` | `POST /v1/receipts`           | 120/ora | 1h       |
+| `api:list:{apiKeyId}` | `GET /v1/receipts`            | 60/ora  | 1h       |
+| `api:void:{apiKeyId}` | `POST /v1/receipts/{id}/void` | 20/ora  | 1h       |
 
-Più generosi dei limiti UI (30 emit/ora) perché le integrazioni POS sono automatizzate.
+`GET /v1/receipts/{id}` (lettura singola indicizzata) non ha rate limiter
+dedicato. Più generosi dei limiti UI (30 emit/ora) perché le integrazioni POS
+sono automatizzate.
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -375,7 +375,7 @@ fino a 24h, irrilevante su soglie di mesi.
 ### 49. API v1: 409 `reauthRequired` senza `code` machine-readable e non documentato
 
 - **Categoria:** architettura/API · **Severità:** Low — Developer API a bassa adozione, ma il contratto è ambiguo
-- **File:** `src/app/api/v1/receipts/route.ts:94-106` e `src/app/api/v1/receipts/[id]/void/route.ts:70-82` (response 409 inline, duplicata, senza `code`); `src/lib/api-v1-helpers.ts:160-171` (`SERVICE_ERROR_STATUS_MAP`); `docs/api-spec.md:688` e `DEVELOPER.md` (409 documentato solo come conflitto idempotency)
+- **File:** `src/app/api/v1/receipts/route.ts:94-106` e `src/app/api/v1/receipts/[id]/void/route.ts:70-82` (response 409 inline, duplicata, senza `code`); `src/lib/api-v1-helpers.ts:160-174` (`SERVICE_ERROR_STATUS_MAP`); `DEVELOPER.md` (sezione "Errori standard") e `/help/api` (409 documentato solo come conflitto idempotency)
 
 **Problema.** Il nuovo 409 per sessione CIE scaduta ritorna solo
 `{ error: "<messaggio in italiano>" }`, mentre gli altri quattro 409

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,7 +1,17 @@
-# ScontrinoZero — Specifica API
+# ScontrinoZero — Specifica integrazione AdE
 
-Questo documento descrive le API pubbliche di ScontrinoZero e il mapping verso
-gli endpoint dell'Agenzia delle Entrate (AdE) per il Documento Commerciale Online.
+Questo documento descrive l'**integrazione HTTP con l'Agenzia delle Entrate
+(AdE)** per il Documento Commerciale Online (flussi di login, endpoint documenti,
+payload, codifiche) e il **contratto adapter interno** (`src/lib/ade/`) che mappa
+i DTO applicativi sul payload AdE.
+
+> **Non è la documentazione dell'API REST pubblica per sviluppatori.** L'API HTTP
+> esposta agli integratori (`POST /api/v1/receipts`, `GET /api/v1/receipts`,
+> `GET /api/v1/receipts/{id}`, `POST /api/v1/receipts/{id}/void`) è documentata
+> nella pagina pubblica **`/help/api`** (`src/app/(marketing)/help/api/page.tsx`)
+> e nel prodotto/architettura in **`DEVELOPER.md`**. I nomi campo del corpo HTTP
+> pubblico (`grossUnitPrice`, `paymentMethod`) **differiscono** da quelli del DTO
+> adapter interno descritto qui (`unitPriceGross`, `payments[]`).
 
 ---
 
@@ -587,55 +597,46 @@ sono accettati dal server, ma usiamo 2 per coerenza.
 
 ---
 
-## 8. API pubbliche ScontrinoZero
+## 8. Contratto adapter interno (DTO)
 
-### 8.1 Emissione vendita
+> ⚠️ **Questa NON è l'API HTTP pubblica** (vedi la nota in testa al documento e
+> `/help/api`). Descrive i **DTO interni** definiti in
+> `src/lib/ade/public-types.ts` che il service layer costruisce e passa al mapper
+> AdE (sez. 9). I nomi campo qui (`unitPriceGross`, `payments[]`) sono quelli del
+> DTO, **non** quelli del corpo HTTP pubblico (`grossUnitPrice`, `paymentMethod`).
+> L'`idempotencyKey` e il `businessId` sono passati a parte al service, non dentro
+> il DTO di vendita.
 
-`POST /api/v1/commercial-documents/sales`
+### 8.1 DTO vendita (`SaleDocumentRequest`)
 
-Request:
-
-```json
-{
-  "idempotencyKey": "uuid-v4",
-  "document": {
-    "date": "2026-02-15",
-    "customerTaxCode": null,
-    "isGiftDocument": false,
-    "lines": [
-      {
-        "description": "Cappuccino",
-        "quantity": 2,
-        "unitPriceGross": 1.5,
-        "unitDiscount": 0.0,
-        "vatCode": "10",
-        "isGift": false
-      }
-    ],
-    "payments": [{ "type": "CASH", "amount": 3.0 }],
-    "globalDiscount": 0.0,
-    "deductibleAmount": 0.0
-  }
-}
-```
-
-Response (200):
+Costruito da `emitReceiptForBusiness` (`src/lib/services/receipt-service.ts`) e
+passato a `mapSaleToAdePayload`:
 
 ```json
 {
-  "success": true,
-  "status": "ACCEPTED",
-  "transactionId": "151085589",
-  "documentProgressive": "DCW2026/5111-2188",
-  "errors": []
+  "date": "2026-02-15",
+  "lotteryCode": null,
+  "isGiftDocument": false,
+  "lines": [
+    {
+      "description": "Cappuccino",
+      "quantity": 2,
+      "unitPriceGross": 1.5,
+      "unitDiscount": 0.0,
+      "vatCode": "10",
+      "isGift": false
+    }
+  ],
+  "payments": [{ "type": "CASH", "amount": 3.0 }],
+  "globalDiscount": 0.0,
+  "deductibleAmount": 0.0
 }
 ```
 
-### 8.2 Annullamento
+### 8.2 DTO annullo (`VoidRequest`)
 
-`POST /api/v1/commercial-documents/voids`
-
-Request:
+Costruito da `voidReceiptForBusiness` (`src/lib/services/void-service.ts`) e
+passato a `mapVoidToAdePayload`:
 
 ```json
 {
@@ -648,66 +649,21 @@ Request:
 }
 ```
 
-Response (200):
+### 8.3 Esito
 
-```json
-{
-  "success": true,
-  "status": "VOID_ACCEPTED",
-  "transactionId": "151086012",
-  "documentProgressive": "DCW2026/5111-2611",
-  "errors": []
-}
-```
-
-### 8.3 Recupero documento
-
-`GET /api/v1/commercial-documents/{transactionId}`
-
-### 8.4 Download PDF
-
-`GET /api/v1/commercial-documents/{transactionId}/pdf`
-
-### 8.5 Error model
-
-Response errore (422):
-
-```json
-{
-  "success": false,
-  "status": "REJECTED",
-  "errors": [
-    {
-      "code": "ADE_VALIDATION_ERROR",
-      "message": "Errore restituito da AdE",
-      "field": "document.lines[0].vatCode"
-    }
-  ]
-}
-```
-
-Codici HTTP:
-
-- 200: invio accettato
-- 400: validazione input
-- 409: conflitto idempotency — un'altra richiesta con la stessa `idempotencyKey`
-  è in corso (`PENDING_IN_PROGRESS` / `VOID_PENDING_IN_PROGRESS`), è già stata
-  rifiutata (`ALREADY_REJECTED`), oppure la key è stata riusata con un payload
-  diverso (`IDEMPOTENCY_PAYLOAD_MISMATCH`: in tal caso usa una nuova key). Due
-  casi specifici dello stesso stato:
-  - `IDEMPOTENCY_PAYLOAD_MISMATCH` copre anche il **riuso cross-operazione**
-    della key: una key già usata per un'emissione non può essere usata per un
-    annullo e viceversa. **La idempotency key deve essere unica per operazione:
-    emit e void non condividono mai la stessa key.**
-  - `ALREADY_VOIDED`: la key identifica uno scontrino già annullato. Un replay
-    dell'emissione con quella key viene rifiutato (il documento non è più
-    valido): emetti un nuovo scontrino con una key diversa.
-- 422: rifiuto funzionale / errore AdE
-- 503: errore tecnico temporaneo AdE
+L'adapter normalizza la risposta AdE (`AdeResponse`, sez. 2.5) e il service
+ritorna al chiamante un risultato tipizzato (`SubmitReceiptResult` /
+`VoidReceiptResult`) con `documentId`/`voidDocumentId`, `adeTransactionId`,
+`adeProgressive` — oppure `error` + `code` machine-readable. La forma HTTP finale
+(status code, envelope `{ "error": "…" }`) è responsabilità delle route
+`/api/v1/receipts/*` → vedi `/help/api` e `DEVELOPER.md`.
 
 ---
 
-## 9. Mapping API pubblica → payload AdE
+## 9. Mapping DTO adapter → payload AdE
+
+> Nella colonna "DTO adapter" i nomi si riferiscono ai tipi interni di sez. 8
+> (`public-types.ts`), non al corpo HTTP pubblico.
 
 ### 9.1 Campi root (sempre presenti)
 
@@ -769,21 +725,26 @@ L'utente non li passa nella request pubblica.
 
 ---
 
-## 10. Validazioni API pubblica
+## 10. Validazioni
 
-| Campo                                  | Regola                                      |
-| -------------------------------------- | ------------------------------------------- |
-| `idempotencyKey`                       | UUID v4 obbligatorio                        |
-| `document.date`                        | ISO 8601 (`yyyy-MM-dd`)                     |
-| `document.lines`                       | Array non vuoto (vendita)                   |
-| `document.lines[].quantity`            | > 0                                         |
-| `document.lines[].unitPriceGross`      | >= 0                                        |
-| `document.lines[].vatCode`             | Uno dei codici in sezione 6                 |
-| `document.lines[].description`         | Max 1000 caratteri                          |
-| `document.payments`                    | Obbligatorio in vendita, vietato in annullo |
-| Somma pagamenti                        | = totale documento (tolleranza 0.01)        |
-| `originalDocument.transactionId`       | Obbligatorio per annullo                    |
-| `originalDocument.documentProgressive` | Obbligatorio per annullo                    |
+La validazione **autoritativa** del corpo HTTP pubblico vive in
+`src/lib/receipts/receipt-schema.ts` (`saleBodySchema`, condiviso con la server
+action `emitReceipt`). La tabella sotto riassume gli invarianti a livello DTO /
+mapper AdE; per i nomi campo e i limiti esatti del corpo HTTP pubblico vedi
+`/help/api`.
+
+| Campo (DTO)                            | Regola                                                       |
+| -------------------------------------- | ------------------------------------------------------------ |
+| `idempotencyKey`                       | UUID v4 obbligatorio                                         |
+| `date`                                 | ISO 8601 (`yyyy-MM-dd`)                                      |
+| `lines`                                | Array non vuoto, max 100 righe (vendita)                     |
+| `lines[].quantity`                     | > 0, ≤ 9999, max 3 decimali                                  |
+| `lines[].unitPriceGross`               | ≥ 0, ≤ 999.999,99, max 2 decimali                            |
+| `lines[].vatCode`                      | Solo `4`/`5`/`10`/`22`/`N1`–`N6` (sottoinsieme della sez. 6) |
+| `lines[].description`                  | 1–200 caratteri (limite corpo HTTP)                          |
+| `payments`                             | Un pagamento con `amount` = totale documento                 |
+| `originalDocument.transactionId`       | Obbligatorio per annullo                                     |
+| `originalDocument.documentProgressive` | Obbligatorio per annullo                                     |
 
 ---
 
@@ -791,45 +752,48 @@ L'utente non li passa nella request pubblica.
 
 ### Tabella `commercial_documents`
 
-| Colonna              | Tipo        | Note                                       |
-| -------------------- | ----------- | ------------------------------------------ |
-| `id`                 | uuid        | PK                                         |
-| `user_id`            | uuid        | FK → auth.users                            |
-| `kind`               | enum        | `SALE`, `VOID`                             |
-| `idempotency_key`    | uuid        | Unique                                     |
-| `public_request`     | jsonb       | Payload API pubblica                       |
-| `ade_request`        | jsonb       | Payload inviato ad AdE                     |
-| `ade_response`       | jsonb       | Risposta AdE raw                           |
-| `ade_transaction_id` | text        | `idtrx` AdE                                |
-| `ade_progressive`    | text        | `progressivo` AdE                          |
-| `status`             | enum        | `PENDING`, `ACCEPTED`, `REJECTED`, `ERROR` |
-| `created_at`         | timestamptz |                                            |
-| `updated_at`         | timestamptz |                                            |
+| Colonna              | Tipo        | Note                                                                           |
+| -------------------- | ----------- | ------------------------------------------------------------------------------ |
+| `id`                 | uuid        | PK                                                                             |
+| `business_id`        | uuid        | NOT NULL, FK → `businesses` (cascade)                                          |
+| `kind`               | enum        | `SALE`, `VOID`                                                                 |
+| `idempotency_key`    | uuid        | Unique **per business** (`business_id` + `idempotency_key`, migr. 0009)        |
+| `public_request`     | jsonb       | Payload applicativo (`paymentMethod`, `lotteryCode`)                           |
+| `request_hash`       | text        | SHA-256 canonico del SALE (rileva riuso key con payload diverso). NULL su VOID |
+| `ade_response`       | jsonb       | Risposta AdE raw                                                               |
+| `ade_transaction_id` | text        | `idtrx` AdE                                                                    |
+| `ade_progressive`    | text        | `progressivo` AdE                                                              |
+| `lottery_code`       | text        | Codice lotteria (solo SALE con pagamento `PE`)                                 |
+| `api_key_id`         | uuid        | FK → `api_keys` (set null). NULL = emissione via UI dashboard                  |
+| `voided_document_id` | uuid        | Solo VOID: self-FK al SALE annullato. Unique parziale (anti doppio-annullo)    |
+| `status`             | enum        | `PENDING`, `ACCEPTED`, `VOID_ACCEPTED`, `REJECTED`, `ERROR`                    |
+| `created_at`         | timestamptz |                                                                                |
+| `updated_at`         | timestamptz |                                                                                |
 
 ### Tabella `commercial_document_lines`
 
-| Colonna            | Tipo    | Note                              |
-| ------------------ | ------- | --------------------------------- |
-| `id`               | uuid    | PK                                |
-| `document_id`      | uuid    | FK → commercial_documents         |
-| `line_index`       | int     | Ordine riga                       |
-| `description`      | text    |                                   |
-| `quantity`         | numeric |                                   |
-| `gross_unit_price` | numeric |                                   |
-| `vat_code`         | text    |                                   |
-| `ade_line_id`      | text    | `idElementoContabile` per annulli |
+| Colonna            | Tipo          | Note                                  |
+| ------------------ | ------------- | ------------------------------------- |
+| `id`               | uuid          | PK                                    |
+| `document_id`      | uuid          | FK → `commercial_documents` (cascade) |
+| `line_index`       | int           | Ordine riga                           |
+| `description`      | text          | ≤ 200 caratteri (CHECK, migr. 0019)   |
+| `quantity`         | numeric(10,3) | ≥ 0 (CHECK)                           |
+| `gross_unit_price` | numeric(10,2) | ≥ 0 (CHECK)                           |
+| `vat_code`         | text          |                                       |
 
 ---
 
 ## 12. Architettura adapter
 
 ```
-Client → API pubblica ScontrinoZero → Validazione (Zod)
+Route /api/v1/receipts o server action emitReceipt → Validazione (Zod, saleBodySchema)
+  → Service layer (DTO SaleDocumentRequest / VoidRequest, sez. 8)
   → Mapper (mapSaleToAdePayload / mapVoidToAdePayload)
   → AdeClient (interfaccia)
     ├── RealAdeClient (HTTP verso AdE)
     └── MockAdeClient (simula risposta, stessa logica senza HTTP)
-  → Persistenza (ade_request + ade_response)
+  → Persistenza (public_request + ade_response)
   → Risposta normalizzata al client
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lint-staged": "^17.0.8",
-        "next": "^16.2.10",
+        "next": "^16.2.11",
         "pino-pretty": "^13.1.3",
         "prettier": "^3.9.5",
         "prettier-plugin-tailwindcss": "^0.8.0",
@@ -2881,9 +2881,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2897,9 +2897,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
       "cpu": [
         "arm64"
       ],
@@ -2913,9 +2913,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
       "cpu": [
         "x64"
       ],
@@ -2929,9 +2929,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
       "cpu": [
         "arm64"
       ],
@@ -2945,9 +2945,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
       ],
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
       "cpu": [
         "x64"
       ],
@@ -2977,9 +2977,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
       ],
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
       "cpu": [
         "arm64"
       ],
@@ -3009,9 +3009,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
       "cpu": [
         "x64"
       ],
@@ -14287,12 +14287,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.2.11",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -14306,14 +14306,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
+        "@next/swc-darwin-arm64": "16.2.11",
+        "@next/swc-darwin-x64": "16.2.11",
+        "@next/swc-linux-arm64-gnu": "16.2.11",
+        "@next/swc-linux-arm64-musl": "16.2.11",
+        "@next/swc-linux-x64-gnu": "16.2.11",
+        "@next/swc-linux-x64-musl": "16.2.11",
+        "@next/swc-win32-arm64-msvc": "16.2.11",
+        "@next/swc-win32-x64-msvc": "16.2.11",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.0.8",
-    "next": "^16.2.10",
+    "next": "^16.2.11",
     "pino-pretty": "^13.1.3",
     "prettier": "^3.9.5",
     "prettier-plugin-tailwindcss": "^0.8.0",

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -803,6 +803,10 @@ const idempotencyKey = crypto.randomUUID();`}</code>
                   "Il piano attivo non include l'accesso alle API. Passa al Piano Pro.",
                 ],
                 [
+                  "404",
+                  "Scontrino non trovato: l'ID non esiste o appartiene a un altro esercente. Vale per GET /v1/receipts/{id} e per l'annullamento.",
+                ],
+                [
                   "409",
                   "Conflitto di idempotenza: una richiesta con la stessa idempotencyKey è ancora in corso, è già stata rifiutata, oppure la chiave è stata riusata con un contenuto diverso. In quest'ultimo caso usa una nuova chiave.",
                 ],
@@ -812,6 +816,10 @@ const idempotencyKey = crypto.randomUUID();`}</code>
                 ],
                 ["429", "Rate limit superato. Riprova tra qualche minuto."],
                 ["500", "Errore interno del server."],
+                [
+                  "503",
+                  "Servizio temporaneamente sovraccarico (es. database sotto pressione). È un errore transitorio: riprova dopo i secondi indicati nell'header Retry-After.",
+                ],
               ].map(([code, desc]) => (
                 <tr key={code} className="border-b last:border-0">
                   <td className="py-2 pr-6 font-mono text-xs font-semibold">

--- a/src/app/api/v1/receipts/[id]/void/route.test.ts
+++ b/src/app/api/v1/receipts/[id]/void/route.test.ts
@@ -169,14 +169,27 @@ describe("POST /api/v1/receipts/[id]/void", () => {
     expect(res.status).toBe(400);
   });
 
-  it("ritorna 422 se il service ritorna un errore", async () => {
+  it("ritorna 404 se lo scontrino non è trovato (code NOT_FOUND)", async () => {
     mockVoidReceiptForBusiness.mockResolvedValue({
       error: "Scontrino non trovato.",
+      code: "NOT_FOUND",
+    });
+
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Scontrino non trovato.");
+    expect(body.code).toBe("NOT_FOUND");
+  });
+
+  it("ritorna 422 se il service ritorna un errore generico senza code", async () => {
+    mockVoidReceiptForBusiness.mockResolvedValue({
+      error: "Il documento non è in uno stato annullabile.",
     });
 
     const res = await POST(makeRequest(), makeParams());
     expect(res.status).toBe(422);
     const body = await res.json();
-    expect(body.error).toBe("Scontrino non trovato.");
+    expect(body.error).toBe("Il documento non è in uno stato annullabile.");
   });
 });

--- a/src/lib/api-v1-helpers.test.ts
+++ b/src/lib/api-v1-helpers.test.ts
@@ -238,6 +238,19 @@ describe("serviceErrorResponse", () => {
     expect(res.headers.get("Retry-After")).toBe("2");
   });
 
+  it("maps NOT_FOUND to 404 with the code in the body", async () => {
+    const res = serviceErrorResponse({
+      error: "Scontrino non trovato.",
+      code: "NOT_FOUND",
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Retry-After")).toBeNull();
+    expect(await res.json()).toEqual({
+      code: "NOT_FOUND",
+      error: "Scontrino non trovato.",
+    });
+  });
+
   it("falls back to 422 for an unknown code", async () => {
     const res = serviceErrorResponse({ error: "boom", code: "WHAT_IS_THIS" });
     expect(res.status).toBe(422);

--- a/src/lib/api-v1-helpers.ts
+++ b/src/lib/api-v1-helpers.ts
@@ -169,6 +169,9 @@ const SERVICE_ERROR_STATUS_MAP: Record<
   VOID_ALREADY_TARGETED: { status: 409 },
   VOID_SYNC_FAILED: { status: 500 },
   IDEMPOTENCY_PAYLOAD_MISMATCH: { status: 409 },
+  // Documento inesistente / cross-tenant: 404, coerente con GET /v1/receipts/{id}
+  // (che risponde 404 direttamente nella route). Prima cadeva nel fallback 422.
+  NOT_FOUND: { status: 404 },
 };
 
 export function serviceErrorResponse(result: {

--- a/src/lib/services/void-service.ts
+++ b/src/lib/services/void-service.ts
@@ -535,7 +535,10 @@ async function prepareVoidDocument(
         "v1 document not found",
       );
     }
-    return { kind: "done", result: { error: "Scontrino non trovato." } };
+    return {
+      kind: "done",
+      result: { error: "Scontrino non trovato.", code: "NOT_FOUND" },
+    };
   }
   if (saleDoc.kind !== "SALE") {
     return {

--- a/src/types/storico.ts
+++ b/src/types/storico.ts
@@ -86,13 +86,16 @@ export interface VoidReceiptInput {
  *   DB finale è fallita. Richiede cleanup manuale.
  * - IDEMPOTENCY_PAYLOAD_MISMATCH: la idempotencyKey è già stata usata per
  *   annullare un documento diverso. Il client deve usare una nuova key.
+ * - NOT_FOUND: lo scontrino da annullare non esiste (o appartiene a un altro
+ *   business). Sul canale API mappa a 404, coerente con GET /v1/receipts/{id}.
  */
 export type VoidReceiptErrorCode =
   | "VOID_PENDING_IN_PROGRESS"
   | "VOID_ALREADY_TARGETED"
   | "DB_TIMEOUT"
   | "VOID_SYNC_FAILED"
-  | "IDEMPOTENCY_PAYLOAD_MISMATCH";
+  | "IDEMPOTENCY_PAYLOAD_MISMATCH"
+  | "NOT_FOUND";
 
 export interface VoidReceiptResult {
   error?: string;

--- a/tests/unit/void-service.test.ts
+++ b/tests/unit/void-service.test.ts
@@ -217,7 +217,10 @@ describe("voidReceiptForBusiness", () => {
       const { voidReceiptForBusiness } =
         await import("@/lib/services/void-service");
       const result = await voidReceiptForBusiness(makeInput());
-      expect(result).toEqual({ error: "Scontrino non trovato." });
+      expect(result).toEqual({
+        error: "Scontrino non trovato.",
+        code: "NOT_FOUND",
+      });
     });
 
     it("returns error when document kind is not SALE", async () => {


### PR DESCRIPTION
## Summary

Adds proper HTTP 404 status code mapping for the `NOT_FOUND` error code returned by the void service when a receipt does not exist or belongs to another business. Previously, this error fell through to the generic 422 fallback, which was inconsistent with the `GET /v1/receipts/{id}` endpoint behavior.

## Changes

- **`src/lib/api-v1-helpers.ts`**: Added `NOT_FOUND` to the `SERVICE_ERROR_STATUS_MAP` with status 404, making void operations consistent with GET receipt lookups
- **`src/lib/services/void-service.ts`**: Added `code: "NOT_FOUND"` to the error result when a sale document is not found during void preparation
- **`src/types/storico.ts`**: Added `NOT_FOUND` to the `VoidReceiptErrorCode` union type with documentation explaining it maps to 404 on the API channel
- **`src/app/api/v1/receipts/[id]/void/route.test.ts`**: Updated test to verify 404 response with `code: "NOT_FOUND"` in the body; added separate test for generic 422 errors without a code
- **`tests/unit/void-service.test.ts`**: Updated test assertion to expect the `code` field in the error result
- **`src/app/(marketing)/help/api/page.tsx`**: Added 404 error documentation to the API help page, clarifying it applies to both `GET /v1/receipts/{id}` and void operations
- **`docs/api-spec.md`**: Clarified that the document is about AdE integration and internal adapter contracts, not the public REST API; updated error code table and rate limit documentation
- **`DEVELOPER.md`**: Expanded API endpoint table to include `GET /v1/receipts` (list), added void response example, clarified error envelope structure, and updated rate limit table with endpoint mappings

## Implementation Details

- The error code is now machine-readable in the response body (`{ "code": "NOT_FOUND", "error": "…" }`), allowing API clients to distinguish between "document not found" (404) and other functional rejections (422)
- Consistent with REST conventions: 404 for resource not found, 422 for unprocessable entity (e.g., document in non-voidable state)
- All tests updated to verify the new behavior; no breaking changes to existing passing tests

https://claude.ai/code/session_01W7rBJZpXCof7F3bjcn4bQb