### PR TITLE
fix(test): rimuove le act() ridondanti e aggiunge type al bottone del tour

### DIFF
--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-patterns
-description: Use when writing or fixing Vitest tests — avoiding SonarCloud S6661 Blocker (every it()/test() must have at least one expect()), mocking classes correctly with function/class keyword (never arrow), prefixing vi.mock factory variables with "mock" for hoisting, mocking Drizzle's db.transaction() callback with a passthrough, stubbing NODE_ENV with vi.stubEnv, updating mocks after refactoring N queries into a JOIN, INSERT ON CONFLICT DO NOTHING for race conditions, sanitizing context before Sentry.captureException via sanitizeForTelemetry(), auth-first ordering in deleteAccount, conditional last_used_at writes to prevent write-amplification, react/cache deduplication across RSC and Route Handlers, simulating a hostile browser (sessionStorage/localStorage throwing SecurityError, in-app webview, cookies disabled) for UI components that read Web Storage, or mocking Sentry.withScope + scope.setFingerprint when testing logger.ts fingerprint-aware capture. Also lists the consolidated rate-limit thresholds for server actions (emit/void/pdf/checkout/portal/auth).
+description: Use when writing or fixing Vitest tests — avoiding SonarCloud S6661 Blocker (every it()/test() must have at least one expect()), mocking classes correctly with function/class keyword (never arrow), prefixing vi.mock factory variables with "mock" for hoisting, mocking Drizzle's db.transaction() callback with a passthrough, stubbing NODE_ENV with vi.stubEnv, updating mocks after refactoring N queries into a JOIN, INSERT ON CONFLICT DO NOTHING for race conditions, sanitizing context before Sentry.captureException via sanitizeForTelemetry(), auth-first ordering in deleteAccount, conditional last_used_at writes to prevent write-amplification, react/cache deduplication across RSC and Route Handlers, simulating a hostile browser (sessionStorage/localStorage throwing SecurityError, in-app webview, cookies disabled) for UI components that read Web Storage, or mocking Sentry.withScope + scope.setFingerprint when testing logger.ts fingerprint-aware capture, removing redundant act() calls around fireEvent (SonarCloud "already flushes its own updates") and flushing async updates under vi.useFakeTimers() where waitFor/findBy hang. Also lists the consolidated rate-limit thresholds for server actions (emit/void/pdf/checkout/portal/auth).
 ---
 
 # testing-patterns — Vitest patterns e regole CI
@@ -24,6 +24,7 @@ Indice (salta alla sezione che serve, non leggere tutto):
 - `last_used_at` condizionale (anti write-amplification)
 - Browser ostile (storage bloccato, webview, cookies off)
 - Mock di `Sentry.withScope` + `setFingerprint` (R23)
+- `act()` ridondante intorno a `fireEvent` + trap dei fake timer
 
 ---
 
@@ -434,3 +435,55 @@ Casi da testare sempre insieme:
   `captureException`: è metadato di routing, non payload.
 
 Esempio canonico: `src/lib/logger.test.ts:223`.
+
+---
+
+## `act()` ridondante intorno a `fireEvent` (e il trap dei fake timer)
+
+SonarCloud segnala _"Remove this redundant `act()` call; the wrapped call
+already flushes its own updates"_ su ogni `await act(async () => { … })` il cui
+corpo contiene **solo** chiamate RTL (`render`, `fireEvent.*`, `userEvent.*`):
+si auto-avvolgono già in `act()` via l'`eventWrapper` di RTL.
+
+```tsx
+// ❌ SBAGLIATO — act ridondante (Code Smell)
+await act(async () => {
+  fireEvent.submit(form);
+});
+expect(mockAction).toHaveBeenCalled();
+
+// ✅ CORRETTO — l'attesa dell'update async passa da waitFor/findBy*
+fireEvent.submit(form);
+await waitFor(() => {
+  expect(mockAction).toHaveBeenCalled();
+});
+```
+
+`act()` resta **legittimo** quando avvolge qualcosa che RTL non avvolge:
+`vi.advanceTimersByTime()`, `window.dispatchEvent()`, `store.emit()`.
+
+### Sotto fake timer NON si possono usare `waitFor`/`findBy*`
+
+RTL riconosce solo i fake timer **di Jest**: `jestFakeTimersAreEnabled()`
+(`@testing-library/dom/dist/helpers.js`) controlla il global `jest`, che con
+Vitest non esiste. Con `vi.useFakeTimers()` attivi, l'`asyncWrapper` di
+`@testing-library/react` resta appeso a un `setTimeout(…, 0)` finto che nessuno
+avanzerà mai → il test va in **timeout**, non in fallimento chiaro.
+
+Il flush corretto è un tick asincrono dei timer finti dentro `act()` —
+helper condiviso `tests/_helpers/flush-fake-timers.ts`:
+
+```tsx
+fireEvent.click(screen.getByRole("button", { name: "Verifica connessione" }));
+await flushWithFakeTimers(); // act(async () => await vi.advanceTimersByTimeAsync(0))
+
+expect(screen.getByText("Connessione verificata.")).toBeInTheDocument();
+```
+
+Se invece il click produce solo update **sincroni** (cambio di `view`, apertura
+di un Dialog Radix), non serve nessun flush: basta `fireEvent` + assertion
+sincrona, e il test può smettere di essere `async`.
+
+Esempi canonici: `src/components/settings/ade-credentials-section.test.tsx:307`
+(fake timer), `src/components/catalogo/add-item-dialog.test.tsx:82` (waitFor),
+`src/components/storico/void-receipt-dialog.test.tsx:81` (sincrono).

--- a/src/components/cassa/receipt-success.test.tsx
+++ b/src/components/cassa/receipt-success.test.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { ReceiptSuccess } from "./receipt-success";
+import { flushWithFakeTimers } from "../../../tests/_helpers/flush-fake-timers";
 
 // Mock navigator APIs
 const mockShare = vi.fn();
@@ -101,9 +102,8 @@ describe("ReceiptSuccess", () => {
   it("copies URL to clipboard and shows 'Link copiato!' feedback", async () => {
     render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Invia ricevuta"));
-    });
+    fireEvent.click(screen.getByText("Invia ricevuta"));
+    await flushWithFakeTimers();
 
     expect(mockWriteText).toHaveBeenCalledWith(
       expect.stringContaining("/r/doc-uuid-123"),
@@ -114,9 +114,8 @@ describe("ReceiptSuccess", () => {
   it("resets 'Link copiato!' back to share button after 2 seconds (useEffect cleanup)", async () => {
     render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Invia ricevuta"));
-    });
+    fireEvent.click(screen.getByText("Invia ricevuta"));
+    await flushWithFakeTimers();
 
     expect(screen.getByText("Link copiato!")).toBeInTheDocument();
 
@@ -141,12 +140,10 @@ describe("ReceiptSuccess", () => {
     expect(screen.queryByText("Mostra QR code")).not.toBeInTheDocument();
   });
 
-  it("opens a dialog with the receipt QR code and URL on click", async () => {
+  it("opens a dialog with the receipt QR code and URL on click", () => {
     render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Mostra QR code"));
-    });
+    fireEvent.click(screen.getByText("Mostra QR code"));
 
     // The dialog renders the public receipt URL in plain text
     expect(
@@ -165,9 +162,8 @@ describe("ReceiptSuccess", () => {
 
     render(<ReceiptSuccess {...defaultProps} documentId="doc-uuid-123" />);
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Invia ricevuta"));
-    });
+    fireEvent.click(screen.getByText("Invia ricevuta"));
+    await flushWithFakeTimers();
 
     expect(mockShare).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/components/catalogo/add-item-dialog.test.tsx
+++ b/src/components/catalogo/add-item-dialog.test.tsx
@@ -1,10 +1,4 @@
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AddItemDialog } from "./add-item-dialog";
 import type { CatalogItem } from "@/types/catalogo";
@@ -95,17 +89,17 @@ describe("AddItemDialog", () => {
       target: { value: "1.20" },
     });
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+    );
 
-    expect(mockAddCatalogItem).toHaveBeenCalledWith({
-      businessId: "biz-123",
-      description: "Caffè espresso",
-      defaultPrice: "1.20",
-      defaultVatCode: "22",
+    await waitFor(() => {
+      expect(mockAddCatalogItem).toHaveBeenCalledWith({
+        businessId: "biz-123",
+        description: "Caffè espresso",
+        defaultPrice: "1.20",
+        defaultVatCode: "22",
+      });
     });
   });
 
@@ -120,13 +114,13 @@ describe("AddItemDialog", () => {
       target: { value: "1.00" },
     });
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+    );
 
-    expect(onSuccess).toHaveBeenCalledWith(PERSISTED_ITEM);
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(PERSISTED_ITEM);
+    });
   });
 
   it("mostra l'errore restituito da addCatalogItem", async () => {
@@ -135,11 +129,9 @@ describe("AddItemDialog", () => {
     });
     render(<AddItemDialog {...DEFAULT_PROPS} />);
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+    );
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(
@@ -153,12 +145,13 @@ describe("AddItemDialog", () => {
     const onSuccess = vi.fn();
     render(<AddItemDialog {...DEFAULT_PROPS} onSuccess={onSuccess} />);
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+    );
 
+    // L'alert compare solo dopo che la promise della server action è risolta:
+    // se `onSuccess` dovesse partire, a questo punto sarebbe già partita.
+    expect(await screen.findByRole("alert")).toHaveTextContent("Errore test");
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
@@ -169,11 +162,9 @@ describe("AddItemDialog", () => {
     });
     render(<AddItemDialog {...DEFAULT_PROPS} />);
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+    );
 
     await waitFor(() => {
       const link = screen.getByRole("link", { name: /attiva un piano/i });
@@ -190,11 +181,9 @@ describe("AddItemDialog", () => {
     });
     render(<AddItemDialog {...DEFAULT_PROPS} />);
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Aggiungi" }).closest("form")!,
+    );
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();

--- a/src/components/catalogo/catalogo-client.test.tsx
+++ b/src/components/catalogo/catalogo-client.test.tsx
@@ -1,10 +1,4 @@
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CatalogoClient } from "./catalogo-client";
@@ -170,9 +164,7 @@ describe("CatalogoClient", () => {
     );
 
     // Click Elimina → esegue la cancellazione
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Elimina" }));
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Elimina" }));
 
     await waitFor(() => {
       expect(screen.queryByText("Caffè espresso")).not.toBeInTheDocument();
@@ -234,9 +226,7 @@ describe("CatalogoClient", () => {
       screen.getByRole("button", { name: /elimina caffè espresso/i }),
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Elimina" }));
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Elimina" }));
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(
@@ -268,9 +258,7 @@ describe("CatalogoClient", () => {
       target: { value: "Cornetto" },
     });
 
-    await act(async () => {
-      fireEvent.submit(screen.getByLabelText("Descrizione").closest("form")!);
-    });
+    fireEvent.submit(screen.getByLabelText("Descrizione").closest("form")!);
 
     await waitFor(() => {
       expect(screen.getByText("Cornetto")).toBeInTheDocument();
@@ -305,9 +293,7 @@ describe("CatalogoClient", () => {
       target: { value: "Zucchero" },
     });
 
-    await act(async () => {
-      fireEvent.submit(screen.getByLabelText("Descrizione").closest("form")!);
-    });
+    fireEvent.submit(screen.getByLabelText("Descrizione").closest("form")!);
 
     await waitFor(() => {
       expect(screen.getByText("Zucchero")).toBeInTheDocument();
@@ -328,10 +314,8 @@ describe("CatalogoClient", () => {
     );
     const confirmBtn = screen.getByRole("button", { name: "Elimina" });
 
-    await act(async () => {
-      fireEvent.click(confirmBtn);
-      fireEvent.click(confirmBtn); // secondo click mentre la riga sparisce
-    });
+    fireEvent.click(confirmBtn);
+    fireEvent.click(confirmBtn); // secondo click mentre la riga sparisce
 
     await waitFor(() => {
       expect(screen.queryByText("Caffè espresso")).not.toBeInTheDocument();

--- a/src/components/catalogo/edit-item-dialog.test.tsx
+++ b/src/components/catalogo/edit-item-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EditItemDialog } from "./edit-item-dialog";
 import type { CatalogItem } from "@/types/catalogo";
@@ -86,32 +86,32 @@ describe("EditItemDialog", () => {
       target: { value: "Pizza marinara" },
     });
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Salva" }).closest("form")!,
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Salva" }).closest("form")!,
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateCatalogItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemId: "item-123",
+          businessId: "biz-456",
+          description: "Pizza marinara",
+        }),
       );
     });
-
-    expect(mockUpdateCatalogItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        itemId: "item-123",
-        businessId: "biz-456",
-        description: "Pizza marinara",
-      }),
-    );
   });
 
   it("chiama onSuccess con l'item aggiornato dopo aggiornamento riuscito", async () => {
     const onSuccess = vi.fn();
     render(<EditItemDialog {...DEFAULT_PROPS} onSuccess={onSuccess} />);
 
-    await act(async () => {
-      fireEvent.submit(
-        screen.getByRole("button", { name: "Salva" }).closest("form")!,
-      );
-    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "Salva" }).closest("form")!,
+    );
 
-    expect(onSuccess).toHaveBeenCalledWith(UPDATED_ITEM);
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(UPDATED_ITEM);
+    });
   });
 
   it("pre-popola il campo prezzo come stringa vuota se defaultPrice è null", () => {

--- a/src/components/dashboard/onboarding-tour.test.tsx
+++ b/src/components/dashboard/onboarding-tour.test.tsx
@@ -167,4 +167,15 @@ describe("OnboardingTour", () => {
     expect(screen.getByText("Indietro")).toBeInTheDocument();
     expect(screen.getByText("Fine")).toBeInTheDocument();
   });
+
+  it("la X di chiusura è un type=button (niente submit implicito in un form)", async () => {
+    render(<OnboardingTour />);
+    await screen.findByTestId("joyride");
+
+    const closeButtons = screen.getAllByRole("button", { name: "Chiudi" });
+    expect(closeButtons.length).toBeGreaterThan(0);
+    for (const button of closeButtons) {
+      expect(button).toHaveAttribute("type", "button");
+    }
+  });
 });

--- a/src/components/dashboard/onboarding-tour.tsx
+++ b/src/components/dashboard/onboarding-tour.tsx
@@ -123,6 +123,7 @@ function TourTooltip({
         <CardTitle className="text-base">{step.title}</CardTitle>
         <button
           {...closeProps}
+          type="button"
           className="text-muted-foreground hover:text-foreground absolute top-3 right-3"
         >
           <X className="size-4" />

--- a/src/components/settings/account-delete-section.test.tsx
+++ b/src/components/settings/account-delete-section.test.tsx
@@ -1,10 +1,4 @@
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AccountDeleteSection } from "./account-delete-section";
@@ -125,13 +119,13 @@ describe("AccountDeleteSection", () => {
       target: { value: "  SuperSecret123!  " },
     });
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Elimina definitivamente" }),
-      );
-    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Elimina definitivamente" }),
+    );
 
-    expect(mockDeleteAccount).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockDeleteAccount).toHaveBeenCalledTimes(1);
+    });
     const fd = mockDeleteAccount.mock.calls[0][0] as FormData;
     expect(fd.get("currentPassword")).toBe("  SuperSecret123!  ");
   });
@@ -145,11 +139,9 @@ describe("AccountDeleteSection", () => {
       target: { value: "wrong-password" },
     });
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Elimina definitivamente" }),
-      );
-    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Elimina definitivamente" }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Password non corretta.")).toBeInTheDocument();
@@ -165,11 +157,9 @@ describe("AccountDeleteSection", () => {
       target: { value: "SuperSecret123!" },
     });
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Elimina definitivamente" }),
-      );
-    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Elimina definitivamente" }),
+    );
 
     await waitFor(() => {
       expect(
@@ -190,17 +180,20 @@ describe("AccountDeleteSection", () => {
       target: { value: "SuperSecret123!" },
     });
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Elimina definitivamente" }),
-      );
-    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Elimina definitivamente" }),
+    );
 
+    // La mutation è settled quando il bottone esce dallo stato "Eliminazione…":
+    // solo allora ha senso asserire che l'errore generico NON è comparso.
     await waitFor(() => {
       expect(
-        screen.queryByText("Si è verificato un errore. Riprova più tardi."),
-      ).not.toBeInTheDocument();
+        screen.getByRole("button", { name: "Elimina definitivamente" }),
+      ).toBeEnabled();
     });
+    expect(
+      screen.queryByText("Si è verificato un errore. Riprova più tardi."),
+    ).not.toBeInTheDocument();
   });
 
   it("chiude il dialog al click su Annulla", async () => {

--- a/src/components/settings/ade-credentials-section.test.tsx
+++ b/src/components/settings/ade-credentials-section.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AdeCredentialsSection } from "./ade-credentials-section";
+import { flushWithFakeTimers } from "../../../tests/_helpers/flush-fake-timers";
 
 // --- Mocks ---
 
@@ -303,11 +304,10 @@ describe("AdeCredentialsSection", () => {
         />,
       );
 
-      await act(async () => {
-        fireEvent.click(
-          screen.getByRole("button", { name: "Verifica connessione" }),
-        );
-      });
+      fireEvent.click(
+        screen.getByRole("button", { name: "Verifica connessione" }),
+      );
+      await flushWithFakeTimers();
 
       expect(screen.getByText("Connessione verificata.")).toBeInTheDocument();
 
@@ -329,11 +329,10 @@ describe("AdeCredentialsSection", () => {
         />,
       );
 
-      await act(async () => {
-        fireEvent.click(
-          screen.getByRole("button", { name: "Verifica connessione" }),
-        );
-      });
+      fireEvent.click(
+        screen.getByRole("button", { name: "Verifica connessione" }),
+      );
+      await flushWithFakeTimers();
 
       act(() => {
         vi.advanceTimersByTime(2999);
@@ -352,11 +351,10 @@ describe("AdeCredentialsSection", () => {
       );
 
       // First verification
-      await act(async () => {
-        fireEvent.click(
-          screen.getByRole("button", { name: "Verifica connessione" }),
-        );
-      });
+      fireEvent.click(
+        screen.getByRole("button", { name: "Verifica connessione" }),
+      );
+      await flushWithFakeTimers();
 
       expect(screen.getByText("Connessione verificata.")).toBeInTheDocument();
 
@@ -365,11 +363,10 @@ describe("AdeCredentialsSection", () => {
         vi.advanceTimersByTime(1500);
       });
 
-      await act(async () => {
-        fireEvent.click(
-          screen.getByRole("button", { name: "Verifica connessione" }),
-        );
-      });
+      fireEvent.click(
+        screen.getByRole("button", { name: "Verifica connessione" }),
+      );
+      await flushWithFakeTimers();
 
       expect(screen.getByText("Connessione verificata.")).toBeInTheDocument();
 
@@ -496,11 +493,10 @@ describe("AdeCredentialsSection", () => {
         />,
       );
 
-      await act(async () => {
-        fireEvent.click(
-          screen.getByRole("button", { name: "Verifica connessione" }),
-        );
-      });
+      fireEvent.click(
+        screen.getByRole("button", { name: "Verifica connessione" }),
+      );
+      await flushWithFakeTimers();
 
       expect(screen.getByText("Verifica fallita.")).toBeInTheDocument();
 

--- a/src/components/settings/edit-ade-credentials-section.test.tsx
+++ b/src/components/settings/edit-ade-credentials-section.test.tsx
@@ -103,10 +103,8 @@ describe("EditAdeCredentialsSection", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Salva" }));
 
-    await waitFor(() =>
-      expect(
-        screen.getByText("L'accesso con SPID non è disponibile."),
-      ).toBeInTheDocument(),
-    );
+    expect(
+      await screen.findByText("L'accesso con SPID non è disponibile."),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/storico/void-receipt-dialog.test.tsx
+++ b/src/components/storico/void-receipt-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { VoidReceiptDialog } from "./void-receipt-dialog";
 import { voidReceipt } from "@/server/void-actions";
@@ -78,14 +78,12 @@ describe("VoidReceiptDialog — QR code", () => {
     expect(screen.queryByText("Mostra QR code")).not.toBeInTheDocument();
   });
 
-  it("switches to the QR view showing the receipt URL on click", async () => {
+  it("switches to the QR view showing the receipt URL on click", () => {
     renderWithQuery(
       <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Mostra QR code"));
-    });
+    fireEvent.click(screen.getByText("Mostra QR code"));
 
     expect(
       screen.getByText((content) => content.includes("/r/doc-uuid-123")),
@@ -94,17 +92,13 @@ describe("VoidReceiptDialog — QR code", () => {
     expect(screen.getByText("Indietro")).toBeInTheDocument();
   });
 
-  it("goes back to the detail view from the QR view", async () => {
+  it("goes back to the detail view from the QR view", () => {
     renderWithQuery(
       <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Mostra QR code"));
-    });
-    await act(async () => {
-      fireEvent.click(screen.getByText("Indietro"));
-    });
+    fireEvent.click(screen.getByText("Mostra QR code"));
+    fireEvent.click(screen.getByText("Indietro"));
 
     // Back in detail view: the void button is visible again
     expect(screen.getByText("Annulla scontrino")).toBeInTheDocument();
@@ -113,18 +107,14 @@ describe("VoidReceiptDialog — QR code", () => {
 });
 
 describe("VoidReceiptDialog — banner reauth CIE (REVIEW #54)", () => {
-  async function openReauthBanner() {
+  function openReauthBanner() {
     renderWithQuery(
       <VoidReceiptDialog {...defaultProps} receipt={ACCEPTED_RECEIPT} />,
     );
     // detail → confirmingVoid
-    await act(async () => {
-      fireEvent.click(screen.getByText("Annulla scontrino"));
-    });
+    fireEvent.click(screen.getByText("Annulla scontrino"));
     // confirmingVoid → conferma → mutation risolve reauthRequired
-    await act(async () => {
-      fireEvent.click(screen.getByText("Annulla scontrino"));
-    });
+    fireEvent.click(screen.getByText("Annulla scontrino"));
     return screen.findByText(/Sessione CIE scaduta/);
   }
 

--- a/tests/_helpers/flush-fake-timers.ts
+++ b/tests/_helpers/flush-fake-timers.ts
@@ -1,0 +1,23 @@
+import { act } from "@testing-library/react";
+import { vi } from "vitest";
+
+/**
+ * Flusha le promise in volo (e i re-render React che ne derivano) mentre sono
+ * attivi i fake timer di Vitest.
+ *
+ * Sotto `vi.useFakeTimers()` NON si possono usare `waitFor`/`findBy*`: RTL
+ * riconosce solo i fake timer di Jest (`jestFakeTimersAreEnabled` controlla il
+ * global `jest`), quindi il suo `asyncWrapper` resta appeso a un
+ * `setTimeout(…, 0)` che nessuno avanzerà mai → il test va in timeout.
+ *
+ * Un tick asincrono dei timer finti dentro `act()` fa lo stesso lavoro: cede il
+ * controllo alla microtask queue e applica gli update risultanti. È anche l'uso
+ * legittimo di `act()` — avvolge l'avanzamento dei timer, non una chiamata
+ * `fireEvent`/`render` (che si auto-avvolgono già, vedi regola SonarCloud
+ * "Remove this redundant act() call").
+ */
+export async function flushWithFakeTimers(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}

--- a/tests/unit/pwa-install-prompt.test.tsx
+++ b/tests/unit/pwa-install-prompt.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import { PwaInstallPrompt } from "@/components/pwa/install-prompt";
 import { resetInstallPromptStoreForTests } from "@/lib/pwa/install-prompt-store";
 
@@ -119,10 +125,10 @@ describe("PwaInstallPrompt", () => {
       await act(async () => {
         window.dispatchEvent(event);
       });
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: /installa/i }));
+      fireEvent.click(screen.getByRole("button", { name: /installa/i }));
+      await waitFor(() => {
+        expect(event.prompt).toHaveBeenCalledOnce();
       });
-      expect(event.prompt).toHaveBeenCalledOnce();
     });
 
     it("hides banner after install button is clicked", async () => {
@@ -131,12 +137,12 @@ describe("PwaInstallPrompt", () => {
       await act(async () => {
         window.dispatchEvent(event);
       });
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: /installa/i }));
+      fireEvent.click(screen.getByRole("button", { name: /installa/i }));
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /installa/i }),
+        ).not.toBeInTheDocument();
       });
-      expect(
-        screen.queryByRole("button", { name: /installa/i }),
-      ).not.toBeInTheDocument();
     });
 
     it("hides banner and sets localStorage when dismiss button is clicked", async () => {
@@ -145,9 +151,8 @@ describe("PwaInstallPrompt", () => {
       await act(async () => {
         window.dispatchEvent(event);
       });
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: /non ora/i }));
-      });
+      // `handleDismiss` è sincrono: `fireEvent` flusha già l'update.
+      fireEvent.click(screen.getByRole("button", { name: /non ora/i }));
       expect(
         screen.queryByRole("button", { name: /installa/i }),
       ).not.toBeInTheDocument();


### PR DESCRIPTION
36 issue SonarCloud in un colpo solo.

- 34× "Remove this redundant act() call": `await act(async () => …)` che
  avvolgeva SOLO chiamate RTL (`fireEvent.*`), già auto-avvolte
  dall'`eventWrapper` di RTL. Sostituite con `fireEvent` + `waitFor`/`findBy*`
  sull'effetto osservabile.
- Dove sono attivi i fake timer (`receipt-success`, `ade-credentials-section`)
  `waitFor`/`findBy*` NON sono utilizzabili: RTL riconosce solo i fake timer di
  Jest, quindi il suo `asyncWrapper` attende un `setTimeout(…, 0)` finto che
  non scatterà mai → timeout. Nuovo helper condiviso
  `tests/_helpers/flush-fake-timers.ts` (tick asincrono dei timer dentro
  `act()`, uso legittimo perché non avvolge chiamate RTL).
- 1× "Prefer findByText over waitFor + getByText" in
  `edit-ade-credentials-section.test.tsx`.
- 1× "Add an explicit type attribute to this button": la X di chiusura del
  tooltip di `onboarding-tour.tsx` è ora `type="button"` (+ test di regressione).

Le asserzioni che prima passavano "per costruzione" dentro l'act ora aspettano
un segnale reale: alert renderizzato, mutation settled, bottone riabilitato.

Skill `testing-patterns` aggiornata con la regola e il trap dei fake timer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KzFjBXLHfMpbFyinpPypw7