### PR TITLE
fix(printing): rifiuta le stampanti non ESC/POS invece di stampare spazzatura

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -700,38 +700,6 @@ in `searchReceipts`) produrrebbe uno scontrino termico con zero articoli e
 
 ---
 
-### 79. Cat printer (profilo `meow`, service `0000ae30`): accoppiabile dal chooser ma stamperebbe spazzatura
-
-- **Categoria:** correttezza/hardware · **Severità:** Low — hardware di nicchia, ma l'esito è un documento fiscale illeggibile senza alcun segnale d'errore
-- **File:** `src/lib/printing/bluetooth-printer.ts:116-127` (`onConnected`), `src/lib/printing/printer-profile.ts:74-80` (`resolvePrinterLanguage`); complementare al finding #62
-
-**Problema.** I filtri del chooser del trasporto includono il service
-`0000ae30` — le "cat printer" economiche. Per quel profilo il trasporto emette
-`language: "meow"`, un protocollo **raster proprietario** che l'encoder v3 non
-supporta affatto. `resolvePrinterLanguage` degrada a `"esc-pos"`: il pairing
-riesce, la UI dice "Collegata", ma i byte ESC/POS su quell'hardware producono
-caratteri casuali o nessuna uscita. Il degrado (giusto per i nomi legacy tipo
-`meow` mai visti su hardware ESC/POS reale) qui trasforma un'incompatibilità
-certa in un fallimento silenzioso al momento della stampa.
-
-**Fix (non ambiguo).**
-
-1. In `onConnected`: se `device.language === "meow"` (valore RAW del
-   trasporto, prima della normalizzazione), NON marcare `connected`:
-   chiamare `transport.disconnect()`, non salvare `writeLastPrinter`, e
-   riportare lo snapshot a `idle`.
-2. Il rifiuto deve arrivare in UI: nuovo `PrintErrorCode`
-   `"incompatible-printer"` con messaggio in `error-messages.ts` ("Questa
-   stampante non è compatibile: serve una stampante termica ESC/POS.").
-   `connectPrinter` lo lancia quando il flush degli eventi si conclude con
-   quel rifiuto (flag di modulo settato da `onConnected`, azzerato a ogni
-   `connectPrinter`).
-3. **Test:** evento `connected` con `language: "meow"` → snapshot non
-   `connected`, nessun `writeLastPrinter`, `connectPrinter` rigetta
-   `incompatible-printer`; `language: "esc-pos"` → invariato.
-
----
-
 ## Rischi accettati (documentati, non da fixare)
 
 Scelte consapevoli con un trigger di riapertura. Non sono finding da pianificare.

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -61,7 +61,10 @@ fallimento di emissione.
 3. Profilo stampante normalizzato alla connessione da
    `src/lib/printing/printer-profile.ts`: il trasporto emette nomi di
    `codepageMapping`/`language` che l'encoder non accetta più (`default`,
-   `zjiang`, `meow`) e che lo farebbero **lanciare**.
+   `zjiang`, `meow`) e che lo farebbero **lanciare**. I profili che non sono
+   ESC/POS travestito (`meow`, le "cat printer") non vengono normalizzati ma
+   **rifiutati** all'accoppiamento (`isIncompatiblePrinterLanguage`): degradarli
+   darebbe "Collegata" in UI e caratteri casuali sullo scontrino.
 4. Rendering: `src/lib/printing/receipt-escpos.ts` (puro) rispecchia sezione per
    sezione il PDF di `src/lib/pdf/generate-sale-receipt.ts` e riusa
    `computeReceiptTotals` da `src/lib/receipts/receipt-totals.ts` (regola 17).
@@ -76,9 +79,9 @@ fallimento di emissione.
    stampa di prova e preferenze per dispositivo
    (`src/lib/printing/printer-preferences.ts`, su `localStorage`: una stampante
    è attaccata a un telefono, non a un account).
-7. Errori: mai Sentry (regola 20). Bluetooth spento, chooser annullato e
-   stampante fuori portata sono condizioni prevedibili dall'input utente →
-   messaggi azionabili da `src/lib/printing/error-messages.ts`.
+7. Errori: mai Sentry (regola 20). Bluetooth spento, chooser annullato,
+   stampante fuori portata o non ESC/POS sono condizioni prevedibili dall'input
+   utente → messaggi azionabili da `src/lib/printing/error-messages.ts`.
 
 ## Annullo documento (void)
 

--- a/src/lib/printing/bluetooth-printer.test.ts
+++ b/src/lib/printing/bluetooth-printer.test.ts
@@ -34,6 +34,8 @@ const mockTransport = {
   /** Caso difensivo: un `print()` che rigetta (non è ciò che fa la v2). */
   printThrows: false,
   reconnectFindsDevice: true,
+  /** GATT già caduto quando proviamo a chiudere la connessione. */
+  disconnectThrows: false,
   printed: [] as Uint8Array[],
   disconnectCalls: 0,
   instances: [] as MockPrinterInstance[],
@@ -86,6 +88,9 @@ vi.mock("@point-of-sale/webbluetooth-receipt-printer", () => {
 
     async disconnect() {
       mockTransport.disconnectCalls += 1;
+      if (mockTransport.disconnectThrows) {
+        throw new DOMException("GATT Server is disconnected", "NetworkError");
+      }
       this.emit("disconnected");
     }
 
@@ -137,9 +142,13 @@ beforeEach(() => {
   mockTransport.printHangs = false;
   mockTransport.printThrows = false;
   mockTransport.reconnectFindsDevice = true;
+  mockTransport.disconnectThrows = false;
   mockTransport.printed = [];
   mockTransport.disconnectCalls = 0;
   mockTransport.instances = [];
+  // `device` è condiviso fra i test: il profilo va riportato a una stampante
+  // ESC/POS ordinaria, altrimenti un test sul profilo `meow` sporca i seguenti.
+  mockTransport.device.language = "esc-pos";
   stubBluetoothAvailable();
 });
 
@@ -239,6 +248,79 @@ describe("connectPrinter", () => {
   it("converte un throw inatteso del trasporto in PrinterError", async () => {
     mockTransport.connectThrows = true;
     await expect(connectPrinter()).rejects.toThrow(PrinterError);
+  });
+});
+
+describe("connectPrinter — stampante non ESC/POS (profilo `meow`)", () => {
+  /**
+   * Le "cat printer" economiche: il chooser del trasporto le mostra (service
+   * `0000ae30`) ma parlano un raster proprietario. Accettarle significherebbe
+   * "Collegata" in UI e caratteri casuali sullo scontrino consegnato al
+   * cliente — un fallimento silenzioso su un documento fiscale.
+   */
+  beforeEach(() => {
+    mockTransport.device.language = "meow";
+  });
+
+  it("rifiuta l'accoppiamento con incompatible-printer invece di dire Collegata", async () => {
+    await expect(connectPrinter()).rejects.toMatchObject({
+      code: "incompatible-printer",
+    });
+  });
+
+  it("non marca la stampante come collegata", async () => {
+    await expect(connectPrinter()).rejects.toThrow(PrinterError);
+    expect(getPrinterSnapshot().status).toBe("idle");
+  });
+
+  it("non salva l'accoppiamento: non va riproposta al prossimo avvio", async () => {
+    await expect(connectPrinter()).rejects.toThrow(PrinterError);
+    expect(readLastPrinter()).toBeNull();
+  });
+
+  it("chiude il GATT invece di lasciare la connessione appesa", async () => {
+    await expect(connectPrinter()).rejects.toThrow(PrinterError);
+    expect(mockTransport.disconnectCalls).toBe(1);
+  });
+
+  it("resta idle anche dopo il `disconnected` in coda dal rifiuto", async () => {
+    // `disconnect()` emette l'evento su un macrotask successivo: senza
+    // invalidare il trasporto lo stato finirebbe su `disconnected`, cioè la UI
+    // offrirebbe "Ricollega" proprio sulla stampante appena rifiutata.
+    await expect(connectPrinter()).rejects.toThrow(PrinterError);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getPrinterSnapshot().status).toBe("idle");
+  });
+
+  it("rifiuta comunque se il GATT è già caduto mentre lo chiudiamo", async () => {
+    // La chiusura è pulizia, non il rifiuto: se fallisce non deve trasformarsi
+    // in un unhandled rejection né mascherare il vero motivo (regola 20).
+    mockTransport.disconnectThrows = true;
+
+    await expect(connectPrinter()).rejects.toMatchObject({
+      code: "incompatible-printer",
+    });
+    expect(getPrinterSnapshot().status).toBe("idle");
+  });
+
+  it("lascia ricollegare una stampante compatibile subito dopo", async () => {
+    await expect(connectPrinter()).rejects.toThrow(PrinterError);
+
+    mockTransport.device.language = "esc-pos";
+    await connectPrinter();
+
+    expect(getPrinterSnapshot().status).toBe("connected");
+  });
+
+  it("resta silenziosa sulla riconnessione automatica", async () => {
+    // `tryReconnectPrinter` gira al mount: un accoppiamento salvato prima di
+    // questo rifiuto non deve diventare un errore in UI (regola 20).
+    writeLastPrinter({ id: "dev-1", name: "Cat Printer" });
+    resetPrinterStoreForTests();
+    mockTransport.device.language = "meow";
+
+    await expect(tryReconnectPrinter()).resolves.toBeUndefined();
+    expect(getPrinterSnapshot().status).not.toBe("connected");
   });
 });
 

--- a/src/lib/printing/bluetooth-printer.ts
+++ b/src/lib/printing/bluetooth-printer.ts
@@ -27,6 +27,7 @@ import {
   writeLastPrinter,
 } from "./printer-preferences";
 import {
+  isIncompatiblePrinterLanguage,
   resolveCodepageMapping,
   resolvePrinterLanguage,
 } from "./printer-profile";
@@ -51,7 +52,9 @@ export type PrintErrorCode =
   /** Stampa richiesta senza una connessione attiva. */
   | "not-connected"
   /** La scrittura GATT è fallita: stampante spenta, fuori portata o occupata. */
-  | "unreachable";
+  | "unreachable"
+  /** Il dispositivo scelto non parla ESC/POS: accoppiamento rifiutato. */
+  | "incompatible-printer";
 
 export class PrinterError extends Error {
   readonly code: PrintErrorCode;
@@ -90,6 +93,9 @@ let initialized = false;
 /** La riconnessione automatica si tenta una volta per sessione: più componenti
  * montano l'hook e senza guard partirebbero `gatt.connect()` concorrenti. */
 let reconnectAttempted = false;
+/** L'ultimo `connected` osservato era hardware non ESC/POS: lo legge
+ * `connectPrinter` dopo il flush per trasformarlo in un errore in UI. */
+let incompatiblePrinter = false;
 const subscribers = new Set<() => void>();
 
 /** Sostituisce lo snapshot solo quando cambia davvero: `useSyncExternalStore`
@@ -113,7 +119,39 @@ function hydrateLastPrinter(): void {
   if (last) setSnapshot({ deviceName: last.name });
 }
 
+/**
+ * Chiude un accoppiamento con hardware che non parla ESC/POS.
+ *
+ * Il singleton viene invalidato **prima** di chiudere il GATT: `disconnect()`
+ * emette il suo evento su un macrotask successivo, e senza invalidazione quel
+ * `disconnected` in ritardo porterebbe lo snapshot su `disconnected` — che per
+ * contratto significa "era collegata, offri Ricollega", esattamente ciò che non
+ * vogliamo su una stampante appena rifiutata. Stesso pattern di
+ * `withPrintTimeout`.
+ */
+function rejectIncompatibleDevice(): void {
+  incompatiblePrinter = true;
+  const rejected = transport;
+  transport = null;
+  transportReady = null;
+  setSnapshot({ status: "idle" });
+  // L'accoppiamento non viene memorizzato (`writeLastPrinter` mai chiamata):
+  // la riconnessione automatica non riproporrà questo dispositivo.
+  void rejected?.disconnect().catch(() => {
+    // Il GATT si chiuderà comunque alla chiusura della pagina.
+  });
+}
+
 function onConnected(device: ConnectedDevice): void {
+  if (isIncompatiblePrinterLanguage(device.language)) {
+    // Il chooser del trasporto include anche stampanti non ESC/POS (le "cat
+    // printer", service 0000ae30). Normalizzare il loro profilo a `esc-pos`
+    // farebbe passare l'accoppiamento e uscire caratteri casuali da uno
+    // scontrino già emesso: qui l'incompatibilità è certa, va detta subito.
+    rejectIncompatibleDevice();
+    return;
+  }
+
   writeLastPrinter({ id: device.id, name: device.name });
   setSnapshot({
     status: "connected",
@@ -196,6 +234,7 @@ export function getPrinterServerSnapshot(): PrinterSnapshot {
  */
 export async function connectPrinter(): Promise<void> {
   await assertBluetoothUsable();
+  incompatiblePrinter = false;
   setSnapshot({ status: "connecting" });
 
   try {
@@ -207,6 +246,15 @@ export async function connectPrinter(): Promise<void> {
     throw new PrinterError(
       "not-selected",
       error instanceof Error ? error.message : undefined,
+    );
+  }
+
+  if (incompatiblePrinter) {
+    // Distinto da `not-selected`: qui l'utente ha scelto, ed è il dispositivo
+    // a non andare bene. Dirgli "riprova" lo manderebbe in loop.
+    throw new PrinterError(
+      "incompatible-printer",
+      "Stampante non compatibile ESC/POS",
     );
   }
 
@@ -331,5 +379,6 @@ export function resetPrinterStoreForTests(): void {
   transportReady = null;
   initialized = false;
   reconnectAttempted = false;
+  incompatiblePrinter = false;
   subscribers.clear();
 }

--- a/src/lib/printing/error-messages.test.ts
+++ b/src/lib/printing/error-messages.test.ts
@@ -9,6 +9,7 @@ const ALL_ERROR_CODES: PrintErrorCode[] = [
   "not-selected",
   "not-connected",
   "unreachable",
+  "incompatible-printer",
 ];
 
 describe("printErrorMessage", () => {
@@ -33,6 +34,12 @@ describe("printErrorMessage", () => {
 
   it("elenca cosa controllare quando la stampante non risponde", () => {
     expect(printErrorMessage("unreachable")).toContain("carta");
+  });
+
+  it("dice quale stampante serve quando quella scelta non è compatibile", () => {
+    // Senza il nome dello standard l'utente non sa cosa comprare né perché
+    // una stampante che il telefono vede non funziona.
+    expect(printErrorMessage("incompatible-printer")).toContain("ESC/POS");
   });
 });
 

--- a/src/lib/printing/error-messages.ts
+++ b/src/lib/printing/error-messages.ts
@@ -26,6 +26,11 @@ export function printErrorMessage(code: PrintErrorCode): string {
       return "Nessuna stampante collegata. Collegala dalle impostazioni.";
     case "unreachable":
       return "Stampante non raggiungibile: controlla che sia accesa, con carta e a portata, poi ricollegala.";
+    case "incompatible-printer":
+      // Il chooser Bluetooth mostra anche stampantine che non parlano ESC/POS
+      // (le "cat printer" da etichette): senza dire quale standard serve,
+      // l'utente riprova all'infinito con lo stesso dispositivo.
+      return "Questa stampante non è compatibile: serve una stampante termica ESC/POS. Con questa puoi comunque stampare il PDF.";
   }
 }
 

--- a/src/lib/printing/printer-profile.test.ts
+++ b/src/lib/printing/printer-profile.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  isIncompatiblePrinterLanguage,
   resolveCodepageMapping,
   resolvePrinterLanguage,
 } from "./printer-profile";
@@ -39,10 +40,34 @@ describe("resolvePrinterLanguage", () => {
   it('degrada "meow" a esc-pos invece di far lanciare l\'encoder', () => {
     // Profilo delle stampantine "cat" (service 0000ae30) del trasporto v2:
     // l'encoder v3 lancia "The specified language is not supported".
+    // Il degrado resta la rete di sicurezza: l'accoppiamento con quel profilo
+    // è però già rifiutato a monte da `isIncompatiblePrinterLanguage`.
     expect(resolvePrinterLanguage("meow")).toBe("esc-pos");
   });
 
   it("degrada undefined a esc-pos", () => {
     expect(resolvePrinterLanguage(undefined)).toBe("esc-pos");
+  });
+});
+
+describe("isIncompatiblePrinterLanguage", () => {
+  it('rifiuta "meow": raster proprietario, non è ESC/POS travestito', () => {
+    // Stampare byte ESC/POS su una cat printer produce caratteri casuali su
+    // un documento fiscale, senza alcun errore: va fermato all'accoppiamento.
+    expect(isIncompatiblePrinterLanguage("meow")).toBe(true);
+  });
+
+  it("non rifiuta i linguaggi che l'encoder supporta", () => {
+    expect(isIncompatiblePrinterLanguage("esc-pos")).toBe(false);
+  });
+
+  it("non rifiuta un profilo sconosciuto: lì il degrado a esc-pos è la scelta giusta", () => {
+    // Un nome nuovo a monte è quasi sempre una ESC/POS non ancora in tabella:
+    // rifiutarla la renderebbe inutilizzabile senza motivo.
+    expect(isIncompatiblePrinterLanguage("qualcosa-di-nuovo")).toBe(false);
+  });
+
+  it("non rifiuta undefined", () => {
+    expect(isIncompatiblePrinterLanguage(undefined)).toBe(false);
   });
 });

--- a/src/lib/printing/printer-profile.ts
+++ b/src/lib/printing/printer-profile.ts
@@ -68,8 +68,41 @@ export function resolveCodepageMapping(
 }
 
 /**
+ * Linguaggi del trasporto che NON sono ESC/POS travestito: degradarli sarebbe
+ * peggio che rifiutarli, perché produrrebbe byte insensati per l'hardware.
+ *
+ * `meow` è il profilo delle "cat printer" economiche (service `0000ae30`, nei
+ * filtri del chooser del trasporto): raster proprietario, nessuna parentela con
+ * ESC/POS. Un accoppiamento riuscito con quel profilo darebbe "Collegata" in UI
+ * e caratteri casuali sullo scontrino — un fallimento silenzioso su un
+ * documento fiscale già emesso.
+ */
+const INCOMPATIBLE_TRANSPORT_LANGUAGES: ReadonlySet<string> = new Set(["meow"]);
+
+/**
+ * L'hardware parla un protocollo che non possiamo produrre? Va rifiutato
+ * all'accoppiamento (cfr. `bluetooth-printer.ts`), non scoperto a stampa
+ * avviata.
+ *
+ * Solo per i profili di cui sappiamo con certezza che non sono ESC/POS: un
+ * nome sconosciuto è quasi sempre una ESC/POS non ancora in tabella e resta
+ * gestito dal degrado di `resolvePrinterLanguage`.
+ */
+export function isIncompatiblePrinterLanguage(
+  transportLanguage: string | undefined,
+): boolean {
+  return (
+    transportLanguage !== undefined &&
+    INCOMPATIBLE_TRANSPORT_LANGUAGES.has(transportLanguage)
+  );
+}
+
+/**
  * Normalizza il linguaggio del trasporto. Degrada a `esc-pos` (lo standard
  * de-facto) invece di propagare un valore che farebbe lanciare l'encoder.
+ *
+ * È la rete di sicurezza per i nomi ignoti: i profili notoriamente non
+ * ESC/POS non arrivano fin qui, li ferma `isIncompatiblePrinterLanguage`.
  */
 export function resolvePrinterLanguage(
   transportLanguage: string | undefined,


### PR DESCRIPTION
I filtri del chooser del trasporto includono il service `0000ae30` — le
"cat printer" economiche — per cui il trasporto emette `language: "meow"`,
un raster proprietario. `resolvePrinterLanguage` lo degradava a `esc-pos`:
l'accoppiamento riusciva, la UI diceva "Collegata" e i byte ESC/POS
producevano caratteri casuali su uno scontrino già emesso, senza alcun
segnale d'errore.

Ora `isIncompatiblePrinterLanguage` marca i profili notoriamente non
ESC/POS e `onConnected` li rifiuta: niente `writeLastPrinter`, GATT chiuso,
snapshot a `idle` e nuovo `PrintErrorCode` "incompatible-printer" con un
messaggio che dice quale standard serve. Il singleton del trasporto viene
invalidato prima della chiusura, così il `disconnected` in coda non porta
lo stato su "disconnected" ("offri Ricollega" sulla stampante appena
rifiutata). Il degrado a `esc-pos` resta per i nomi sconosciuti, che sono
quasi sempre ESC/POS non ancora in tabella.

Chiude il finding #79 di REVIEW.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UGopmMTo9U5vtrCpPv2aJc