### PR TITLE
fix(crypto): key map multi-versione per la rotazione zero-downtime (REVIEW #17)

### DIFF
--- a/.claude/skills/ade-integration/SKILL.md
+++ b/.claude/skills/ade-integration/SKILL.md
@@ -131,32 +131,47 @@ flusso, l'invariante da testare è: nessun percorso chiama `submitSale`/
 Le credenziali Fisconline sono cifrate con AES-256-GCM; la chiave sta in
 `ENCRYPTION_KEY` (env var, 64 hex chars). Se compromessa o da ruotare:
 
-### Procedura obbligatoria prima del deploy
+### Runbook zero-downtime in tre fasi
 
-**PRIMA di cambiare l'env var sul server**, eseguire la migrazione:
+L'app costruisce la key map di `decrypt()` con **`getEncryptionKeys()`**
+(`src/lib/crypto.ts`), che tiene in memoria la chiave corrente **più** quella
+precedente opzionale: durante la rotazione righe a v1 e righe a v2 sono
+entrambe leggibili, quindi non serve alcuna finestra di fermo.
+
+**Fase 1 — deploy con entrambe le chiavi in env:**
+
+```bash
+ENCRYPTION_KEY=<NUOVA_64_HEX>            ENCRYPTION_KEY_VERSION=<NUOVA>
+ENCRYPTION_KEY_PREVIOUS=<VECCHIA_64_HEX> ENCRYPTION_KEY_PREVIOUS_VERSION=<VECCHIA>
+```
+
+Da qui le nuove scritture nascono già alla versione nuova. Smoke post-deploy
+(regola 25) **prima** di procedere: una config a metà (`ENCRYPTION_KEY_PREVIOUS`
+senza la sua `_VERSION`, o le due versioni uguali, o la stessa chiave in
+entrambe) fa fallire `getEncryptionKeys()` con messaggio esplicito.
+
+**Fase 2 — ri-cifrare le righe rimaste indietro** (ad app accesa):
 
 ```bash
 npx tsx scripts/rotate-encryption-key.ts \
-  --old-key  $ENCRYPTION_KEY \
-  --old-version $ENCRYPTION_KEY_VERSION \
-  --new-key  <NEW_64_HEX_KEY> \
-  --new-version <NEW_VERSION>
+  --old-key  $ENCRYPTION_KEY_PREVIOUS \
+  --old-version $ENCRYPTION_KEY_PREVIOUS_VERSION \
+  --new-key  <NUOVA_64_HEX> \
+  --new-version <NUOVA_VERSIONE>
 ```
 
-`scripts/rotate-encryption-key.ts`:
+Lo script legge tutti i record `ade_credentials`, decifra con la vecchia chiave,
+ri-cifra con la nuova, aggiorna `key_version`, il tutto in `db.transaction()`
+(atomico). È **idempotente**: salta le righe già alla nuova versione, quindi è
+ri-eseguibile. Ripetere finché `Rotated: 0, Skipped: <tutte>`.
 
-- Legge tutti i record `ade_credentials`
-- Decifra con la vecchia chiave
-- Ricicla con la nuova chiave
-- Aggiorna `key_version` nel DB
-- Wrappa tutto in `db.transaction()` → atomico
+**Fase 3 — rimuovere `ENCRYPTION_KEY_PREVIOUS*` dall'env e ri-deployare.** Mai
+prima della fase 2 completa: una riga ancora a v1 senza chiave v1 in env fa
+fallire `decrypt()` con `Unknown key version: 1` (errore esplicito, non dato
+corrotto — ma le credenziali di quel business restano inutilizzabili).
 
-Dopo la migrazione verificare che tutti i record abbiano `key_version = NEW_VERSION`,
-poi aggiornare le env var sul server e fare deploy.
-
-**Rollback:** se il deploy fallisce, riportare le env var alla versione precedente —
-i record con il vecchio `key_version` sono ancora decifrabili con la vecchia chiave
-(presente nell'immagine Docker precedente).
+**Rollback (fasi 1-2):** invertire le due env (vecchia come `ENCRYPTION_KEY`,
+nuova come `ENCRYPTION_KEY_PREVIOUS`) e ri-eseguire lo script a parti invertite.
 
 ### Generare una nuova chiave
 

--- a/.claude/skills/security-patterns/SKILL.md
+++ b/.claude/skills/security-patterns/SKILL.md
@@ -259,7 +259,15 @@ di quella riga. Da qui due regole:
    Include i campi opzionali (`encrypted_pin`, `encrypted_username`): decifra e
    ri-cifra solo se non-null, mai `decrypt(null)`.
 
-Riferimento: `reencryptCredentialFields` in `src/server/onboarding-actions.ts`.
+3. **Lato lettura, la key map viene da `getEncryptionKeys()`** (`src/lib/crypto.ts`),
+   mai da `new Map([[row.keyVersion, getEncryptionKey()]])`: quest'ultima mappa
+   la versione **memorizzata** sulla chiave **corrente**, cioè mente esattamente
+   nella finestra di rotazione in cui la key map serve. Simmetria da tenere a
+   mente: si **decifra** da N versioni (`getEncryptionKeys()`), si **cifra** su
+   una sola (`getEncryptionKey()` + `getKeyVersion()`).
+
+Riferimento: `reencryptCredentialFields` in `src/server/onboarding-actions.ts`;
+runbook di rotazione nella skill `ade-integration`.
 
 **Test:** con `ENCRYPTION_KEY_VERSION` diverso dalla `keyVersion` della riga,
 asserire che OGNI chiamata a `encrypt` usa la versione corrente e che il set

--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,12 @@ SENTRY_SENTINEL_TOKEN=
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ENCRYPTION_KEY=your-64-char-hex-key-here
 ENCRYPTION_KEY_VERSION=1
+# Chiave PRECEDENTE, opzionale: valorizzare ENTRAMBE queste variabili solo
+# durante una rotazione (fasi 1-2 del runbook in scripts/rotate-encryption-key.ts),
+# così le righe non ancora ri-cifrate restano leggibili. Rimuoverle dopo la
+# fase 2. Una sola delle due valorizzata = errore al primo decrypt.
+ENCRYPTION_KEY_PREVIOUS=
+ENCRYPTION_KEY_PREVIOUS_VERSION=
 
 # =============================================================================
 # Anti-frode trial: pepper per l'HMAC-SHA256 della P.IVA nel registro

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Per chi preferisce gestire l'installazione in autonomia (gratis, ma anche tutta 
    ```bash
    node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
    ```
-   e impostala in `ENCRYPTION_KEY` (vedi `CLAUDE.md` per la procedura di rotazione).
+   e impostala in `ENCRYPTION_KEY` (procedura di rotazione zero-downtime
+   nell'header di `scripts/rotate-encryption-key.ts`).
 4. Build e run con Docker Compose (`next-app` + `cloudflared`):
    ```bash
    docker compose pull && docker compose up -d

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -160,36 +160,6 @@ errori tipizzati nativamente. L'encoder invece va tenuto: il mapping codepage è
 esattamente il pezzo che non ha senso riscrivere. _Trigger:_ una segnalazione di
 stampante non riconosciuta, o un altro breaking change fra le due versioni.
 
-### 17. Key rotation zero-downtime: i caller passano sempre una sola chiave
-
-- **Categoria:** sicurezza/operatività · **Severità:** Low (finché non serve ruotare)
-- **File:** `src/lib/crypto.ts:103` (`getEncryptionKey`), `:142` (doc del pattern); caller: `src/lib/server-auth.ts:123-127`, `src/server/onboarding-actions.ts:267,349,610`; script esistente: `scripts/rotate-encryption-key.ts`
-
-**Problema.** `decrypt()` supporta già `Map<number, Buffer>` multi-versione, ma
-tutti i caller costruiscono `new Map([[row.keyVersion, getEncryptionKey()]])`:
-mappano la versione **memorizzata** sulla chiave **corrente**. Dopo una rotazione
-di `ENCRYPTION_KEY` le credenziali cifrate con la versione precedente diventano
-illeggibili (decrypt fallisce) finché non si ri-cifra tutto: la rotazione
-zero-downtime è impossibile nello stato attuale dei caller.
-
-**Fix (non ambiguo).**
-
-1. Introdurre `getEncryptionKeys(): Map<number, Buffer>` in `crypto.ts` che legge
-   la chiave corrente (`ENCRYPTION_KEY` + `ENCRYPTION_KEY_VERSION`) e,
-   opzionalmente, la precedente (`ENCRYPTION_KEY_PREVIOUS` +
-   `ENCRYPTION_KEY_PREVIOUS_VERSION`), con validazione fail-fast coerente con
-   `getEncryptionKey`.
-2. Migrare i 4 caller a `decrypt(payload, getEncryptionKeys())`.
-3. Runbook documentato (in `scripts/rotate-encryption-key.ts` header o
-   `docs/`): (a) deploy con entrambe le chiavi in env; (b) run
-   `rotate-encryption-key.ts` che ri-cifra le righe `key_version` vecchia;
-   (c) rimozione della chiave precedente dall'env.
-4. **Test E2E:** cifra con v1 → rotazione → decrypt con Map {1: old, 2: new}
-   funziona; dopo re-encryption decrypt con sola v2 funziona; chiave mancante per
-   una versione presente nel DB → errore esplicito (non silent garbage).
-
----
-
 ### 23. Indice composito `api_keys (business_id, revoked_at)`
 
 - **Categoria:** performance DB · **Severità:** Low · **Target: Developer API Fase B** (ora nice-to-have in PLAN.md)

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -61,6 +61,10 @@ NEW_SIGNUP_NOTIFICATION_EMAIL=
 # ---- Encryption -------------------------------------------------------------
 ENCRYPTION_KEY=your-64-char-hex-key-here
 ENCRYPTION_KEY_VERSION=1
+# Chiave precedente, solo durante una rotazione (vedi
+# scripts/rotate-encryption-key.ts). Entrambe o nessuna.
+ENCRYPTION_KEY_PREVIOUS=
+ENCRYPTION_KEY_PREVIOUS_VERSION=
 
 # Anti-frode trial: pepper HMAC della P.IVA (registro trial_vat_ledger).
 # Server-side runtime. Generate with: openssl rand -hex 32

--- a/scripts/rotate-encryption-key.ts
+++ b/scripts/rotate-encryption-key.ts
@@ -1,8 +1,34 @@
 /**
  * Key rotation script for ade_credentials.
  *
- * Re-encrypts all Fisconline credentials from old ENCRYPTION_KEY to a new one.
- * Run this BEFORE deploying updated env vars to the server.
+ * Ri-cifra le credenziali dalla vecchia ENCRYPTION_KEY alla nuova. È il passo 2
+ * di un runbook in tre fasi che NON richiede downtime (REVIEW #17): l'app legge
+ * la key map con `getEncryptionKeys()` (`src/lib/crypto.ts`), quindi durante la
+ * rotazione decifra sia le righe già ruotate sia quelle ancora alla versione
+ * precedente.
+ *
+ *   Fase 1 — deploy con ENTRAMBE le chiavi in env:
+ *     ENCRYPTION_KEY=<nuova>            ENCRYPTION_KEY_VERSION=<nuova versione>
+ *     ENCRYPTION_KEY_PREVIOUS=<vecchia> ENCRYPTION_KEY_PREVIOUS_VERSION=<vecchia>
+ *     Da qui le nuove scritture nascono già alla versione nuova e le righe
+ *     vecchie restano leggibili. Verificare con lo smoke post-deploy
+ *     (regola 25) prima di procedere.
+ *
+ *   Fase 2 — questo script, che ri-cifra le righe rimaste alla versione
+ *     precedente. È idempotente: le righe già alla nuova versione sono
+ *     saltate, quindi può essere ri-eseguito senza danni. Va eseguito ad app
+ *     accesa; l'unica finestra di rischio è una scrittura concorrente sulla
+ *     stessa riga (cambio password AdE), coperta dall'optimistic lock su
+ *     `updated_at` in `changeAdePassword`.
+ *
+ *   Fase 3 — rimuovere ENCRYPTION_KEY_PREVIOUS* dall'env e ri-deployare, solo
+ *     dopo che lo script riporta `Rotated: N, Skipped: <tutte le righe>`.
+ *     Rimuoverla prima rende illeggibili le righe non ancora ruotate
+ *     ("Unknown key version" esplicito, non garbage).
+ *
+ * Rollback (fasi 1-2): rimettere la vecchia chiave come ENCRYPTION_KEY e la
+ * nuova come ENCRYPTION_KEY_PREVIOUS, poi ri-eseguire lo script a parti
+ * invertite.
  *
  * Usage:
  *   npx tsx scripts/rotate-encryption-key.ts \
@@ -10,8 +36,6 @@
  *     --old-version <integer>    \
  *     --new-key  <64 hex chars>  \
  *     --new-version <integer>
- *
- * See CLAUDE.md rule 24 for the full rotation runbook.
  */
 
 import postgres from "postgres";

--- a/src/lib/crypto.test.ts
+++ b/src/lib/crypto.test.ts
@@ -8,6 +8,7 @@ import {
   decrypt,
   generateKey,
   getEncryptionKey,
+  getEncryptionKeys,
   getKeyVersion,
 } from "./crypto";
 
@@ -125,6 +126,13 @@ describe("getEncryptionKey", () => {
     process.env.ENCRYPTION_KEY = "abc123";
     expect(() => getEncryptionKey()).toThrow("ENCRYPTION_KEY");
   });
+
+  it("throws when ENCRYPTION_KEY is 64 chars but not hex", () => {
+    // Prima del fix passava la sola check di lunghezza: `Buffer.from(hex, "hex")`
+    // troncava silenziosamente al primo carattere non-hex → chiave corta.
+    process.env.ENCRYPTION_KEY = "z".repeat(64);
+    expect(() => getEncryptionKey()).toThrow("ENCRYPTION_KEY");
+  });
 });
 
 describe("getKeyVersion", () => {
@@ -173,4 +181,226 @@ describe("getKeyVersion", () => {
       expect(() => getKeyVersion()).toThrow(/ENCRYPTION_KEY_VERSION/);
     },
   );
+});
+
+describe("getEncryptionKeys", () => {
+  const KEY_ENVS = [
+    "ENCRYPTION_KEY",
+    "ENCRYPTION_KEY_VERSION",
+    "ENCRYPTION_KEY_PREVIOUS",
+    "ENCRYPTION_KEY_PREVIOUS_VERSION",
+  ] as const;
+  const original = new Map(KEY_ENVS.map((name) => [name, process.env[name]]));
+
+  const CURRENT_HEX = "ab".repeat(32);
+  const PREVIOUS_HEX = "cd".repeat(32);
+
+  afterEach(() => {
+    for (const name of KEY_ENVS) {
+      const value = original.get(name);
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  function setCurrent(hex = CURRENT_HEX, version = "2") {
+    process.env.ENCRYPTION_KEY = hex;
+    process.env.ENCRYPTION_KEY_VERSION = version;
+  }
+
+  function setPrevious(hex = PREVIOUS_HEX, version = "1") {
+    process.env.ENCRYPTION_KEY_PREVIOUS = hex;
+    process.env.ENCRYPTION_KEY_PREVIOUS_VERSION = version;
+  }
+
+  function clearPrevious() {
+    delete process.env.ENCRYPTION_KEY_PREVIOUS;
+    delete process.env.ENCRYPTION_KEY_PREVIOUS_VERSION;
+  }
+
+  it("returns only the current key when no previous key is configured", () => {
+    setCurrent(CURRENT_HEX, "2");
+    clearPrevious();
+
+    const keys = getEncryptionKeys();
+
+    expect([...keys.keys()]).toEqual([2]);
+    expect(keys.get(2)?.toString("hex")).toBe(CURRENT_HEX);
+  });
+
+  it("defaults the current version to 1 when ENCRYPTION_KEY_VERSION is unset", () => {
+    process.env.ENCRYPTION_KEY = CURRENT_HEX;
+    delete process.env.ENCRYPTION_KEY_VERSION;
+    clearPrevious();
+
+    expect([...getEncryptionKeys().keys()]).toEqual([1]);
+  });
+
+  it("returns both versions when the previous key is configured", () => {
+    setCurrent(CURRENT_HEX, "2");
+    setPrevious(PREVIOUS_HEX, "1");
+
+    const keys = getEncryptionKeys();
+
+    expect([...keys.keys()].sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(keys.get(1)?.toString("hex")).toBe(PREVIOUS_HEX);
+    expect(keys.get(2)?.toString("hex")).toBe(CURRENT_HEX);
+  });
+
+  it("treats present-but-empty previous envs as not configured (regola 18)", () => {
+    setCurrent(CURRENT_HEX, "2");
+    process.env.ENCRYPTION_KEY_PREVIOUS = "";
+    process.env.ENCRYPTION_KEY_PREVIOUS_VERSION = "";
+
+    expect([...getEncryptionKeys().keys()]).toEqual([2]);
+  });
+
+  it("throws when the previous key is set without its version", () => {
+    setCurrent(CURRENT_HEX, "2");
+    clearPrevious();
+    process.env.ENCRYPTION_KEY_PREVIOUS = PREVIOUS_HEX;
+
+    expect(() => getEncryptionKeys()).toThrow(
+      /ENCRYPTION_KEY_PREVIOUS_VERSION/,
+    );
+  });
+
+  it("throws when the previous version is set without its key", () => {
+    setCurrent(CURRENT_HEX, "2");
+    clearPrevious();
+    process.env.ENCRYPTION_KEY_PREVIOUS_VERSION = "1";
+
+    expect(() => getEncryptionKeys()).toThrow(/ENCRYPTION_KEY_PREVIOUS/);
+  });
+
+  it.each(["abc123", "zz".repeat(32), "ab".repeat(31)])(
+    "throws on a malformed previous key %s",
+    (hex) => {
+      setCurrent(CURRENT_HEX, "2");
+      setPrevious(hex, "1");
+
+      expect(() => getEncryptionKeys()).toThrow(/ENCRYPTION_KEY_PREVIOUS/);
+    },
+  );
+
+  it.each(["0", "256", "abc", "1.5", ""])(
+    "throws on an invalid previous version %s",
+    (version) => {
+      setCurrent(CURRENT_HEX, "2");
+      process.env.ENCRYPTION_KEY_PREVIOUS = PREVIOUS_HEX;
+      process.env.ENCRYPTION_KEY_PREVIOUS_VERSION = version;
+
+      expect(() => getEncryptionKeys()).toThrow(
+        /ENCRYPTION_KEY_PREVIOUS_VERSION/,
+      );
+    },
+  );
+
+  it("throws when previous and current share the same version", () => {
+    setCurrent(CURRENT_HEX, "2");
+    setPrevious(PREVIOUS_HEX, "2");
+
+    expect(() => getEncryptionKeys()).toThrow(/same version/i);
+  });
+
+  it("throws when the previous key is a copy of the current key", () => {
+    setCurrent(CURRENT_HEX, "2");
+    setPrevious(CURRENT_HEX, "1");
+
+    expect(() => getEncryptionKeys()).toThrow(/same key/i);
+  });
+
+  it("accepts a previous version higher than the current one (rollback)", () => {
+    // Rollback di una rotazione: la chiave "precedente" è quella nuova, con
+    // versione più alta. Legale — l'ordine delle versioni non è un vincolo.
+    setCurrent(CURRENT_HEX, "2");
+    setPrevious(PREVIOUS_HEX, "3");
+
+    const keys = getEncryptionKeys();
+
+    expect([...keys.keys()].sort((a, b) => a - b)).toEqual([2, 3]);
+  });
+
+  it("propagates the ENCRYPTION_KEY failure when the current key is missing", () => {
+    delete process.env.ENCRYPTION_KEY;
+    clearPrevious();
+
+    expect(() => getEncryptionKeys()).toThrow("ENCRYPTION_KEY");
+  });
+});
+
+describe("key rotation E2E (REVIEW #17)", () => {
+  const KEY_ENVS = [
+    "ENCRYPTION_KEY",
+    "ENCRYPTION_KEY_VERSION",
+    "ENCRYPTION_KEY_PREVIOUS",
+    "ENCRYPTION_KEY_PREVIOUS_VERSION",
+  ] as const;
+  const original = new Map(KEY_ENVS.map((name) => [name, process.env[name]]));
+
+  const OLD_HEX = "11".repeat(32);
+  const NEW_HEX = "22".repeat(32);
+
+  afterEach(() => {
+    for (const name of KEY_ENVS) {
+      const value = original.get(name);
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  it("decrypts v1 rows after rotating to v2 with both keys in env", () => {
+    // Fase A: cifrato in produzione con la sola chiave v1.
+    process.env.ENCRYPTION_KEY = OLD_HEX;
+    process.env.ENCRYPTION_KEY_VERSION = "1";
+    const stored = encrypt("PIN-1234", getEncryptionKey(), getKeyVersion());
+
+    // Fase B: deploy con entrambe le chiavi, prima di ri-cifrare le righe.
+    process.env.ENCRYPTION_KEY = NEW_HEX;
+    process.env.ENCRYPTION_KEY_VERSION = "2";
+    process.env.ENCRYPTION_KEY_PREVIOUS = OLD_HEX;
+    process.env.ENCRYPTION_KEY_PREVIOUS_VERSION = "1";
+
+    expect(decrypt(stored, getEncryptionKeys())).toBe("PIN-1234");
+  });
+
+  it("decrypts with the current key alone once the row is re-encrypted (fase C)", () => {
+    process.env.ENCRYPTION_KEY = OLD_HEX;
+    process.env.ENCRYPTION_KEY_VERSION = "1";
+    const stored = encrypt("PIN-1234", getEncryptionKey(), getKeyVersion());
+
+    process.env.ENCRYPTION_KEY = NEW_HEX;
+    process.env.ENCRYPTION_KEY_VERSION = "2";
+    process.env.ENCRYPTION_KEY_PREVIOUS = OLD_HEX;
+    process.env.ENCRYPTION_KEY_PREVIOUS_VERSION = "1";
+
+    // Ri-cifratura (scripts/rotate-encryption-key.ts) → riga marcata v2.
+    const rotated = encrypt(
+      decrypt(stored, getEncryptionKeys()),
+      getEncryptionKey(),
+      getKeyVersion(),
+    );
+
+    // Fase C: chiave precedente rimossa dall'env.
+    delete process.env.ENCRYPTION_KEY_PREVIOUS;
+    delete process.env.ENCRYPTION_KEY_PREVIOUS_VERSION;
+
+    expect(decrypt(rotated, getEncryptionKeys())).toBe("PIN-1234");
+  });
+
+  it("fails explicitly when a stored version has no key in env", () => {
+    process.env.ENCRYPTION_KEY = OLD_HEX;
+    process.env.ENCRYPTION_KEY_VERSION = "1";
+    const stored = encrypt("PIN-1234", getEncryptionKey(), getKeyVersion());
+
+    // Rotazione senza chiave precedente in env: errore esplicito, non garbage.
+    process.env.ENCRYPTION_KEY = NEW_HEX;
+    process.env.ENCRYPTION_KEY_VERSION = "2";
+    delete process.env.ENCRYPTION_KEY_PREVIOUS;
+    delete process.env.ENCRYPTION_KEY_PREVIOUS_VERSION;
+
+    expect(() => decrypt(stored, getEncryptionKeys())).toThrow(
+      "Unknown key version: 1",
+    );
+  });
 });

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -96,16 +96,41 @@ export function generateKey(): string {
 }
 
 /**
+ * Parse a 64-character hex key from an env var, con messaggio che nomina la
+ * variabile: un errore generico su una config a due chiavi (corrente +
+ * precedente) non dice quale delle due è rotta.
+ */
+function parseKeyHex(hex: string, envName: string): Buffer {
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(`${envName} must be a 64-character hex string`);
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/** Parse a key version (intero in [1, 255]) da un env var nominata. */
+function parseKeyVersion(raw: string, envName: string): number {
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${envName} must be a positive integer (1-255), got: ${raw}`,
+    );
+  }
+
+  const version = Number.parseInt(raw, 10);
+  if (!Number.isInteger(version) || version < 1 || version > 255) {
+    throw new Error(
+      `${envName} must be an integer in range [1, 255], got: ${raw}`,
+    );
+  }
+  return version;
+}
+
+/**
  * Load the active encryption key from the ENCRYPTION_KEY environment variable.
  *
  * @throws If the variable is missing or not a 64-character hex string.
  */
 export function getEncryptionKey(): Buffer {
-  const hex = process.env.ENCRYPTION_KEY;
-  if (hex?.length !== 64) {
-    throw new Error("ENCRYPTION_KEY must be a 64-character hex string");
-  }
-  return Buffer.from(hex, "hex");
+  return parseKeyHex(process.env.ENCRYPTION_KEY ?? "", "ENCRYPTION_KEY");
 }
 
 /**
@@ -119,35 +144,105 @@ export function getEncryptionKey(): Buffer {
 export function getKeyVersion(): number {
   const raw = process.env.ENCRYPTION_KEY_VERSION;
   if (raw === undefined || raw === "") return 1;
-
-  if (!/^\d+$/.test(raw)) {
-    throw new Error(
-      `ENCRYPTION_KEY_VERSION must be a positive integer (1-255), got: ${raw}`,
-    );
-  }
-
-  const version = Number.parseInt(raw, 10);
-  if (!Number.isInteger(version) || version < 1 || version > 255) {
-    throw new Error(
-      `ENCRYPTION_KEY_VERSION must be an integer in range [1, 255], got: ${raw}`,
-    );
-  }
-  return version;
+  return parseKeyVersion(raw, "ENCRYPTION_KEY_VERSION");
 }
 
 /**
- * KEY ROTATION WARNING
+ * Legge la chiave PRECEDENTE opzionale (`ENCRYPTION_KEY_PREVIOUS` +
+ * `ENCRYPTION_KEY_PREVIOUS_VERSION`), presente solo durante una rotazione.
  *
- * The callers of decrypt() build the key map as:
- *   new Map([[cred.keyVersion, getEncryptionKey()]])
+ * Entrambe assenti o vuote (regola 18: un env "present-but-empty" non è un
+ * default) → `null`, nessuna chiave aggiuntiva. Metà configurazione → throw:
+ * silenziosamente ignorarla renderebbe illeggibili le righe non ancora
+ * ri-cifrate, cioè esattamente il bug che questa funzione esiste per evitare.
+ */
+function readPreviousKey(): { version: number; key: Buffer } | null {
+  const hex = process.env.ENCRYPTION_KEY_PREVIOUS;
+  const rawVersion = process.env.ENCRYPTION_KEY_PREVIOUS_VERSION;
+  const hasKey = hex !== undefined && hex !== "";
+  const hasVersion = rawVersion !== undefined && rawVersion !== "";
+
+  if (!hasKey && !hasVersion) return null;
+  if (!hasVersion) {
+    throw new Error(
+      "ENCRYPTION_KEY_PREVIOUS_VERSION must be set alongside ENCRYPTION_KEY_PREVIOUS",
+    );
+  }
+  if (!hasKey) {
+    throw new Error(
+      "ENCRYPTION_KEY_PREVIOUS must be set alongside ENCRYPTION_KEY_PREVIOUS_VERSION",
+    );
+  }
+
+  return {
+    version: parseKeyVersion(rawVersion, "ENCRYPTION_KEY_PREVIOUS_VERSION"),
+    key: parseKeyHex(hex, "ENCRYPTION_KEY_PREVIOUS"),
+  };
+}
+
+/**
+ * Key map da passare a `decrypt()`: la chiave corrente più, durante una
+ * rotazione, quella precedente.
  *
- * This means they always map the stored keyVersion to the CURRENT key.
- * If you rotate (new ENCRYPTION_KEY + new ENCRYPTION_KEY_VERSION), old
- * credentials encrypted with the previous key will fail to decrypt.
+ * Perché esiste (REVIEW #17): i caller costruivano
+ * `new Map([[row.keyVersion, getEncryptionKey()]])`, cioè mappavano la versione
+ * MEMORIZZATA sulla chiave CORRENTE. A cavallo di una rotazione quella mappa
+ * mente — decifra un payload v1 con la chiave v2 → authTag mismatch — e la
+ * rotazione richiedeva quindi una finestra di downtime fra la ri-cifratura
+ * delle righe e il deploy della nuova env. Qui ogni versione è mappata sulla
+ * chiave che l'ha davvero prodotta, e una versione senza chiave in env
+ * fallisce esplicita in `decrypt()` ("Unknown key version") invece di
+ * produrre garbage.
  *
- * Before rotating keys you MUST re-encrypt all ade_credentials rows
- * with the new key first, THEN deploy the updated env vars.
+ * Runbook di rotazione zero-downtime:
  *
- * Future improvement: support multiple active keys via env vars so that
- * zero-downtime rotation is possible without a re-encryption migration.
+ *  1. Deploy con ENTRAMBE le chiavi in env: la nuova come `ENCRYPTION_KEY` +
+ *     `ENCRYPTION_KEY_VERSION`, la vecchia come `ENCRYPTION_KEY_PREVIOUS` +
+ *     `ENCRYPTION_KEY_PREVIOUS_VERSION`. Le righe ancora alla versione vecchia
+ *     restano leggibili; le nuove scritture nascono già alla versione nuova.
+ *  2. `npx tsx scripts/rotate-encryption-key.ts` per ri-cifrare le righe
+ *     rimaste alla versione precedente (idempotente, ri-eseguibile).
+ *  3. Rimuovere `ENCRYPTION_KEY_PREVIOUS*` dall'env e ri-deployare.
+ *
+ * @throws Se la chiave corrente manca/è malformata, se la coppia precedente è
+ * configurata a metà, o se la precedente collide con la corrente (stessa
+ * versione o stessa chiave: entrambe rendono la rotazione una no-op silenziosa).
+ */
+export function getEncryptionKeys(): Map<number, Buffer> {
+  const currentVersion = getKeyVersion();
+  const currentKey = getEncryptionKey();
+  const keys = new Map<number, Buffer>([[currentVersion, currentKey]]);
+
+  const previous = readPreviousKey();
+  if (!previous) return keys;
+
+  if (previous.version === currentVersion) {
+    throw new Error(
+      `ENCRYPTION_KEY_PREVIOUS_VERSION and ENCRYPTION_KEY_VERSION are set to the same version (${currentVersion}): the previous key would shadow the current one`,
+    );
+  }
+  if (previous.key.equals(currentKey)) {
+    throw new Error(
+      "ENCRYPTION_KEY_PREVIOUS is the same key as ENCRYPTION_KEY: a rotation needs a distinct previous key",
+    );
+  }
+
+  keys.set(previous.version, previous.key);
+  return keys;
+}
+
+/**
+ * KEY ROTATION
+ *
+ * I caller di `decrypt()` devono costruire la key map con
+ * `getEncryptionKeys()`, MAI con `new Map([[row.keyVersion, getEncryptionKey()]])`:
+ * quest'ultima etichetta la chiave corrente con la versione memorizzata e
+ * mente a cavallo di una rotazione (REVIEW #17).
+ *
+ * `encrypt()` invece usa sempre e solo la chiave corrente,
+ * `encrypt(plaintext, getEncryptionKey(), getKeyVersion())`: si decifra da N
+ * versioni, si cifra su una sola.
+ *
+ * Runbook completo nella doc di `getEncryptionKeys()` sopra e nell'header di
+ * `scripts/rotate-encryption-key.ts`.
  */

--- a/src/lib/server-auth.test.ts
+++ b/src/lib/server-auth.test.ts
@@ -44,6 +44,7 @@ const mockDecrypt = vi.fn().mockReturnValue("decrypted-value");
 vi.mock("@/lib/crypto", () => ({
   decrypt: (...args: unknown[]) => mockDecrypt(...args),
   getEncryptionKey: () => Buffer.alloc(32),
+  getEncryptionKeys: () => new Map([[1, Buffer.alloc(32)]]),
 }));
 
 const mockBuildCedenteFromBusiness = vi

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -4,7 +4,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getDb } from "@/db";
 import { adeCredentials, businesses, profiles } from "@/db/schema";
-import { decrypt, getEncryptionKey } from "@/lib/crypto";
+import { decrypt, getEncryptionKeys } from "@/lib/crypto";
 import { buildCedenteFromBusiness } from "@/lib/ade/mapper";
 import { UnauthenticatedError } from "@/lib/auth-errors";
 import { logger } from "@/lib/logger";
@@ -225,8 +225,9 @@ export async function fetchAdePrerequisites(
     };
   }
 
-  const key = getEncryptionKey();
-  const keys = new Map<number, Buffer>([[row.cred.keyVersion, key]]);
+  // Key map per VERSIONE reale (REVIEW #17): la riga può essere ancora alla
+  // chiave precedente durante una rotazione.
+  const keys = getEncryptionKeys();
   const codiceFiscale = decrypt(row.cred.encryptedCodiceFiscale, keys);
   const password = decrypt(row.cred.encryptedPassword, keys);
   const pin = decrypt(row.cred.encryptedPin, keys);

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -100,6 +100,12 @@ vi.mock("@/lib/crypto", () => ({
   // Legge la env come il modulo reale: serve ai test di rotazione chiave
   // (REVIEW #71), dove ENCRYPTION_KEY_VERSION=2 su righe ancora a v1.
   getKeyVersion: () => Number(process.env.ENCRYPTION_KEY_VERSION ?? "1"),
+  // Map corrente + precedente, come il modulo reale sotto rotazione (#17).
+  getEncryptionKeys: () =>
+    new Map([
+      [Number(process.env.ENCRYPTION_KEY_VERSION ?? "1"), Buffer.alloc(32)],
+      [1, Buffer.alloc(32)],
+    ]),
 }));
 
 const mockLogin = vi.fn();

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -19,6 +19,7 @@ import {
   encrypt,
   decrypt,
   getEncryptionKey,
+  getEncryptionKeys,
   getKeyVersion,
 } from "@/lib/crypto";
 import { createAdeClient, getAdeMode } from "@/lib/ade";
@@ -967,8 +968,9 @@ export async function verifyAdeCredentials(
   // below will match 0 rows, preventing verifiedAt from being set on stale data.
   const credentialVersion = cred.updatedAt;
 
-  const key = getEncryptionKey();
-  const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);
+  // Key map per VERSIONE reale (REVIEW #17): sotto rotazione la riga può
+  // essere ancora cifrata con la chiave precedente.
+  const keys = getEncryptionKeys();
 
   const adeClient = createAdeClient(getAdeMode());
 
@@ -1343,8 +1345,10 @@ export async function changeAdePassword(
     return { error: "Codice fiscale non disponibile per il cambio password." };
   }
 
+  // Si decifra da N versioni (`keys`, REVIEW #17) ma si ri-cifra sempre con la
+  // chiave corrente (`key`), coerentemente con `reencryptCredentialFields`.
   const key = getEncryptionKey();
-  const keys = new Map<number, Buffer>([[cred.keyVersion, key]]);
+  const keys = getEncryptionKeys();
   const codiceFiscale = decrypt(cred.encryptedCodiceFiscale, keys);
   // Snapshot per l'optimistic lock, letto PRIMA del flusso HTTP AdE: è la
   // finestra (secondi) in cui un altro tab può sostituire le credenziali.

--- a/tests/unit/server-onboarding-actions.test.ts
+++ b/tests/unit/server-onboarding-actions.test.ts
@@ -8,6 +8,7 @@ const {
   mockCheckBusinessOwnership,
   mockGetDb,
   mockGetEncryptionKey,
+  mockGetEncryptionKeys,
   mockGetKeyVersion,
   mockEncrypt,
   mockDecrypt,
@@ -31,6 +32,7 @@ const {
   mockCheckBusinessOwnership: vi.fn(),
   mockGetDb: vi.fn(),
   mockGetEncryptionKey: vi.fn(),
+  mockGetEncryptionKeys: vi.fn(),
   mockGetKeyVersion: vi.fn(),
   mockEncrypt: vi.fn(),
   mockDecrypt: vi.fn(),
@@ -69,6 +71,7 @@ vi.mock("@/db/schema", () => ({
 
 vi.mock("@/lib/crypto", () => ({
   getEncryptionKey: mockGetEncryptionKey,
+  getEncryptionKeys: mockGetEncryptionKeys,
   getKeyVersion: mockGetKeyVersion,
   encrypt: mockEncrypt,
   decrypt: mockDecrypt,
@@ -192,6 +195,9 @@ describe("verifyAdeCredentials", () => {
     });
     mockCheckBusinessOwnership.mockResolvedValue(null);
     mockGetEncryptionKey.mockReturnValue(Buffer.from("a".repeat(32)));
+    mockGetEncryptionKeys.mockReturnValue(
+      new Map([[1, Buffer.from("a".repeat(32))]]),
+    );
     mockGetKeyVersion.mockReturnValue(1);
     mockDecrypt.mockReturnValue("decrypted-value");
 

--- a/tests/unit/server-onboarding-change-password.test.ts
+++ b/tests/unit/server-onboarding-change-password.test.ts
@@ -18,6 +18,7 @@ const {
   mockUpdateReturning,
   mockGetKeyVersion,
   mockGetEncryptionKey,
+  mockGetEncryptionKeys,
   mockDecrypt,
   mockEncrypt,
   mockCreateAdeClient,
@@ -39,6 +40,7 @@ const {
   mockUpdateReturning: vi.fn(),
   mockGetKeyVersion: vi.fn(),
   mockGetEncryptionKey: vi.fn(),
+  mockGetEncryptionKeys: vi.fn(),
   mockDecrypt: vi.fn(),
   mockEncrypt: vi.fn(),
   mockCreateAdeClient: vi.fn(),
@@ -70,6 +72,7 @@ vi.mock("@/lib/crypto", () => ({
   encrypt: mockEncrypt,
   decrypt: mockDecrypt,
   getEncryptionKey: mockGetEncryptionKey,
+  getEncryptionKeys: mockGetEncryptionKeys,
   // Hoisted (non `vi.fn()` inline): `vi.resetAllMocks()` nei beforeEach
   // azzererebbe l'implementazione di un mock inline, facendo tornare
   // `undefined` come key version.
@@ -150,6 +153,7 @@ describe("changeAdePassword", () => {
     mockCheckBusinessOwnership.mockResolvedValue(null);
     mockRateLimiterCheck.mockReturnValue({ success: true });
     mockGetEncryptionKey.mockReturnValue(FAKE_KEY);
+    mockGetEncryptionKeys.mockReturnValue(new Map([[1, FAKE_KEY]]));
     mockGetKeyVersion.mockReturnValue(1);
     mockDecrypt.mockReturnValue("CODICEFISCALE12");
     mockEncrypt.mockReturnValue("new-enc-pw");
@@ -322,6 +326,7 @@ describe("verifyAdeCredentials — AdePasswordExpiredError", () => {
     // default check() ritorna undefined dopo resetAllMocks → crash su .success.
     mockRateLimiterCheck.mockReturnValue({ success: true });
     mockGetEncryptionKey.mockReturnValue(FAKE_KEY);
+    mockGetEncryptionKeys.mockReturnValue(new Map([[1, FAKE_KEY]]));
     mockDecrypt.mockReturnValue("decoded");
     mockAdeLogin.mockResolvedValue({});
     mockCreateAdeClient.mockReturnValue({


### PR DESCRIPTION
I caller di `decrypt()` costruivano `new Map([[row.keyVersion, getEncryptionKey()]])`,
cioè mappavano la versione MEMORIZZATA sulla chiave CORRENTE. A cavallo di una
rotazione quella mappa mente (payload v1 decifrato con la chiave v2 → authTag
mismatch), quindi ruotare `ENCRYPTION_KEY` richiedeva una finestra di downtime
fra la ri-cifratura delle righe e il deploy della nuova env — esattamente lo
scenario in cui non la vuoi (sospetto leak = emergenza).

- `getEncryptionKeys()` in `src/lib/crypto.ts`: chiave corrente più, durante la
  rotazione, la precedente opzionale (`ENCRYPTION_KEY_PREVIOUS` +
  `ENCRYPTION_KEY_PREVIOUS_VERSION`). Fail-fast su config a metà, versioni
  coincidenti o stessa chiave in entrambe; present-but-empty = non configurata
  (regola 18).
- Migrati i 3 call-site (`server-auth.ts`, `onboarding-actions.ts` ×2). Si
  decifra da N versioni, si cifra sempre su una sola.
- `getEncryptionKey()` ora valida anche i caratteri hex: 64 char non-hex
  passavano la sola check di lunghezza e `Buffer.from(hex, "hex")` troncava
  silenziosamente al primo carattere invalido.
- Runbook in tre fasi nell'header di `scripts/rotate-encryption-key.ts` (lo
  script era già idempotente), skill `ade-integration` riscritta, env example.

Test: 22 nuovi casi fra unit su `getEncryptionKeys` ed E2E di rotazione
(cifra v1 → deploy a due chiavi → ri-cifratura → rimozione della precedente;
versione senza chiave in env → "Unknown key version", mai garbage).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VhEMMzTNpKUh4iM67xv13e