### PR TITLE
API v1: validate list pagination params & fix reauthRequired response

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -217,7 +217,12 @@ Tutte le risposte d'errore hanno l'envelope `{ "error": "<messaggio>" }`; gli
 errori con un `code` machine-readable lo includono anche nel body (`{ "code":
 "…", "error": "…" }`). **Non esiste un campo `adeErrors`.**
 
-- `400` — validazione input (corpo malformato, UUID non valido)
+- `400` — validazione input (corpo malformato, UUID non valido). Su
+  `GET /v1/receipts` anche i parametri di query malformati sono rifiutati (niente
+  ignore silenzioso): `page`/`limit` non interi o `< 1`, e `kind` diverso da
+  `SALE`/`VOID` → `400`. Un `limit > 100` **non** è un errore: viene ridotto a
+  `100` (soft cap). Parametri assenti usano i default (`page=1`, `limit=20`,
+  tutti i `kind`)
 - `401` — API key mancante, non valida, revocata o scaduta
 - `402` — piano non supporta API access (upgrade a Pro/Developer)
 - `403` — chiave di tipo sbagliato (es. management key su un endpoint business)
@@ -228,6 +233,11 @@ errori con un `code` machine-readable lo includono anche nel body (`{ "code":
   `IDEMPOTENCY_PAYLOAD_MISMATCH` (key riusata con payload diverso **o**
   cross-operazione), `ALREADY_VOIDED` (la key identifica uno scontrino già
   annullato), `VOID_ALREADY_TARGETED` (annullo concorrente sullo stesso SALE)
+- `409` — `ADE_REAUTH_REQUIRED` (body include `code`): la sessione AdE
+  interattiva (CIE) è scaduta e va rinnovata **dall'app web ScontrinoZero**
+  (secondo fattore umano). A differenza degli altri `409`, il retry automatico
+  è inutile finché l'esercente non si ricollega — nessun `Retry-After`. Vale su
+  `POST /v1/receipts` e `POST /v1/receipts/{id}/void`
 - `422` — rifiuto funzionale AdE o altro errore di logica senza `code` (es.
   documento non annullabile, dati AdE mancanti). Body: solo `{ "error": "…" }`
 - `429` — rate limit superato (header `Retry-After`)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -76,17 +76,17 @@ costo del DOM per la lista completa lato client.
 ### 12. Paginazione cursor-based su storico, export e Developer API
 
 - **Categoria:** performance/scalabilità · **Severità:** Medium (cresce col volume per-tenant)
-- **File:** `src/server/storico-actions.ts:39-113` (`searchReceipts`: offset-based + `COUNT(*)` per request); `src/server/export-actions.ts:78+` (`exportUserData`: export senza limiti); `src/app/api/v1/receipts/route.ts:246-260` (clamp silenzioso di `page`/`limit`/`kind`) e `:292-296` (`COUNT(*)` full-match a ogni richiesta paginata)
+- **File:** `src/server/storico-actions.ts:39-113` (`searchReceipts`: offset-based + `COUNT(*)` per request); `src/server/export-actions.ts:78+` (`exportUserData`: export senza limiti); `src/app/api/v1/receipts/route.ts` (`COUNT(*)` full-match a ogni richiesta paginata)
 
-**Problema.** Tre facce dello stesso debt:
+**Problema.** Due facce dello stesso debt (la validazione dei parametri di query
+`page`/`limit`/`kind` dell'API con **400** — il terzo aspetto originario — è già
+stata risolta separatamente):
 
 1. `searchReceipts` e `GET /api/v1/receipts` usano LIMIT/OFFSET + un `COUNT(*)`
    che scansiona l'intero match a **ogni** pagina richiesta: con 100k+ documenti
    per business la latenza è dominata dal count.
 2. `exportUserData` carica tutti i documenti senza bound (rischio OOM su tenant
    grandi).
-3. I parametri `page`/`limit`/`kind` dell'API sono clampati silenziosamente
-   (`page=-100` → 200 con `page=1`) invece di essere rifiutati.
 
 **Fix (non ambiguo).**
 
@@ -96,14 +96,11 @@ costo del DOM per la lista completa lato client.
 2. **Breaking change Developer API** da gestire esplicitamente: rendere `total`
    opt-in (`includeTotal=true`) o sostituirlo con `nextCursor`/`limit+1`;
    aggiornare `docs/api-spec.md` e `DEVELOPER.md`.
-3. Validare `page`/`limit`/`kind` con schema Zod che rifiuta valori invalidi con
-   **400** (niente clamp silenzioso); stesso schema condiviso con la server
-   action (vedi item 18).
-4. Export: stream/chunking con bound esplicito (es. batch da 1000 con cursore) e
+3. Export: stream/chunking con bound esplicito (es. batch da 1000 con cursore) e
    limite documentato.
-5. **Test:** cursore stabile sotto insert concorrenti; pagina vuota; `400` su
-   `page=abc`/`limit=-1`/`kind=FOO`; export con N > batch size.
-6. Da affrontare **quando il volume per-tenant lo richiede** — monitorare p95
+4. **Test:** cursore stabile sotto insert concorrenti; pagina vuota; export con
+   N > batch size.
+5. Da affrontare **quando il volume per-tenant lo richiede** — monitorare p95
    della lista storico.
 
 ---
@@ -369,34 +366,6 @@ fino a 24h, irrilevante su soglie di mesi.
    `authDeleted`).
 3. **Test:** con fake timers, il callback iniziale scatta dopo il delay e non
    impila un secondo interval; la guardia d'idempotenza resta valida.
-
----
-
-### 49. API v1: 409 `reauthRequired` senza `code` machine-readable e non documentato
-
-- **Categoria:** architettura/API · **Severità:** Low — Developer API a bassa adozione, ma il contratto è ambiguo
-- **File:** `src/app/api/v1/receipts/route.ts:94-106` e `src/app/api/v1/receipts/[id]/void/route.ts:70-82` (response 409 inline, duplicata, senza `code`); `src/lib/api-v1-helpers.ts:160-174` (`SERVICE_ERROR_STATUS_MAP`); `DEVELOPER.md` (sezione "Errori standard") e `/help/api` (409 documentato solo come conflitto idempotency)
-
-**Problema.** Il nuovo 409 per sessione CIE scaduta ritorna solo
-`{ error: "<messaggio in italiano>" }`, mentre gli altri quattro 409
-dell'API (`PENDING_IN_PROGRESS`, `ALREADY_REJECTED`, `VOID_ALREADY_TARGETED`,
-`IDEMPOTENCY_PAYLOAD_MISMATCH`) hanno tutti un `code`: un client non può
-distinguere "ritenta tra 2s" da "serve un'azione umana sull'app web" senza
-parsare il testo italiano. Il body è inoltre duplicato verbatim nelle due
-route, e `docs/api-spec.md`/`DEVELOPER.md` non menzionano il nuovo caso.
-
-**Fix (non ambiguo).**
-
-1. Aggiungere `ADE_REAUTH_REQUIRED: { status: 409 }` a
-   `SERVICE_ERROR_STATUS_MAP` e sostituire i due blocchi inline con
-   `serviceErrorResponse({ error: <messaggio attuale>, code: "ADE_REAUTH_REQUIRED" })`
-   (elimina anche la duplicazione).
-2. Documentare in `docs/api-spec.md` (sezione errori, accanto al 409
-   idempotency) e `DEVELOPER.md`: 409 + `code: ADE_REAUTH_REQUIRED` = la
-   sessione AdE interattiva (CIE) va rinnovata dall'app web, il retry
-   automatico è inutile finché l'utente non si ricollega.
-3. **Test:** envelope `{ code, error }` su entrambe le route quando il
-   servizio ritorna `reauthRequired`.
 
 ---
 

--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -795,7 +795,7 @@ const idempotencyKey = crypto.randomUUID();`}</code>
               {[
                 [
                   "400",
-                  "Corpo della richiesta non valido (campo mancante, tipo errato, UUID non valido).",
+                  "Richiesta non valida: corpo malformato (campo mancante, tipo errato, UUID non valido) oppure, sulla lista, un parametro di query malformato — page o limit non interi o minori di 1, oppure kind diverso da SALE/VOID. I valori malformati vengono rifiutati, non corretti in silenzio (un limit oltre 100 fa eccezione: viene ridotto a 100).",
                 ],
                 ["401", "Chiave API assente, non valida, revocata o scaduta."],
                 [
@@ -808,7 +808,7 @@ const idempotencyKey = crypto.randomUUID();`}</code>
                 ],
                 [
                   "409",
-                  "Conflitto di idempotenza: una richiesta con la stessa idempotencyKey è ancora in corso, è già stata rifiutata, oppure la chiave è stata riusata con un contenuto diverso. In quest'ultimo caso usa una nuova chiave.",
+                  "Due casi, distinti dal campo code nel body. Conflitto di idempotenza: una richiesta con la stessa idempotencyKey è ancora in corso, è già stata rifiutata, oppure la chiave è stata riusata con un contenuto diverso (in quest'ultimo caso usa una nuova chiave). Oppure code ADE_REAUTH_REQUIRED: la sessione con l'Agenzia delle Entrate (CIE) è scaduta e va rinnovata dall'app web ScontrinoZero — il retry automatico è inutile finché l'esercente non si ricollega.",
                 ],
                 [
                   "422",

--- a/src/app/api/v1/receipts/[id]/void/route.test.ts
+++ b/src/app/api/v1/receipts/[id]/void/route.test.ts
@@ -192,4 +192,15 @@ describe("POST /api/v1/receipts/[id]/void", () => {
     const body = await res.json();
     expect(body.error).toBe("Il documento non è in uno stato annullabile.");
   });
+
+  it("ritorna 409 con code ADE_REAUTH_REQUIRED se la sessione CIE è scaduta", async () => {
+    mockVoidReceiptForBusiness.mockResolvedValue({ reauthRequired: true });
+
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("ADE_REAUTH_REQUIRED");
+    expect(typeof body.error).toBe("string");
+    expect(body.error.length).toBeGreaterThan(0);
+  });
 });

--- a/src/app/api/v1/receipts/[id]/void/route.ts
+++ b/src/app/api/v1/receipts/[id]/void/route.ts
@@ -9,6 +9,7 @@ import {
   parseAndValidateBody,
   serviceErrorResponse,
   withCors,
+  ADE_REAUTH_REQUIRED_MESSAGE,
 } from "@/lib/api-v1-helpers";
 
 const voidBodySchema = z.object({
@@ -68,15 +69,11 @@ export async function POST(
   );
 
   if (result.reauthRequired) {
-    return withCors(
-      Response.json(
-        {
-          error:
-            "Sessione AdE (CIE) scaduta: ricollegati dall'app web ScontrinoZero prima di riprovare.",
-        },
-        { status: 409 },
-      ),
-    );
+    // Vedi POST /v1/receipts: 409 + code machine-readable, retry umano.
+    return serviceErrorResponse({
+      error: ADE_REAUTH_REQUIRED_MESSAGE,
+      code: "ADE_REAUTH_REQUIRED",
+    });
   }
 
   if (result.error) {

--- a/src/app/api/v1/receipts/route.test.ts
+++ b/src/app/api/v1/receipts/route.test.ts
@@ -9,12 +9,14 @@ const {
   mockCanUseApi,
   mockEmitReceiptForBusiness,
   mockRateLimiterCheck,
+  mockWithStatementTimeout,
 } = vi.hoisted(() => ({
   mockAuthenticateApiKey: vi.fn(),
   mockIsApiKeyAuthError: vi.fn(),
   mockCanUseApi: vi.fn(),
   mockEmitReceiptForBusiness: vi.fn(),
   mockRateLimiterCheck: vi.fn(),
+  mockWithStatementTimeout: vi.fn(),
 }));
 
 vi.mock("@/lib/api-auth", () => ({
@@ -28,6 +30,10 @@ vi.mock("@/lib/plans", () => ({
 
 vi.mock("@/lib/services/receipt-service", () => ({
   emitReceiptForBusiness: mockEmitReceiptForBusiness,
+}));
+
+vi.mock("@/lib/db-timeout", () => ({
+  withStatementTimeout: mockWithStatementTimeout,
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -73,9 +79,15 @@ function makeRequest(body: unknown = VALID_BODY) {
   });
 }
 
+function makeGetRequest(query: string) {
+  return new Request(`http://localhost/api/v1/receipts?${query}`, {
+    method: "GET",
+  });
+}
+
 // --- Tests ---
 
-import { POST } from "./route";
+import { GET, POST } from "./route";
 
 describe("POST /api/v1/receipts", () => {
   beforeEach(() => {
@@ -184,6 +196,17 @@ describe("POST /api/v1/receipts", () => {
     expect(body.error).toBe("Credenziali AdE non trovate.");
   });
 
+  it("ritorna 409 con code ADE_REAUTH_REQUIRED se la sessione CIE è scaduta", async () => {
+    mockEmitReceiptForBusiness.mockResolvedValue({ reauthRequired: true });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("ADE_REAUTH_REQUIRED");
+    expect(typeof body.error).toBe("string");
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
   it("ritorna 400 se idempotencyKey non è un UUID valido", async () => {
     const res = await POST(
       makeRequest({ ...VALID_BODY, idempotencyKey: "not-a-uuid" }),
@@ -249,5 +272,58 @@ describe("POST /api/v1/receipts", () => {
     );
     expect(res.status).toBe(201);
     expect(mockEmitReceiptForBusiness).toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/v1/receipts (validazione param lista)", () => {
+  const VALID_RANGE = "from=2026-01-01&to=2026-01-31";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsApiKeyAuthError.mockReturnValue(false);
+    mockAuthenticateApiKey.mockResolvedValue(FAKE_AUTH);
+    mockCanUseApi.mockReturnValue(true);
+    mockRateLimiterCheck.mockReturnValue({ success: true });
+    // Callback ignorata: nessun accesso DB, ritorna una pagina vuota.
+    mockWithStatementTimeout.mockResolvedValue({
+      total: 0,
+      docs: [],
+      lines: [],
+    });
+  });
+
+  it.each([
+    { name: "page=abc", query: "page=abc" },
+    { name: "page=-100", query: "page=-100" },
+    { name: "page=0", query: "page=0" },
+    { name: "limit=-1", query: "limit=-1" },
+    { name: "limit=abc", query: "limit=abc" },
+    { name: "kind=FOO", query: "kind=FOO" },
+  ])(
+    "ritorna 400 (malformato, niente clamp silenzioso) su $name",
+    async ({ query }) => {
+      const res = await GET(makeGetRequest(`${VALID_RANGE}&${query}`));
+      expect(res.status).toBe(400);
+      // La validazione esce prima di qualunque query DB.
+      expect(mockWithStatementTimeout).not.toHaveBeenCalled();
+    },
+  );
+
+  it("param assenti: usa i default (page=1, limit=20) e ritorna 200", async () => {
+    const res = await GET(makeGetRequest(VALID_RANGE));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pagination).toMatchObject({ page: 1, limit: 20 });
+    expect(body.data).toEqual([]);
+  });
+
+  it("param validi: page/limit/kind riflessi nella pagination, 200", async () => {
+    const res = await GET(
+      makeGetRequest(`${VALID_RANGE}&page=2&limit=50&kind=SALE`),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pagination).toMatchObject({ page: 2, limit: 50 });
+    expect(mockWithStatementTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/api/v1/receipts/route.ts
+++ b/src/app/api/v1/receipts/route.ts
@@ -17,8 +17,10 @@ import {
   corsOptionsResponse,
   checkRateLimitApi,
   parseAndValidateBody,
+  parseListPagination,
   serviceErrorResponse,
   withCors,
+  ADE_REAUTH_REQUIRED_MESSAGE,
 } from "@/lib/api-v1-helpers";
 import type { SubmitReceiptInput } from "@/types/cassa";
 
@@ -39,8 +41,6 @@ const listApiLimiter = new RateLimiter({
 });
 
 const MAX_RANGE_DAYS = 31;
-const DEFAULT_LIMIT = 20;
-const MAX_LIMIT = 100;
 
 // list query: count + select fino a 100 doc + lines fetch su quel batch.
 // 5s di budget tiene il p95 anche su un page=100 con catalogo grande, e
@@ -94,15 +94,12 @@ export async function POST(request: Request): Promise<Response> {
   if (result.reauthRequired) {
     // Sessione AdE interattiva (CIE) scaduta: richiede un ri-collegamento
     // dall'app web (secondo fattore umano), non automatizzabile via API.
-    return withCors(
-      Response.json(
-        {
-          error:
-            "Sessione AdE (CIE) scaduta: ricollegati dall'app web ScontrinoZero prima di riprovare.",
-        },
-        { status: 409 },
-      ),
-    );
+    // 409 + code machine-readable così il client distingue "azione umana"
+    // dagli altri 409 retryable (PENDING_IN_PROGRESS, ecc.).
+    return serviceErrorResponse({
+      error: ADE_REAUTH_REQUIRED_MESSAGE,
+      code: "ADE_REAUTH_REQUIRED",
+    });
   }
 
   if (result.error) {
@@ -210,22 +207,12 @@ export async function GET(request: Request): Promise<Response> {
   const toDateExclusive = new Date(toDate);
   toDateExclusive.setUTCDate(toDateExclusive.getUTCDate() + 1);
 
-  // Optional params
-  const pageStr = searchParams.get("page");
-  const limitStr = searchParams.get("limit");
-  const kindStr = searchParams.get("kind");
-
-  const page = Math.max(1, Number.parseInt(pageStr ?? "1", 10) || 1);
-  const limit = Math.min(
-    MAX_LIMIT,
-    Math.max(
-      1,
-      Number.parseInt(limitStr ?? String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT,
-    ),
-  );
+  // Optional params: page/limit/kind validati al boundary (regola 9). Valori
+  // invalidi → 400 esplicito, niente clamp/ignore silenzioso.
+  const paginationResult = parseListPagination(searchParams);
+  if ("error" in paginationResult) return paginationResult.error;
+  const { page, limit, kind } = paginationResult.data;
   const offset = (page - 1) * limit;
-  const kind: "SALE" | "VOID" | null =
-    kindStr === "SALE" || kindStr === "VOID" ? kindStr : null;
 
   // ── DB queries ────────────────────────────────────────────────────────────
   const conditions = [

--- a/src/lib/api-v1-helpers.test.ts
+++ b/src/lib/api-v1-helpers.test.ts
@@ -32,9 +32,13 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import {
+  ADE_REAUTH_REQUIRED_MESSAGE,
   checkRateLimitApi,
   corsOptionsResponse,
+  LIST_DEFAULT_LIMIT,
+  LIST_MAX_LIMIT,
   parseAndValidateBody,
+  parseListPagination,
   requireBusinessApiAuth,
   serviceErrorResponse,
   withCors,
@@ -251,6 +255,19 @@ describe("serviceErrorResponse", () => {
     });
   });
 
+  it("maps ADE_REAUTH_REQUIRED to 409 with the code and no Retry-After", async () => {
+    const res = serviceErrorResponse({
+      error: ADE_REAUTH_REQUIRED_MESSAGE,
+      code: "ADE_REAUTH_REQUIRED",
+    });
+    expect(res.status).toBe(409);
+    expect(res.headers.get("Retry-After")).toBeNull();
+    expect(await res.json()).toEqual({
+      code: "ADE_REAUTH_REQUIRED",
+      error: ADE_REAUTH_REQUIRED_MESSAGE,
+    });
+  });
+
   it("falls back to 422 for an unknown code", async () => {
     const res = serviceErrorResponse({ error: "boom", code: "WHAT_IS_THIS" });
     expect(res.status).toBe(422);
@@ -330,6 +347,77 @@ describe("parseAndValidateBody", () => {
       1000,
     );
     expect(result).toEqual({ data: { foo: "bar" } });
+  });
+});
+
+describe("parseListPagination", () => {
+  function params(query: string): URLSearchParams {
+    return new URLSearchParams(query);
+  }
+
+  it("returns the documented defaults when no params are present", () => {
+    const result = parseListPagination(params(""));
+    expect(result).toEqual({
+      data: { page: 1, limit: LIST_DEFAULT_LIMIT, kind: null },
+    });
+  });
+
+  it("parses valid page/limit/kind", () => {
+    const result = parseListPagination(params("page=2&limit=50&kind=SALE"));
+    expect(result).toEqual({ data: { page: 2, limit: 50, kind: "SALE" } });
+  });
+
+  it("accepts kind=VOID", () => {
+    const result = parseListPagination(params("kind=VOID"));
+    expect(result).toEqual({
+      data: { page: 1, limit: LIST_DEFAULT_LIMIT, kind: "VOID" },
+    });
+  });
+
+  it("accepts limit at the maximum", () => {
+    const result = parseListPagination(params(`limit=${LIST_MAX_LIMIT}`));
+    expect(result).toEqual({
+      data: { page: 1, limit: LIST_MAX_LIMIT, kind: null },
+    });
+  });
+
+  it("caps a valid limit above the maximum down to LIST_MAX_LIMIT (soft cap, not 400)", () => {
+    const result = parseListPagination(params(`limit=${LIST_MAX_LIMIT + 400}`));
+    expect(result).toEqual({
+      data: { page: 1, limit: LIST_MAX_LIMIT, kind: null },
+    });
+  });
+
+  it.each([
+    { name: "page=abc (non numeric)", query: "page=abc", field: "page" },
+    { name: "page=12abc (numeric prefix)", query: "page=12abc", field: "page" },
+    { name: "page=-100 (negative)", query: "page=-100", field: "page" },
+    { name: "page=0 (below min)", query: "page=0", field: "page" },
+    { name: "page=1.5 (non integer)", query: "page=1.5", field: "page" },
+    { name: "page= (empty)", query: "page=", field: "page" },
+    { name: "limit=-1 (negative)", query: "limit=-1", field: "limit" },
+    { name: "limit=0 (below min)", query: "limit=0", field: "limit" },
+    { name: "limit=abc (non numeric)", query: "limit=abc", field: "limit" },
+    { name: "kind=FOO (invalid enum)", query: "kind=FOO", field: "kind" },
+  ])(
+    "rejects $name with a 400 mentioning the field",
+    async ({ query, field }) => {
+      const result = parseListPagination(params(query));
+      expect("error" in result).toBe(true);
+      const res = (result as { error: Response }).error;
+      expect(res.status).toBe(400);
+      expect(res.headers.get(ORIGIN_HEADER)).toBe("*");
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain(`'${field}'`);
+    },
+  );
+
+  it("reports only the first invalid param when several are wrong", async () => {
+    const result = parseListPagination(params("page=abc&kind=FOO"));
+    const res = (result as { error: Response }).error;
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("'page'");
   });
 });
 

--- a/src/lib/api-v1-helpers.ts
+++ b/src/lib/api-v1-helpers.ts
@@ -15,7 +15,16 @@ import { logger } from "@/lib/logger";
 import { readJsonWithLimit } from "@/lib/request-utils";
 import type { RateLimiter } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/error-messages";
-import type { ZodType } from "zod/v4";
+import { z, type ZodType } from "zod/v4";
+
+/**
+ * Messaggio del 409 quando la sessione AdE interattiva (CIE) è scaduta: va
+ * rinnovata dall'app web (secondo fattore umano), il retry automatico via API
+ * è inutile finché l'utente non si ricollega. Condiviso da POST /v1/receipts e
+ * POST /v1/receipts/{id}/void per evitare la duplicazione del body inline.
+ */
+export const ADE_REAUTH_REQUIRED_MESSAGE =
+  "Sessione AdE (CIE) scaduta: ricollegati dall'app web ScontrinoZero prima di riprovare.";
 
 /** ApiKeyContext with businessId narrowed to string (management keys excluded). */
 export type BusinessApiContext = Omit<ApiKeyContext, "businessId"> & {
@@ -169,6 +178,9 @@ const SERVICE_ERROR_STATUS_MAP: Record<
   VOID_ALREADY_TARGETED: { status: 409 },
   VOID_SYNC_FAILED: { status: 500 },
   IDEMPOTENCY_PAYLOAD_MISMATCH: { status: 409 },
+  // Sessione AdE interattiva (CIE) scaduta: 409 senza Retry-After — il retry
+  // automatico è inutile finché l'utente non si ricollega dall'app web.
+  ADE_REAUTH_REQUIRED: { status: 409 },
   // Documento inesistente / cross-tenant: 404, coerente con GET /v1/receipts/{id}
   // (che risponde 404 direttamente nella route). Prima cadeva nel fallback 422.
   NOT_FOUND: { status: 404 },
@@ -240,4 +252,68 @@ export async function parseAndValidateBody<T>(
   }
 
   return { data: parsed.data };
+}
+
+/** Page size di default per GET /api/v1/receipts (nessun `limit` in query). */
+export const LIST_DEFAULT_LIMIT = 20;
+/** Page size massimo per GET /api/v1/receipts. */
+export const LIST_MAX_LIMIT = 100;
+
+// `z.coerce.number().int()` rifiuta NaN/Infinity (Number.isInteger è false) e i
+// non-interi: "abc"/"12abc"/"1.5"/"Infinity" → 400. `.min(1)` copre 0 e i
+// negativi ("-100", "0", "" → Number("")=0). Assenti → default nel chiamante.
+// Nota: nessun `.max()` su `limit` — un `limit` oltre il massimo NON è un errore
+// ma viene *ridotto* a LIST_MAX_LIMIT nel return (soft cap convenzionale). Solo
+// i valori malformati (non interi, < 1) sono rifiutati con 400.
+const listQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).optional(),
+  kind: z.enum(["SALE", "VOID"]).optional(),
+});
+
+const LIST_QUERY_ERROR: Record<string, string> = {
+  page: "Il parametro 'page' deve essere un intero maggiore o uguale a 1.",
+  limit: "Il parametro 'limit' deve essere un intero maggiore o uguale a 1.",
+  kind: "Il parametro 'kind' deve essere 'SALE' o 'VOID'.",
+};
+
+/**
+ * Valida i parametri opzionali di lista (`page`/`limit`/`kind`) di
+ * GET /api/v1/receipts. Valori *malformati* → `400` (regola 9: validazione al
+ * boundary) invece del clamp/ignore silenzioso precedente (`page=-100`→1,
+ * `kind=FOO`→tutti). Un `limit` oltre il massimo viene ridotto a
+ * `LIST_MAX_LIMIT` (soft cap convenzionale, non un errore). Parametri assenti →
+ * default documentati (`page=1`, `limit=20`, `kind=null` = entrambi i tipi).
+ *
+ * Ritorna `{ error: Response }` sul primo parametro invalido, così il caller fa:
+ *   if ("error" in result) return result.error;
+ */
+export function parseListPagination(
+  searchParams: URLSearchParams,
+):
+  | { error: Response }
+  | { data: { page: number; limit: number; kind: "SALE" | "VOID" | null } } {
+  const raw: Record<string, string> = {};
+  for (const key of ["page", "limit", "kind"] as const) {
+    const value = searchParams.get(key);
+    if (value !== null) raw[key] = value;
+  }
+
+  const parsed = listQuerySchema.safeParse(raw);
+  if (!parsed.success) {
+    const field = parsed.error.issues[0]?.path?.[0];
+    const msg =
+      (typeof field === "string" && LIST_QUERY_ERROR[field]) ||
+      "Parametri di query non validi.";
+    return { error: withCors(Response.json({ error: msg }, { status: 400 })) };
+  }
+
+  return {
+    data: {
+      page: parsed.data.page ?? 1,
+      // Soft cap: un limit valido oltre il massimo viene ridotto, non rifiutato.
+      limit: Math.min(LIST_MAX_LIMIT, parsed.data.limit ?? LIST_DEFAULT_LIMIT),
+      kind: parsed.data.kind ?? null,
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Resolves two related API v1 issues:

1. **List pagination validation (regola 9):** `GET /api/v1/receipts` now validates `page`, `limit`, and `kind` query parameters at the boundary, rejecting malformed values with `400` instead of silently clamping/ignoring them.
2. **Reauth response standardization:** Both `POST /v1/receipts` and `POST /v1/receipts/{id}/void` now return a machine-readable `code: "ADE_REAUTH_REQUIRED"` alongside the error message when the CIE session expires, allowing clients to distinguish this non-retryable case from other `409` responses.

## Key Changes

- **`src/lib/api-v1-helpers.ts`**
  - Added `ADE_REAUTH_REQUIRED_MESSAGE` constant (shared by both receipt routes to eliminate duplication)
  - Added `ADE_REAUTH_REQUIRED: { status: 409 }` to `SERVICE_ERROR_STATUS_MAP`
  - Exported `LIST_DEFAULT_LIMIT` (20) and `LIST_MAX_LIMIT` (100) constants
  - Implemented `parseListPagination()` function using Zod schema:
    - Validates `page` (integer ≥ 1), `limit` (integer ≥ 1), `kind` (enum: SALE/VOID)
    - Returns `400` with field-specific error message on first invalid parameter
    - Soft-caps `limit` to `LIST_MAX_LIMIT` without error (convention)
    - Applies documented defaults: `page=1`, `limit=20`, `kind=null`

- **`src/app/api/v1/receipts/route.ts`**
  - Replaced inline pagination parsing with `parseListPagination()` call
  - Replaced inline `reauthRequired` response with `serviceErrorResponse()` call using the new constant
  - Removed local `DEFAULT_LIMIT` and `MAX_LIMIT` constants (now in helpers)

- **`src/app/api/v1/receipts/[id]/void/route.ts`**
  - Replaced inline `reauthRequired` response with `serviceErrorResponse()` call (eliminates duplication)

- **Tests**
  - Added comprehensive `parseListPagination()` test suite covering:
    - Default values when params absent
    - Valid page/limit/kind parsing
    - Soft-cap behavior on limit > max
    - Rejection of malformed values (non-integer, negative, invalid enum) with `400`
    - First-error-only reporting when multiple params invalid
  - Added `GET /api/v1/receipts` integration tests validating pagination params
  - Added `reauthRequired` response tests for both POST routes

- **Documentation**
  - Updated `DEVELOPER.md` to document `400` on malformed pagination params and soft-cap behavior
  - Updated `/help/api` page to clarify pagination validation and `ADE_REAUTH_REQUIRED` code
  - Updated `REVIEW.md` to mark item #12 (pagination validation) as resolved

## Implementation Details

- Zod schema uses `z.coerce.number().int().min(1)` to reject non-integers, negatives, and zero in a single validation pass
- `kind` enum validation rejects invalid values like `"FOO"` with `400` (no silent fallback to `null`)
- `limit` beyond max is reduced to `LIST_MAX_LIMIT` (soft cap, not an error) — matches API convention
- `parseListPagination()` returns discriminated union `{ error: Response } | { data: {...} }` for ergonomic caller handling
- `ADE_REAUTH_REQUIRED_MESSAGE` is exported and reused in both receipt routes, eliminating string duplication and ensuring consistency

https://claude.ai/code/session_01LkoJxTF7GXeBfA89an9W8Q