### PR TITLE
fix(printing): l'auto-stampa non riparte alla riconnessione (niente doppia copia)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -130,41 +130,6 @@ fatto che i payload sono statici, ma è un single point of failure.
 
 ---
 
-### 74. Auto-stampa + "Ricollega e stampa" dalla schermata di successo → scontrino stampato due volte
-
-- **Categoria:** correttezza/UX · **Severità:** Medium — doppia copia cartacea dello stesso documento al banco; scenario ordinario (prima stampa della sessione con auto-stampa attiva, default ON)
-- **File:** `src/components/cassa/receipt-success.tsx:96-102` (effect auto-stampa: guard `autoPrintDone` settata solo a stampa avviata); `src/components/printing/print-receipt-button.tsx:96-104` (`handleConnectAndPrint`)
-
-**Problema.** L'effect di auto-stampa NON marca `autoPrintDone` quando al
-mount la stampante non è collegata: esce e resta armato (le deps includono
-`printer`, che cambia identità a ogni render, quindi l'effect rivaluta a ogni
-cambiamento di stato). Se l'utente, dalla stessa schermata, tocca "Stampa" →
-"Ricollega e stampa": `printer.connect()` porta lo snapshot a `connected`, il
-re-render fa ripartire l'effect che stampa (guard ancora `false`), e subito
-dopo `handleConnectAndPrint` chiama comunque `printToPrinter` → **due stampe
-dello stesso documento**. Condizioni: `autoPrint` attivo (default ON),
-`printableReceipt` disponibile, stampante non collegata al momento
-dell'emissione — cioè tipicamente il primo scontrino della giornata.
-
-**Fix (non ambiguo).**
-
-1. Nell'effect: alla **prima** valutazione con `printableReceipt` non-null,
-   marcare `autoPrintDone.current = true` PRIMA di decidere se stampare;
-   stampare solo se in quel momento `printer.status === "connected"` e
-   `autoPrint` è attivo. Semantica risultante (da documentare nel commento):
-   l'auto-stampa vale per la stampante già collegata all'emissione; una
-   connessione successiva è un'azione esplicita dell'utente, che la stampa la
-   ottiene già dal bottone. (Trade-off accettato: una riconnessione silenziosa
-   via `getDevices` completata un istante dopo il mount non auto-stampa più —
-   oggi `getDevices` è dietro flag, il caso è teorico.)
-2. **Test** (nel file esistente
-   `src/components/cassa/receipt-success-autoprint.test.tsx`): mount con
-   `status: "idle"` e auto-stampa ON → rerender con `status: "connected"` → `print` MAI chiamato
-   dall'effect; mount già `connected` → una sola chiamata (già coperto);
-   auto-stampa OFF → invariato.
-
----
-
 ## P3 — Bassa priorità
 
 ### 62. Stampa termica: i due pacchetti `@point-of-sale/*` hanno tabelle divergenti

--- a/src/components/cassa/receipt-success-autoprint.test.tsx
+++ b/src/components/cassa/receipt-success-autoprint.test.tsx
@@ -138,12 +138,67 @@ describe("auto-stampa", () => {
     expect(print).not.toHaveBeenCalled();
   });
 
+  it("non stampa quando la stampante si collega dopo il mount", async () => {
+    // Regressione: con la stampante non collegata all'emissione, l'utente tocca
+    // "Stampa" → "Ricollega e stampa". La connessione ri-renderizza questa
+    // schermata; se l'effect fosse ancora armato stamperebbe qui, e subito dopo
+    // il bottone stamperebbe di nuovo → due copie cartacee dello stesso
+    // documento.
+    const print = vi.fn().mockResolvedValue(null);
+    mockPrinter.current = printerState({ status: "idle", print });
+    const { rerender } = renderSuccess();
+    expect(await screen.findByText("Scontrino emesso")).toBeDefined();
+
+    mockPrinter.current = printerState({ status: "connected", print });
+    rerender(
+      <ReceiptSuccess
+        documentId="doc-1"
+        adeProgressive="0001-0042"
+        createdAt="2026-07-28T12:32:00.000Z"
+        lines={LINES}
+        paymentMethod="PC"
+        lotteryCode={null}
+        printHeader={HEADER}
+        onNewReceipt={vi.fn()}
+      />,
+    );
+
+    expect(print).not.toHaveBeenCalled();
+  });
+
   it("non stampa senza intestazione esercente", async () => {
     const print = vi.fn().mockResolvedValue(null);
     mockPrinter.current = printerState({ print });
     renderSuccess({ printHeader: null });
     expect(await screen.findByText("Scontrino emesso")).toBeDefined();
     expect(print).not.toHaveBeenCalled();
+  });
+
+  it("stampa quando i dati dello scontrino arrivano dopo il mount", async () => {
+    // L'effect si "arma" sulla prima valutazione con uno scontrino
+    // stampabile, non sul mount: se l'intestazione arriva un render dopo, con
+    // la stampante già collegata l'auto-stampa deve comunque partire (una
+    // volta sola).
+    const print = vi.fn().mockResolvedValue(null);
+    mockPrinter.current = printerState({ print });
+    const { rerender } = renderSuccess({ printHeader: null });
+    expect(await screen.findByText("Scontrino emesso")).toBeDefined();
+    expect(print).not.toHaveBeenCalled();
+
+    rerender(
+      <ReceiptSuccess
+        documentId="doc-1"
+        adeProgressive="0001-0042"
+        createdAt="2026-07-28T12:32:00.000Z"
+        lines={LINES}
+        paymentMethod="PC"
+        lotteryCode={null}
+        printHeader={HEADER}
+        onNewReceipt={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(print).toHaveBeenCalledTimes(1));
   });
 
   it("mostra comunque lo scontrino emesso se la stampa fallisce", async () => {

--- a/src/components/cassa/receipt-success.tsx
+++ b/src/components/cassa/receipt-success.tsx
@@ -93,11 +93,17 @@ export function ReceiptSuccess({
   // la blocca mai: se la stampante non risponde, l'utente vede comunque lo
   // scontrino emesso e ha il bottone "Stampa" per riprovare. Un fallimento di
   // stampa non è mai un fallimento di emissione.
+  //
+  // È un colpo solo, sparato alla prima valutazione con uno scontrino
+  // stampabile: vale per la stampante GIÀ collegata al momento dell'emissione.
+  // Una connessione successiva è un'azione esplicita dell'utente ("Ricollega e
+  // stampa"), che la stampa la ottiene già dal bottone — se l'effect restasse
+  // armato, quel tap produrrebbe due copie cartacee dello stesso documento.
   useEffect(() => {
-    if (autoPrintDone.current) return;
-    if (!printableReceipt || printer.status !== "connected") return;
-    if (!readPrinterPreferences().autoPrint) return;
+    if (autoPrintDone.current || !printableReceipt) return;
     autoPrintDone.current = true;
+    if (printer.status !== "connected") return;
+    if (!readPrinterPreferences().autoPrint) return;
     void printer.print(printableReceipt);
   }, [printableReceipt, printer]);
 


### PR DESCRIPTION
L'effect di auto-stampa in ReceiptSuccess non marcava `autoPrintDone` quando
al mount la stampante non era collegata: restava armato e, poiché le deps
includono `printer` (identità nuova a ogni render), rivalutava a ogni cambio
di stato. Toccando "Stampa" → "Ricollega e stampa" la connessione faceva
partire l'auto-stampa e subito dopo `handleConnectAndPrint` chiamava
`printToPrinter`: due copie cartacee dello stesso documento, nello scenario
ordinario del primo scontrino della giornata.

L'effect ora è un colpo solo: si arma alla prima valutazione con uno
scontrino stampabile e stampa solo se in quel momento la stampante è
collegata e l'auto-stampa è attiva. Una connessione successiva è un'azione
esplicita dell'utente, che la stampa la ottiene già dal bottone.

Test: mount `idle` + auto-stampa ON → rerender `connected` → nessuna stampa
dall'effect; dati dello scontrino che arrivano dopo il mount con stampante
già collegata → una sola stampa.

Chiude il finding #74 di REVIEW.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E8qU596Y4uH9UokwjKSe5g