### PR TITLE
fix(stripe): guardia sull'ordine degli eventi webhook (REVIEW #61)

### DIFF
--- a/.claude/skills/stripe-webhooks/SKILL.md
+++ b/.claude/skills/stripe-webhooks/SKILL.md
@@ -37,7 +37,7 @@ e la recovery da `past_due` non funziona mai.
 | `checkout.session.expired`        | Cleanup righe `pending` abbandonate (24h di default)         |
 | `customer.subscription.updated`   | Rinnovi, upgrade/downgrade, recovery da `past_due`           |
 | `customer.subscription.deleted`   | Cancellazione → reset a `trial` in transaction               |
-| `invoice.paid`                    | Aggiorna `currentPeriodEnd` su ogni rinnovo (safety net)     |
+| `invoice.paid`                    | Registrato/deduplicato, **nessuna scrittura** (vedi sotto)   |
 | `invoice.payment_failed`          | Imposta status `past_due`                                    |
 | `invoice.payment_action_required` | 3D Secure / SCA obbligatorio in EU (PSD2)                    |
 | `charge.dispute.created`          | Alert chargeback con `critical: true` — nessuna scrittura DB |
@@ -47,6 +47,40 @@ e la recovery da `past_due` non funziona mai.
 - `customer.subscription.created` — coperto da `checkout.session.completed`
 - `payment_intent.*` — coperti dagli eventi `invoice.*`
 - `customer.subscription.paused/resumed` — feature non usata
+
+### Ordering: Stripe non garantisce l'ordine di consegna
+
+Un evento consegnato in ritardo (retry fino a 3 giorni, consegne concorrenti)
+può riportare in DB uno stato **già superato**: due `customer.subscription.updated`
+ravvicinati — "annulla a fine periodo" poi "riattiva" dal portale — invertiti
+lasciano `cancel_at_period_end = true` finché un evento successivo non corregge.
+La dedup per `event.id` protegge dai duplicati, **non** dall'ordine.
+
+Guardia: `subscriptions.last_stripe_event_created` è il watermark
+`event.created` dell'ultimo evento **full-sync** applicato. `syncSubscriptionData`
+e `handleSubscriptionDeleted` aggiungono alla WHERE dell'UPDATE
+`isNotOlderThanWatermark(eventCreatedAt)` → `watermark IS NULL OR watermark <= created`;
+0 righe ⇒ evento stale ⇒ `logger.warn` `stripe_event_out_of_order` + **200**
+(ack, niente retry: l'evento è processato, non fallito).
+
+Tre regole quando tocchi il webhook:
+
+1. **La guardia vive nella WHERE, non in un read-then-write.** Sotto READ
+   COMMITTED il secondo UPDATE concorrente si accoda sul row lock e rivaluta la
+   condizione sulla riga aggiornata. Un confronto letto in anticipo ha una
+   finestra TOCTOU e con due consegne simultanee fa vincere l'ultimo a
+   committare — cioè il bug che stai cercando di chiudere.
+2. **Gli handler `invoice.*` non toccano il watermark.** Scrivono campi mirati
+   (solo `status` via `applySubscriptionUpdate`), non un full-sync: alzare il
+   watermark col `created` di un'invoice scarterebbe il
+   `customer.subscription.updated` appaiato, che ha spesso un `created` di poco
+   precedente. Per lo stesso motivo `invoice.paid` **non scrive**
+   `currentPeriodEnd`: `invoice.period_end` è la fine del ciclo appena _chiuso_,
+   e il writer unico di quella grandezza è `syncSubscriptionData`.
+3. **Il lookup `subRow` precede l'UPDATE full-sync**, per distinguere le due
+   cause di "0 righe": riga assente (desync reale → throw, Stripe ritenta) vs
+   guardia scattata (evento stale → warn + ack). Invertirli rende un desync
+   indistinguibile da un evento vecchio, e finirebbe silenziosamente in un warn.
 
 ### Stato "misto" subscription card (pending + trial)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -323,34 +323,6 @@ shape esatta non è verificata a runtime.
 
 ---
 
-### 61. Webhook Stripe senza guardia sull'ordine degli eventi (`event.created`)
-
-- **Categoria:** robustezza/billing · **Severità:** Low — Stripe di norma consegna in ordine, ma non lo garantisce (retry, concorrenza)
-- **File:** `src/app/api/stripe/webhook/route.ts:255-259` (`customer.subscription.updated` → `syncSubscriptionData` applica sempre) e `:373-443` (`syncSubscriptionData` sovrascrive status/priceId/cancelAtPeriodEnd/currentPeriodEnd senza confronto temporale); schema: `src/db/schema/subscriptions.ts`
-
-**Problema.** Due `customer.subscription.updated` ravvicinati (es. annulla a
-fine periodo → riattiva dal portale) consegnati fuori ordine lasciano nel DB
-lo stato **vecchio** (`cancelAtPeriodEnd: true`) finché un evento successivo
-non lo corregge — con effetto su copy UI e gate. La dedup per `event.id` non
-protegge dall'ordering; i retry di Stripe (fino a 3 giorni) amplificano la
-finestra.
-
-**Fix (non ambiguo).**
-
-1. Colonna `last_stripe_event_created` (timestamptz, nullable) su
-   `subscriptions` (migration handwritten, skill `db-migrations`).
-2. In `syncSubscriptionData` e `handleSubscriptionDeleted`: passare
-   `event.created`; l'UPDATE aggiunge
-   `WHERE last_stripe_event_created IS NULL OR last_stripe_event_created <= to_timestamp($created)`
-   e imposta la colonna. Evento più vecchio → 0 righe → log `warn`
-   `stripe_event_out_of_order` e **200** (ack, niente retry).
-3. Gli handler `invoice.*` (campi mirati, non full-sync) restano invariati.
-4. **Test:** updated con `created` più vecchio del registrato → stato DB
-   invariato + warn; sequenza in ordine → invariato; primo evento (colonna
-   NULL) → applica.
-
----
-
 ## Rischi accettati (documentati, non da fixare)
 
 Scelte consapevoli con un trigger di riapertura. Non sono finding da pianificare.

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -64,6 +64,9 @@ vi.mock("@/lib/logger", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  or: vi.fn(),
+  lte: vi.fn(),
+  isNull: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -81,15 +84,17 @@ function makeInsertBuilder(result: unknown[]) {
   return b;
 }
 
-function makeUpdateBuilder() {
+function makeUpdateBuilder(
+  returningResult: unknown[] = [{ id: "sub-id-default" }],
+) {
   // .where() returns the builder (for chaining .returning()).
-  // .returning() resolves to [row] by default (1 row updated).
-  // Handlers that do `await tx.update().set().where()` receive the builder
-  // object, which is discarded — that's fine since the value is never used.
+  // .returning() resolves to [row] by default (1 row updated); passare [] simula
+  // un UPDATE che non tocca righe — è così che si testa la guardia di ordering
+  // (REVIEW.md #61), che scarta gli eventi più vecchi del watermark.
   const builder = {
     set: vi.fn(),
     where: vi.fn(),
-    returning: vi.fn().mockResolvedValue([{ id: "sub-id-default" }]),
+    returning: vi.fn().mockResolvedValue(returningResult),
   };
   builder.set.mockReturnValue(builder);
   builder.where.mockReturnValue(builder);
@@ -131,6 +136,7 @@ function setupTransactionPassthrough() {
 // Tests
 // ---------------------------------------------------------------------------
 
+import { isNull, lte, or } from "drizzle-orm";
 import { POST } from "./route";
 
 describe("POST /api/stripe/webhook — request validation", () => {
@@ -328,6 +334,7 @@ describe("POST /api/stripe/webhook — invoice.paid (REVIEW #70)", () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_sub_upd_period",
       type: "customer.subscription.updated",
+      created: 1_700_000_000,
       data: {
         object: {
           id: "sub_123",
@@ -403,13 +410,15 @@ describe("POST /api/stripe/webhook — customer.subscription.deleted", () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_del_001",
       type: "customer.subscription.deleted",
+      created: 1_700_000_000,
       data: { object: { id: "sub_deleted_123", customer: "cus_123" } },
     });
 
     const res = await POST(makeRequest());
     expect(res.status).toBe(200);
     expect(mockTransaction).toHaveBeenCalled();
-    // First update: subscription → canceled + null su id/price/period.
+    // First update: subscription → canceled + null su id/price/period, più il
+    // watermark di ordering (REVIEW.md #61).
     // Necessario perché un futuro customer.subscription.updated cerca per
     // stripeSubscriptionId e non troverebbe la nuova sub se la riga ne porta uno stale.
     expect(updateBuilder.set).toHaveBeenCalledWith({
@@ -417,6 +426,7 @@ describe("POST /api/stripe/webhook — customer.subscription.deleted", () => {
       stripeSubscriptionId: null,
       stripePriceId: null,
       currentPeriodEnd: null,
+      lastStripeEventCreated: new Date(1_700_000_000 * 1000),
     });
     // Second update: profile → trial
     expect(updateBuilder.set).toHaveBeenCalledWith({ plan: "trial" });
@@ -432,6 +442,7 @@ describe("POST /api/stripe/webhook — customer.subscription.deleted", () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_del_002",
       type: "customer.subscription.deleted",
+      created: 1_700_000_000,
       data: { object: { id: "sub_deleted_456", customer: "cus_456" } },
     });
 
@@ -447,6 +458,7 @@ describe("POST /api/stripe/webhook — customer.subscription.deleted", () => {
       stripeSubscriptionId: null,
       stripePriceId: null,
       currentPeriodEnd: null,
+      lastStripeEventCreated: new Date(1_700_000_000 * 1000),
     });
   });
 
@@ -516,6 +528,7 @@ describe("POST /api/stripe/webhook — checkout.session.completed type guard", (
     mockConstructEvent.mockReturnValue({
       id: "evt_co_002",
       type: "checkout.session.completed",
+      created: 1_700_000_000,
       data: {
         object: {
           subscription: "sub_123",
@@ -590,6 +603,7 @@ describe("POST /api/stripe/webhook — customer.subscription.updated", () => {
     return {
       id: `evt_sub_upd_${cancelAtPeriodEnd}`,
       type: "customer.subscription.updated",
+      created: 1_700_000_000,
       data: {
         object: {
           id: "sub_123",
@@ -736,5 +750,272 @@ describe("POST /api/stripe/webhook — charge.dispute.created", () => {
     // Only the claim's completedAt is updated (success path); no other DB write
     expect(mockUpdate).toHaveBeenCalledTimes(1);
     expect(mockTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/stripe/webhook — ordering guard event.created (REVIEW #61)", () => {
+  const OLD_EVENT_CREATED = 1_700_000_000;
+  const NEW_EVENT_CREATED = 1_700_009_999;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    mockInsert.mockReturnValue(makeInsertBuilder([{ eventId: "evt_default" }]));
+    mockDelete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    mockSelect.mockReturnValue(makeSelectBuilder([{ userId: "user-123" }]));
+    mockPlanFromPriceId.mockReturnValue("pro");
+    mockIntervalFromPriceId.mockReturnValue("month");
+    setupTransactionPassthrough();
+  });
+
+  function makeUpdatedEvent(created: number, cancelAtPeriodEnd: boolean) {
+    return {
+      id: `evt_sub_upd_${created}`,
+      type: "customer.subscription.updated",
+      created,
+      data: {
+        object: {
+          id: "sub_123",
+          customer: "cus_123",
+          status: "active",
+          cancel_at_period_end: cancelAtPeriodEnd,
+          items: {
+            data: [{ price: { id: "price_pro" }, current_period_end: 9999 }],
+          },
+        },
+      },
+    };
+  }
+
+  it("registra event.created come watermark quando l'evento viene applicato", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue(
+      makeUpdatedEvent(NEW_EVENT_CREATED, false),
+    );
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastStripeEventCreated: new Date(NEW_EVENT_CREATED * 1000),
+      }),
+    );
+  });
+
+  it("costruisce la guardia come (watermark IS NULL OR watermark <= event.created)", async () => {
+    // `lte` (non `lt`): due eventi possono condividere lo stesso `created` e la
+    // dedup per event.id impedisce comunque di riapplicare lo stesso evento.
+    // La colonna NULL (primo evento in assoluto) deve sempre passare.
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue(
+      makeUpdatedEvent(NEW_EVENT_CREATED, false),
+    );
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    // `@/db/schema` è mockato come stringa, quindi la colonna passata agli
+    // operatori non è ispezionabile: si asserisce il secondo argomento di
+    // `lte` (la data dell'evento) e la presenza del ramo IS NULL nell'OR.
+    expect(vi.mocked(lte).mock.calls[0]?.[1]).toEqual(
+      new Date(NEW_EVENT_CREATED * 1000),
+    );
+    expect(vi.mocked(isNull)).toHaveBeenCalled();
+    expect(vi.mocked(or)).toHaveBeenCalled();
+  });
+
+  it("scarta un customer.subscription.updated più vecchio del watermark senza toccare il profilo", async () => {
+    // 0 righe aggiornate = la guardia ha respinto l'evento: la riga esiste
+    // (il SELECT trova userId) ma porta un watermark più recente.
+    const updateBuilder = makeUpdateBuilder([]);
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue(
+      makeUpdatedEvent(OLD_EVENT_CREATED, true),
+    );
+
+    const res = await POST(makeRequest());
+    // 200: ack, non è un errore da ritentare — l'evento è semplicemente stale.
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({ plan: "pro" }),
+    );
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripeCustomerId: "cus_123",
+        eventCreated: OLD_EVENT_CREATED,
+      }),
+      expect.stringContaining("stripe_event_out_of_order"),
+    );
+  });
+
+  it("applica normalmente quando la guardia lascia passare l'evento", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue(
+      makeUpdatedEvent(NEW_EVENT_CREATED, true),
+    );
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).toHaveBeenCalledWith(
+      expect.objectContaining({ cancelAtPeriodEnd: true }),
+    );
+    expect(updateBuilder.set).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: "pro" }),
+    );
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("stripe_event_out_of_order"),
+    );
+  });
+
+  it("propaga event.created anche da checkout.session.completed", async () => {
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+    mockSubscriptionsRetrieve.mockResolvedValue({
+      id: "sub_123",
+      status: "active",
+      customer: "cus_123",
+      cancel_at_period_end: false,
+      items: {
+        data: [{ price: { id: "price_pro" }, current_period_end: 9999 }],
+      },
+    });
+
+    mockConstructEvent.mockReturnValue({
+      id: "evt_co_watermark",
+      type: "checkout.session.completed",
+      created: NEW_EVENT_CREATED,
+      data: { object: { subscription: "sub_123", customer: "cus_123" } },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastStripeEventCreated: new Date(NEW_EVENT_CREATED * 1000),
+      }),
+    );
+  });
+
+  it("scarta un customer.subscription.deleted più vecchio senza declassare il profilo a trial", async () => {
+    const updateBuilder = makeUpdateBuilder([]);
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue({
+      id: "evt_del_stale",
+      type: "customer.subscription.deleted",
+      created: OLD_EVENT_CREATED,
+      data: { object: { id: "sub_123", customer: "cus_123" } },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).not.toHaveBeenCalledWith({ plan: "trial" });
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripeSubscriptionId: "sub_123",
+        eventCreated: OLD_EVENT_CREATED,
+      }),
+      expect.stringContaining("stripe_event_out_of_order"),
+    );
+  });
+
+  it("distingue riga assente da evento fuori ordine su customer.subscription.deleted", async () => {
+    // 0 righe aggiornate ma nessuna riga trovata dal SELECT: non è un problema
+    // di ordering, è una subscription che non abbiamo mai registrato.
+    const updateBuilder = makeUpdateBuilder([]);
+    mockUpdate.mockReturnValue(updateBuilder);
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+
+    mockConstructEvent.mockReturnValue({
+      id: "evt_del_missing",
+      type: "customer.subscription.deleted",
+      created: NEW_EVENT_CREATED,
+      data: { object: { id: "sub_unknown", customer: "cus_unknown" } },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("stripe_event_out_of_order"),
+    );
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ stripeSubscriptionId: "sub_unknown" }),
+      expect.stringContaining("no subscription row found"),
+    );
+  });
+
+  it("non rilascia il claim su un evento scartato (niente retry di Stripe)", async () => {
+    // Un evento stale è *processato*, non fallito: il claim resta e la dedup
+    // impedisce che i retry di Stripe (fino a 3 giorni) lo ripresentino.
+    const updateBuilder = makeUpdateBuilder([]);
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue(
+      makeUpdatedEvent(OLD_EVENT_CREATED, true),
+    );
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("continua a fallire con 500 se la riga subscription non esiste affatto", async () => {
+    // Il lookup precede l'UPDATE proprio per non confondere questo desync
+    // (riga mai creata → Stripe deve ritentare) con un evento fuori ordine.
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+    mockSelect.mockReturnValue(makeSelectBuilder([]));
+    mockTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<void>) => {
+        await fn({ update: mockUpdate, select: mockSelect });
+      },
+    );
+
+    mockConstructEvent.mockReturnValue(
+      makeUpdatedEvent(NEW_EVENT_CREATED, false),
+    );
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ stripeCustomerId: "cus_123" }),
+      expect.stringContaining("no subscription row found"),
+    );
+    // Claim rilasciato: questo sì che deve essere ritentato da Stripe.
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("non alza il watermark dagli handler invoice.* (full-sync appaiato non va perso)", async () => {
+    // invoice.payment_failed scrive solo `status`: se alzasse il watermark col
+    // proprio `created`, il customer.subscription.updated appaiato — che ha
+    // spesso un `created` di poco precedente — verrebbe scartato.
+    const updateBuilder = makeUpdateBuilder();
+    mockUpdate.mockReturnValue(updateBuilder);
+
+    mockConstructEvent.mockReturnValue({
+      id: "evt_pd_watermark",
+      type: "invoice.payment_failed",
+      created: NEW_EVENT_CREATED,
+      data: {
+        object: {
+          parent: { subscription_details: { subscription: "sub_123" } },
+        },
+      },
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateBuilder.set).toHaveBeenCalledWith({ status: "past_due" });
+    expect(updateBuilder.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({ lastStripeEventCreated: expect.anything() }),
+    );
   });
 });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull, lte, or } from "drizzle-orm";
 import { getDb } from "@/db";
 import { subscriptions, profiles, stripeWebhookEvents } from "@/db/schema";
 import {
@@ -235,7 +235,12 @@ async function handleEvent(event: Stripe.Event, stripe: Stripe): Promise<void> {
         // Stripe ritenterà l'evento.
         throw err;
       }
-      await syncSubscriptionData(db, session.customer as string, stripeSub);
+      await syncSubscriptionData(
+        db,
+        session.customer as string,
+        stripeSub,
+        event.created,
+      );
       break;
     }
 
@@ -256,7 +261,12 @@ async function handleEvent(event: Stripe.Event, stripe: Stripe): Promise<void> {
 
     case "customer.subscription.updated": {
       const sub = event.data.object as Stripe.Subscription;
-      await syncSubscriptionData(db, sub.customer as string, sub);
+      await syncSubscriptionData(
+        db,
+        sub.customer as string,
+        sub,
+        event.created,
+      );
       break;
     }
 
@@ -288,7 +298,7 @@ async function handleEvent(event: Stripe.Event, stripe: Stripe): Promise<void> {
 
     case "customer.subscription.deleted": {
       const sub = event.data.object as Stripe.Subscription;
-      await handleSubscriptionDeleted(db, sub);
+      await handleSubscriptionDeleted(db, sub, event.created);
       break;
     }
 
@@ -328,6 +338,28 @@ async function applySubscriptionUpdate(
 }
 
 /**
+ * Guardia sull'ordine di consegna (REVIEW.md #61): un evento full-sync si
+ * applica solo se non è più vecchio dell'ultimo già applicato sulla riga.
+ *
+ * `lte` e non `lt`: due eventi Stripe possono condividere lo stesso `created`
+ * (es. `invoice.paid` + `customer.subscription.updated` allo stesso secondo) e
+ * la dedup per `event.id` impedisce comunque di riapplicare lo stesso evento.
+ * `IS NULL` copre la prima scrittura, quando il watermark non esiste ancora.
+ *
+ * Vive nella WHERE dell'UPDATE, non in un read-then-write: sotto READ COMMITTED
+ * il secondo UPDATE concorrente si mette in coda sul row lock e rivaluta la
+ * condizione sulla riga aggiornata, quindi l'evento stale trova 0 righe. Un
+ * confronto letto in anticipo avrebbe una finestra TOCTOU e, con due consegne
+ * simultanee, lascerebbe vincere l'ultimo a committare — cioè il bug stesso.
+ */
+function isNotOlderThanWatermark(eventCreatedAt: Date) {
+  return or(
+    isNull(subscriptions.lastStripeEventCreated),
+    lte(subscriptions.lastStripeEventCreated, eventCreatedAt),
+  );
+}
+
+/**
  * Cancel a deleted Stripe subscription and downgrade the user's plan to trial.
  * Extracted to reduce Cognitive Complexity of handleEvent: the transaction
  * callback adds nesting that would otherwise push handleEvent over the limit.
@@ -335,7 +367,10 @@ async function applySubscriptionUpdate(
 async function handleSubscriptionDeleted(
   db: ReturnType<typeof getDb>,
   sub: Stripe.Subscription,
+  eventCreated: number,
 ): Promise<void> {
+  const eventCreatedAt = new Date(eventCreated * 1000);
+
   // Find the userId from the subscriptions table (read-only, outside tx)
   const [subRow] = await db
     .select({ userId: subscriptions.userId })
@@ -351,15 +386,29 @@ async function handleSubscriptionDeleted(
     // Lasciarli stale fa fallire `applySubscriptionUpdate` quando arriva un
     // customer.subscription.updated per la sub successiva creata dopo un
     // re-checkout (lookup per stripeSubscriptionId non trova la nuova).
-    await tx
+    const applied = await tx
       .update(subscriptions)
       .set({
         status: "canceled",
         stripeSubscriptionId: null,
         stripePriceId: null,
         currentPeriodEnd: null,
+        lastStripeEventCreated: eventCreatedAt,
       })
-      .where(eq(subscriptions.stripeSubscriptionId, sub.id));
+      .where(
+        and(
+          eq(subscriptions.stripeSubscriptionId, sub.id),
+          isNotOlderThanWatermark(eventCreatedAt),
+        ),
+      )
+      .returning({ id: subscriptions.id });
+
+    if (applied.length === 0) {
+      // 0 righe: o la riga non esiste (nessun `subRow`), o la guardia ha
+      // respinto un evento più vecchio del watermark. `subRow` discrimina.
+      logOutOfOrderOrMissing(sub.id, eventCreated, Boolean(subRow));
+      return;
+    }
 
     if (subRow) {
       await tx
@@ -368,6 +417,30 @@ async function handleSubscriptionDeleted(
         .where(eq(profiles.authUserId, subRow.userId));
     }
   });
+}
+
+/**
+ * Log del caso "UPDATE a 0 righe" su `customer.subscription.deleted`. Estratto
+ * per non annidare un if/else dentro il callback della transazione (Cognitive
+ * Complexity) e per tenere i due messaggi vicini: distinguerli è ciò che rende
+ * `stripe_event_out_of_order` una metrica leggibile invece di un catch-all.
+ */
+function logOutOfOrderOrMissing(
+  stripeSubscriptionId: string,
+  eventCreated: number,
+  rowExists: boolean,
+): void {
+  if (rowExists) {
+    logger.warn(
+      { stripeSubscriptionId, eventCreated, outOfOrder: true },
+      "stripe_event_out_of_order: customer.subscription.deleted più vecchio dell'ultimo evento applicato — ignorato, evento acknowledged",
+    );
+    return;
+  }
+  logger.warn(
+    { stripeSubscriptionId, eventCreated },
+    "customer.subscription.deleted: no subscription row found — event acknowledged",
+  );
 }
 
 /**
@@ -380,6 +453,7 @@ async function syncSubscriptionData(
   db: ReturnType<typeof getDb>,
   stripeCustomerId: string,
   stripeSub: Stripe.Subscription,
+  eventCreated: number,
 ): Promise<void> {
   const priceId = stripeSub.items.data[0]?.price.id ?? "";
   const plan = planFromPriceId(priceId);
@@ -406,21 +480,14 @@ async function syncSubscriptionData(
   // resta 'active' fino a currentPeriodEnd. Scriviamo sempre il valore corrente
   // così la riattivazione (toggle a false) si riallinea senza update parziali.
   const cancelAtPeriodEnd = stripeSub.cancel_at_period_end;
+  const eventCreatedAt = new Date(eventCreated * 1000);
 
   await db.transaction(async (tx) => {
-    await tx
-      .update(subscriptions)
-      .set({
-        stripeSubscriptionId: stripeSub.id,
-        stripePriceId: priceId,
-        status,
-        interval,
-        currentPeriodEnd,
-        cancelAtPeriodEnd,
-      })
-      .where(eq(subscriptions.stripeCustomerId, stripeCustomerId));
-
-    // Get userId from subscriptions to update profiles
+    // Il lookup precede l'UPDATE di proposito: serve a distinguere le due
+    // cause di un UPDATE a 0 righe — riga assente (desync, si rilancia perché
+    // Stripe ritenti) contro guardia di ordering scattata (evento stale, si
+    // acknowledgia). Senza questa lettura i due casi sono indistinguibili e un
+    // desync reale finirebbe silenziosamente in un warn.
     const [subRow] = await tx
       .select({ userId: subscriptions.userId })
       .from(subscriptions)
@@ -439,6 +506,41 @@ async function syncSubscriptionData(
       throw new Error(
         `syncSubscriptionData: no subscription row for stripeCustomerId ${stripeCustomerId}`,
       );
+    }
+
+    const applied = await tx
+      .update(subscriptions)
+      .set({
+        stripeSubscriptionId: stripeSub.id,
+        stripePriceId: priceId,
+        status,
+        interval,
+        currentPeriodEnd,
+        cancelAtPeriodEnd,
+        lastStripeEventCreated: eventCreatedAt,
+      })
+      .where(
+        and(
+          eq(subscriptions.stripeCustomerId, stripeCustomerId),
+          isNotOlderThanWatermark(eventCreatedAt),
+        ),
+      )
+      .returning({ id: subscriptions.id });
+
+    if (applied.length === 0) {
+      // La riga esiste (il SELECT sopra l'ha trovata) ⇒ 0 righe significa
+      // guardia di ordering. Niente scrittura sul profilo: applicare il plan
+      // di un evento stale è esattamente il bug che questa guardia previene.
+      logger.warn(
+        {
+          stripeCustomerId,
+          stripeSubscriptionId: stripeSub.id,
+          eventCreated,
+          outOfOrder: true,
+        },
+        "stripe_event_out_of_order: evento subscription più vecchio dell'ultimo applicato — ignorato, evento acknowledged",
+      );
+      return;
     }
 
     await tx

--- a/src/db/schema/subscriptions.ts
+++ b/src/db/schema/subscriptions.ts
@@ -28,6 +28,17 @@ export const subscriptions = pgTable("subscriptions", {
   cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
   /** 'month' | 'year' */
   interval: text("interval"),
+  /**
+   * Watermark `event.created` dell'ultimo evento Stripe **full-sync** applicato
+   * (`syncSubscriptionData`, `handleSubscriptionDeleted`). Stripe non garantisce
+   * l'ordine di consegna: senza questa guardia due `customer.subscription.updated`
+   * ravvicinati consegnati fuori ordine lasciano in DB lo stato vecchio
+   * (REVIEW.md #61). Gli handler `invoice.*` non lo toccano: scrivono campi
+   * mirati, non un full-sync. NULL = nessun evento registrato → il primo applica.
+   */
+  lastStripeEventCreated: timestamp("last_stripe_event_created", {
+    withTimezone: true,
+  }),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/supabase/migrations/0029_subscriptions_last_stripe_event_created.sql
+++ b/supabase/migrations/0029_subscriptions_last_stripe_event_created.sql
@@ -1,0 +1,28 @@
+-- Migration: 0029_subscriptions_last_stripe_event_created
+-- Guardia sull'ordine di consegna degli eventi Stripe (REVIEW.md #61).
+--
+-- Stripe consegna i webhook *di norma* in ordine, ma non lo garantisce: retry
+-- (fino a 3 giorni) e consegne concorrenti possono invertire due
+-- `customer.subscription.updated` ravvicinati (es. "annulla a fine periodo"
+-- seguito da "riattiva" dal portale). La dedup per `event.id` protegge dai
+-- duplicati, non dall'ordering: applicando per ultimo l'evento più vecchio, in
+-- DB resta `cancel_at_period_end = true` — quindi copy UI e plan-gate sbagliati
+-- — finché un evento successivo non corregge lo stato.
+--
+-- `last_stripe_event_created`: watermark = `event.created` dell'ultimo evento
+-- **full-sync** applicato (`syncSubscriptionData` e `handleSubscriptionDeleted`).
+-- L'UPDATE aggiunge `WHERE last_stripe_event_created IS NULL OR
+-- last_stripe_event_created <= <event.created>`: un evento più vecchio aggiorna
+-- 0 righe → warn `stripe_event_out_of_order` + 200 (ack, niente retry inutile).
+--
+-- Gli handler `invoice.*` restano fuori dal watermark di proposito: scrivono
+-- campi mirati (solo `status`), non un full-sync, e alzare il watermark con il
+-- `created` di un'invoice bloccherebbe il `customer.subscription.updated`
+-- appaiato, che ha spesso un `created` di poco precedente.
+--
+-- Nullable, nessun backfill: NULL = "nessun evento full-sync registrato" → il
+-- primo evento applica sempre. Solo ADD COLUMN IF NOT EXISTS → idempotente al
+-- re-run.
+
+ALTER TABLE "subscriptions"
+  ADD COLUMN IF NOT EXISTS "last_stripe_event_created" timestamptz;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1783764000000,
       "tag": "0028_profiles_last_seen",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1785628800000,
+      "tag": "0029_subscriptions_last_stripe_event_created",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Stripe consegna i webhook di norma in ordine ma non lo garantisce: retry
(fino a 3 giorni) e consegne concorrenti possono invertire due
`customer.subscription.updated` ravvicinati — es. "annulla a fine periodo"
seguito da "riattiva" dal portale. Applicando per ultimo l'evento più
vecchio in DB restava `cancel_at_period_end = true`, quindi copy UI e
plan-gate sbagliati, finché un evento successivo non correggeva lo stato.
La dedup per `event.id` protegge dai duplicati, non dall'ordering.

- Colonna `subscriptions.last_stripe_event_created` (timestamptz nullable,
  migration 0029): watermark `event.created` dell'ultimo evento full-sync
  applicato. NULL = nessun evento registrato → il primo applica sempre.
- `syncSubscriptionData` e `handleSubscriptionDeleted` ricevono
  `event.created`; la WHERE dell'UPDATE aggiunge
  `watermark IS NULL OR watermark <= created`. 0 righe ⇒ evento stale ⇒
  `logger.warn` `stripe_event_out_of_order` + 200 (ack, niente retry: è
  processato, non fallito).
- La guardia sta nella WHERE, non in un read-then-write: sotto READ
  COMMITTED il secondo UPDATE concorrente si accoda sul row lock e
  rivaluta la condizione sulla riga aggiornata. Un confronto letto in
  anticipo avrebbe una finestra TOCTOU e con due consegne simultanee
  farebbe vincere l'ultimo a committare — cioè il bug stesso.
- In `syncSubscriptionData` il lookup `subRow` precede ora l'UPDATE, per
  distinguere le due cause di "0 righe": riga assente (desync reale →
  throw, Stripe ritenta) contro guardia scattata (warn + ack).
- Gli handler `invoice.*` restano fuori dal watermark: scrivono campi
  mirati, non un full-sync, e alzarlo col `created` di un'invoice
  scarterebbe il `customer.subscription.updated` appaiato.

10 test nuovi (33 nel file): watermark registrato, forma della guardia
(`lte` e non `lt`, ramo IS NULL), evento stale scartato senza toccare il
profilo, sequenza in ordine, propagazione da checkout.session.completed,
deleted fuori ordine, riga assente distinta da evento stale, claim non
rilasciato su evento scartato, 500 invariato sul desync reale, invoice.*
che non alza il watermark.

Aggiornata la skill stripe-webhooks (sezione ordering + riga `invoice.paid`
della tabella, stale dal fix #70) e rimosso il finding da REVIEW.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WSjFH3foMtavvCJyQaaBdM