### PR TITLE
fix(seo): deriva "Ultimo aggiornamento" da dateModified e corregge il copy /help

### DIFF
--- a/.claude/skills/marketing-content/SKILL.md
+++ b/.claude/skills/marketing-content/SKILL.md
@@ -38,6 +38,71 @@ Esempio del costo di questa regola violata: REVIEW.md #47 — la copy di
 `/help` è rimasta Fisconline-only dopo che il login CIE è stato spedito in
 v1.5.0, e il sito contraddiceva il prodotto.
 
+### Feature che il marketing ha già promesso per sbaglio (non reintrodurle)
+
+Sono capability **assenti dal prodotto** e classificate in `PLAN.md` sotto
+"Nice to have (**no release**)". Un copy che le dà per fatte è un bug, non
+un'esagerazione di marketing. Audit agosto 2026: erano finite in 8 punti fra
+`/funzionalita`, `/per` e `/guide`.
+
+- **Pagamento misto / ripartito** — `PaymentMethod` è `"PC" | "PE"`, uno per
+  documento (`src/types/cassa.ts`, `src/lib/receipts/receipt-schema.ts`).
+  Anche i **buoni pasto** sono nice-to-have: mai citarli fra i metodi.
+- **Codice fiscale del cliente / "scontrino parlante"** — `saleBodySchema`
+  non ha il campo. Chi lo chiede va indirizzato al portale AdE o alla fattura.
+- **Barcode scanner** — fuori roadmap per decisione esplicita.
+- **Modalità offline / coda di trasmissione differita** — l'emissione senza
+  rete fallisce e basta; non esiste retry differito lato client.
+
+Prima di attribuire una capability al prodotto, verificala sullo schema o sul
+componente, non sul copy vicino: le pagine `/help` sono risultate accurate
+mentre `/per` e `/funzionalita` promettevano di più.
+
+## Doppia scrittura vietata: date, prezzi, limiti di piano
+
+Un dato che vive **sia** in un data file **sia** a mano nel JSX diverge, e
+diverge in silenzio. Caso reale (audit agosto 2026): la riga visibile
+"Ultimo aggiornamento" era hardcoded in ogni `page.tsx` di `/help` e si era
+desincronizzata dal `dateModified` del registry su **19 articoli su 26** — il
+testo diceva "aprile 2026", l'`Article` JSON-LD letto da Google e dalle AI
+diceva luglio. Il freshness signal, cioè metà del vantaggio competitivo SEO,
+era rotto senza che nessun test fallisse.
+
+Fix strutturale: `HelpArticleUpdatedAt`
+(`src/components/help/article-updated-at.tsx`) deriva la data da
+`helpArticles[slug].dateModified`, stessa fonte del JSON-LD e della sitemap.
+**Non reintrodurre date scritte a mano nel JSX.** Stessa regola per prezzi
+(`src/components/marketing/pricing-section.tsx`) e limiti di piano
+(`STARTER_CATALOG_LIMIT`, `TRIAL_DAYS` in `src/lib/plans-shared.ts`).
+
+`formatUpdatedAt` formatta la stringa ISO **senza** `new Date()`: una
+data-only è parsata come UTC ma renderizzata in locale, quindi nei fusi
+negativi il giorno 01 slitta al mese precedente (e produce un mismatch di
+idratazione).
+
+## Riferimenti normativi: una sola versione in tutto il repo
+
+Le date e le leggi citate vanno verificate su fonte esterna e devono essere
+**identiche** in `/help`, `/guide` e `/per`. Un repo che si contraddice
+perde la citabilità AI che è lo scopo della checklist GEO.
+
+Riferimenti canonici oggi in uso (audit agosto 2026):
+
+| Tema                        | Riferimento corretto                                                                                                                                                                                  |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Collegamento POS 2026       | **L. 207/2024** (Bilancio 2025) art. 1 commi **74-77** + Provv. AdE **424470 del 31/10/2025**; servizio "Gestione Collegamenti" dal **5 marzo 2026**, prima comunicazione entro il **20 aprile 2026** |
+| Sanzioni collegamento POS   | 1.000-4.000 € + sospensione 15 gg-2 mesi (art. 11 c. 5 D.Lgs. 471/1997); 100 €/operazione (art. 11 c. 2-quinquies)                                                                                    |
+| Sanzioni corrispettivi      | **70%** dell'imposta, minimo **300 €** (art. 6 c. 2-bis D.Lgs. 471/1997 dopo il D.Lgs. 87/2024, dal 1° settembre 2024)                                                                                |
+| Soglia forfettario 85.000 € | L. 197/2022 (Bilancio 2023) — **non** confonderla con la norma POS                                                                                                                                    |
+| Lotteria scontrini          | solo pagamenti **elettronici** sopra 1 €, 1 biglietto/euro fino a 1.000; estrazioni settimanali 25.000 €, mensili 100.000 €, annuale 5 mln; **istantanea mai avviata**                                |
+| Garanzia legale             | **24 mesi** dalla consegna (art. 133 D.Lgs. 206/2005) — 26 mesi è la prescrizione dell'azione, non la durata                                                                                          |
+
+Trappola vista sul campo: la guida `/guide/pos-rt-obbligo-2026` citava
+"L. 197/2022 art. 1 c. 74" mentre `/help/normativa-pos-2026` citava
+correttamente L. 207/2024 — stesso numero di comma, legge diversa, plausibile
+a occhio. Quando due pagine dello stesso repo divergono su una norma,
+**verifica esternamente**, non scegliere la più recente.
+
 ## Slug separati /help vs /guide (canonical clash)
 
 Sulle keyword condivise usare slug **diversi** per evitare canonical clash:

--- a/src/app/(marketing)/funzionalita/page.tsx
+++ b/src/app/(marketing)/funzionalita/page.tsx
@@ -11,7 +11,8 @@ import {
   Share2,
   Printer,
   Ticket,
-  Clock,
+  CreditCard,
+  ScrollText,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MarketingHero } from "@/components/marketing/marketing-hero";
@@ -49,13 +50,13 @@ const sections = [
         icon: Ticket,
         title: "Lotteria degli Scontrini",
         description:
-          "Supporto nativo alla Lotteria degli Scontrini: inserisci il codice lotteria del cliente e viene trasmesso automaticamente all'AdE con il documento commerciale.",
+          "Supporto nativo alla Lotteria degli Scontrini: sui pagamenti elettronici — gli unici che partecipano alle estrazioni — inserisci il codice del cliente e viene trasmesso all'AdE insieme al documento commerciale.",
       },
       {
-        icon: Clock,
-        title: "Multi-metodo pagamento",
+        icon: CreditCard,
+        title: "Metodo di pagamento tracciato",
         description:
-          "Contanti, carte, pagamenti elettronici o misti: scegli il metodo per ogni scontrino. Puoi anche dividere il pagamento tra più modalità.",
+          "Su ogni scontrino indichi se l'incasso è in contanti o elettronico: il dato viaggia dentro il documento commerciale trasmesso all'AdE. Un metodo per documento — la ripartizione dello stesso scontrino fra contanti e carta oggi non è gestita.",
       },
     ],
   },
@@ -108,10 +109,10 @@ const sections = [
           'Ogni documento commerciale viene trasmesso automaticamente all\'Agenzia delle Entrate tramite la procedura ufficiale "Documento Commerciale Online". Nessun passaggio manuale.',
       },
       {
-        icon: Ticket,
+        icon: ScrollText,
         title: "Allineato alla normativa POS 2026",
         description:
-          "Dal 1° gennaio 2026 è in vigore l'obbligo di collegamento fra terminale POS e sistema di trasmissione dei corrispettivi. ScontrinoZero segue i flussi previsti dall'Agenzia delle Entrate e si aggiorna in automatico per restare in regola.",
+          "Dal 1° gennaio 2026 è in vigore l'obbligo di collegamento fra terminale POS e strumento di memorizzazione dei corrispettivi (L. 207/2024, art. 1 commi 74-77). ScontrinoZero segue i flussi previsti dall'Agenzia delle Entrate e si aggiorna in automatico per restare in regola.",
       },
     ],
   },

--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -45,9 +46,7 @@ export default function AliquoteIvaPage() {
           tramite il catalogo prodotti, e quali metodi di pagamento sono
           disponibili oggi.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="aliquote-iva" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/cassa-tastierino.png"
@@ -269,8 +268,8 @@ export default function AliquoteIvaPage() {
           il dato viene trasmesso all&apos;AdE come parte del documento
           commerciale. Il campo opzionale{" "}
           <strong>codice lotteria scontrini</strong> compare solo quando scegli
-          pagamento con carta (la lotteria istantanea richiede il pagamento
-          elettronico).
+          pagamento con carta: alla Lotteria degli Scontrini partecipano
+          soltanto gli acquisti sopra 1 € pagati con strumenti elettronici.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Il tracciato AdE prevede ulteriori metodi (ticket / buono pasto,

--- a/src/app/(marketing)/help/analytics-e-report/page.tsx
+++ b/src/app/(marketing)/help/analytics-e-report/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -42,9 +43,7 @@ export default function AnalyticsEReportPage() {
           su tutti i piani; i grafici avanzati e il selettore di periodo sono
           sul piano <strong>Pro</strong>.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> luglio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="analytics-e-report" />
 
         {/* ─── Come accedere ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/annullare-scontrino/page.tsx
+++ b/src/app/(marketing)/help/annullare-scontrino/page.tsx
@@ -9,6 +9,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -75,9 +76,7 @@ export default function AnnullareScontrinoPage() {
           originale nel cassetto fiscale dell&apos;Agenzia delle Entrate. Questa
           guida spiega come farlo da ScontrinoZero e in quali casi è possibile.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> luglio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="annullare-scontrino" />
 
         {/* ─── Quando si può annullare ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/cambio-piano/page.tsx
+++ b/src/app/(marketing)/help/cambio-piano/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -44,9 +45,7 @@ export default function CambioPianoPage() {
           <strong>54% su Pro</strong> (€49,99/anno invece di €107,88). Il cambio
           avviene tramite il portale di fatturazione Stripe.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="cambio-piano" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-piano.png"

--- a/src/app/(marketing)/help/cassetto-fiscale/page.tsx
+++ b/src/app/(marketing)/help/cassetto-fiscale/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("cassetto-fiscale");
@@ -40,9 +41,7 @@ export default function CassettoFiscalePage() {
           <strong>cassetto fiscale</strong> del portale Fatture e Corrispettivi.
           Questa guida spiega dove cercarli e cosa fare se qualcosa non torna.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="cassetto-fiscale" />
 
         {/* ─── Cos'è il cassetto fiscale ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
+++ b/src/app/(marketing)/help/chiusura-giornaliera/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("chiusura-giornaliera");
@@ -43,9 +44,7 @@ export default function ChiusuraGiornalieraPage() {
           tempo reale, scontrino per scontrino. Nessun gesto manuale a fine
           giornata, nessun rischio di dimenticarsi.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="chiusura-giornaliera" />
 
         {/* ─── Cos'è la chiusura giornaliera ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/collegare-ade-con-cie/page.tsx
+++ b/src/app/(marketing)/help/collegare-ade-con-cie/page.tsx
@@ -10,6 +10,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("collegare-ade-con-cie");
@@ -76,9 +77,7 @@ export default function CollegareAdeConCie() {
           </Link>{" "}
           per chi accede all&apos;AdE con la Carta d&apos;Identità Elettronica.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> luglio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="collegare-ade-con-cie" />
 
         {/* ─── Fisconline o CIE ─── */}
         <div className="bg-muted/50 mt-6 rounded-md p-4 text-sm">

--- a/src/app/(marketing)/help/come-collegare-ade/page.tsx
+++ b/src/app/(marketing)/help/come-collegare-ade/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -52,9 +53,7 @@ export default function ComeCollegareAde() {
           </Link>
           ). In entrambi i casi si completa in circa 5 minuti.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="come-collegare-ade" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-attivita.png"

--- a/src/app/(marketing)/help/contatto-assistenza/page.tsx
+++ b/src/app/(marketing)/help/contatto-assistenza/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -44,9 +45,7 @@ export default function ContattoAssistenzaPage() {
           Center: la maggior parte delle domande frequenti ha già una guida
           dedicata.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> maggio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="contatto-assistenza" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-preferenze.png"

--- a/src/app/(marketing)/help/credenziali-fisconline/page.tsx
+++ b/src/app/(marketing)/help/credenziali-fisconline/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -43,9 +44,7 @@ export default function CredenzialiPage() {
           dell&apos;attività. Questa guida spiega cosa sono, chi può ottenerle e
           come verificare che funzionino.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="credenziali-fisconline" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-attivita.png"

--- a/src/app/(marketing)/help/errori-ade/page.tsx
+++ b/src/app/(marketing)/help/errori-ade/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -44,9 +45,7 @@ export default function ErroriAdePage() {
           <strong>Impostazioni → Credenziali AdE</strong> mostra un messaggio.
           Questa guida copre i casi più frequenti con la soluzione per ciascuno.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="errori-ade" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-attivita.png"

--- a/src/app/(marketing)/help/fatture-e-ricevute/page.tsx
+++ b/src/app/(marketing)/help/fatture-e-ricevute/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("fatture-e-ricevute");
@@ -39,9 +40,7 @@ export default function FattureERicevutePage() {
           ogni addebito; puoi anche scaricarle in qualsiasi momento dal portale
           di fatturazione.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="fatture-e-ricevute" />
 
         {/* ─── Ricevuta via email ─── */}
         <h2 className="mt-10 text-xl font-semibold">Ricevute via email</h2>

--- a/src/app/(marketing)/help/installare-app/page.tsx
+++ b/src/app/(marketing)/help/installare-app/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("installare-app");
@@ -40,9 +41,7 @@ export default function InstallareAppPage() {
           Store o dal Google Play. L&apos;esperienza è identica a quella di
           un&apos;app nativa.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="installare-app" />
 
         <div className="bg-muted text-muted-foreground mt-6 rounded-lg p-4 text-sm leading-relaxed">
           <strong>Nota sul dominio.</strong>

--- a/src/app/(marketing)/help/intestazione-scontrino/page.tsx
+++ b/src/app/(marketing)/help/intestazione-scontrino/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -45,9 +46,7 @@ export default function IntestazioneScontrinoPage() {
           modificarli direttamente in app, eccetto P.IVA e codice fiscale che
           restano gestiti dall&apos;Agenzia delle Entrate.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="intestazione-scontrino" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/documento-commerciale.png"

--- a/src/app/(marketing)/help/normativa-pos-2026/page.tsx
+++ b/src/app/(marketing)/help/normativa-pos-2026/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("normativa-pos-2026");
@@ -45,9 +46,7 @@ export default function NormativaPos2026Page() {
           applica <strong>anche a chi usa ScontrinoZero</strong>: questa guida
           ti spiega cosa devi fare e quali sono le scadenze.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="normativa-pos-2026" />
 
         <div className="mt-6 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm dark:border-amber-800 dark:bg-amber-950">
           <strong>In breve:</strong> se usi ScontrinoZero e accetti pagamenti
@@ -185,12 +184,13 @@ export default function NormativaPos2026Page() {
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          È in discussione un emendamento per introdurre una{" "}
-          <strong>franchigia del 5%</strong>: sotto questa soglia di operazioni
-          non collegate non scatterebbe la sanzione. Verifica gli aggiornamenti
-          sul sito dell&apos;Agenzia delle Entrate o con il tuo commercialista,
-          perché la disciplina può evolvere nei mesi successivi alla prima
-          scadenza.
+          Alla data di questo aggiornamento (2 agosto 2026) è in discussione, in
+          sede di conversione del decreto fiscale, un emendamento che
+          introdurrebbe una <strong>franchigia del 5%</strong>: sotto questa
+          soglia di operazioni non collegate non scatterebbe la sanzione. Finché
+          non è approvato resta applicabile la disciplina vigente. Verifica gli
+          aggiornamenti sul sito dell&apos;Agenzia delle Entrate o con il tuo
+          commercialista.
         </p>
 
         {/* ─── Differenze RT vs DCO ─── */}

--- a/src/app/(marketing)/help/numero-documento-azzeramento/page.tsx
+++ b/src/app/(marketing)/help/numero-documento-azzeramento/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -47,9 +48,7 @@ export default function NumeroDocumentoAzzeramentoPage() {
           online il numero è invece un codice unico assegnato dall&apos;Agenzia
           delle Entrate, e l&apos;azzeramento non esiste.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> luglio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="numero-documento-azzeramento" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/documento-commerciale.png"

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -86,7 +86,7 @@ const helpCategories: HelpCategory[] = [
         href: "/help/regime-forfettario",
       },
       {
-        title: "Come gestire aliquote IVA, reparti e metodi di pagamento",
+        title: "Come gestire aliquote IVA, catalogo e metodi di pagamento",
         href: "/help/aliquote-iva",
       },
       {

--- a/src/app/(marketing)/help/piani-e-prezzi/page.tsx
+++ b/src/app/(marketing)/help/piani-e-prezzi/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -37,9 +38,7 @@ export default function PianiEPrezziPage() {
           versione self-hosted completamente gratuita per chi preferisce gestire
           il proprio server.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> maggio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="piani-e-prezzi" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-piano.png"

--- a/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
+++ b/src/app/(marketing)/help/pos-rt-obbligo/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("pos-rt-obbligo");
@@ -46,9 +47,7 @@ export default function PosRtObbligoPage() {
           <em>Fatture e Corrispettivi</em>: è una procedura a carico
           dell&apos;esercente.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="pos-rt-obbligo" />
 
         {/* ─── Cosa prevede la normativa ─── */}
         <h2 className="mt-10 text-xl font-semibold">
@@ -56,8 +55,8 @@ export default function PosRtObbligoPage() {
         </h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           La <strong>Legge di Bilancio 2025</strong> (L. 30 dicembre 2024 n.
-          207, commi 74-76) ha sostituito il comma 3 dell&apos;art. 2 del D.Lgs.
-          127/2015. La nuova formulazione richiede la{" "}
+          207, art. 1, commi 74-77) ha sostituito il comma 3 dell&apos;art. 2
+          del D.Lgs. 127/2015. La nuova formulazione richiede la{" "}
           <strong>piena integrazione</strong> tra il processo di registrazione
           dei corrispettivi e quello di pagamento elettronico: lo strumento con
           cui si accettano pagamenti elettronici deve essere <em>sempre</em>{" "}
@@ -155,7 +154,7 @@ export default function PosRtObbligoPage() {
                 <td className="py-2 pr-6 font-medium">1° gen. 2026</td>
                 <td className="py-2">
                   Entrata in vigore dell&apos;obbligo di collegamento POS-RT (L.
-                  207/2024, commi 74-76).
+                  207/2024, art. 1, commi 74-77).
                 </td>
               </tr>
               <tr className="border-b">

--- a/src/app/(marketing)/help/presenta-un-amico/page.tsx
+++ b/src/app/(marketing)/help/presenta-un-amico/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -42,9 +43,7 @@ export default function PresentaUnAmicoPage() {
           ottiene <strong>un mese di prova in più</strong> e il presentatore{" "}
           <strong>un mese in più sul proprio piano</strong>.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> giugno 2026
-        </p>
+        <HelpArticleUpdatedAt slug="presenta-un-amico" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-piano.png"

--- a/src/app/(marketing)/help/prima-configurazione/page.tsx
+++ b/src/app/(marketing)/help/prima-configurazione/page.tsx
@@ -9,6 +9,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -44,9 +45,7 @@ export default function PrimaConfigurazioneePage() {
           dashboard. L&apos;intero processo richiede circa 10 minuti se hai già
           le credenziali Fisconline a portata di mano.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="prima-configurazione" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-attivita.png"

--- a/src/app/(marketing)/help/primo-scontrino/page.tsx
+++ b/src/app/(marketing)/help/primo-scontrino/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -44,9 +45,7 @@ export default function PrimoScontrinoPage() {
           processo richiede circa 30 secondi una volta che la configurazione è
           completata.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="primo-scontrino" />
 
         {/* ─── Prerequisiti ─── */}
         <h2 className="mt-10 text-xl font-semibold">Prima di iniziare</h2>

--- a/src/app/(marketing)/help/regime-forfettario/page.tsx
+++ b/src/app/(marketing)/help/regime-forfettario/page.tsx
@@ -10,6 +10,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("regime-forfettario");
@@ -82,9 +83,7 @@ export default function RegimeForfettarioPage() {
           correttamente per evitare errori nei documenti commerciali trasmessi
           all&apos;Agenzia delle Entrate.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> luglio 2026
-        </p>
+        <HelpArticleUpdatedAt slug="regime-forfettario" />
 
         {/* ─── Cos'è il regime forfettario ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/app/(marketing)/help/registrare-pos-portale-ade/page.tsx
+++ b/src/app/(marketing)/help/registrare-pos-portale-ade/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 
 export const metadata = helpArticleMetadata("registrare-pos-portale-ade");
@@ -46,9 +47,7 @@ export default function RegistrarePosPortaleAdePage() {
           fai la prima volta che metti in funzione il terminale e poi non devi
           più rifarla, salvo cambi di terminale o di banca.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="registrare-pos-portale-ade" />
 
         {/* ─── Promemoria sulla differenza POS bancario vs POS-RT ─── */}
         <div className="bg-muted/50 mt-6 rounded-md p-4 text-sm">

--- a/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
+++ b/src/app/(marketing)/help/sicurezza-credenziali/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -43,9 +44,7 @@ export default function SicurezzaCredenzialiPage() {
           archiviate, chi può accedervi e come puoi revocare il consenso in
           qualsiasi momento.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="sicurezza-credenziali" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/impostazioni-attivita.png"
@@ -229,8 +228,10 @@ export default function SicurezzaCredenzialiPage() {
           diritto alla cancellazione è garantito dal GDPR art. 17.
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Un pulsante dedicato per rimuovere solo le credenziali AdE senza
-          eliminare l&apos;account è in roadmap.
+          Oggi non esiste un pulsante dedicato per rimuovere solo le credenziali
+          AdE lasciando attivo l&apos;account: le due strade disponibili sono
+          sovrascriverle da <strong>Modifica credenziali</strong> oppure
+          eliminare l&apos;account.
         </p>
 
         {/* ─── FAQ ─── */}

--- a/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
+++ b/src/app/(marketing)/help/stampare-scontrino-termica/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -47,9 +48,7 @@ export default function StampareScontrinoTermicaPage() {
           <strong>non è obbligatoria</strong>: in alternativa puoi mostrare lo
           scontrino a schermo al cliente.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="stampare-scontrino-termica" />
         <figure className="mt-6">
           <AppScreenshot
             src="/screenshots/documento-commerciale.png"

--- a/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
+++ b/src/app/(marketing)/help/storico-ed-esportazione/page.tsx
@@ -8,6 +8,7 @@ import {
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
 import { helpArticleMetadata } from "@/lib/help/metadata";
 import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
 import { RelatedHelpArticles } from "@/components/help/related-articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
 
@@ -45,9 +46,7 @@ export default function StoricoEdEsportazionePage() {
           L&apos;esportazione CSV per il commercialista è disponibile sul piano
           Pro.
         </p>
-        <p className="text-muted-foreground mt-1 text-sm">
-          <strong>Ultimo aggiornamento:</strong> aprile 2026
-        </p>
+        <HelpArticleUpdatedAt slug="storico-ed-esportazione" />
 
         {/* ─── Come accedere ─── */}
         <h2 className="mt-10 text-xl font-semibold">

--- a/src/components/help/article-updated-at.test.tsx
+++ b/src/components/help/article-updated-at.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { HelpArticleUpdatedAt, formatUpdatedAt } from "./article-updated-at";
+import { helpArticles, helpSlugs } from "@/lib/help/articles";
+
+describe("formatUpdatedAt", () => {
+  it("formatta la data ISO come «mese aaaa» in italiano", () => {
+    expect(formatUpdatedAt("2026-08-02")).toBe("agosto 2026");
+  });
+
+  it("copre tutti i mesi senza cadere su undefined", () => {
+    const mesi = [
+      "gennaio",
+      "febbraio",
+      "marzo",
+      "aprile",
+      "maggio",
+      "giugno",
+      "luglio",
+      "agosto",
+      "settembre",
+      "ottobre",
+      "novembre",
+      "dicembre",
+    ];
+    for (const [i, mese] of mesi.entries()) {
+      const mm = String(i + 1).padStart(2, "0");
+      expect(formatUpdatedAt(`2026-${mm}-15`)).toBe(`${mese} 2026`);
+    }
+  });
+
+  it("non usa il fuso orario locale (niente shift al giorno prima)", () => {
+    // Una data col giorno 01 parsata come Date locale in un fuso negativo
+    // ricadrebbe nel mese precedente: il formatter lavora sulla stringa.
+    expect(formatUpdatedAt("2026-03-01")).toBe("marzo 2026");
+  });
+});
+
+describe("HelpArticleUpdatedAt", () => {
+  it("mostra il dateModified del registry, non una data hardcoded", () => {
+    const { container } = render(
+      <HelpArticleUpdatedAt slug="normativa-pos-2026" />,
+    );
+    const iso = helpArticles["normativa-pos-2026"]!.dateModified;
+    const time = container.querySelector("time");
+    expect(time).toHaveTextContent(formatUpdatedAt(iso));
+    expect(time).toHaveAttribute("dateTime", iso);
+  });
+
+  it("resta allineato al registry per ogni slug help", () => {
+    for (const slug of helpSlugs) {
+      const { container, unmount } = render(
+        <HelpArticleUpdatedAt slug={slug} />,
+      );
+      const iso = helpArticles[slug]!.dateModified;
+      expect(container.querySelector("time")).toHaveTextContent(
+        formatUpdatedAt(iso),
+      );
+      unmount();
+    }
+  });
+
+  it("lancia su uno slug sconosciuto invece di renderizzare una data vuota", () => {
+    expect(() =>
+      render(<HelpArticleUpdatedAt slug="slug-inesistente" />),
+    ).toThrow(/Unknown help article slug/);
+  });
+});

--- a/src/components/help/article-updated-at.tsx
+++ b/src/components/help/article-updated-at.tsx
@@ -1,0 +1,51 @@
+import { getHelpArticle } from "@/lib/help/articles";
+
+const MESI = [
+  "gennaio",
+  "febbraio",
+  "marzo",
+  "aprile",
+  "maggio",
+  "giugno",
+  "luglio",
+  "agosto",
+  "settembre",
+  "ottobre",
+  "novembre",
+  "dicembre",
+] as const;
+
+/**
+ * "2026-08-02" → "agosto 2026".
+ *
+ * Formatta la stringa ISO **senza** passare da `new Date()`: il parsing di una
+ * data-only in JS è UTC, ma la formattazione locale la riporterebbe al giorno
+ * prima nei fusi negativi, facendo slittare di un mese le date col giorno 01
+ * (e producendo un mismatch di idratazione fra server e client).
+ */
+export function formatUpdatedAt(isoDate: string): string {
+  const [year, month] = isoDate.split("-");
+  return `${MESI[Number(month) - 1]} ${year}`;
+}
+
+/**
+ * Riga "Ultimo aggiornamento" visibile in testa a ogni articolo di /help.
+ *
+ * Legge `dateModified` dal registry `helpArticles` — la stessa fonte che
+ * alimenta l'`Article` JSON-LD (`HelpArticleJsonLd`) e la sitemap. Prima la
+ * data era scritta a mano nel JSX di ogni pagina e si era desincronizzata su
+ * 19 articoli su 26: il testo visibile diceva "aprile 2026" mentre lo
+ * structured data letto da Google e dalle AI diceva luglio. Una sola fonte di
+ * verità rende il drift strutturalmente impossibile.
+ */
+export function HelpArticleUpdatedAt({ slug }: { readonly slug: string }) {
+  const article = getHelpArticle(slug);
+  return (
+    <p className="text-muted-foreground mt-1 text-sm">
+      <strong>Ultimo aggiornamento:</strong>{" "}
+      <time dateTime={article.dateModified}>
+        {formatUpdatedAt(article.dateModified)}
+      </time>
+    </p>
+  );
+}

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -162,7 +162,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Sì, si può: da gennaio 2020 qualunque partita IVA può emettere lo scontrino elettronico senza registratore di cassa fisico, gratis dal portale \"Fatture e Corrispettivi\" dell'Agenzia delle Entrate oppure in pochi secondi con un'app dal telefono. Vediamo cosa serve, quanto costa e come scegliere l'app giusta.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-07-22",
+    updatedAt: "2026-08-02",
     readingMinutes: 8,
     sections: [
       {
@@ -239,7 +239,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Cosa succede se internet non funziona?",
         answer:
-          "L'Agenzia delle Entrate prevede una procedura di emergenza: emetti uno scontrino manuale (anche su carta) annotando i corrispettivi, e i dati vanno comunque trasmessi al portale entro 12 giorni dall'effettuazione dell'operazione, una volta ripristinata la connessione. ScontrinoZero rileva l'assenza di connessione e suggerisce la procedura.",
+          "L'Agenzia delle Entrate prevede una procedura di emergenza: emetti uno scontrino manuale (anche su carta) annotando i corrispettivi, e i dati vanno comunque trasmessi al portale entro 12 giorni dall'effettuazione dell'operazione, una volta ripristinata la connessione. Senza rete l'emissione da app non va a buon fine e l'errore te lo segnala subito: non esiste una coda offline che trasmetta più tardi al posto tuo.",
       },
       {
         question: "Devo informare l'Agenzia delle Entrate della mia scelta?",
@@ -275,7 +275,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Scontrino, ricevuta fiscale e fattura sono tre documenti diversi con regole diverse. Saper distinguere quando emettere l'uno o l'altro è la base per non sbagliare adempimenti. Vediamo le differenze pratiche con esempi concreti per chi lavora al pubblico.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-05-14",
+    updatedAt: "2026-08-02",
     readingMinutes: 5,
     sections: [
       {
@@ -292,7 +292,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Casi misti tipici",
-        body: 'Ristorante che serve un cliente privato: scontrino. Ristorante che fa un catering aziendale: fattura. Idraulico che fa una riparazione a casa di un privato: scontrino, salvo che il cliente chieda fattura per detrazione. Idraulico che lavora per un\'impresa: fattura. Negozio che vende elettronica a un consumatore: scontrino, salvo richiesta esplicita di fattura "parlante" per la garanzia.',
+        body: "Ristorante che serve un cliente privato: scontrino. Ristorante che fa un catering aziendale: fattura. Idraulico che fa una riparazione a casa di un privato: scontrino, salvo che il cliente chieda fattura per detrazione. Idraulico che lavora per un'impresa: fattura. Negozio che vende elettronica a un consumatore: scontrino, che è già di per sé la prova d'acquisto valida per la garanzia legale, salvo richiesta esplicita di fattura.",
       },
       {
         heading: "E la ricevuta fiscale?",
@@ -307,12 +307,12 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Posso emettere scontrino E fattura per la stessa vendita?",
         answer:
-          'No. Se emetti fattura per una vendita, NON devi emettere anche scontrino: sarebbe una duplicazione del corrispettivo. La fattura ha già il valore fiscale completo. Su ScontrinoZero, se emetti scontrino e poi il cliente chiede fattura, lo scontrino va annullato prima di emettere la fattura "parlante".',
+          "No. Se emetti fattura per una vendita, NON devi emettere anche scontrino: sarebbe una duplicazione del corrispettivo. La fattura ha già il valore fiscale completo. Su ScontrinoZero, se emetti scontrino e poi il cliente chiede fattura, lo scontrino va annullato prima di emettere la fattura.",
       },
       {
         question: 'Il cliente mi chiede uno scontrino "parlante": che faccio?',
         answer:
-          'Lo "scontrino parlante" è uno scontrino con il codice fiscale del cliente, valido per detrazioni fiscali (es. spese mediche, farmaci). Su ScontrinoZero puoi aggiungere il codice fiscale del cliente in fase di emissione: il documento sarà valido per la detrazione.',
+          'Lo "scontrino parlante" è il documento commerciale che riporta il codice fiscale del cliente e serve a portare in detrazione la spesa (tipicamente spese sanitarie e farmaci). ScontrinoZero non ha oggi un campo per il codice fiscale del cliente: se te lo chiedono, emetti quel singolo documento dal portale Fatture e Corrispettivi dell\'Agenzia delle Entrate, che il campo lo prevede, oppure emetti fattura. Per farmacie e parafarmacie il canale delle spese detraibili resta comunque il Sistema Tessera Sanitaria.',
       },
       {
         question: "Sono in regime forfettario: emetto scontrino o fattura?",
@@ -338,22 +338,22 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     metaDescription:
       "Dal 1° gennaio 2026 il POS va collegato al registratore telematico per trasmettere i pagamenti elettronici. Scadenze, sanzioni e cosa cambia per chi usa software.",
     heroIntro:
-      "Dal 1° gennaio 2026 è entrato in vigore l'obbligo di collegamento fra POS (terminale di pagamento) e registratore telematico, per trasmettere all'Agenzia delle Entrate gli incassi elettronici insieme ai corrispettivi. La norma ha generato molta confusione: cosa cambia davvero e cosa fare se non usi un RT fisico?",
+      'Dal 1° gennaio 2026 è in vigore l\'obbligo di collegare il POS allo strumento che memorizza i corrispettivi (art. 1, commi 74-77, L. 207/2024): il collegamento si comunica online dal servizio "Gestione Collegamenti" del portale Fatture e Corrispettivi. La norma ha generato molta confusione: vediamo cosa cambia davvero, le scadenze e cosa fare se non usi un registratore telematico fisico.',
     publishedAt: "2026-05-14",
-    updatedAt: "2026-07-22",
+    updatedAt: "2026-08-02",
     readingMinutes: 7,
     sections: [
       {
         heading: "Cos'è il collegamento POS-RT",
-        body: "L'obbligo previsto dalla Legge di Bilancio 2023 (art. 1 c. 74 L. 197/2022) richiede che il POS sia tecnicamente collegato al registratore telematico, in modo che ogni pagamento elettronico transiti dal POS al RT e venga incluso nei dati trasmessi all'AdE come parte integrante del corrispettivo giornaliero. Lo scopo è la tracciabilità: lo Stato vuole vedere insieme l'incasso elettronico e lo scontrino.",
+        body: "L'obbligo previsto dalla Legge di Bilancio 2025 (art. 1, commi 74-77, L. 207/2024) richiede che lo strumento di pagamento elettronico sia collegato a quello che memorizza e trasmette i corrispettivi, in modo che l'incasso elettronico e lo scontrino risultino associati nei dati che arrivano all'AdE. Lo scopo è la tracciabilità: lo Stato vuole vedere insieme l'incasso elettronico e il corrispettivo certificato.",
       },
       {
-        heading: "Scadenze e proroghe",
-        body: "L'obbligo era inizialmente previsto per il 1° luglio 2023, poi rinviato più volte. Dal 1° gennaio 2026 è operativo per tutti gli esercenti soggetti all'obbligo di memorizzazione e trasmissione dei corrispettivi. Le sanzioni effettive sono entrate in vigore con un periodo di tolleranza iniziale (provvedimenti AdE successivi). Verifica sempre la versione più aggiornata su agenziaentrate.gov.it.",
+        heading: "Scadenze e come si comunica il collegamento",
+        body: "L'obbligo è in vigore dal 1° gennaio 2026. Le regole operative sono nel Provvedimento AdE n. 424470 del 31 ottobre 2025: il collegamento si comunica esclusivamente online, dal servizio \"Gestione Collegamenti\" nel portale Fatture e Corrispettivi, aperto il 5 marzo 2026. Per i POS già in uso al 1° gennaio 2026 (o acquisiti entro gennaio) il termine della prima comunicazione era il 20 aprile 2026; per i dispositivi nuovi o in caso di variazioni la comunicazione va fatta fra il sesto e l'ultimo giorno del secondo mese successivo all'evento.",
       },
       {
         heading: "Sanzioni previste",
-        body: "Per la mancata trasmissione del singolo pagamento elettronico, la sanzione amministrativa è pari al 70% dell'IVA non documentata correttamente (art. 6 c. 2-bis D.Lgs. 471/1997, dopo la riforma del D.Lgs. 87/2024), con un minimo di 300 €. Esistono inoltre sanzioni accessorie in caso di violazioni reiterate (sospensione della licenza). I controlli sono incrociati: AdE confronta dati POS dalle banche con corrispettivi trasmessi.",
+        body: "Le sanzioni del collegamento POS sono diverse da quelle dello scontrino non emesso. Per l'omessa installazione o il mancato collegamento del POS si va da 1.000 € a 4.000 €, con possibile sospensione della licenza da 15 giorni a 2 mesi (art. 11, comma 5, D.Lgs. 471/1997); per l'omessa o incompleta trasmissione la sanzione è di 100 € per operazione (art. 11, comma 2-quinquies). Restano a parte le sanzioni sui corrispettivi veri e propri: 70% dell'imposta con minimo 300 € per lo scontrino non emesso o non trasmesso (art. 6, comma 2-bis, D.Lgs. 471/1997, dopo il D.Lgs. 87/2024). I controlli sono incrociati: l'AdE confronta i dati POS comunicati dagli operatori finanziari con i corrispettivi trasmessi.",
       },
       {
         heading: "Deroghe e casistiche particolari",
@@ -365,7 +365,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Come ScontrinoZero gestisce i pagamenti elettronici",
-        body: "In fase di emissione dello scontrino, ScontrinoZero permette di specificare il metodo di pagamento (contanti, elettronico, misto). Questa informazione viene inclusa nel DCO trasmesso all'AdE, soddisfacendo l'obbligo di tracciabilità del pagamento elettronico. Non serve hardware aggiuntivo né integrazione fisica con il POS.",
+        body: "In fase di emissione dello scontrino, ScontrinoZero permette di specificare il metodo di pagamento (contanti o elettronico, uno per documento). Questa informazione viene inclusa nel DCO trasmesso all'AdE, soddisfacendo l'obbligo di tracciabilità del pagamento elettronico. Non serve hardware aggiuntivo né integrazione fisica con il POS.",
       },
     ],
     faq: [
@@ -382,10 +382,9 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
           "Se hai un registratore telematico fisico, sì: il POS deve essere certificato come compatibile con quel modello di RT. Se invece usi solo software (DCO via ScontrinoZero), qualunque POS bancario standard va bene: registri il metodo di pagamento nello scontrino e basta.",
       },
       {
-        question:
-          "Le sanzioni si applicano subito o c'è un periodo di tolleranza?",
+        question: "Entro quando andava comunicato il collegamento?",
         answer:
-          "I provvedimenti AdE hanno previsto un periodo di tolleranza iniziale per consentire l'adeguamento di chi aveva RT fisici. Lo stato attuale dei controlli varia: il consiglio è di verificare con il commercialista il proprio profilo di rischio e di essere sempre conformi nella sostanza (tracciabilità del pagamento).",
+          "Per i POS già in uso al 1° gennaio 2026 il termine della prima comunicazione era il 20 aprile 2026, cioè 45 giorni dall'apertura del servizio \"Gestione Collegamenti\" (5 marzo 2026). Per i dispositivi attivati dopo, o quando cambia qualcosa, si comunica fra il sesto e l'ultimo giorno del secondo mese successivo all'evento. Se sei fuori termine, verifica con il commercialista il quadro sanzionatorio e regolarizza appena possibile.",
       },
     ],
     relatedHelp: ["pos-rt-obbligo", "normativa-pos-2026", "primo-scontrino"],
@@ -405,7 +404,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Sì: anche in regime forfettario devi emettere lo scontrino (documento commerciale) per ogni vendita al consumatore finale. Il forfettario semplifica IVA, ritenute e contabilità, ma NON esonera dalla certificazione dei corrispettivi B2C. Vediamo come gestire l'emissione, l'IVA \"a zero\" (natura N2) e gli aspetti operativi tipici del forfettario.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-07-22",
+    updatedAt: "2026-08-02",
     readingMinutes: 6,
     sections: [
       {
@@ -449,7 +448,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
         question:
           "Come gestisco i contanti vs i pagamenti elettronici da forfettario?",
         answer:
-          "Allo stesso modo di qualunque altro esercente: in fase di emissione indichi il metodo di pagamento (contanti, carta, misto). L'informazione finisce nel DCO trasmesso all'AdE. Non c'è una gestione speciale per il forfettario su questo punto.",
+          "Allo stesso modo di qualunque altro esercente: in fase di emissione indichi il metodo di pagamento, contanti o elettronico, uno per documento. L'informazione finisce nel DCO trasmesso all'AdE. Non c'è una gestione speciale per il forfettario su questo punto.",
       },
       {
         question: "Nello scontrino del forfettario c'è l'IVA?",
@@ -549,7 +548,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       'La "chiusura giornaliera" era l\'operazione classica di fine giornata con il registratore di cassa: si stampava lo scontrino di chiusura (la storica "Z") e si trasmettevano i corrispettivi. Con il documento commerciale online la logica è diversa, e in molti casi più semplice. Vediamo cosa devi davvero fare a fine giornata.',
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05-15",
+    updatedAt: "2026-08-02",
     readingMinutes: 5,
     sections: [
       {
@@ -583,7 +582,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Cosa devo dare al commercialista per la dichiarazione IVA?",
         answer:
-          "Il commercialista può scaricare direttamente dal portale Fatture e Corrispettivi il riepilogo dei corrispettivi trasmessi per il periodo richiesto. In alternativa, esporta dal software l'elenco scontrini in CSV/Excel con totali per aliquota IVA e metodo di pagamento. ScontrinoZero esporta i dati in formato standard.",
+          "Il commercialista può scaricare direttamente dal portale Fatture e Corrispettivi il riepilogo dei corrispettivi trasmessi per il periodo richiesto. In alternativa, esporta dal software l'elenco scontrini in CSV con totali per aliquota IVA e metodo di pagamento: in ScontrinoZero l'export CSV è incluso nel piano Pro (ed è utilizzabile anche durante i 30 giorni di prova).",
       },
       {
         question:
@@ -704,12 +703,12 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "La Lotteria degli Scontrini è un sistema premio per i consumatori che presentano un codice al momento dell'acquisto. Per il commerciante è un'attività operativa semplice: contrariamente a quanto si legge in giro, oggi non esiste una sanzione amministrativa per il rifiuto del codice — la previsione iniziale del decreto fiscale 2020 fu eliminata in sede di conversione. Resta però un meccanismo di segnalazione del cliente sul Portale Lotteria, che alimenta l'analisi del rischio dell'Agenzia delle Entrate.",
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05-15",
+    updatedAt: "2026-08-02",
     readingMinutes: 6,
     sections: [
       {
         heading: "Come funziona la Lotteria degli Scontrini",
-        body: "Il consumatore richiede gratuitamente sul sito lotteriadegliscontrini.gov.it un codice personale di 8 caratteri alfanumerici. Quando fa un acquisto, lo presenta all'esercente (cartaceo, smartphone o tessera plastificata): l'esercente lo inserisce nel DCO, il codice viene trasmesso ad AdE insieme allo scontrino, e ad ogni euro di spesa corrispondono uno o più biglietti virtuali per le estrazioni periodiche.",
+        body: "Il consumatore richiede gratuitamente sul sito lotteriadegliscontrini.gov.it un codice personale di 8 caratteri alfanumerici. Quando fa un acquisto, lo presenta all'esercente (cartaceo, smartphone o tessera plastificata): l'esercente lo inserisce nel DCO e il codice viene trasmesso ad AdE insieme allo scontrino. Partecipano solo gli acquisti di importo superiore a 1 € pagati con strumenti elettronici: ogni euro speso vale 1 biglietto virtuale, fino a un massimo di 1.000 biglietti per scontrino. Gli acquisti in contanti sono esclusi.",
       },
       {
         heading: "Cosa deve fare il commerciante",
@@ -717,11 +716,11 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Come acquisire il codice in fase di emissione",
-        body: "Tutti i software che emettono DCO devono prevedere un campo dedicato per il codice lotteria. Su ScontrinoZero, prima di confermare l'emissione, compare un campo opzionale dove inserire il codice (8 caratteri maiuscoli o numeri). Una validazione lato app verifica il formato; il codice corretto viene incluso nel tracciato DCO trasmesso ad AdE. Tempo aggiuntivo per scontrino: 5-10 secondi.",
+        body: "Tutti i software che emettono DCO devono prevedere un campo dedicato per il codice lotteria. Su ScontrinoZero, prima di confermare l'emissione, compare un campo opzionale dove inserire il codice (8 caratteri fra lettere maiuscole e numeri). Il campo appare solo se hai selezionato il pagamento elettronico, e resta disattivato sotto 1 € di totale: sono le due condizioni di partecipazione alla lotteria. Con l'incasso in contanti il codice non serve e non viene trasmesso. Una validazione lato app verifica il formato; il codice corretto viene incluso nel tracciato DCO trasmesso ad AdE. Tempo aggiuntivo per scontrino: 5-10 secondi.",
       },
       {
         heading: "Lotteria periodica e lotteria istantanea: stato attuale",
-        body: "Oggi è attiva solo la lotteria periodica: il sistema effettua estrazioni regolari (mensili e annuali) fra tutti gli scontrini trasmessi con un codice lotteria valido. La lotteria istantanea — vincita comunicata pochi secondi dopo l'emissione, riservata ai pagamenti elettronici — è stata annunciata più volte ma a maggio 2026 non risulta ancora avviata (le gare d'appalto per il sistema sono andate deserte). Quando partirà, il commerciante non dovrà cambiare nulla nel flusso di emissione: l'eventuale vincita viene comunicata direttamente al cliente.",
+        body: "Oggi è attiva solo la lotteria periodica: fra tutti gli scontrini trasmessi con un codice lotteria valido si estraggono premi settimanali da 25.000 €, mensili da 100.000 € e un premio annuale da 5 milioni di euro. La lotteria istantanea — vincita comunicata pochi secondi dopo l'emissione — è stata annunciata più volte ma ad agosto 2026 non risulta ancora avviata, a oltre tre anni dall'annuncio e nonostante circa 1,6 milioni di esercenti abbiano già adeguato i registratori. Quando partirà, il commerciante non dovrà cambiare nulla nel flusso di emissione: l'eventuale vincita viene comunicata direttamente al cliente.",
       },
       {
         heading: "Conseguenze del rifiuto",
@@ -751,6 +750,12 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
         answer:
           "Il codice lotteria è anonimo per il commerciante: non corrisponde al codice fiscale né a dati anagrafici visibili. Non devi conservarlo nei tuoi sistemi oltre la trasmissione AdE: viene incluso nel DCO e poi non serve più localmente. Lo stesso codice può essere usato dal cliente in vari negozi.",
       },
+      {
+        question:
+          "Il cliente paga in contanti e mi dà il codice lotteria: cosa faccio?",
+        answer:
+          "Quell'acquisto non partecipa: alla Lotteria degli Scontrini concorrono solo gli acquisti sopra 1 € pagati con strumenti elettronici (carte di credito, debito, prepagate e app di pagamento). Spiegalo al cliente: in ScontrinoZero il campo del codice compare infatti solo quando selezioni il pagamento elettronico.",
+      },
     ],
     relatedHelp: [
       "primo-scontrino",
@@ -772,7 +777,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Il mercato dei software per scontrini elettronici è cresciuto rapidamente: web app, app mobile, gestionali integrati, soluzioni self-hosted. Scegliere quello giusto significa risparmiare ore di lavoro mensili ed evitare incidenti fiscali. Vediamo 6 criteri pratici per orientarti senza farti convincere dal marketing.",
     publishedAt: "2026-05-15",
-    updatedAt: "2026-05-15",
+    updatedAt: "2026-08-02",
     readingMinutes: 7,
     sections: [
       {
@@ -793,7 +798,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Criterio 5: conformità normativa e supporto fiscale",
-        body: 'Verifica che il software sia esplicitamente conforme al D.Lgs. 127/2015, al Provvedimento AdE del 28 ottobre 2016 n. 182017 e alle modifiche successive. Le pagine di prodotto onesti citano i riferimenti normativi; quelle vaghe parlano solo di "compliance fiscale". Verifica che il software gestisca il regime forfettario (IVA 0% e dicitura esenzione), l\'obbligo POS-RT 2026, le aliquote IVA differenziate. Il supporto deve sapere rispondere a domande fiscali, non solo tecniche.',
+        body: 'Verifica che il software sia esplicitamente conforme al D.Lgs. 127/2015, al Provvedimento AdE del 28 ottobre 2016 n. 182017 e alle modifiche successive. Le pagine di prodotto onesti citano i riferimenti normativi; quelle vaghe parlano solo di "compliance fiscale". Verifica che il software gestisca il regime forfettario (righe a 0% con natura N2 — sullo scontrino la dicitura di esenzione non serve, serve in fattura), l\'obbligo di collegamento POS 2026, le aliquote IVA differenziate. Il supporto deve sapere rispondere a domande fiscali, non solo tecniche.',
       },
       {
         heading: "Criterio 6: lock-in e portabilità dei dati",

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -18,7 +18,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "aliquote-iva": {
     slug: "aliquote-iva",
     datePublished: "2026-04-17",
-    dateModified: "2026-07-13",
+    dateModified: "2026-08-02",
     title: "Aliquote IVA, catalogo e metodi di pagamento",
     metaTitle: "Come gestire aliquote IVA, catalogo e metodi di pagamento",
     description:
@@ -180,7 +180,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "normativa-pos-2026": {
     slug: "normativa-pos-2026",
     datePublished: "2026-04-17",
-    dateModified: "2026-06-21",
+    dateModified: "2026-08-02",
     title: "Collegamento POS-cassa 2026: cosa cambia",
     metaTitle: "Normativa POS 2026: obbligo, scadenze e sanzioni POS-cassa",
     description:
@@ -214,7 +214,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "pos-rt-obbligo": {
     slug: "pos-rt-obbligo",
     datePublished: "2026-04-20",
-    dateModified: "2026-06-21",
+    dateModified: "2026-08-02",
     title: "Collegamento POS-RT: obbligo e scadenze 2026",
     metaTitle: "Collegamento POS-RT: chi è obbligato e scadenze 2026",
     description:
@@ -281,7 +281,7 @@ export const helpArticles: Record<string, HelpArticle> = {
   "sicurezza-credenziali": {
     slug: "sicurezza-credenziali",
     datePublished: "2026-04-16",
-    dateModified: "2026-07-15",
+    dateModified: "2026-08-02",
     title: "Sicurezza e privacy delle credenziali",
     metaTitle: "Sicurezza e privacy: come proteggiamo le tue credenziali",
     description:

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -75,7 +75,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "Emetti scontrini al banco del mercato, dal furgone, ovunque sei. Basta lo smartphone che hai già in tasca.",
     audience: "ambulanti, operatori di mercato, venditori su area pubblica",
     useCase:
-      "Se vendi al mercato settimanale, alle fiere, in spiaggia o porta a porta, il registratore di cassa fisso è scomodo: pesa, va alimentato, va portato dietro. ScontrinoZero ti permette di emettere lo scontrino elettronico (Documento Commerciale Online) direttamente dallo smartphone, anche con connessione mobile, e di trasmettere automaticamente i corrispettivi all'Agenzia delle Entrate a fine giornata.",
+      "Se vendi al mercato settimanale, alle fiere, in spiaggia o porta a porta, il registratore di cassa fisso è scomodo: pesa, va alimentato, va portato dietro. ScontrinoZero ti permette di emettere lo scontrino elettronico (Documento Commerciale Online) direttamente dallo smartphone, anche con connessione mobile: il corrispettivo parte verso l'Agenzia delle Entrate a ogni singola emissione, quindi non c'è nessuna chiusura di fine giornata da ricordare.",
     obligations: [
       "Emissione del Documento Commerciale Online per ogni vendita B2C, anche di piccolo importo (DPR 633/72 art. 22).",
       "Trasmissione telematica dei corrispettivi all'Agenzia delle Entrate entro 12 giorni dalla data dell'operazione.",
@@ -85,7 +85,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     benefits: [
       "Funziona ovunque ci sia rete 4G/5G, anche senza linea fissa.",
       "Non serve hardware: zero investimento iniziale, niente registratore da trasportare.",
-      "Pagamenti misti (contanti + carte + buoni) gestiti in pochi tap.",
+      "Contanti o carta: scegli il metodo con un tap e il dato viaggia nello scontrino trasmesso all'AdE.",
       "Storico vendite consultabile su qualsiasi dispositivo, utile per il commercialista.",
     ],
     faq: [
@@ -126,7 +126,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     ],
     benefits: [
       "Tablet alla reception: zero ingombro sul banco, design pulito da salone moderno.",
-      "Gestione di pagamenti misti (es. parte in carta, parte in contanti, gift card).",
+      "Metodo di pagamento (contanti o carta) selezionabile su ogni scontrino, trasmesso all'AdE con il documento.",
       "Catalogo prodotti e servizi configurabile, per emettere lo scontrino in 2 tap.",
       "Storico consultabile dal commercialista senza dover esportare nulla manualmente.",
     ],
@@ -140,7 +140,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       {
         question: "Serve uno scanner di codici a barre per i prodotti?",
         answer:
-          "No. Per chi vende pochi prodotti il catalogo manuale è sufficiente. Il barcode scanner via fotocamera è una delle feature in roadmap per le prossime versioni.",
+          "No, e nemmeno è previsto: il catalogo prodotti si compila a mano una volta sola ed è sufficiente per chi rivende poche referenze. La lettura del codice a barre via fotocamera non è oggi disponibile e non è in roadmap; la valuteremo se arriveranno richieste da chi gestisce molti articoli.",
       },
       {
         question: "Posso stampare lo scontrino su carta?",
@@ -213,7 +213,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "Trasmissione corrispettivi entro 12 giorni dall'operazione.",
     ],
     benefits: [
-      "Niente canone fisso annuale: paghi solo quando emetti scontrini.",
+      "Niente hardware da ammortizzare: con il piano mensile paghi i mesi di apertura e disdici a fine stagione.",
       "Configurazione una tantum di aliquota e voci ricorrenti (pernottamento, colazione, supplementi).",
       "Storico ordinato per stagione, utile per dichiarazione dei redditi e analisi.",
       "Funziona su qualsiasi smartphone o tablet, anche quello che già usi per ricevere gli ospiti.",
@@ -399,7 +399,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "Zero hardware da montare allo stand: basta lo smartphone, anche con connessione mobile.",
       "Piano mensile disdicibile: paghi nei mesi in cui vendi, lo storico resta sempre accessibile.",
       "Catalogo con i tuoi articoli ricorrenti per emettere in pochi tap anche con la fila al banchetto.",
-      "Pagamenti misti contanti + carta gestiti nello stesso scontrino.",
+      "Metodo di pagamento (contanti o carta) scelto scontrino per scontrino, senza passaggi in più.",
     ],
     faq: [
       {
@@ -684,7 +684,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       {
         question: "Il cliente può avere lo scontrino per la garanzia?",
         answer:
-          "Sì: il documento commerciale vale come prova d'acquisto ai fini della garanzia legale di 26 mesi. Puoi stamparlo su termica o inviarlo via email/QR: la copia digitale ha lo stesso valore di quella cartacea.",
+          "Sì: il documento commerciale vale come prova d'acquisto ai fini della garanzia legale di conformità, che dura 24 mesi dalla consegna (art. 133 Codice del Consumo, D.Lgs. 206/2005). Puoi stamparlo su termica o inviarlo via email/QR: la copia digitale ha lo stesso valore di quella cartacea.",
       },
     ],
     relatedHelp: ["primo-scontrino", "annullare-scontrino", "aliquote-iva"],
@@ -797,7 +797,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     ],
     benefits: [
       "Listino servizi nel catalogo: lavaggio camicia, piumone, orlo — scontrino in due tap.",
-      "Incassi misti (contanti + carta) gestiti nello stesso documento.",
+      "Metodo di pagamento (contanti o carta) indicato su ogni ricevuta di ritiro.",
       "Scontrino al momento del ritiro, anche con acconto alla consegna dei capi.",
       "Storico digitale per il commercialista, senza rotoli da archiviare.",
     ],


### PR DESCRIPTION
La riga "Ultimo aggiornamento" era scritta a mano nel JSX di ogni pagina
/help e si era desincronizzata dal `dateModified` del registry su 19
articoli su 26: il testo visibile diceva "aprile 2026" mentre l'Article
JSON-LD letto da Google e dalle AI diceva luglio. Il freshness signal —
metà del vantaggio competitivo SEO dichiarato nella skill — era rotto
senza che nessun test fallisse.

Nuovo componente `HelpArticleUpdatedAt` che legge
`helpArticles[slug].dateModified`, cioè la stessa fonte del JSON-LD e
della sitemap, rendendo il drift strutturalmente impossibile.
`formatUpdatedAt` lavora sulla stringa ISO senza passare da `new Date()`:
una data-only è parsata come UTC ma renderizzata in locale, quindi nei
fusi negativi il giorno 01 slitterebbe al mese precedente (mismatch di
idratazione oltre che data sbagliata).

Correzioni di contenuto nelle stesse pagine:

- sicurezza-credenziali: "un pulsante dedicato ... è in roadmap" prometteva
  una feature assente da PLAN.md, anche fra i nice-to-have. Sostituito con
  lo stato di fatto (sovrascrivi le credenziali o elimina l'account).
- aliquote-iva: il vincolo del codice lotteria non è della sola lotteria
  istantanea (che non è mai partita) ma di tutta la lotteria, che ammette
  solo acquisti sopra 1 € pagati con strumenti elettronici.
- pos-rt-obbligo: la L. 207/2024 è citata ai commi 74-77, non 74-76.
- normativa-pos-2026: l'emendamento sulla franchigia del 5% è datato e
  marcato come non ancora approvato, invece di un "in discussione" senza
  data destinato a invecchiare.
- hub /help: l'articolo su aliquote IVA parlava di "reparti", concetto da
  registratore telematico che nel prodotto non esiste (è il catalogo).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y3Ty2Pb4HJhc3J4ba4ratB