### PR TITLE
fix(security): risolve le advisory del Scheduled Security Audit #18

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -584,14 +584,43 @@ throttling di business: 30/h è sotto il caso d'uso dichiarato del prodotto.
 
 Scelte consapevoli con un trigger di riapertura. Non sono finding da pianificare.
 
-### audit-ci: 3 advisory `esbuild` dev-only
+### audit-ci: advisory `esbuild` dev-only
 
-`audit-ci.json` allowlista `GHSA-67mh-4wv8-2f99` (dev-server SSRF),
-`GHSA-gv7w-rqvm-qjhr` (Deno RCE), `GHSA-g7r4-m6w7-qqqr` (file-read Windows).
+`audit-ci.json` allowlista `GHSA-67mh-4wv8-2f99` (dev-server SSRF).
 `esbuild` non è in `dependencies` prod: entra solo transitivamente via toolchain
 dev (`drizzle-kit`/`tsx`/`@esbuild-kit/*`, tutte `devDependencies`), mai a runtime
 né nella build Next (SWC). Superficie ≈ 0. **Riaprire:** quando la toolchain
 aggiorna `esbuild` > 0.28.0 senza major rischioso → togliere l'allowlist.
+
+### audit-ci: `GHSA-mh99-v99m-4gvg` brace-expansion sotto `minimatch@3`
+
+`audit-ci.json` allowlista l'advisory **solo sulla catena lint**, con una entry
+path-scoped a wildcard:
+`GHSA-mh99-v99m-4gvg|*eslint-plugin-*>minimatch>brace-expansion*`. Il nodo root
+`brace-expansion` resta sotto audit, quindi se la stessa advisory ricompare su
+un path di produzione il job rifallisce.
+
+⚠️ **I path emessi da audit-ci non sono deterministici**: tra un run e l'altro
+il prefisso `eslint-config-next>` e un `>` finale migrano fra i tre plugin
+(`eslint-config-next>eslint-plugin-import>minimatch>brace-expansion` in un run,
+`eslint-plugin-import>minimatch>brace-expansion` in quello dopo). Copiare le
+righe stampate dal job in allowlist produce CI a intermittenza: audit-ci
+confronta `<advisoryId>|<path>` con `matchString`, che supporta `*` — usare
+sempre la forma wildcard, mai i path letterali.
+
+Nessun fix upstream esiste: l'advisory copre `<=5.0.7` ed è patchata **solo**
+in `5.0.8`, senza backport `1.x`/`2.x`. Forzare `5.0.8` sotto
+`minimatch@^3.0.0` rompe ESLint — il build CJS di brace-expansion 5.x esporta
+un namespace (`{ EXPANSION_MAX, EXPANSION_MAX_LENGTH, expand }`), non una
+funzione, mentre `minimatch@3.1.5` fa `expand(...)` sul `require` →
+`be is not a function`. I tre plugin pinnano `minimatch: ^3.1.2` e
+`eslint-config-next@16.2.12` ha le stesse dipendenze: bumparla non cambia nulla.
+
+Catena interamente `devDependencies`: mai nel bundle spedito né nel runtime del
+container. Il DoS richiede pattern glob controllati dall'attaccante, mentre qui
+i pattern arrivano dalla nostra eslint config. **Riaprire:** quando esce un
+backport `brace-expansion` 1.1.17+, o quando i plugin ESLint passano a
+`minimatch` >= 9 → togliere le tre entry dall'allowlist.
 
 ### #57 verifica su AdE reale sostituita da sentinella Sentry
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,7 @@
 {
   "moderate": true,
-  "allowlist": ["GHSA-67mh-4wv8-2f99"]
+  "allowlist": [
+    "GHSA-67mh-4wv8-2f99",
+    "GHSA-mh99-v99m-4gvg|*eslint-plugin-*>minimatch>brace-expansion*"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8698,15 +8698,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -14229,9 +14229,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -15079,9 +15079,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15098,7 +15098,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "express-rate-limit": "^8.5.1",
     "fast-uri": "^3.1.4",
     "qs": "^6.15.2",
-    "postcss": "^8.5.10",
-    "brace-expansion": "5.0.7",
+    "postcss": "^8.5.18",
+    "brace-expansion": "5.0.8",
     "micromatch": {
       "picomatch": "2.3.2"
     },


### PR DESCRIPTION
Il job settimanale falliva su due advisory high pubblicate dopo l'ultimo
refresh del lockfile (5 path, audit-ci con moderate:true).

Fix reali via overrides:

- postcss ^8.5.10 -> ^8.5.18 (lock 8.5.15 -> 8.5.23) per
  GHSA-r28c-9q8g-f849, path traversal nel source-map auto-loading;
  transitiva di next, quindi in produzione. L'override esistente
  permetteva gia' la versione patchata, era il lockfile a essere fermo:
  alzato anche il floor per evitare la regressione.
- brace-expansion 5.0.7 -> 5.0.8 (nodo root) per GHSA-mh99-v99m-4gvg.

Rischio accettato per la catena lint (GHSA-mh99-v99m-4gvg):

I tre path residui sono eslint-plugin-{import,jsx-a11y,react} >
minimatch@3.1.5 > brace-expansion@1.1.16, tutti devDependencies. Non
esiste fix upstream: l'advisory copre <=5.0.7 ed e' patchata solo in
5.0.8, senza backport 1.x/2.x; forzare 5.0.8 sotto minimatch@^3.0.0
rompe ESLint perche' il build CJS di brace-expansion 5.x esporta un
namespace e non una funzione, mentre minimatch 3 fa expand(...) sul
require. eslint-config-next@16.2.12 ha le stesse dipendenze dei plugin.

Allowlist path-scoped in audit-ci.json, non per advisory: il nodo root
resta sotto audit e un'eventuale ricomparsa su un path di produzione
fa rifallire il job. Usata la forma wildcard perche' i path emessi da
audit-ci non sono deterministici fra un run e l'altro (il prefisso
eslint-config-next> e un > finale migrano fra i tre plugin): copiare i
path letterali stampati dal job darebbe CI a intermittenza.

Motivazione e trigger di riapertura documentati in REVIEW.md, sezione
"Rischi accettati"; corretto li' anche il titolo della voce esbuild,
rimasto a "3 advisory" dopo che 4f1edc6 ne ha rimosse due.

Verifica: audit-ci verde 4 run su 4, npm run lint verde (conferma che la
catena minimatch@3 e' integra), 230 test file verdi, arch:check verde.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B2BBapCvDFU4monaunxe8N