### PR TITLE
fix(pwa): NetworkOnly sulle GET tenant del service worker (REVIEW #73)

### DIFF
--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -96,6 +96,7 @@ curl -fsS https://<host>/api/health/live
 curl -fsS https://<host>/api/_health/env | jq .
 curl -fsS -H "x-sentinel-token: $TOKEN" \
   "https://<host>/api/_debug/sentry-sentinel?id=v$VERSION"
+curl -fsSI https://<host>/sw.js | head -1
 ```
 
 - `/api/health/live` (`src/app/api/health/live/route.ts`) → 200 = process
@@ -116,6 +117,15 @@ curl -fsS -H "x-sentinel-token: $TOKEN" \
   sentinella non appare in dashboard entro ~5 minuti**; se non appare →
   integrazione rotta = bug bloccante, rollback o riapri la PR. Query lato
   Sentry (`errorClass:sentinel sentinelId:v$VERSION`) → skill `sentry-hygiene`.
+- `/sw.js` → **200**, non 404. È la quarta probe, aggiunta dopo REVIEW #84: il
+  service worker aveva smesso di essere emesso dal build (plugin webpack sotto
+  Turbopack) e nessuno se n'era accorto per mesi, perché un 404 su `/sw.js`
+  non degrada nulla di visibile lato server — degrada offline e installazione
+  PWA lato browser. Il build ora fallisce se il bundle manca
+  (`scripts/check-service-worker.mjs`), ma questa probe copre il caso diverso
+  in cui il bundle esiste nell'immagine e non viene **servito** (volume
+  montato male, `public/` non copiata, regola proxy). Dettagli → skill
+  `pwa-serwist`.
 
 Il pattern è "live + env + drain": catturava `@react-email/render` mancante
 (SCONTRINOZERO-B, gap dev container vs standalone), `NEXT_PUBLIC_APP_URL`

--- a/.claude/skills/pwa-serwist/SKILL.md
+++ b/.claude/skills/pwa-serwist/SKILL.md
@@ -53,6 +53,34 @@ scoperte, le cacha comunque a runtime la `NetworkFirst` delle navigazioni di
 definizione quando la rete non c'è. È aggiunta esplicitamente ai `globPatterns`.
 Se tocchi i glob, verifica che `"/offline"` sia ancora nel manifest generato.
 
+### Registrazione: esplicita, con due default da spegnere
+
+Il vecchio plugin webpack iniettava lui lo script di registrazione. In
+configurator mode **no**: la registrazione va dichiarata, con `SerwistProvider`
+da `@serwist/next/react` in `src/components/providers.tsx` (stesso entry client
+dove `initInstallPromptCapture()` gira a module-load).
+
+Due default di `SerwistProvider` sono attivi e vanno spenti in un POS:
+
+- **`reloadOnOnline` (default `true`)** → `location.reload()` sull'evento
+  `online`. Al banco, con rete ballerina, ricarica la pagina **proprio quando
+  la connessione torna**: carrello in corso perso (righe, codice lotteria).
+  È lo scenario tipico, non un caso limite.
+- **`cacheOnNavigation` (default `true`)** → sovrascrive `history.pushState` e
+  `replaceState` per cachare le URL navigate. Interop rischiosa col router
+  dell'App Router e nessun beneficio: le pagine visitate le cacha già la
+  `NetworkFirst` delle navigazioni di `defaultCache`.
+
+`disable={process.env.NODE_ENV === "development"}`: `serwist build` è
+incatenato allo script `build`, non a `dev`, quindi in sviluppo il file non
+esiste e registrarlo darebbe 404 a ogni avvio.
+
+⚠️ **CSP:** `src/lib/csp.ts` dichiara `worker-src 'self'` esplicito. Senza,
+la registrazione ricadrebbe sul fallback `child-src` → `script-src`: funziona
+oggi solo perché `script-src` contiene `'self'`, ma in enforce mode una
+restrizione futura di `script-src` spegnerebbe il SW **in silenzio** (il
+browser non registra e non c'è errore lato server).
+
 ### Lint sul bundle generato
 
 `public/sw.js` è un bundle esbuild minificato: va tenuto nei `globalIgnores` di

--- a/.claude/skills/pwa-serwist/SKILL.md
+++ b/.claude/skills/pwa-serwist/SKILL.md
@@ -5,6 +5,26 @@ description: Use when working on the PWA — the service worker src/sw.ts (Serwi
 
 # pwa-serwist — service worker, install prompt, matcher
 
+## ⚠️ Prima di tutto: il SW oggi NON viene emesso (Turbopack)
+
+Next 16 builda con **Turbopack di default** e `@serwist/next@9` è un plugin
+**webpack**: non gira, stampa un warning, e il build **prosegue verde** senza
+emettere il service worker in `public/sw*.js`. In produzione `/sw.js` risponde
+404 → nessun SW
+registrato, nessun offline, nessun `beforeinstallprompt` (quindi niente
+installazione su Android). È il finding P1 **REVIEW.md #84**.
+
+Conseguenza pratica per chi lavora qui: **`src/sw.ts` è codice non spedito**
+finché #84 non è chiuso. Continua a mantenerlo corretto (il file torna vivo nel
+momento in cui si ripristina la build), ma non concludere che un
+comportamento del SW sia attivo in produzione senza prima verificare che
+`public/sw*.js` esista dopo `npm run build` e che `GET /sw.js` dia 200.
+
+Lezione generalizzabile: un plugin di build che degrada a **warning** invece di
+fallire è indistinguibile dal successo in CI. Se una feature dipende da un
+artefatto generato, l'unica verifica che tiene è **asserire l'esistenza
+dell'artefatto**, non la correttezza del sorgente che lo produce.
+
 ## Serwist — attenzione al `defaultCache`
 
 Il service worker (`src/sw.ts`) usa `runtimeCaching: defaultCache` di
@@ -29,12 +49,26 @@ le richieste `/api/*`. Conseguenze:
   per route autenticate fare affidamento su `cookies()`/redirect server-side,
   non su "il SW non interferisce".
 
-> ⚠️ **Stato oggi: l'override NON è implementato.** `src/sw.ts` passa
-> `runtimeCaching: defaultCache` senza alcuna regola precedente, quindi le GET
-> `/api/*` con dati fiscali per-tenant (PDF scontrino, export CSV, lista
-> Developer API) sono cacheabili in produzione — è il finding P1 **REVIEW.md
-> #73**, con il fix già scritto lì. Se tocchi `src/sw.ts` per altro, non dare
-> per scontato che la prescrizione sopra sia già applicata: verificala.
+> ✅ **Stato oggi: l'override è implementato** (fix REVIEW.md #73). `src/sw.ts`
+> costruisce `runtimeCaching` con una regola `NetworkOnly` su
+> `sameOrigin && (pathname.startsWith("/api/") || pathname.startsWith("/v1/"))`
+> **prima** dello spread di `defaultCache`. `/v1/` c'è perché è il path
+> pre-rewrite del subdomain API (`next.config.ts` → `rewrites()`): dimenticarlo
+> lascerebbe scoperta la Developer API. La pagina pubblica `/r/<id>` è
+> **volutamente** fuori dall'override (non autenticata, nessun leak
+> cross-account, offline è un vantaggio).
+>
+> **L'ordine è la sostanza:** vince il primo matcher, quindi una regola messa
+> dopo `...defaultCache` non intercetterebbe nulla. Il test `src/sw.test.ts`
+> pinna posizione, matcher e la presenza di `defaultCache` dopo l'override.
+>
+> `src/sw.ts` resta escluso da `sonar.exclusions` ma **non** dalla coverage
+> (`vitest.config.ts`). Per testarlo: `vi.stubGlobal("self", { __SW_MANIFEST })`
+> prima dell'import (in environment node `self` non esiste), e le classi mockate
+> (`Serwist`, `NetworkOnly`) vanno definite dentro `vi.hoisted`, non nel factory
+> di `vi.mock` — il factory viene ri-valutato e una classe definita lì dentro
+> avrebbe identità diversa da quella vista dal test, facendo fallire ogni
+> `instanceof`.
 
 `src/components/pwa/` contiene gli hook lato client per install prompt e
 update detection — sono Client Components che usano `window.matchMedia` e

--- a/.claude/skills/pwa-serwist/SKILL.md
+++ b/.claude/skills/pwa-serwist/SKILL.md
@@ -83,10 +83,17 @@ browser non registra e non c'è errore lato server).
 
 ### Lint sul bundle generato
 
-`public/sw.js` è un bundle esbuild minificato: va tenuto nei `globalIgnores` di
-`eslint.config.mjs` (insieme alla sua `.map`). Prima di #84 non veniva mai
-emesso, quindi non era mai presente nel working tree e il problema non si era
-mai visto.
+Il SW emesso (`public/sw*.js` e la sua `.map`) è un bundle esbuild minificato:
+va tenuto nei `globalIgnores` di `eslint.config.mjs`. Prima di #84 non veniva
+mai emesso, quindi non era mai presente nel working tree e il problema non si
+era mai visto.
+
+⚠️ **Citalo sempre come glob, mai come path letterale**, qui e in ogni doc
+validato da `scripts/check-architecture-docs.mjs`: è un artefatto di build,
+gitignored, quindi in un checkout pulito **non esiste** e il check fallisce.
+In locale l'errore non si vede se hai appena buildato — è esattamente così
+che è passato in CI la prima volta. Stessa regola dei file HAR (skill
+`ade-integration`).
 
 ## Serwist — attenzione al `defaultCache`
 

--- a/.claude/skills/pwa-serwist/SKILL.md
+++ b/.claude/skills/pwa-serwist/SKILL.md
@@ -5,25 +5,60 @@ description: Use when working on the PWA — the service worker src/sw.ts (Serwi
 
 # pwa-serwist — service worker, install prompt, matcher
 
-## ⚠️ Prima di tutto: il SW oggi NON viene emesso (Turbopack)
+## Come viene costruito il SW: configurator mode, NON un plugin
 
-Next 16 builda con **Turbopack di default** e `@serwist/next@9` è un plugin
-**webpack**: non gira, stampa un warning, e il build **prosegue verde** senza
-emettere il service worker in `public/sw*.js`. In produzione `/sw.js` risponde
-404 → nessun SW
-registrato, nessun offline, nessun `beforeinstallprompt` (quindi niente
-installazione su Android). È il finding P1 **REVIEW.md #84**.
+Il service worker **non** è costruito da un plugin dentro `next.config.ts`. Lo
+era (`withSerwistInit`), ma quello è un plugin **webpack** e Next 16 builda con
+**Turbopack**: non girava, degradava a un **warning**, e il build restava verde
+senza emettere nulla. Risultato: `/sw.js` 404 in produzione per mesi — niente
+offline, niente `beforeinstallprompt`, quindi niente installazione su Android
+(iOS non è colpito, il che rendeva l'asimmetria fuorviante). Era REVIEW #84.
 
-Conseguenza pratica per chi lavora qui: **`src/sw.ts` è codice non spedito**
-finché #84 non è chiuso. Continua a mantenerlo corretto (il file torna vivo nel
-momento in cui si ripristina la build), ma non concludere che un
-comportamento del SW sia attivo in produzione senza prima verificare che
-`public/sw*.js` esista dopo `npm run build` e che `GET /sw.js` dia 200.
+Oggi la catena è esplicita e bundler-agnostica:
 
-Lezione generalizzabile: un plugin di build che degrada a **warning** invece di
-fallire è indistinguibile dal successo in CI. Se una feature dipende da un
-artefatto generato, l'unica verifica che tiene è **asserire l'esistenza
-dell'artefatto**, non la correttezza del sorgente che lo produce.
+```
+npm run build → next build && npm run build:sw
+                              └─ serwist build serwist.config.mjs
+                                 └─ node scripts/check-service-worker.mjs
+```
+
+- `serwist.config.mjs` usa `serwist.withNextConfig(...)` dall'export `./config`
+  di `@serwist/next` + il CLI `@serwist/cli` (devDependency). Non si aggancia al
+  bundler: gira **dopo** `next build` e legge gli asset già emessi.
+- È incatenato allo script `build` di `package.json`, non a un workflow CI —
+  così vale anche per il Dockerfile.
+- `scripts/check-service-worker.mjs` fallisce se il bundle manca o è sotto 1 KB.
+
+> **Lezione, generalizzabile oltre il SW:** un tool di build che degrada a
+> warning invece di fallire è **indistinguibile dal successo** in CI. Quando una
+> feature dipende da un artefatto generato, l'unica verifica che tiene è
+> asserire l'esistenza dell'**artefatto**; verificare il sorgente che lo produce
+> non basta, perché il produttore può smettere di girare del tutto.
+
+### Cosa finisce nel precache (e cosa no)
+
+I default del configurator precacherebbero **~12 MB**: 5.3 MB di HTML SSG (89
+pagine fra landing, `/help` e `/guide`), 3 MB di screenshot prodotto, 3.2 MB di
+app shell. Su un target mobile-first di micro-esercenti sono 8.3 MB di roba
+marketing scaricata in 4G e mai usata offline — chi installa la PWA vive in
+`/dashboard`, che è dinamica e nemmeno precacheabile.
+
+Perciò `serwist.config.mjs` imposta `precachePrerendered: false` e ignora
+`public/screenshots/**`: **3.55 MB, 67 URL**. Le pagine marketing non restano
+scoperte, le cacha comunque a runtime la `NetworkFirst` delle navigazioni di
+`defaultCache` — ma solo quelle davvero visitate.
+
+⚠️ L'unica pagina prerenderizzata che **deve** restare nel precache è
+`/offline`: è il fallback di navigazione dichiarato in `src/sw.ts` e serve per
+definizione quando la rete non c'è. È aggiunta esplicitamente ai `globPatterns`.
+Se tocchi i glob, verifica che `"/offline"` sia ancora nel manifest generato.
+
+### Lint sul bundle generato
+
+`public/sw.js` è un bundle esbuild minificato: va tenuto nei `globalIgnores` di
+`eslint.config.mjs` (insieme alla sua `.map`). Prima di #84 non veniva mai
+emesso, quindi non era mai presente nel working tree e il problema non si era
+mai visto.
 
 ## Serwist — attenzione al `defaultCache`
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,48 +18,41 @@ consapevoli accettati vivono in fondo, in "Rischi accettati".
 
 ## P1 — Alta priorità
 
-### 84. PWA: il service worker era costruito da un plugin webpack sotto Turbopack — **build ripristinata, resta la registrazione**
+### 84. PWA: verifica manuale su sandbox del service worker ripristinato
 
-- **Categoria:** funzionalità/regressione · **Severità:** High
-- **File residui:** `src/components/providers.tsx` (registrazione), `deploy/` + skill `deploy-release` (probe di smoke)
+- **Categoria:** verifica di rollout · **Severità:** Low — il codice è spedito, resta da confermare sul campo
+- **File:** nessuno da modificare. Riferimenti: `serwist.config.mjs`, `src/sw.ts`, `src/components/providers.tsx`, `scripts/check-service-worker.mjs`
 
-**Problema (storico).** `withSerwistInit` in `next.config.ts` era un plugin
-**webpack**; Next 16 builda con **Turbopack**, quindi non girava. Degradava a un
-warning senza far fallire il build: `public/sw.js` non veniva mai emesso, né lo
-script di registrazione che il plugin iniettava. Verificato il 2026-08-03:
-`GET https://app.scontrinozero.it/sw.js` → **404** (idem sul dominio marketing),
-mentre `/manifest.webmanifest` → 200. Conseguenze silenziose: nessun offline,
-nessun precache e — perché Chrome emette `beforeinstallprompt` solo con un SW
-registrato — **nessuna installazione su Android**, cioè proprio il bug che
-`src/lib/pwa/install-prompt-store.ts` era stato scritto per risolvere. iOS non
-era colpito, il che rendeva l'asimmetria fuorviante.
+**Contesto.** `withSerwistInit` era un plugin **webpack** e Next 16 builda con
+**Turbopack**: non girava, degradava a warning e il build restava verde senza
+emettere nulla. `GET /sw.js` era **404** in produzione (verificato il
+2026-08-03) — niente offline, niente precache e, poiché Chrome emette
+`beforeinstallprompt` solo con un SW registrato, **nessuna installazione su
+Android**, cioè proprio il bug che `src/lib/pwa/install-prompt-store.ts` era
+stato scritto per risolvere. iOS non era colpito, il che rendeva l'asimmetria
+fuorviante.
 
-**Fatto (configurator mode).** Il SW ora è uno step di build a sé, bundler-agnostico:
-`serwist.config.mjs` (`serwist.withNextConfig` dall'export `./config` di
-`@serwist/next`) + `@serwist/cli`, incatenato allo script `build` di
-`package.json` così vale anche per il Dockerfile. `scripts/check-service-worker.mjs`
-fallisce se il bundle manca o è sotto 1 KB — la guardia che sarebbe servita, dato
-che un tool degradato a warning è indistinguibile dal successo in CI. Precache
-ristretto all'app shell (`precachePrerendered: false` + `public/screenshots/**`
-ignorati): **3.55 MB / 67 URL** invece dei 12 MB di default, di cui 8.3 MB erano
-marketing mai usato offline. `/offline` resta precacheato esplicitamente perché
-è il fallback di navigazione di `src/sw.ts`.
+Risolto passando alla configurator mode (build bundler-agnostica + guardia che
+fa fallire il build se il bundle manca) e dichiarando la registrazione con
+`SerwistProvider`. Dettagli e trappole → skill `pwa-serwist`.
 
-**Resta da fare.**
+**Resta da fare: verifica manuale su sandbox prima di prod.** Non è
+automatizzabile — richiede un browser reale e un dispositivo Android.
 
-1. **Registrazione lato client.** Il plugin webpack iniettava lo script da sé; in
-   configurator mode va esplicitata con `SerwistProvider` da
-   `@serwist/next/react` (`swUrl="/sw.js"`, `disable` in development — in dev il
-   CLI non gira e il file non esiste). Slot naturale:
-   `src/components/providers.tsx`, già entry client dove
-   `initInstallPromptCapture()` è chiamato a module-load.
-2. **Smoke post-deploy (regola 25):** aggiungere alle probe
-   `curl -sfI https://<host>/sw.js` → 200 con content-type JavaScript.
-3. **Verifica manuale su sandbox prima di prod:** DevTools → Application →
-   Service Workers mostra il SW `activated`; il pulsante "Installa" compare su
-   Chrome Android; e — punto 6 dell'ex #73, finora non eseguibile perché non
-   c'era alcun SW — Cache Storage non contiene **nessuna** voce
-   `/api/documents/.../pdf` dopo aver scaricato un PDF autenticato.
+1. DevTools → Application → Service Workers: il SW risulta **activated** e
+   `/sw.js` risponde 200 (è anche la quarta probe di smoke, skill
+   `deploy-release`).
+2. DevTools → Application → Cache Storage: dopo aver scaricato un PDF
+   autenticato **nessuna** voce `/api/documents/.../pdf` compare in cache; poi
+   forzare "Offline" e verificare che la stessa GET **fallisca** invece di
+   restituire il documento. È il punto 6 dell'ex #73, finora non eseguibile
+   perché non esisteva alcun SW.
+3. Chrome su Android: il pulsante "Installa" compare davvero (è la conferma
+   end-to-end che chiude il giro con `install-prompt-store.ts`).
+4. Navigazione offline → viene servita `/offline`, non l'errore di rete del
+   browser.
+
+Chiudere questa voce quando i quattro punti sono verdi su sandbox.
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,85 +18,76 @@ consapevoli accettati vivono in fondo, in "Rischi accettati".
 
 ## P1 — Alta priorità
 
-### 73. Service worker: nessun override `NetworkOnly` sulle GET `/api/*` tenant-specific
+### 84. Il service worker non viene più generato: `@serwist/next` non gira sotto Turbopack → PWA inerte in produzione
 
-- **Categoria:** sicurezza/privacy · **Severità:** High — **attivo in produzione oggi**, non gated su feature future
-- **File:** `src/sw.ts:18` (`runtimeCaching: defaultCache`, nessuna regola precedente); route GET esposte: `src/app/api/documents/[documentId]/pdf/route.ts`, `src/app/api/export/receipts/route.ts`, `src/app/api/v1/receipts/route.ts`
+- **Categoria:** funzionalità/regressione · **Severità:** High — una feature annunciata (installazione PWA, offline) **non esiste in produzione oggi**
+- **File:** `next.config.ts:7-12` (`withSerwistInit`, `swSrc: "src/sw.ts"` → `swDest: "public/sw.js"`), `package.json` (`"build": "next build"`), `Dockerfile:78`, `.github/workflows/ci.yml:342`. Consumer che danno per scontato un SW attivo: `src/lib/pwa/install-prompt-store.ts`, `src/components/pwa/`, `src/app/offline/page.tsx`, l'esclusione `sw\.js` dal matcher di `src/proxy.ts`, e l'articolo `src/app/(marketing)/help/installare-app/page.tsx`
 
-**Problema.** `src/sw.ts` registra `runtimeCaching: defaultCache` di
-`@serwist/next/worker` **senza alcun override**. Come documentato nella skill
-`pwa-serwist` (sezione "Serwist — attenzione al `defaultCache`"), `defaultCache`
-**non è asset-only**: include una strategia `NetworkFirst` per le richieste
-same-origin `/api/*`, che **scrive la response nella CacheStorage** via
-`fetchAndCachePut`. Il `cacheOkAndOpaquePlugin` aggiunto di default decide solo
-in base allo status HTTP (200/opaque) e **ignora `Cache-Control`** — quindi il
-`Cache-Control: no-store` già presente su `/api/export/receipts` **non impedisce
-la scrittura in cache**.
+**Problema.** Next 16 builda con **Turbopack di default**; `@serwist/next@9` è un
+plugin **webpack** e sotto Turbopack non gira. Il build lo dice esplicitamente
+(`[@serwist/next] WARNING: ... it doesn't support Turbopack`) ma **non fallisce**:
+prosegue e `public/sw.js` non viene mai emesso, insieme allo script di
+registrazione che il plugin inietta.
 
-Le GET coinvolte restituiscono dati fiscali del singolo tenant:
+Evidenza (verificata il 2026-08-03): dopo `npm run build` non esiste alcun
+`public/sw.js`, e in produzione `GET https://app.scontrinozero.it/sw.js` →
+**404** (idem sul dominio marketing), mentre `/manifest.webmanifest` → 200.
 
-- `GET /api/documents/[documentId]/pdf` → PDF dello scontrino (autenticato via cookie);
-- `GET /api/export/receipts` → CSV con **tutti** gli scontrini del business;
-- `GET /api/v1/receipts` → lista documenti (Bearer key).
+Conseguenze, tutte silenziose:
 
-La CacheStorage è **per-origin e sopravvive al logout**: su un dispositivo
-condiviso (tablet di negozio, PWA installata, cambio di account, rivendita del
-device) una richiesta del secondo utente che va in timeout o parte offline può
-essere servita dalla cache col **documento fiscale del primo utente**. Anche
-senza cambio account resta il problema minore dei dati stale serviti come
-freschi. La skill prescrive esplicitamente l'override; il codice non lo
-implementa, e `src/sw.ts` è escluso sia da SonarCloud (`sonar.exclusions`) sia
-dalla coverage (`vitest.config.ts`), quindi nessun test lo copre.
+- **Nessuna installazione su Android.** Chrome emette `beforeinstallprompt` solo
+  se è registrato un SW con fetch handler: senza, il pulsante "Installa" non
+  compare mai — cioè esattamente il bug che lo store singleton
+  `install-prompt-store.ts` era stato scritto per risolvere, che oggi è
+  irraggiungibile per un motivo diverso e a monte. iOS non è colpito ("Aggiungi
+  a schermata Home" non richiede SW), il che rende l'asimmetria fuorviante:
+  sembra un problema Android, è l'assenza totale del SW.
+- **Nessun offline e nessun precache:** `/offline` non viene mai servita, e ogni
+  navigazione senza rete è un errore di rete del browser.
+- `/help/installare-app` descrive un flusso che su Android non funziona
+  (regola 8: mai promettere feature non live).
 
-**Fix (non ambiguo).**
+Nessun test se n'è accorto perché nessuno guarda **l'output del build**:
+`src/sw.test.ts` verifica il contenuto del modulo `src/sw.ts`, non che il
+bundle venga emesso.
 
-1. In `src/sw.ts`, costruire l'array di runtime caching mettendo una regola
-   `NetworkOnly` **PRIMA** dello spread di `defaultCache` (l'ordine conta: vince
-   il primo matcher):
+> **Relazione con #73 (chiuso).** L'override `NetworkOnly` sulle GET
+> `/api/*` + `/v1/` è **già** in `src/sw.ts`: ripristinare la build del SW
+> **non** reintroduce il leak di CacheStorage. Resta però da eseguire la
+> verifica manuale che era il punto 6 di #73 (DevTools → Application → Cache
+> Storage: nessuna voce `/api/documents/.../pdf`) **appena il SW torna a essere
+> servito** — finora non era eseguibile, perché non c'era alcun SW.
 
-   ```ts
-   import { NetworkOnly } from "serwist";
-   // ...
-   runtimeCaching: [
-     {
-       matcher: ({ url, sameOrigin }) =>
-         sameOrigin &&
-         (url.pathname.startsWith("/api/") || url.pathname.startsWith("/v1/")),
-       handler: new NetworkOnly(),
-     },
-     ...defaultCache,
-   ],
-   ```
+**Fix (una decisione + due guardie).**
 
-   Includere `/v1/` perché è il path con cui le richieste arrivano dal subdomain
-   API **prima** del rewrite (`next.config.ts` → `rewrites()`).
+1. Scegliere come tornare a emettere il SW:
+   - **A — `next build --webpack`** (e `next dev --webpack`): ripristina il
+     plugin così com'è, zero migrazione, ma rinuncia a Turbopack in build e ci
+     lega a un bundler in uscita.
+   - **B — `@serwist/turbopack`**: allineato alla direzione di Next, supporto
+     dichiarato **sperimentale** dagli autori.
+   - **C — configurator mode di `@serwist/next`**: supporta Turbopack restando
+     nel pacchetto già in uso.
 
-2. **Non** limitarsi ad aggiungere `Cache-Control: no-store` sulle route: come
-   sopra, non previene la scrittura in cache. **Non** affidarsi a
-   `Vary: Cookie` — isola al più la voce per variante, non la impedisce.
+   Raccomandazione: **A** per ripristinare subito la feature (cambio di una
+   riga, rischio nullo), poi valutare **C** come uscita definitiva da webpack.
+   Qualunque strada: confrontare i tempi di build in CI prima/dopo, perché è
+   l'unico costo reale di A.
 
-3. Bonus difensivo (stesso PR, stesso file): valutare l'esclusione anche di
-   `/r/` (pagina pubblica scontrino) dalla `NetworkFirst` delle navigazioni, se
-   la si vuole sempre fresca. **Opzionale** — quella pagina non è autenticata,
-   quindi non è un leak: decidere e documentare la scelta nel commento.
-
-4. Rimuovere `src/sw.ts` dalla `coverage.exclude` di `vitest.config.ts` (resta
-   escluso da `sonar.exclusions`, che è un'altra cosa) e aggiungere
-   `src/sw.test.ts`.
-
-5. **Test** (`src/sw.test.ts`, mockando `serwist` e `@serwist/next/worker` come
-   già si fa per i moduli infrastrutturali — vedi `src/instrumentation.test.ts`):
-   - il `runtimeCaching` passato al costruttore `Serwist` ha come **primo**
-     elemento la regola con handler `NetworkOnly`;
-   - il matcher ritorna `true` per `{ sameOrigin: true, url: new URL("https://app.x/api/export/receipts") }`
-     e per `/v1/receipts`, `false` per `/dashboard` e per `sameOrigin: false`;
-   - `defaultCache` è ancora presente **dopo** la regola (non sostituito).
-
-6. **Verifica manuale post-deploy** (sandbox prima di prod): DevTools →
-   Application → Cache Storage, scaricare un PDF autenticato e confermare che
-   **nessuna** voce `/api/documents/.../pdf` compaia nelle cache Serwist. Poi
-   forzare "Offline" e verificare che la stessa GET fallisca invece di
-   restituire il documento cached.
+2. **Guardia anti-regressione nel build** — è l'unica cosa che avrebbe
+   intercettato questo: uno step dopo `next build` che fallisce se
+   `public/sw.js` non esiste o è vuoto (script in `scripts/`, invocato dal
+   `build` di `package.json` così vale anche per il Dockerfile, non solo per
+   CI). Un warning del plugin che non rompe il build non basta: è già lì e non
+   ha fermato nulla.
+3. **Smoke post-deploy (regola 25):** aggiungere alle probe un
+   `curl -sfI https://<host>/sw.js` che deve dare 200 con
+   `content-type: application/javascript`.
+4. **Test:** oltre alla guardia di build, un test sul `config.matcher` di
+   `src/proxy.ts` che continua a escludere `/sw.js` (già presente, skill
+   `pwa-serwist`), e verifica manuale post-deploy su sandbox: DevTools →
+   Application → Service Workers mostra il SW `activated`, e il pulsante
+   "Installa" compare su Chrome Android.
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,97 +18,48 @@ consapevoli accettati vivono in fondo, in "Rischi accettati".
 
 ## P1 — Alta priorità
 
-### 84. Il service worker non viene più generato: `@serwist/next` non gira sotto Turbopack → PWA inerte in produzione
+### 84. PWA: il service worker era costruito da un plugin webpack sotto Turbopack — **build ripristinata, resta la registrazione**
 
-- **Categoria:** funzionalità/regressione · **Severità:** High — una feature annunciata (installazione PWA, offline) **non esiste in produzione oggi**
-- **File:** `next.config.ts:7-12` (`withSerwistInit`, `swSrc: "src/sw.ts"` → `swDest: "public/sw.js"`), `package.json` (`"build": "next build"`), `Dockerfile:78`, `.github/workflows/ci.yml:342`. Consumer che danno per scontato un SW attivo: `src/lib/pwa/install-prompt-store.ts`, `src/components/pwa/`, `src/app/offline/page.tsx`, l'esclusione `sw\.js` dal matcher di `src/proxy.ts`, e l'articolo `src/app/(marketing)/help/installare-app/page.tsx`
+- **Categoria:** funzionalità/regressione · **Severità:** High
+- **File residui:** `src/components/providers.tsx` (registrazione), `deploy/` + skill `deploy-release` (probe di smoke)
 
-**Problema.** Next 16 builda con **Turbopack di default**; `@serwist/next@9` è un
-plugin **webpack** e sotto Turbopack non gira. Il build lo dice esplicitamente
-(`[@serwist/next] WARNING: ... it doesn't support Turbopack`) ma **non fallisce**:
-prosegue e `public/sw.js` non viene mai emesso, insieme allo script di
-registrazione che il plugin inietta.
+**Problema (storico).** `withSerwistInit` in `next.config.ts` era un plugin
+**webpack**; Next 16 builda con **Turbopack**, quindi non girava. Degradava a un
+warning senza far fallire il build: `public/sw.js` non veniva mai emesso, né lo
+script di registrazione che il plugin iniettava. Verificato il 2026-08-03:
+`GET https://app.scontrinozero.it/sw.js` → **404** (idem sul dominio marketing),
+mentre `/manifest.webmanifest` → 200. Conseguenze silenziose: nessun offline,
+nessun precache e — perché Chrome emette `beforeinstallprompt` solo con un SW
+registrato — **nessuna installazione su Android**, cioè proprio il bug che
+`src/lib/pwa/install-prompt-store.ts` era stato scritto per risolvere. iOS non
+era colpito, il che rendeva l'asimmetria fuorviante.
 
-Evidenza (verificata il 2026-08-03): dopo `npm run build` non esiste alcun
-`public/sw.js`, e in produzione `GET https://app.scontrinozero.it/sw.js` →
-**404** (idem sul dominio marketing), mentre `/manifest.webmanifest` → 200.
+**Fatto (configurator mode).** Il SW ora è uno step di build a sé, bundler-agnostico:
+`serwist.config.mjs` (`serwist.withNextConfig` dall'export `./config` di
+`@serwist/next`) + `@serwist/cli`, incatenato allo script `build` di
+`package.json` così vale anche per il Dockerfile. `scripts/check-service-worker.mjs`
+fallisce se il bundle manca o è sotto 1 KB — la guardia che sarebbe servita, dato
+che un tool degradato a warning è indistinguibile dal successo in CI. Precache
+ristretto all'app shell (`precachePrerendered: false` + `public/screenshots/**`
+ignorati): **3.55 MB / 67 URL** invece dei 12 MB di default, di cui 8.3 MB erano
+marketing mai usato offline. `/offline` resta precacheato esplicitamente perché
+è il fallback di navigazione di `src/sw.ts`.
 
-Conseguenze, tutte silenziose:
+**Resta da fare.**
 
-- **Nessuna installazione su Android.** Chrome emette `beforeinstallprompt` solo
-  se è registrato un SW con fetch handler: senza, il pulsante "Installa" non
-  compare mai — cioè esattamente il bug che lo store singleton
-  `install-prompt-store.ts` era stato scritto per risolvere, che oggi è
-  irraggiungibile per un motivo diverso e a monte. iOS non è colpito ("Aggiungi
-  a schermata Home" non richiede SW), il che rende l'asimmetria fuorviante:
-  sembra un problema Android, è l'assenza totale del SW.
-- **Nessun offline e nessun precache:** `/offline` non viene mai servita, e ogni
-  navigazione senza rete è un errore di rete del browser.
-- `/help/installare-app` descrive un flusso che su Android non funziona
-  (regola 8: mai promettere feature non live).
-
-Nessun test se n'è accorto perché nessuno guarda **l'output del build**:
-`src/sw.test.ts` verifica il contenuto del modulo `src/sw.ts`, non che il
-bundle venga emesso.
-
-> **Relazione con #73 (chiuso).** L'override `NetworkOnly` sulle GET
-> `/api/*` + `/v1/` è **già** in `src/sw.ts`: ripristinare la build del SW
-> **non** reintroduce il leak di CacheStorage. Resta però da eseguire la
-> verifica manuale che era il punto 6 di #73 (DevTools → Application → Cache
-> Storage: nessuna voce `/api/documents/.../pdf`) **appena il SW torna a essere
-> servito** — finora non era eseguibile, perché non c'era alcun SW.
-
-**Fix (una decisione + due guardie).**
-
-1. Scegliere come tornare a emettere il SW. **Decisione: C.**
-   - **A — `next build --webpack`** (e `next dev --webpack`). ⚠️ **Non è un
-     cambio di una riga:** `next.config.ts:28-33` dichiara l'alias di
-     `@point-of-sale/webbluetooth-receipt-printer` **solo** sotto la chiave
-     `turbopack`, che webpack ignora. Senza un blocco `webpack:` gemello il
-     build salta con module-not-found sul pass Client Component SSR — l'attrito
-     documentato in #62 — e proprio sul pacchetto della stampa termica v1.6.0.
-     Costo reale: un alias duplicato da tenere allineato, più l'intero build
-     riportato su un percorso non più esercitato dall'upgrade a Next 16, per
-     salvare un plugin.
-   - **B — `@serwist/turbopack`** (esiste, 9.5.12): dipendenza nuova, supporto
-     dichiarato **sperimentale** dagli autori, e soprattutto ri-accoppia il SW
-     al bundler — cioè ricompra la stessa classe di rottura al prossimo
-     cambio di bundler.
-   - **C — configurator mode**, export `./config` di `@serwist/next` **già
-     installato** (`serwist.withNextConfig(...)` + `generateGlobPatterns(distDir)`).
-     Non è un plugin del bundler: è uno step di build a sé, guidato da
-     `@serwist/cli`. È l'unica strada bundler-agnostica, e trasforma il SW in un
-     artefatto esplicito del build — quindi uno step che **può fallire**, che è
-     esattamente ciò che mancava qui (punto 2).
-
-   Cosa comporta C, in concreto:
-   - aggiungere `@serwist/cli` alle devDependencies (unico pezzo mancante:
-     `@serwist/next`, `@serwist/build`, `@serwist/window` ci sono già);
-   - togliere `withSerwistInit` da `next.config.ts` e spostare la config del SW
-     nel file del CLI;
-   - incatenare lo step al `build` di `package.json` (così vale anche per il
-     Dockerfile, non solo per CI);
-   - **la registrazione del SW diventa esplicita**: il plugin webpack iniettava
-     lo script da sé, in configurator mode si usa `SerwistProvider` da
-     `@serwist/next/react` (`swUrl="/sw.js"`). Slot naturale:
-     `src/components/providers.tsx`, che è già l'entry client dove
-     `initInstallPromptCapture()` viene chiamato a module-load. È il pezzo con
-     più incognite: validarlo su sandbox prima di prod.
-
-2. **Guardia anti-regressione nel build** — è l'unica cosa che avrebbe
-   intercettato questo: uno step dopo `next build` che fallisce se
-   `public/sw.js` non esiste o è vuoto (script in `scripts/`, invocato dal
-   `build` di `package.json` così vale anche per il Dockerfile, non solo per
-   CI). Un warning del plugin che non rompe il build non basta: è già lì e non
-   ha fermato nulla.
-3. **Smoke post-deploy (regola 25):** aggiungere alle probe un
-   `curl -sfI https://<host>/sw.js` che deve dare 200 con
-   `content-type: application/javascript`.
-4. **Test:** oltre alla guardia di build, un test sul `config.matcher` di
-   `src/proxy.ts` che continua a escludere `/sw.js` (già presente, skill
-   `pwa-serwist`), e verifica manuale post-deploy su sandbox: DevTools →
-   Application → Service Workers mostra il SW `activated`, e il pulsante
-   "Installa" compare su Chrome Android.
+1. **Registrazione lato client.** Il plugin webpack iniettava lo script da sé; in
+   configurator mode va esplicitata con `SerwistProvider` da
+   `@serwist/next/react` (`swUrl="/sw.js"`, `disable` in development — in dev il
+   CLI non gira e il file non esiste). Slot naturale:
+   `src/components/providers.tsx`, già entry client dove
+   `initInstallPromptCapture()` è chiamato a module-load.
+2. **Smoke post-deploy (regola 25):** aggiungere alle probe
+   `curl -sfI https://<host>/sw.js` → 200 con content-type JavaScript.
+3. **Verifica manuale su sandbox prima di prod:** DevTools → Application →
+   Service Workers mostra il SW `activated`; il pulsante "Installa" compare su
+   Chrome Android; e — punto 6 dell'ex #73, finora non eseguibile perché non
+   c'era alcun SW — Cache Storage non contiene **nessuna** voce
+   `/api/documents/.../pdf` dopo aver scaricato un PDF autenticato.
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -60,19 +60,40 @@ bundle venga emesso.
 
 **Fix (una decisione + due guardie).**
 
-1. Scegliere come tornare a emettere il SW:
-   - **A — `next build --webpack`** (e `next dev --webpack`): ripristina il
-     plugin così com'è, zero migrazione, ma rinuncia a Turbopack in build e ci
-     lega a un bundler in uscita.
-   - **B — `@serwist/turbopack`**: allineato alla direzione di Next, supporto
-     dichiarato **sperimentale** dagli autori.
-   - **C — configurator mode di `@serwist/next`**: supporta Turbopack restando
-     nel pacchetto già in uso.
+1. Scegliere come tornare a emettere il SW. **Decisione: C.**
+   - **A — `next build --webpack`** (e `next dev --webpack`). ⚠️ **Non è un
+     cambio di una riga:** `next.config.ts:28-33` dichiara l'alias di
+     `@point-of-sale/webbluetooth-receipt-printer` **solo** sotto la chiave
+     `turbopack`, che webpack ignora. Senza un blocco `webpack:` gemello il
+     build salta con module-not-found sul pass Client Component SSR — l'attrito
+     documentato in #62 — e proprio sul pacchetto della stampa termica v1.6.0.
+     Costo reale: un alias duplicato da tenere allineato, più l'intero build
+     riportato su un percorso non più esercitato dall'upgrade a Next 16, per
+     salvare un plugin.
+   - **B — `@serwist/turbopack`** (esiste, 9.5.12): dipendenza nuova, supporto
+     dichiarato **sperimentale** dagli autori, e soprattutto ri-accoppia il SW
+     al bundler — cioè ricompra la stessa classe di rottura al prossimo
+     cambio di bundler.
+   - **C — configurator mode**, export `./config` di `@serwist/next` **già
+     installato** (`serwist.withNextConfig(...)` + `generateGlobPatterns(distDir)`).
+     Non è un plugin del bundler: è uno step di build a sé, guidato da
+     `@serwist/cli`. È l'unica strada bundler-agnostica, e trasforma il SW in un
+     artefatto esplicito del build — quindi uno step che **può fallire**, che è
+     esattamente ciò che mancava qui (punto 2).
 
-   Raccomandazione: **A** per ripristinare subito la feature (cambio di una
-   riga, rischio nullo), poi valutare **C** come uscita definitiva da webpack.
-   Qualunque strada: confrontare i tempi di build in CI prima/dopo, perché è
-   l'unico costo reale di A.
+   Cosa comporta C, in concreto:
+   - aggiungere `@serwist/cli` alle devDependencies (unico pezzo mancante:
+     `@serwist/next`, `@serwist/build`, `@serwist/window` ci sono già);
+   - togliere `withSerwistInit` da `next.config.ts` e spostare la config del SW
+     nel file del CLI;
+   - incatenare lo step al `build` di `package.json` (così vale anche per il
+     Dockerfile, non solo per CI);
+   - **la registrazione del SW diventa esplicita**: il plugin webpack iniettava
+     lo script da sé, in configurator mode si usa `SerwistProvider` da
+     `@serwist/next/react` (`swUrl="/sw.js"`). Slot naturale:
+     `src/components/providers.tsx`, che è già l'entry client dove
+     `initInstallPromptCapture()` viene chiamato a module-load. È il pezzo con
+     più incognite: validarlo su sandbox prima di prod.
 
 2. **Guardia anti-regressione nel build** — è l'unica cosa che avrebbe
    intercettato questo: uno step dopo `next build` che fallisce se

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,17 @@ const eslintConfig = defineConfig([
     },
   },
   prettierConfig,
-  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+    // Service worker generato da `serwist build` (bundle esbuild minificato +
+    // precache manifest). Prima di REVIEW #84 non veniva mai emesso, quindi
+    // non era mai presente nel working tree e nessuno se n'era accorto.
+    "public/sw.js",
+    "public/sw.js.map",
+  ]),
 ]);
 
 export default eslintConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,15 +1,13 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
-import withSerwistInit from "@serwist/next";
 import { parseTrustedHostnameEnv } from "./src/lib/hostname-env";
 import { buildSecurityHeaders } from "./src/lib/security-headers";
 
-const withSerwist = withSerwistInit({
-  swSrc: "src/sw.ts",
-  swDest: "public/sw.js",
-  // Disable SW in development to avoid caching issues during development.
-  disable: process.env.NODE_ENV === "development",
-});
+// Il service worker NON è più costruito da un plugin qui: `withSerwistInit` è
+// un plugin webpack e Next 16 builda con Turbopack, quindi non girava e il SW
+// non veniva emesso senza rompere il build (REVIEW #84). Ora è uno step di
+// build a sé — `serwist.config.mjs` + `serwist build`, incatenato allo script
+// `build` di package.json e verificato da scripts/check-service-worker.mjs.
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -152,7 +150,7 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(withSerwist(nextConfig), {
+export default withSentryConfig(nextConfig, {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   silent: !process.env.CI,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@serwist/cli": "^9.5.12",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2739,6 +2740,350 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3261,6 +3606,51 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@point-of-sale/codepage-encoder": {
@@ -6325,6 +6715,129 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@serwist/cli": {
+      "version": "9.5.12",
+      "resolved": "https://registry.npmjs.org/@serwist/cli/-/cli-9.5.12.tgz",
+      "integrity": "sha512-wjGtKP+q7Z+AgHDrwvKj7PxcEaFveANo08oG21g7whvlRjHxWhvsVFVidK2gpX2uROxERfM6+km3F+Mz6iKheA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "8.5.2",
+        "@serwist/build": "9.5.12",
+        "@serwist/utils": "9.5.12",
+        "chalk": "5.6.2",
+        "chokidar": "5.0.0",
+        "common-tags": "1.8.2",
+        "glob": "13.0.6",
+        "meow": "14.1.0",
+        "pretty-bytes": "6.1.1",
+        "stringify-object": "7.0.0",
+        "update-notifier": "7.3.1",
+        "zod": "4.4.3"
+      },
+      "bin": {
+        "serwist": "cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.25.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serwist/cli/node_modules/@serwist/build": {
+      "version": "9.5.12",
+      "resolved": "https://registry.npmjs.org/@serwist/build/-/build-9.5.12.tgz",
+      "integrity": "sha512-U2UkA9BjdpniZkXDIG6NQRBEbXccRvqewzL3hfNEQERvM2bL6ezKvsVF9359akUWP8BxV950Kkq9LKGFmOR8Uw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@serwist/utils": "9.5.12",
+        "common-tags": "1.8.2",
+        "glob": "13.0.6",
+        "pretty-bytes": "6.1.1",
+        "source-map": "0.8.0",
+        "type-fest": "5.8.0",
+        "zod": "4.4.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serwist/cli/node_modules/@serwist/utils": {
+      "version": "9.5.12",
+      "resolved": "https://registry.npmjs.org/@serwist/utils/-/utils-9.5.12.tgz",
+      "integrity": "sha512-BHDwiGL7H7JS7wFvVlAWTFHGt0ffHuPgKtdkaYP0lEWJFl6fKJRCnTDZhwhusFvBhicf37XP8Y6PouTZbcLmgg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "browserslist": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "browserslist": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serwist/cli/node_modules/source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
+      "integrity": "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@serwist/cli/node_modules/stringify-object": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-7.0.0.tgz",
+      "integrity": "sha512-RQU1n5OVVXD9fhww7e/rqiKdMa+LPMFLz0zDTbZ+KUjMfiMmh9soT8aw5iwvCGVquUJOodoinyv3VECyY7aFBQ==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-keys": "^1.0.0",
+        "is-identifier": "^1.0.1",
+        "is-obj": "^3.0.0",
+        "is-regexp": "^3.1.0",
+        "quote-js-string": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@serwist/cli/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "devOptional": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@serwist/next": {
       "version": "9.5.11",
       "resolved": "https://registry.npmjs.org/@serwist/next/-/next-9.5.11.tgz",
@@ -8286,6 +8799,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -8300,7 +8858,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8596,6 +9154,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -8706,6 +9275,42 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "devOptional": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -8876,6 +9481,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -8922,13 +9540,36 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -8959,6 +9600,19 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -8986,6 +9640,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/client-only": {
@@ -9058,6 +9722,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -9080,6 +9781,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/convert-source-map": {
@@ -9472,6 +10186,16 @@
         }
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -9693,6 +10417,35 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "devOptional": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dotenv": {
@@ -10423,6 +11176,13 @@
       "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -10757,6 +11517,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-html": {
@@ -11547,6 +12320,23 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
@@ -11562,6 +12352,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -11783,6 +12583,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
@@ -11844,7 +12657,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11891,7 +12704,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
       "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -11998,6 +12811,22 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/globals": {
       "version": "16.4.0",
@@ -12309,7 +13138,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12327,6 +13156,22 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
+    },
+    "node_modules/identifier-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+      "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -12405,6 +13250,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -12657,6 +13512,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -12690,6 +13555,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+      "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "identifier-regex": "^1.1.0",
+        "super-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
@@ -12717,6 +13615,23 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12767,6 +13682,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-npm": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+      "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -12798,7 +13726,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
       "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12866,7 +13807,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
       "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13374,6 +14315,19 @@
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "license": "MIT"
     },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -13392,6 +14346,22 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+      "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/leac": {
@@ -13855,6 +14825,37 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-asynchronous/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "devOptional": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -13921,6 +14922,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-descriptors": {
@@ -14066,7 +15080,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14092,6 +15106,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -14568,31 +15592,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ora/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -14609,6 +15608,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -14639,6 +15654,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+      "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ky": "^1.2.0",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^6.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pako": {
@@ -15255,6 +16315,13 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -15293,6 +16360,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+      "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/qrcode-generator": {
@@ -15343,6 +16426,19 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/quote-js-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
+      "integrity": "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+      }
     },
     "node_modules/radix-ui": {
       "version": "1.6.4",
@@ -15445,6 +16541,39 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "devOptional": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -15654,6 +16783,20 @@
         }
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -15793,6 +16936,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -15840,6 +17012,19 @@
         "@react-email/render": {
           "optional": true
         }
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resize-image-data": {
@@ -16149,7 +17334,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -16683,7 +17868,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -16893,6 +18078,24 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -17028,7 +18231,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -17044,7 +18247,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -17119,6 +18322,23 @@
         }
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -17140,6 +18360,24 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/super-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+      "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "make-asynchronous": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -17336,6 +18574,22 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
+    },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -17875,6 +19129,44 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-notifier": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+      "integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "configstore": "^7.0.0",
+        "is-in-ci": "^1.0.0",
+        "is-installed-globally": "^1.0.0",
+        "is-npm": "^6.0.0",
+        "latest-version": "^9.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.6.3",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -18194,6 +19486,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -18309,6 +19608,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -18431,6 +19737,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -18439,6 +19761,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -18460,6 +19813,19 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && npm run build:sw",
+    "build:sw": "serwist build serwist.config.mjs && node scripts/check-service-worker.mjs",
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit && tsc -p tsconfig.sw.json --noEmit",
@@ -61,6 +62,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@serwist/cli": "^9.5.12",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.sw.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/check-architecture-docs.mjs
+++ b/scripts/check-architecture-docs.mjs
@@ -31,6 +31,11 @@
  *  - A code span starting with `har/` is ALWAYS an error: HAR captures are
  *    local-only and gitignored, so the path would never exist in CI. Cite the
  *    bare filename instead (see the ade-integration skill).
+ *  - A code span naming a GENERATED build artifact (the Serwist service worker:
+ *    public/sw.js, its .map, public/serwist-*.js) is ALWAYS an error, for the
+ *    same reason — it exists only after a build. This one has a nastier
+ *    failure mode than har/: whoever writes the doc usually has a warm build,
+ *    so the check passes locally and only breaks in CI. Cite it as a glob.
  *  - REVIEW.md and PLAN.md are intentionally NOT scanned: they legitimately
  *    cite historical/removed paths in prose, so the false-positive noise
  *    would outweigh the value.
@@ -184,6 +189,43 @@ export function extractHarViolations(markdown) {
 }
 
 /**
+ * Artefatti di build gitignored: esistono solo dopo un build, quindi in un
+ * checkout pulito (CI) un loro path letterale non risolve mai. Stessa logica
+ * dei file `har/`, ma con un tranello in più: chi scrive il doc ha di solito
+ * la build calda, quindi il check gli passa **in locale** e rompe solo in CI.
+ * Mirror di .gitignore (sezione serwist).
+ */
+const BUILD_ARTIFACT_RE =
+  /^public\/(?:sw\.js(?:\.map)?|serwist-[^/]*\.js(?:\.map)?)$/;
+
+/**
+ * Finds inline code spans citing a generated build artifact as a literal path.
+ * The prescribed form is a glob (`public/sw*.js`), which the path validator
+ * already skips.
+ * @param {string} markdown
+ * @returns {string[]} sorted, de-duplicated offending spans
+ */
+export function extractBuildArtifactViolations(markdown) {
+  const violations = new Set();
+  const spanRe = /`([^`\n]+)`/g;
+  let match;
+  while ((match = spanRe.exec(markdown)) !== null) {
+    const token = match[1].trim();
+    if (BUILD_ARTIFACT_RE.test(token)) violations.add(token);
+  }
+  return [...violations].sort();
+}
+
+/**
+ * @param {string} token  Offending build-artifact span
+ * @param {string} doc    Display path of the doc citing it
+ * @returns {string}
+ */
+function buildArtifactError(token, doc) {
+  return `Build artifact reference "${token}" (in ${doc}): generated and gitignored, so it never exists in a clean checkout — cite it as a glob (e.g. \`public/sw*.js\`). NB: passes locally when you have a warm build.`;
+}
+
+/**
  * @param {string} token  Offending `har/...` span
  * @param {string} doc    Display path of the doc citing it
  * @returns {string}
@@ -242,6 +284,9 @@ export async function checkArchitectureDocs(rootDir) {
     for (const span of extractHarViolations(content)) {
       errors.push(harError(span, `docs/architecture/${file}`));
     }
+    for (const span of extractBuildArtifactViolations(content)) {
+      errors.push(buildArtifactError(span, `docs/architecture/${file}`));
+    }
     for (const name of extractSkillReferences(content)) {
       if (!skillRefs.has(name)) {
         skillRefs.set(name, `docs/architecture/${file}`);
@@ -259,6 +304,9 @@ export async function checkArchitectureDocs(rootDir) {
     }
     for (const span of extractHarViolations(content)) {
       errors.push(harError(span, "CLAUDE.md"));
+    }
+    for (const span of extractBuildArtifactViolations(content)) {
+      errors.push(buildArtifactError(span, "CLAUDE.md"));
     }
     for (const name of extractSkillReferences(content)) {
       if (!skillRefs.has(name)) skillRefs.set(name, "CLAUDE.md");
@@ -302,6 +350,9 @@ export async function checkArchitectureDocs(rootDir) {
     }
     for (const span of extractHarViolations(content)) {
       errors.push(harError(span, displayPath));
+    }
+    for (const span of extractBuildArtifactViolations(content)) {
+      errors.push(buildArtifactError(span, displayPath));
     }
     for (const refName of extractSkillReferences(content)) {
       if (!skillRefs.has(refName)) skillRefs.set(refName, displayPath);

--- a/scripts/check-service-worker.mjs
+++ b/scripts/check-service-worker.mjs
@@ -1,0 +1,83 @@
+/**
+ * Verifica che il build abbia davvero emesso il service worker.
+ *
+ * Esiste per la ragione precisa che ha prodotto REVIEW #84: `@serwist/next`
+ * girava come plugin webpack, Next 16 builda con Turbopack, il plugin non
+ * partiva — e degradava a un **warning**, lasciando il build verde. Per mesi
+ * `/sw.js` è stato 404 in produzione (niente offline, niente installazione su
+ * Android) senza che nulla in CI se ne accorgesse.
+ *
+ * La lezione generalizzata: quando una feature dipende da un artefatto
+ * generato, l'unica verifica che tiene è **asserire l'esistenza
+ * dell'artefatto**. Verificare il sorgente che lo produce non basta: un tool a
+ * monte può smettere di girare del tutto.
+ *
+ * Run: node scripts/check-service-worker.mjs  (incatenato a `npm run build`,
+ * così vale anche per il Dockerfile e non solo per la CI)
+ */
+
+import { stat } from "fs/promises";
+import { join } from "path";
+
+/**
+ * Soglia di plausibilità: un bundle Serwist reale pesa decine di KB (runtime
+ * caching + precache manifest). Sotto 1 KB è uno stub, un file troncato o un
+ * artefatto lasciato da un run fallito — casi in cui `/sw.js` risponderebbe 200
+ * senza fare nulla, che è peggio di un 404 perché silenzioso.
+ */
+export const MIN_SW_BYTES = 1024;
+
+/**
+ * @param {string} swPath  Path assoluto del service worker atteso.
+ * @returns {Promise<{ ok: boolean; errors: string[] }>}
+ */
+export async function checkServiceWorker(swPath) {
+  let stats;
+  try {
+    stats = await stat(swPath);
+  } catch {
+    return {
+      ok: false,
+      errors: [
+        `Service worker non emesso: ${swPath} non esiste. ` +
+          `Lo step \`serwist build\` non è girato o è fallito silenziosamente.`,
+      ],
+    };
+  }
+
+  if (!stats.isFile()) {
+    return { ok: false, errors: [`${swPath} esiste ma non è un file.`] };
+  }
+
+  if (stats.size < MIN_SW_BYTES) {
+    return {
+      ok: false,
+      errors: [
+        `Service worker sospetto: ${swPath} pesa ${stats.size} byte, ` +
+          `sotto il minimo di ${MIN_SW_BYTES}. Bundle troncato o stub.`,
+      ],
+    };
+  }
+
+  return { ok: true, errors: [] };
+}
+
+// Gira solo se eseguito direttamente (non quando importato dai test).
+const isMain = process.argv[1]?.endsWith("check-service-worker.mjs") === true;
+if (isMain) {
+  const swPath = join(process.cwd(), "public", "sw.js");
+  checkServiceWorker(swPath).then((result) => {
+    if (!result.ok) {
+      console.error("❌ Service worker check failed:");
+      for (const err of result.errors) {
+        console.error(`   - ${err}`);
+      }
+      console.error(
+        "\nFix: verifica che `serwist build serwist.config.mjs` sia ancora " +
+          "incatenato allo script `build` di package.json (REVIEW #84).",
+      );
+      process.exit(1);
+    }
+    console.log("✅ Service worker check passed: public/sw.js emesso.");
+  });
+}

--- a/serwist.config.mjs
+++ b/serwist.config.mjs
@@ -1,0 +1,52 @@
+/**
+ * Config del service worker per `@serwist/cli` (configurator mode).
+ *
+ * Perché non il plugin `withSerwistInit` in `next.config.ts`: quello è un
+ * plugin **webpack**, e Next 16 builda con Turbopack. Non girava, degradava a
+ * warning, e il SW non veniva emesso senza rompere il build — REVIEW #84.
+ * La configurator mode non si aggancia al bundler: è uno step di build a sé,
+ * quindi sopravvive a Turbopack e a qualunque bundler venga dopo.
+ *
+ * Gira DOPO `next build` (vedi lo script `build` in package.json): il precache
+ * manifest è generato dagli asset già emessi in `.next/` e `public/`.
+ *
+ * `serwist.withNextConfig` legge la config Next risolta (distDir, basePath,
+ * assetPrefix) e ne deriva glob patterns, ignores e i manifest transforms che
+ * mappano i path di build su URL pubblici. A noi restano sorgente e
+ * destinazione.
+ */
+
+import { generateGlobPatterns, serwist } from "@serwist/next/config";
+
+export default serwist.withNextConfig((nextConfig) => {
+  // Stessa normalizzazione che applica il configurator internamente: ".next"
+  // deve diventare ".next/" perché i glob sono per-prefisso.
+  const distDir = `${nextConfig.distDir.replace(/^\//, "").replace(/\/?$/, "")}/`;
+
+  return {
+    swSrc: "src/sw.ts",
+    swDest: "public/sw.js",
+
+    // I default precacherebbero ~12 MB, di cui 8.3 MB di marketing: 5.3 MB di
+    // HTML SSG (89 pagine fra landing, /help e /guide) e 3 MB di screenshot
+    // del prodotto. Un esercente che installa la PWA vive in /dashboard — che
+    // è dinamica, quindi nemmeno precacheabile — e quei byte se li scarica in
+    // 4G al primo caricamento senza usarli mai. Contro i principi del progetto
+    // (mobile-first, "leggeri sulle risorse"): precachiamo solo l'app shell.
+    //
+    // Le pagine marketing NON restano scoperte: la `NetworkFirst` per le
+    // navigazioni di `defaultCache` le cacha comunque a runtime, ma solo
+    // quelle davvero visitate — che è la strategia giusta per 89 pagine di cui
+    // un utente ne aprirà due.
+    precachePrerendered: false,
+    globPatterns: [
+      ...generateGlobPatterns(distDir),
+      // Unica pagina prerenderizzata che DEVE stare nel precache: è il
+      // fallback di navigazione dichiarato in src/sw.ts, e per definizione
+      // serve quando la rete non c'è. I manifest transforms del configurator
+      // la mappano su "/offline".
+      `${distDir}server/app/offline.html`,
+    ],
+    globIgnores: ["public/screenshots/**"],
+  };
+});

--- a/src/components/providers.test.tsx
+++ b/src/components/providers.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Providers } from "./providers";
+
+const { mockSerwistProvider, mockInitInstallPromptCapture } = vi.hoisted(
+  () => ({
+    mockSerwistProvider: vi.fn(),
+    mockInitInstallPromptCapture: vi.fn(),
+  }),
+);
+
+vi.mock("@serwist/next/react", () => ({
+  SerwistProvider: (props: Record<string, unknown>) => {
+    mockSerwistProvider(props);
+    return props.children as React.ReactNode;
+  },
+}));
+
+vi.mock("@/lib/pwa/install-prompt-store", () => ({
+  initInstallPromptCapture: mockInitInstallPromptCapture,
+}));
+
+// sonner legge window.matchMedia al mount, che jsdom non espone: irrilevante
+// per quello che si asserisce qui.
+vi.mock("@/components/ui/sonner", () => ({
+  Toaster: () => null,
+}));
+
+const serwistProps = () =>
+  mockSerwistProvider.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Providers — registrazione del service worker", () => {
+  it("registers the service worker built by `serwist build`", () => {
+    render(
+      <Providers>
+        <p>contenuto</p>
+      </Providers>,
+    );
+
+    expect(serwistProps().swUrl).toBe("/sw.js");
+    expect(screen.getByText("contenuto")).toBeInTheDocument();
+  });
+
+  it("never reloads the page when the connection comes back", () => {
+    // Default di SerwistProvider: true → `location.reload()` sull'evento
+    // `online`. Su un POS significa perdere il carrello in corso (righe,
+    // codice lotteria) proprio quando la rete torna dopo un buco: è lo
+    // scenario più probabile al banco, non un caso limite.
+    render(
+      <Providers>
+        <p>contenuto</p>
+      </Providers>,
+    );
+
+    expect(serwistProps().reloadOnOnline).toBe(false);
+  });
+
+  it("does not monkey-patch history for navigation caching", () => {
+    // Default: true → sovrascrive history.pushState/replaceState per cachare
+    // le URL navigate. Rischio di interop con il router dell'App Router, e
+    // nessun beneficio: le pagine visitate le cacha già la NetworkFirst delle
+    // navigazioni di defaultCache.
+    render(
+      <Providers>
+        <p>contenuto</p>
+      </Providers>,
+    );
+
+    expect(serwistProps().cacheOnNavigation).toBe(false);
+  });
+
+  it("disables registration in development, where the SW is never built", () => {
+    // `serwist build` è incatenato allo script `build`, non a `dev`: in
+    // sviluppo public/sw.js non esiste e registrarlo darebbe un 404 a ogni
+    // avvio.
+    vi.stubEnv("NODE_ENV", "development");
+
+    render(
+      <Providers>
+        <p>contenuto</p>
+      </Providers>,
+    );
+
+    expect(serwistProps().disable).toBe(true);
+  });
+
+  it("enables registration in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    render(
+      <Providers>
+        <p>contenuto</p>
+      </Providers>,
+    );
+
+    expect(serwistProps().disable).toBe(false);
+  });
+});

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SerwistProvider } from "@serwist/next/react";
 import { useState } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import { initInstallPromptCapture } from "@/lib/pwa/install-prompt-store";
@@ -28,9 +29,31 @@ export function Providers({
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <Toaster />
-    </QueryClientProvider>
+    // Registrazione esplicita del service worker: la configurator mode di
+    // Serwist costruisce il bundle ma non inietta più lo script di
+    // registrazione come faceva il vecchio plugin webpack (REVIEW #84).
+    //
+    // I due default disattivati non sono preferenze estetiche:
+    // - `reloadOnOnline` (default true) ricarica la pagina all'evento `online`.
+    //   Al banco, con rete ballerina, significa perdere il carrello in corso
+    //   proprio quando la connessione torna.
+    // - `cacheOnNavigation` (default true) sovrascrive history.pushState e
+    //   replaceState per cachare le URL navigate: interop rischiosa con il
+    //   router, e nessun beneficio: le pagine visitate le cacha già la
+    //   NetworkFirst delle navigazioni di `defaultCache`.
+    //
+    // `disable` in development perché `serwist build` è incatenato allo script
+    // `build`, non a `dev`: lì public/sw.js non esiste.
+    <SerwistProvider
+      swUrl="/sw.js"
+      disable={process.env.NODE_ENV === "development"}
+      reloadOnOnline={false}
+      cacheOnNavigation={false}
+    >
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <Toaster />
+      </QueryClientProvider>
+    </SerwistProvider>
   );
 }

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -44,6 +44,14 @@ describe("buildCsp", () => {
     expect(policy).toMatch(/script-src[^;]*'unsafe-inline'[^;]*;/);
   });
 
+  it("consente il service worker solo dalla propria origin", () => {
+    // Esplicito e non ereditato da script-src: senza questa direttiva la
+    // registrazione del SW dipenderebbe dal fallback, e restringere
+    // script-src romperebbe la PWA in silenzio (REVIEW #84).
+    expect(policy).toMatch(/worker-src 'self'/);
+    expect(policy).not.toMatch(/worker-src[^;]*'unsafe-inline'/);
+  });
+
   it("blocca completamente i frame ancestors e gli object", () => {
     expect(policy).toMatch(/frame-ancestors 'none'/);
     expect(policy).toMatch(/object-src 'none'/);

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -52,6 +52,13 @@ function buildDirectives(): ReadonlyArray<
       "script-src",
       ["'self'", "'unsafe-inline'", "challenges.cloudflare.com", ...umami],
     ],
+    // Esplicito, non lasciato al fallback: senza `worker-src` la
+    // registrazione del service worker ricade su `child-src` e poi su
+    // `script-src` — che oggi ammette `'unsafe-inline'` e host terzi che a un
+    // worker non servono, e che un domani potrebbe essere ristretto rompendo
+    // il SW in modo silenzioso (in enforce mode il browser non registra e
+    // basta). `'self'`: il SW può venire solo dalla nostra origin.
+    ["worker-src", ["'self'"]],
     ["style-src", ["'self'", "'unsafe-inline'"]],
     ["img-src", ["'self'", "data:"]],
     ["font-src", ["'self'", "data:"]],

--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { RouteMatchCallbackOptions, RuntimeCaching } from "serwist";
+
+// Le classi mockate vivono in `vi.hoisted` (non nel factory) perché il factory
+// viene ri-valutato a ogni istanziazione del modulo: una classe definita lì
+// dentro avrebbe identità diversa da quella vista dal test e ogni `instanceof`
+// fallirebbe. Mai arrow function per un mock di classe (skill
+// `testing-patterns`): `new X()` su una arrow lancia "is not a constructor".
+const {
+  MockNetworkOnly,
+  mockDefaultCacheEntry,
+  mockSerwistOptions,
+  mockAddEventListeners,
+} = vi.hoisted(() => {
+  class MockNetworkOnly {}
+  return {
+    MockNetworkOnly,
+    // Sentinella: serve a distinguere "defaultCache spreddato dopo l'override"
+    // da "defaultCache sostituito dall'override".
+    mockDefaultCacheEntry: {
+      matcher: () => true,
+      handler: "default-cache-sentinel",
+    },
+    mockSerwistOptions: vi.fn(),
+    mockAddEventListeners: vi.fn(),
+  };
+});
+
+vi.mock("@serwist/next/worker", () => ({
+  defaultCache: [mockDefaultCacheEntry],
+}));
+
+vi.mock("serwist", () => {
+  class MockSerwist {
+    readonly addEventListeners = mockAddEventListeners;
+
+    constructor(options: unknown) {
+      mockSerwistOptions(options);
+    }
+  }
+  return { Serwist: MockSerwist, NetworkOnly: MockNetworkOnly };
+});
+
+type SerwistOptions = {
+  precacheEntries: unknown;
+  skipWaiting: boolean;
+  clientsClaim: boolean;
+  navigationPreload: boolean;
+  runtimeCaching: RuntimeCaching[];
+  fallbacks: {
+    entries: {
+      url: string;
+      matcher: (options: { request: Request }) => boolean;
+    }[];
+  };
+};
+
+const matches = (rule: RuntimeCaching, url: string, sameOrigin: boolean) => {
+  const { matcher } = rule;
+  // `RuntimeCaching["matcher"]` ammette anche string/RegExp: l'override deve
+  // essere una callback, altrimenti non potrebbe leggere `sameOrigin`.
+  if (typeof matcher !== "function") {
+    throw new TypeError("il matcher dell'override deve essere una callback");
+  }
+  return matcher({
+    url: new URL(url),
+    sameOrigin,
+  } as RouteMatchCallbackOptions);
+};
+
+describe("service worker (src/sw.ts)", () => {
+  let options: SerwistOptions;
+
+  // Cerca la regola per handler, non per indice: così i test sul matcher non
+  // possono passare per caso pescando una entry di `defaultCache`.
+  const networkOnlyRule = () => {
+    const rule = options.runtimeCaching.find(
+      (entry) => entry.handler instanceof MockNetworkOnly,
+    );
+    if (!rule) throw new Error("nessuna regola NetworkOnly registrata");
+    return rule;
+  };
+
+  beforeAll(async () => {
+    // `self` non esiste nell'environment node: senza stub l'import di sw.ts
+    // esplode su `self.__SW_MANIFEST`.
+    vi.stubGlobal("self", { __SW_MANIFEST: ["/offline"] });
+    await import("./sw");
+    options = mockSerwistOptions.mock.calls[0][0] as SerwistOptions;
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers the service worker event listeners", () => {
+    expect(mockAddEventListeners).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the injected precache manifest and lifecycle flags", () => {
+    expect(options.precacheEntries).toEqual(["/offline"]);
+    expect(options.skipWaiting).toBe(true);
+    expect(options.clientsClaim).toBe(true);
+    expect(options.navigationPreload).toBe(true);
+  });
+
+  it("puts a NetworkOnly rule FIRST, before defaultCache (REVIEW #73)", () => {
+    // L'ordine è la sostanza del fix: vince il primo matcher, quindi una
+    // regola dopo lo spread di defaultCache non intercetterebbe nulla.
+    expect(options.runtimeCaching[0].handler).toBeInstanceOf(MockNetworkOnly);
+  });
+
+  it("keeps defaultCache after the override instead of replacing it", () => {
+    expect(options.runtimeCaching).toHaveLength(2);
+    expect(options.runtimeCaching[1]).toBe(mockDefaultCacheEntry);
+  });
+
+  it("excludes same-origin tenant API GETs from the runtime cache", () => {
+    const rule = networkOnlyRule();
+
+    expect(
+      matches(rule, "https://app.scontrinozero.it/api/export/receipts", true),
+    ).toBe(true);
+    expect(
+      matches(
+        rule,
+        "https://app.scontrinozero.it/api/documents/8f1c1f6e-0000-4000-8000-000000000000/pdf",
+        true,
+      ),
+    ).toBe(true);
+    // `/v1/` è il path pre-rewrite con cui arrivano le richieste dal subdomain API.
+    expect(
+      matches(rule, "https://api.scontrinozero.it/v1/receipts", true),
+    ).toBe(true);
+  });
+
+  it("leaves navigations and cross-origin requests to defaultCache", () => {
+    const rule = networkOnlyRule();
+
+    expect(matches(rule, "https://app.scontrinozero.it/dashboard", true)).toBe(
+      false,
+    );
+    // La pagina pubblica scontrino resta cacheabile: non è autenticata.
+    expect(matches(rule, "https://app.scontrinozero.it/r/abc", true)).toBe(
+      false,
+    );
+    // Un path che contiene "/api/" ma non ci inizia non deve matchare.
+    expect(
+      matches(rule, "https://app.scontrinozero.it/help/api/guida", true),
+    ).toBe(false);
+    // Né un prefisso che somiglia a "/api/" o "/v1/" senza esserlo.
+    expect(
+      matches(rule, "https://app.scontrinozero.it/apiv1/receipts", true),
+    ).toBe(false);
+    expect(
+      matches(rule, "https://app.scontrinozero.it/v10/receipts", true),
+    ).toBe(false);
+    expect(matches(rule, "https://cdn.example.com/api/receipts", false)).toBe(
+      false,
+    );
+  });
+
+  it("serves /offline as the navigation fallback", () => {
+    const fallback = options.fallbacks.entries[0];
+
+    expect(fallback.url).toBe("/offline");
+    expect(fallback.matcher({ request: { mode: "navigate" } as Request })).toBe(
+      true,
+    );
+    expect(fallback.matcher({ request: { mode: "cors" } as Request })).toBe(
+      false,
+    );
+  });
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,6 +1,10 @@
 import { defaultCache } from "@serwist/next/worker";
-import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
-import { Serwist } from "serwist";
+import type {
+  PrecacheEntry,
+  RuntimeCaching,
+  SerwistGlobalConfig,
+} from "serwist";
+import { NetworkOnly, Serwist } from "serwist";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -10,12 +14,40 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope;
 
+// `defaultCache` NON è asset-only: include una `NetworkFirst` per le GET
+// same-origin `/api/*` che scrive la response in CacheStorage via
+// `fetchAndCachePut`. Il `cacheOkAndOpaquePlugin` aggiunto di default decide
+// solo in base allo status HTTP e IGNORA `Cache-Control`, quindi il `no-store`
+// già presente su alcune route non impedisce la scrittura. La CacheStorage è
+// per-origin e sopravvive al logout: su un dispositivo condiviso (tablet di
+// negozio, PWA installata, cambio account) una GET del secondo utente andata
+// in timeout o partita offline verrebbe servita col documento fiscale del
+// primo. L'unica difesa è un override esplicito PRIMA dello spread — vince il
+// primo matcher.
+//
+// `/v1/` è il path con cui le richieste arrivano dal subdomain API *prima* del
+// rewrite (`next.config.ts` → `rewrites()`), quindi va escluso insieme a `/api/`.
+//
+// Scelta consapevole: la pagina pubblica dello scontrino (`/r/<id>`) resta
+// sulla `NetworkFirst` delle navigazioni di `defaultCache`. Non è autenticata —
+// nessun leak cross-account — ed è un artefatto da consegnare al cliente, per
+// cui poterla mostrare offline è un vantaggio, non un rischio.
+const runtimeCaching: RuntimeCaching[] = [
+  {
+    matcher: ({ url, sameOrigin }) =>
+      sameOrigin &&
+      (url.pathname.startsWith("/api/") || url.pathname.startsWith("/v1/")),
+    handler: new NetworkOnly(),
+  },
+  ...defaultCache,
+];
+
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: true,
-  runtimeCaching: defaultCache,
+  runtimeCaching,
   fallbacks: {
     entries: [
       {

--- a/tests/unit/scripts/check-architecture-docs.test.ts
+++ b/tests/unit/scripts/check-architecture-docs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   checkArchitectureDocs,
   extractFrontmatterPathTokens,
+  extractBuildArtifactViolations,
   extractHarViolations,
   extractSkillReferences,
 } from "../../../scripts/check-architecture-docs.mjs";
@@ -493,6 +494,37 @@ describe("extractHarViolations", () => {
 
   it("returns an empty list when no har/ span is present", () => {
     expect(extractHarViolations("Solo `src/lib/a.ts` qui.")).toEqual([]);
+  });
+});
+
+describe("extractBuildArtifactViolations", () => {
+  it("finds the generated service worker cited as a literal path", () => {
+    const md = "Tieni `public/sw.js` nei globalIgnores di `eslint.config.mjs`.";
+
+    expect(extractBuildArtifactViolations(md)).toEqual(["public/sw.js"]);
+  });
+
+  it("finds the source map and the serwist chunks too", () => {
+    const md = "Genera `public/sw.js.map` e `public/serwist-abc123.js`.";
+
+    expect(extractBuildArtifactViolations(md)).toEqual([
+      "public/serwist-abc123.js",
+      "public/sw.js.map",
+    ]);
+  });
+
+  it("allows the glob form, which is the prescribed way to cite it", () => {
+    // `public/sw*.js` contiene `*`, quindi il validatore dei path lo salta
+    // già: è la forma da usare nei doc.
+    expect(
+      extractBuildArtifactViolations("Il SW emesso è `public/sw*.js`."),
+    ).toEqual([]);
+  });
+
+  it("leaves committed assets under public/ alone", () => {
+    const md = "L'icona sta in `public/android-chrome-512x512.png`.";
+
+    expect(extractBuildArtifactViolations(md)).toEqual([]);
   });
 });
 

--- a/tests/unit/scripts/check-service-worker.test.ts
+++ b/tests/unit/scripts/check-service-worker.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  checkServiceWorker,
+  MIN_SW_BYTES,
+} from "../../../scripts/check-service-worker.mjs";
+
+const { mockStat } = vi.hoisted(() => ({ mockStat: vi.fn() }));
+
+vi.mock("fs/promises", () => ({
+  default: { stat: mockStat },
+  stat: mockStat,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("checkServiceWorker", () => {
+  it("passes when the bundle exists and has a plausible size", async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 64_000 });
+
+    const result = await checkServiceWorker("/app/public/sw.js");
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("fails when the bundle was never emitted", async () => {
+    // È il caso reale di REVIEW #84: `@serwist/next` sotto Turbopack stampa un
+    // warning e non emette nulla, lasciando il build verde.
+    mockStat.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    const result = await checkServiceWorker("/app/public/sw.js");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("/app/public/sw.js");
+  });
+
+  it("fails when the path exists but is not a file", async () => {
+    mockStat.mockResolvedValue({ isFile: () => false, size: 4096 });
+
+    const result = await checkServiceWorker("/app/public/sw.js");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("non è un file");
+  });
+
+  it("fails on a truncated or stub bundle", async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: MIN_SW_BYTES - 1 });
+
+    const result = await checkServiceWorker("/app/public/sw.js");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain(String(MIN_SW_BYTES));
+  });
+
+  it("accepts a bundle exactly at the minimum size", async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: MIN_SW_BYTES });
+
+    const result = await checkServiceWorker("/app/public/sw.js");
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,10 @@
     // Service worker requires "webworker" lib globals (ServiceWorkerGlobalScope)
     // which conflicts with the "dom" lib used by the main app.
     // Serwist/webpack compiles it separately with the correct worker context.
-    "src/sw.ts"
+    // Both files are type-checked by tsconfig.sw.json (run by `npm run
+    // type-check`); sw.test.ts is excluded here only because importing sw.ts
+    // would drag the worker globals into this project.
+    "src/sw.ts",
+    "src/sw.test.ts"
   ]
 }

--- a/tsconfig.sw.json
+++ b/tsconfig.sw.json
@@ -1,0 +1,22 @@
+// Type-check dedicato al service worker.
+//
+// `src/sw.ts` è escluso da `tsconfig.json` perché richiede i globals della lib
+// "webworker" (`ServiceWorkerGlobalScope`), incompatibili con la lib "dom" usata
+// dall'app: Serwist/webpack lo compila a parte, nel contesto worker corretto.
+// Da quando esiste `src/sw.test.ts` (REVIEW #73) quel file lo importa, e senza
+// questo progetto separato l'unica alternativa sarebbe escludere anche il test
+// dal type-check — cioè spedirlo non verificato.
+//
+// Girano insieme in `npm run type-check`: la lib qui è "webworker", quindi il
+// test NON deve usare globals solo-DOM (es. `document`, `window`).
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["esnext", "webworker"],
+    "types": ["vitest/globals"],
+    "incremental": false,
+    "plugins": []
+  },
+  "include": ["src/sw.ts", "src/sw.test.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,7 +75,6 @@ export default defineConfig({
         "src/components/settings/edit-settings-dialog.tsx", // UI client component — shared dialog shell, pure UI
         "src/components/settings/edit-ade-credentials-section.tsx", // UI client component — form + dialog, pure UI
         "src/components/ade/change-ade-password-dialog.tsx", // UI client component — form + dialog, pure UI
-        "src/sw.ts", // service worker entry point — pure infrastructure, no testable logic
         "src/app/offline/page.tsx", // static offline shell — pure UI, no logic
       ],
     },


### PR DESCRIPTION
`src/sw.ts` passava `runtimeCaching: defaultCache` senza override. Il
`defaultCache` di `@serwist/next/worker` non è asset-only: include una
`NetworkFirst` per le GET same-origin `/api/*` che scrive la response in
CacheStorage via `fetchAndCachePut`, e il `cacheOkAndOpaquePlugin` di default
decide solo in base allo status HTTP ignorando `Cache-Control` — quindi il
`no-store` già presente su `/api/export/receipts` non impediva la scrittura.
La CacheStorage è per-origin e sopravvive al logout: su un dispositivo
condiviso una GET offline/in timeout del secondo utente poteva essere servita
col documento fiscale del primo (PDF scontrino, export CSV, lista Developer
API).

Ora `runtimeCaching` mette una regola `NetworkOnly` prima dello spread di
`defaultCache` — l'ordine è la sostanza, vince il primo matcher. Il matcher
copre `/api/` e `/v1/` (il path pre-rewrite del subdomain API); `/r/<id>`
resta volutamente fuori: pagina pubblica non autenticata, l'offline è un
vantaggio.

`src/sw.ts` esce dalla `coverage.exclude` di vitest e guadagna `src/sw.test.ts`
(100% righe/branch). Il file resta escluso da `tsconfig.json` perché richiede i
globals della lib "webworker": il nuovo `tsconfig.sw.json` type-checka sorgente
e test nel contesto giusto, e `npm run type-check` lo esegue — così il test non
viaggia non verificato.

Emerso durante la verifica: il service worker non viene più emesso dal build
(`@serwist/next` è un plugin webpack, Next 16 builda con Turbopack) e `/sw.js`
è 404 in produzione. Non è una regressione di questo commit e non lo blocca —
l'override deve essere in piedi *prima* che il SW torni a essere spedito.
Registrato come REVIEW #84 con le tre strade di rimedio e la guardia di build
che avrebbe intercettato il problema.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012VC6w7DJGoPwJ2AE2noLTZ