### PR TITLE
fix(ade): optimistic lock e allineamento key_version su changeAdePassword (REVIEW #60, #71)

### DIFF
--- a/.claude/skills/security-patterns/SKILL.md
+++ b/.claude/skills/security-patterns/SKILL.md
@@ -239,6 +239,62 @@ endpoint che inneschi invio email, call AdE, generazione PDF, ecc.
 
 ---
 
+## `key_version` è per RIGA: chi riscrive un campo cifrato riscrive tutta la riga
+
+`ade_credentials.key_version` è **una colonna per riga**, non per campo: dice
+con quale versione di `ENCRYPTION_KEY` sono cifrati **tutti** gli `encrypted_*`
+di quella riga. Da qui due regole:
+
+1. **Mai cifrare con `getEncryptionKey()` etichettando con la versione letta
+   dalla riga.** `encrypt(value, getEncryptionKey(), row.keyVersion)` sembra
+   innocuo perché oggi coincidono, ma a cavallo di una rotazione
+   (`ENCRYPTION_KEY_VERSION=2`, righe ancora a v1) produce un payload
+   **marcato v1 e cifrato con la chiave v2**. Una key-map multi-versione
+   corretta lo decifra con la chiave v1 → authTag mismatch → dato perso. Usa
+   sempre `getEncryptionKey()` **insieme a** `getKeyVersion()`.
+2. **Aggiornare un solo campo cifrato non basta.** Se scrivi un campo con la
+   chiave corrente devi ri-cifrare **tutti** gli altri campi cifrati della riga
+   e aggiornare `key_version` nella stessa UPDATE — altrimenti i campi non
+   toccati restano cifrati con la chiave vecchia sotto un'etichetta nuova.
+   Include i campi opzionali (`encrypted_pin`, `encrypted_username`): decifra e
+   ri-cifra solo se non-null, mai `decrypt(null)`.
+
+Riferimento: `reencryptCredentialFields` in `src/server/onboarding-actions.ts`.
+
+**Test:** con `ENCRYPTION_KEY_VERSION` diverso dalla `keyVersion` della riga,
+asserire che OGNI chiamata a `encrypt` usa la versione corrente e che il set
+dell'UPDATE contiene `keyVersion` aggiornata.
+
+---
+
+## UPDATE dopo I/O esterno lungo: optimistic lock, non `WHERE id` secco
+
+Una server action che legge una riga, chiama un provider esterno per secondi
+(login/cambio password AdE, Stripe) e **poi** scrive, ha una finestra in cui
+un'altra sessione dello stesso utente può aver sostituito quella riga. Il
+`WHERE businessId` secco sovrascrive il lavoro dell'altra sessione con dati
+derivati da uno snapshot stantio.
+
+Pattern (da `finalizeAdeVerification` / `changeAdePassword`): snapshottare
+`row.updatedAt` **prima** della chiamata esterna e guardare l'UPDATE con
+
+```ts
+sql`date_trunc('milliseconds', ${table.updatedAt}) = ${snapshot.toISOString()}::timestamptz`;
+```
+
+`date_trunc` perché PostgreSQL scrive con precisione microsecondo mentre `Date`
+è millisecondo; ISO string + cast esplicito perché dentro un template `sql`
+Drizzle non ha il tipo colonna per bindare un `Date` (postgres-js crasha su
+`Buffer.byteLength(<Date>)`). Aggiungi al guard anche i campi discriminanti che
+non devono essere cambiati (es. `loginMethod = 'fisconline'`).
+
+Chiudere con `.returning({ id })`: 0 righe = lock miss → `logger.warn` +
+`{ error }` esplicito. **Il messaggio deve riflettere che l'effetto esterno è
+già avvenuto**: dopo un cambio password andato a buon fine su AdE, l'utente va
+spinto alla ri-verifica delle credenziali, non a ritentare il cambio.
+
+---
+
 ## `setInterval` in costruttori long-lived: chiamare `.unref?.()`
 
 Classi che istanziano `setInterval` nel costruttore (`RateLimiter`, scheduler,

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -402,35 +402,6 @@ shape esatta non è verificata a runtime.
 
 ---
 
-### 60. `changeAdePassword` senza optimistic lock né guard sul metodo: una race con `saveAdeCredentials` può corrompere credenziali CIE
-
-- **Categoria:** correttezza/robustezza · **Severità:** Low — finestra di secondi (durata del flusso HTTP AdE di cambio password), richiede azioni concorrenti dello stesso utente
-- **File:** `src/server/onboarding-actions.ts:1265-1268` (UPDATE finale di `encryptedPassword` + `verifiedAt` senza guard su `updatedAt` né su `loginMethod`); pattern corretto già esistente: `finalizeAdeVerification` (`:541-551`, guard `date_trunc('milliseconds', updatedAt) = <snapshot>`)
-
-**Problema.** `changeAdePassword` legge la riga credenziali, esegue il cambio
-password su AdE (secondi di HTTP) e poi scrive `encryptedPassword` +
-`verifiedAt` con `WHERE businessId` secco. Se nel frattempo l'utente ha
-salvato credenziali nuove (`saveAdeCredentials`, es. switch a CIE in un altro
-tab: azzera `verifiedAt` e riscrive i campi), l'UPDATE finale sovrascrive la
-**password CIE** con la password Fisconline appena cambiata e marca
-`verifiedAt` su credenziali mai verificate. `verifyAdeCredentials` ha
-l'optimistic lock proprio per questa classe di race (P1.1); qui manca.
-
-**Fix (non ambiguo).**
-
-1. Snapshot `cred.updatedAt` prima del flusso AdE; UPDATE finale con lo
-   stesso guard di `finalizeAdeVerification`
-   (`date_trunc('milliseconds', updatedAt) = <snapshot ISO>::timestamptz`)
-   - `loginMethod = 'fisconline'`.
-2. 0 righe aggiornate → `logger.warn` e ritorno `{ error: "Le credenziali
-sono state modificate nel frattempo. Verifica la connessione dalle
-impostazioni." }` — la password AdE è già cambiata lato portale, quindi il
-   messaggio deve spingere alla ri-verifica, non al retry del cambio.
-3. **Test:** update concorrente tra login e UPDATE → nessuna scrittura +
-   errore dedicato; flusso normale → invariato.
-
----
-
 ### 61. Webhook Stripe senza guardia sull'ordine degli eventi (`event.created`)
 
 - **Categoria:** robustezza/billing · **Severità:** Low — Stripe di norma consegna in ordine, ma non lo garantisce (retry, concorrenza)
@@ -456,30 +427,6 @@ finestra.
 4. **Test:** updated con `created` più vecchio del registrato → stato DB
    invariato + warn; sequenza in ordine → invariato; primo evento (colonna
    NULL) → applica.
-
----
-
-### 71. `changeAdePassword` cifra con la chiave corrente ma etichetta il payload con la `keyVersion` vecchia della riga
-
-- **Categoria:** sicurezza/operatività (rotazione chiavi) · **Severità:** Low — innocuo finché non si ruota `ENCRYPTION_KEY`; complementare al finding #17
-- **File:** `src/server/onboarding-actions.ts:1280` (`encrypt(newPassword, key, cred.keyVersion)` con `key = getEncryptionKey()` da `:1242`)
-
-**Problema.** Il byte di versione embeddato nel payload è `cred.keyVersion`
-(versione memorizzata sulla riga) mentre la chiave usata è quella corrente. A
-cavallo di una rotazione (`ENCRYPTION_KEY_VERSION=2`, righe ancora v1) produce
-un payload **etichettato v1 ma cifrato con la chiave v2**: la key-map
-multi-versione corretta (fix del finding #17) lo decifrerebbe con la chiave
-v1 → authTag mismatch → credenziali illeggibili. Nota strutturale: la colonna
-`key_version` è per-riga e copre tutti i campi cifrati, quindi ri-cifrare la
-sola password non basta.
-
-**Fix (non ambiguo).** In `changeAdePassword`, nell'UPDATE finale: ri-cifrare
-**tutti** i campi cifrati presenti sulla riga (CF — già decifrato nel flusso —,
-password nuova, PIN da decifrare allo stesso modo) con `getEncryptionKey()` +
-`getKeyVersion()` e aggiornare `key_version` nella stessa UPDATE. **Test:**
-con `ENCRYPTION_KEY_VERSION=2` tutti i campi della riga decifrano con la sola
-chiave v2 e `key_version=2`; con versione invariata → comportamento identico
-a oggi (round-trip decrypt di CF/PIN invariati).
 
 ---
 

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -97,13 +97,16 @@ vi.mock("@/lib/crypto", () => ({
   encrypt: (...args: unknown[]) => mockEncrypt(...args),
   decrypt: (...args: unknown[]) => mockDecrypt(...args),
   getEncryptionKey: () => Buffer.alloc(32),
-  getKeyVersion: () => 1,
+  // Legge la env come il modulo reale: serve ai test di rotazione chiave
+  // (REVIEW #71), dove ENCRYPTION_KEY_VERSION=2 su righe ancora a v1.
+  getKeyVersion: () => Number(process.env.ENCRYPTION_KEY_VERSION ?? "1"),
 }));
 
 const mockLogin = vi.fn();
 const mockLoginCie = vi.fn();
 const mockLogout = vi.fn();
 const mockGetFiscalData = vi.fn();
+const mockChangePasswordFisconline = vi.fn().mockResolvedValue(undefined);
 vi.mock("@/lib/ade", () => ({
   getAdeMode: () => "mock",
   createAdeClient: vi.fn().mockReturnValue({
@@ -111,6 +114,7 @@ vi.mock("@/lib/ade", () => ({
     loginCie: mockLoginCie,
     logout: mockLogout,
     getFiscalData: mockGetFiscalData,
+    changePasswordFisconline: mockChangePasswordFisconline,
   }),
 }));
 
@@ -2204,6 +2208,15 @@ describe("onboarding-actions", () => {
   });
 
   describe("changeAdePassword", () => {
+    // `vi.clearAllMocks()` (beforeEach globale) azzera le call ma NON le
+    // implementazioni: senza questo reset i payload tracciabili impostati da
+    // arrangeChangePassword resterebbero attivi per i test successivi.
+    beforeEach(() => {
+      mockEncrypt.mockReset().mockReturnValue("encrypted-data");
+      mockDecrypt.mockReset().mockReturnValue("decrypted-data");
+      mockChangePasswordFisconline.mockReset().mockResolvedValue(undefined);
+    });
+
     it("degrada a 'Non autenticato.' quando la sessione è scaduta (no throw)", async () => {
       // Sessione assente → degrada prima di ownership/rate-limit/AdE (regola 19/20).
       mockGetUser.mockResolvedValue({ data: { user: null } });
@@ -2230,6 +2243,191 @@ describe("onboarding-actions", () => {
       // Il guard precede l'ownership (SELECT) e il login AdE.
       expect(mockSelect).not.toHaveBeenCalled();
       expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    // --- REVIEW #60 (optimistic lock) + #71 (key version) ---
+
+    const CHANGE_PW_BUSINESS_ID = "11111111-1111-4111-8111-111111111111";
+    const CRED_UPDATED_AT = new Date("2026-07-01T10:00:00.000Z");
+
+    /**
+     * Arrangia il percorso completo di `changeAdePassword`: ownership OK,
+     * riga credenziali letta, cambio password su AdE riuscito. Ritorna la riga
+     * credenziali usata, così i test possono asserire sui campi ri-cifrati.
+     */
+    function arrangeChangePassword(
+      credOverrides: Record<string, unknown> = {},
+    ) {
+      const cred = {
+        id: "cred-1",
+        businessId: CHANGE_PW_BUSINESS_ID,
+        loginMethod: "fisconline",
+        encryptedCodiceFiscale: "enc-cf",
+        encryptedUsername: null,
+        encryptedPassword: "enc-old-pw",
+        encryptedPin: "enc-pin",
+        keyVersion: 1,
+        verifiedAt: new Date("2026-06-01T00:00:00.000Z"),
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: CRED_UPDATED_AT,
+        ...credOverrides,
+      };
+      mockLimit
+        .mockResolvedValueOnce([{ id: CHANGE_PW_BUSINESS_ID }]) // ownership
+        .mockResolvedValueOnce([cred]); // SELECT credenziali
+      // Payload cifrati tracciabili: `enc(<plaintext>|v<version>)`, così un
+      // test può verificare CHE COSA è stato cifrato e con QUALE versione.
+      mockDecrypt.mockImplementation((payload: string) => `plain:${payload}`);
+      mockEncrypt.mockImplementation(
+        (value: string, _key: unknown, version: number) =>
+          `enc(${value}|v${version})`,
+      );
+      mockChangePasswordFisconline.mockResolvedValue(undefined);
+      return cred;
+    }
+
+    async function runChangePassword() {
+      const { changeAdePassword } = await import("./onboarding-actions");
+      return changeAdePassword(
+        CHANGE_PW_BUSINESS_ID,
+        "OldPass1!",
+        "NewPass1!",
+        "NewPass1!",
+      );
+    }
+
+    it("guarda l'UPDATE finale con lo snapshot di updatedAt e loginMethod (REVIEW #60)", async () => {
+      arrangeChangePassword();
+
+      const result = await runChangePassword();
+
+      expect(result.businessId).toBe(CHANGE_PW_BUSINESS_ID);
+
+      // Il WHERE deve contenere il confronto date_trunc sullo snapshot letto
+      // PRIMA del flusso HTTP AdE, serializzato come ISO string + cast (mai un
+      // Date bindato: postgres-js crasherebbe su Buffer.byteLength).
+      const { PgDialect } = await import("drizzle-orm/pg-core");
+      const whereArg = mockUpdateWhere.mock.calls[0]?.[0];
+      const compiled = new PgDialect().sqlToQuery(whereArg);
+
+      expect(compiled.params).toContain(CRED_UPDATED_AT.toISOString());
+      expect(compiled.params.some((p) => p instanceof Date)).toBe(false);
+      expect(compiled.sql).toContain("::timestamptz");
+      // Guard sul metodo: una riga passata a CIE nel frattempo non deve
+      // ricevere la password Fisconline appena cambiata.
+      expect(compiled.params).toContain("fisconline");
+    });
+
+    it("lock miss (0 righe): nessun revalidate e messaggio che spinge alla ri-verifica (REVIEW #60)", async () => {
+      arrangeChangePassword();
+      mockUpdateReturning.mockReset().mockResolvedValue([]);
+
+      const result = await runChangePassword();
+
+      expect(result.error).toBe(
+        "Le credenziali sono state modificate nel frattempo. Verifica la connessione dalle impostazioni.",
+      );
+      expect(result.businessId).toBeUndefined();
+      // La password sul portale AdE è già cambiata: non è un errore da
+      // ritentare, quindi niente cache invalidation di uno stato non scritto.
+      expect(mockRevalidatePath).not.toHaveBeenCalled();
+      const { logger } = await import("@/lib/logger");
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ businessId: CHANGE_PW_BUSINESS_ID }),
+        expect.stringContaining("credenziali modificate"),
+      );
+    });
+
+    it("ri-cifra TUTTI i campi della riga con la chiave corrente e allinea key_version (REVIEW #71)", async () => {
+      // Rotazione in corso: env a v2, riga ancora a v1.
+      process.env.ENCRYPTION_KEY_VERSION = "2";
+      arrangeChangePassword({ keyVersion: 1 });
+
+      const result = await runChangePassword();
+
+      expect(result.businessId).toBe(CHANGE_PW_BUSINESS_ID);
+      const set = mockUpdateSet.mock.calls[0]?.[0];
+      // Nessun campo può restare etichettato v1: key_version è per RIGA.
+      expect(set).toMatchObject({
+        encryptedCodiceFiscale: "enc(plain:enc-cf|v2)",
+        encryptedPassword: "enc(NewPass1!|v2)",
+        encryptedPin: "enc(plain:enc-pin|v2)",
+        keyVersion: 2,
+      });
+      expect(set.verifiedAt).toBeInstanceOf(Date);
+      // Nessuna cifratura con la versione vecchia della riga.
+      expect(mockEncrypt.mock.calls.every((call) => call[2] === 2)).toBe(true);
+    });
+
+    it("versione invariata: comportamento identico a oggi (round-trip CF/PIN)", async () => {
+      process.env.ENCRYPTION_KEY_VERSION = "1";
+      arrangeChangePassword({ keyVersion: 1 });
+
+      const result = await runChangePassword();
+
+      expect(result.businessId).toBe(CHANGE_PW_BUSINESS_ID);
+      const set = mockUpdateSet.mock.calls[0]?.[0];
+      expect(set).toMatchObject({
+        encryptedCodiceFiscale: "enc(plain:enc-cf|v1)",
+        encryptedPassword: "enc(NewPass1!|v1)",
+        encryptedPin: "enc(plain:enc-pin|v1)",
+        keyVersion: 1,
+      });
+      expect(mockRevalidatePath).toHaveBeenCalled();
+    });
+
+    it("campi cifrati assenti restano null (nessun decrypt su null)", async () => {
+      arrangeChangePassword({ encryptedPin: null, encryptedUsername: null });
+
+      const result = await runChangePassword();
+
+      expect(result.businessId).toBe(CHANGE_PW_BUSINESS_ID);
+      const set = mockUpdateSet.mock.calls[0]?.[0];
+      expect(set.encryptedPin).toBeNull();
+      expect(set.encryptedUsername).toBeNull();
+      // Solo il CF viene decifrato: nessun decrypt(null) che lancerebbe.
+      expect(mockDecrypt).toHaveBeenCalledTimes(1);
+    });
+
+    it("ri-cifra anche encryptedUsername quando la riga lo valorizza", async () => {
+      arrangeChangePassword({ encryptedUsername: "enc-username" });
+
+      const result = await runChangePassword();
+
+      expect(result.businessId).toBe(CHANGE_PW_BUSINESS_ID);
+      const set = mockUpdateSet.mock.calls[0]?.[0];
+      expect(set.encryptedUsername).toBe("enc(plain:enc-username|v1)");
+    });
+
+    it("payload cifrato illeggibile: degrada a { error }, nessun throw (regola 19)", async () => {
+      arrangeChangePassword();
+      // Il decrypt del PIN avviene DOPO il cambio password su AdE: un throw
+      // qui sostituirebbe il messaggio inline con l'error boundary di Next.
+      mockDecrypt
+        .mockImplementationOnce((payload: string) => `plain:${payload}`) // CF
+        .mockImplementationOnce(() => {
+          throw new Error("authTag mismatch");
+        });
+
+      const result = await runChangePassword();
+
+      expect(result.error).toContain("Password cambiata sul portale AdE");
+      expect(mockUpdate).not.toHaveBeenCalled();
+      const { logger } = await import("@/lib/logger");
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ businessId: CHANGE_PW_BUSINESS_ID }),
+        expect.stringContaining("ri-cifratura"),
+      );
+    });
+
+    it("cambio password AdE fallito: nessuna scrittura sulle credenziali", async () => {
+      arrangeChangePassword();
+      mockChangePasswordFisconline.mockRejectedValue(new Error("AdE down"));
+
+      const result = await runChangePassword();
+
+      expect(result.error).toBeTruthy();
+      expect(mockUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -1215,6 +1215,77 @@ export async function markOnboardingTourSeen(): Promise<{ error?: string }> {
 
 const ADE_PASSWORD_REGEX = /^[a-zA-Z0-9*+§°ç@^?=)(/&%$£!|\\<>]{8,15}$/;
 
+/**
+ * Traduce un errore del cambio password AdE nel messaggio mostrato all'utente,
+ * loggandolo al livello corretto. Estratta da `changeAdePassword` per tenerla
+ * sotto la soglia S3776 di Cognitive Complexity (stesso motivo di
+ * `formatVoidError`): i due rami d'input utente (password attuale errata,
+ * nuova uguale alla vecchia) sono `warn` e non devono aprire issue Sentry
+ * (regola 20); tutto il resto passa da `logAdeFailure`, che distingue
+ * transient e failure.
+ */
+function formatChangePasswordError(err: unknown, businessId: string): string {
+  if (err instanceof AdeAuthError) {
+    logger.warn({ businessId }, "changeAdePassword: password attuale errata");
+    return "Password attuale non corretta.";
+  }
+  if (err instanceof AdeError && err.code === "ADE_CHANGE_PW_SAME") {
+    return "La nuova password deve essere diversa da quella attuale.";
+  }
+  logAdeFailure(
+    err,
+    { businessId },
+    {
+      transient: "changeAdePassword: AdE transient failure",
+      failure: "Cambio password AdE fallito",
+    },
+  );
+  return getUserFacingAdeErrorMessage(
+    err,
+    "Errore durante il cambio password. Riprova più tardi.",
+  ).message;
+}
+
+/**
+ * Ri-cifra TUTTI i campi cifrati della riga credenziali con la chiave corrente
+ * e ritorna il set da scrivere, `key_version` inclusa.
+ *
+ * Perché tutti e non solo la password appena cambiata: `key_version` è UNA
+ * colonna per RIGA, non per campo. Cifrare la nuova password con
+ * `getEncryptionKey()` (la chiave corrente) etichettandola con
+ * `cred.keyVersion` (la versione MEMORIZZATA) produce, a cavallo di una
+ * rotazione, un payload marcato v1 ma cifrato con la chiave v2: una key-map
+ * multi-versione corretta lo decifrerebbe con la chiave v1 → authTag mismatch
+ * → credenziali illeggibili. Allineare l'intera riga alla versione corrente
+ * chiude il buco (REVIEW #71) e non ostacola la rotazione zero-downtime
+ * (REVIEW #17).
+ *
+ * `encryptedUsername` è normalmente null su Fisconline (l'username è il CF), ma
+ * viene ri-cifrato se presente: qualunque campo lasciato alla chiave vecchia
+ * sotto una `key_version` nuova sarebbe perso.
+ */
+function reencryptCredentialFields(params: {
+  cred: { encryptedUsername: string | null; encryptedPin: string | null };
+  keys: Map<number, Buffer>;
+  key: Buffer;
+  codiceFiscale: string;
+  newPassword: string;
+}) {
+  const { cred, keys, key, codiceFiscale, newPassword } = params;
+  const version = getKeyVersion();
+  const reencrypt = (payload: string | null) =>
+    payload === null ? null : encrypt(decrypt(payload, keys), key, version);
+
+  return {
+    // Il CF è già decifrato dal flusso: nessun decrypt ridondante.
+    encryptedCodiceFiscale: encrypt(codiceFiscale, key, version),
+    encryptedUsername: reencrypt(cred.encryptedUsername),
+    encryptedPassword: encrypt(newPassword, key, version),
+    encryptedPin: reencrypt(cred.encryptedPin),
+    keyVersion: version,
+  };
+}
+
 export async function changeAdePassword(
   businessId: string,
   currentPassword: string,
@@ -1275,6 +1346,9 @@ export async function changeAdePassword(
   const key = getEncryptionKey();
   const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);
   const codiceFiscale = decrypt(cred.encryptedCodiceFiscale, keys);
+  // Snapshot per l'optimistic lock, letto PRIMA del flusso HTTP AdE: è la
+  // finestra (secondi) in cui un altro tab può sostituire le credenziali.
+  const credentialVersion = cred.updatedAt;
 
   const adeClient = createAdeClient(getAdeMode());
 
@@ -1286,35 +1360,68 @@ export async function changeAdePassword(
       confirmNewPassword,
     });
   } catch (err) {
-    if (err instanceof AdeAuthError) {
-      logger.warn({ businessId }, "changeAdePassword: password attuale errata");
-      return { error: "Password attuale non corretta." };
-    }
-    if (err instanceof AdeError && err.code === "ADE_CHANGE_PW_SAME") {
-      return {
-        error: "La nuova password deve essere diversa da quella attuale.",
-      };
-    }
-    logAdeFailure(
-      err,
-      { businessId },
-      {
-        transient: "changeAdePassword: AdE transient failure",
-        failure: "Cambio password AdE fallito",
-      },
-    );
-    const userFacing = getUserFacingAdeErrorMessage(
-      err,
-      "Errore durante il cambio password. Riprova più tardi.",
-    );
-    return { error: userFacing.message };
+    return { error: formatChangePasswordError(err, businessId) };
   }
 
-  const newEncryptedPassword = encrypt(newPassword, key, cred.keyVersion);
-  await db
+  // La ri-cifratura decifra PIN/username: succede DOPO il cambio password sul
+  // portale, quindi un payload illeggibile non deve propagare (regola 19) —
+  // l'error boundary di Next lascerebbe l'utente senza spiegazione con la
+  // password AdE già cambiata.
+  let reencrypted: ReturnType<typeof reencryptCredentialFields>;
+  try {
+    reencrypted = reencryptCredentialFields({
+      cred,
+      keys,
+      key,
+      codiceFiscale,
+      newPassword,
+    });
+  } catch (err) {
+    logger.error(
+      { err, businessId },
+      "changeAdePassword: ri-cifratura credenziali fallita",
+    );
+    return {
+      error:
+        "Password cambiata sul portale AdE, ma non è stato possibile salvarla. Verifica la connessione dalle impostazioni.",
+    };
+  }
+
+  const updated = await db
     .update(adeCredentials)
-    .set({ encryptedPassword: newEncryptedPassword, verifiedAt: new Date() })
-    .where(eq(adeCredentials.businessId, businessId));
+    .set({
+      ...reencrypted,
+      verifiedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(adeCredentials.businessId, businessId),
+        // Guard sul metodo: se nel frattempo la riga è passata a CIE, la
+        // password Fisconline appena cambiata non deve sovrascriverla.
+        eq(adeCredentials.loginMethod, "fisconline"),
+        // Stesso optimistic lock di `finalizeAdeVerification`: `date_trunc`
+        // perché PostgreSQL scrive `updatedAt` con precisione microsecondo
+        // mentre `Date` è millisecondo; snapshot serializzato come ISO string
+        // + cast esplicito perché dentro un template `sql` Drizzle non ha il
+        // tipo colonna per bindare un Date (postgres-js crasherebbe su
+        // `Buffer.byteLength(<Date>)`).
+        sql`date_trunc('milliseconds', ${adeCredentials.updatedAt}) = ${credentialVersion.toISOString()}::timestamptz`,
+      ),
+    )
+    .returning({ id: adeCredentials.id });
+
+  if (updated.length === 0) {
+    // La password sul portale AdE è GIÀ cambiata: il messaggio deve spingere
+    // alla ri-verifica delle credenziali, non a ritentare il cambio.
+    logger.warn(
+      { businessId },
+      "changeAdePassword: credenziali modificate durante il cambio password",
+    );
+    return {
+      error:
+        "Le credenziali sono state modificate nel frattempo. Verifica la connessione dalle impostazioni.",
+    };
+  }
 
   revalidatePath("/dashboard", "layout");
   logger.info({ businessId }, "Password Fisconline aggiornata con successo");

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -15,6 +15,8 @@ const {
   mockUpdate,
   mockSet,
   mockUpdateWhere,
+  mockUpdateReturning,
+  mockGetKeyVersion,
   mockGetEncryptionKey,
   mockDecrypt,
   mockEncrypt,
@@ -34,6 +36,8 @@ const {
   mockUpdate: vi.fn(),
   mockSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
+  mockUpdateReturning: vi.fn(),
+  mockGetKeyVersion: vi.fn(),
   mockGetEncryptionKey: vi.fn(),
   mockDecrypt: vi.fn(),
   mockEncrypt: vi.fn(),
@@ -66,7 +70,10 @@ vi.mock("@/lib/crypto", () => ({
   encrypt: mockEncrypt,
   decrypt: mockDecrypt,
   getEncryptionKey: mockGetEncryptionKey,
-  getKeyVersion: vi.fn().mockReturnValue(1),
+  // Hoisted (non `vi.fn()` inline): `vi.resetAllMocks()` nei beforeEach
+  // azzererebbe l'implementazione di un mock inline, facendo tornare
+  // `undefined` come key version.
+  getKeyVersion: mockGetKeyVersion,
 }));
 
 vi.mock("@/lib/ade", () => ({
@@ -98,13 +105,20 @@ vi.mock("@/lib/validation", () => ({ adePinSchema: { parse: vi.fn() } }));
 const USER_ID = "user-test";
 const BIZ_ID = "11111111-1111-4111-8111-111111111111";
 
+const CRED_UPDATED_AT = new Date("2026-07-01T10:00:00.000Z");
+
 const FAKE_CRED = {
   businessId: BIZ_ID,
+  loginMethod: "fisconline",
   encryptedCodiceFiscale: "enc-cf",
+  encryptedUsername: null,
   encryptedPassword: "enc-pw",
   encryptedPin: "enc-pin",
   keyVersion: 1,
   verifiedAt: null,
+  // Snapshot dell'optimistic lock (REVIEW #60): l'UPDATE finale lo serializza
+  // nel WHERE, quindi la riga di fixture DEVE averlo valorizzato.
+  updatedAt: CRED_UPDATED_AT,
 };
 
 const FAKE_KEY = Buffer.from("a".repeat(64), "hex");
@@ -115,7 +129,9 @@ function setupDb(credRow: object | null = FAKE_CRED) {
   mockFrom.mockReturnValue({ where: mockWhere });
   mockSelect.mockReturnValue({ from: mockFrom });
 
-  mockUpdateWhere.mockResolvedValue([]);
+  // L'UPDATE guardato termina con `.returning()`: 1 riga = lock acquisito.
+  mockUpdateReturning.mockResolvedValue([{ id: "cred-1" }]);
+  mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
   mockSet.mockReturnValue({ where: mockUpdateWhere });
   mockUpdate.mockReturnValue({ set: mockSet });
 
@@ -134,6 +150,7 @@ describe("changeAdePassword", () => {
     mockCheckBusinessOwnership.mockResolvedValue(null);
     mockRateLimiterCheck.mockReturnValue({ success: true });
     mockGetEncryptionKey.mockReturnValue(FAKE_KEY);
+    mockGetKeyVersion.mockReturnValue(1);
     mockDecrypt.mockReturnValue("CODICEFISCALE12");
     mockEncrypt.mockReturnValue("new-enc-pw");
     mockAdeChangePassword.mockResolvedValue(undefined);
@@ -281,13 +298,15 @@ describe("changeAdePassword", () => {
     );
     expect(result.error).toBeUndefined();
     expect(result.businessId).toBe(BIZ_ID);
-    expect(mockEncrypt).toHaveBeenCalledWith(
-      "NewPass12",
-      FAKE_KEY,
-      FAKE_CRED.keyVersion,
-    );
+    // Versione corrente della chiave, non quella memorizzata sulla riga
+    // (REVIEW #71): qui coincidono, il caso divergente è testato in
+    // src/server/onboarding-actions.test.ts.
+    expect(mockEncrypt).toHaveBeenCalledWith("NewPass12", FAKE_KEY, 1);
     expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({ encryptedPassword: "new-enc-pw" }),
+      expect.objectContaining({
+        encryptedPassword: "new-enc-pw",
+        keyVersion: 1,
+      }),
     );
   });
 });


### PR DESCRIPTION
L'UPDATE finale di changeAdePassword scriveva encryptedPassword + verifiedAt
con un `WHERE businessId` secco, dopo secondi di flusso HTTP verso AdE. Se in
quella finestra l'utente salvava credenziali nuove da un altro tab (switch a
CIE), la password CIE veniva sovrascritta con quella Fisconline appena
cambiata e verifiedAt marcato su credenziali mai verificate (#60).

Lo stesso UPDATE cifrava con la chiave corrente ma etichettava il payload con
`cred.keyVersion`, la versione memorizzata sulla riga. A cavallo di una
rotazione avrebbe prodotto payload marcati v1 ma cifrati con la chiave v2:
illeggibili non appena una key-map multi-versione corretta (#17) usasse
davvero la chiave giusta per ogni versione (#71).

- optimistic lock `date_trunc('milliseconds', updatedAt) = <snapshot>` con lo
  stesso pattern di finalizeAdeVerification, piu' guard `loginMethod =
  'fisconline'`; 0 righe -> warn + errore che spinge alla ri-verifica (la
  password sul portale AdE e' gia' cambiata, ritentare il cambio non serve)
- reencryptCredentialFields ri-cifra TUTTI i campi cifrati della riga (CF,
  username, password, PIN) con getEncryptionKey() + getKeyVersion() e allinea
  key_version nella stessa UPDATE: la colonna e' per riga, non per campo
- la ri-cifratura decifra PIN/username dopo l'effetto esterno: guardata da
  try-catch che degrada a { error } invece di propagare (regola 19)
- formatChangePasswordError estratta per restare sotto Cognitive Complexity 15

Test: lock miss, guard loginMethod, rotazione v1->v2, versione invariata,
campi null, username valorizzato, fallimento AdE senza scrittura, decrypt
illeggibile senza throw.

Lezione riusabile aggiunta alla skill security-patterns (key_version per riga,
optimistic lock su UPDATE dopo I/O esterno lungo).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SBJm9rMN5rAyQm48TiqsaM