### PR TITLE
feat(help): guida dedicata ai metodi di pagamento (bonifico e assegno)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -171,6 +171,26 @@ fatto che i payload sono statici, ma è un single point of failure.
 
 ## P3 — Bassa priorità
 
+### 86. Hub `/help`: titoli e link duplicati dal registry, senza guard test
+
+- **Categoria:** doppia scrittura contenuti · **Severità:** Low (contenuto stale / articolo orfano, nessun impatto runtime)
+- **File:** `src/app/(marketing)/help/page.tsx:37-231` (`featuredArticles` e `categories`), registry `src/lib/help/articles.ts`
+
+**Problema.** L'hub del centro assistenza ricopia a mano `title` e `href` di
+ogni articolo, mentre la fonte di verità è `helpArticles`. Due conseguenze
+osservate aggiungendo `metodi-di-pagamento`: (a) un articolo nuovo non compare
+nell'hub finché qualcuno non lo aggiunge a mano — resta raggiungibile solo da
+sitemap e link interni; (b) rinominando `aliquote-iva` il titolo nell'hub è
+rimasto stale, esattamente il pattern di doppia scrittura che la skill
+`marketing-content` vieta per date e prezzi. Nessun test copre la
+corrispondenza, quindi entrambe le derive passano la CI.
+
+**Fix proposto.** Estrarre `categories` in `src/lib/help/hub-categories.ts`
+tenendo solo lo slug (il titolo si legge da `helpArticles[slug].title`), e
+aggiungere un test che per ogni slug del registry esista una voce nell'hub
+(match `/help/<slug>` oppure `/help/<slug>#<ancora>`, come per `api`). Elimina
+sia l'orfano sia il titolo divergente.
+
 ### 81. Sweep GDPR: la query candidati aggrega l'intera tabella `commercial_documents` a ogni giro
 
 - **Categoria:** performance DB · **Severità:** Low (cresce col volume globale, non per-tenant)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,12 @@ sonar.exclusions=src/components/ui/**,src/sw.ts,src/components/marketing/faq-ite
 
 # Exclude static/presentational files from coverage calculation only
 # (they are still analyzed for bugs, code smells, and security)
+#
+# Le pagine sotto help/ sono una glob e non un elenco: vitest.config.ts esclude
+# `src/app/**/page.tsx` in blocco, quindi nessuna pagina help produce mai righe
+# in lcov.info. Elencarle a una a una faceva fallire il quality gate con "0%
+# coverage on new code" a ogni articolo nuovo, finché qualcuno non aggiungeva
+# la riga qui.
 sonar.coverage.exclusions=\
   src/db/schema/**,\
   src/lib/contact.ts,\
@@ -22,34 +28,7 @@ sonar.coverage.exclusions=\
   src/app/(marketing)/termini/v01/page.tsx,\
   src/lib/ade/types.ts,\
   src/components/catalogo/catalogo-client.tsx,\
-  src/app/(marketing)/help/page.tsx,\
-  src/app/(marketing)/help/presenta-un-amico/page.tsx,\
-  src/app/(marketing)/help/api/page.tsx,\
-  src/app/(marketing)/help/come-collegare-ade/page.tsx,\
-  src/app/(marketing)/help/collegare-ade-con-cie/page.tsx,\
-  src/app/(marketing)/help/credenziali-fisconline/page.tsx,\
-  src/app/(marketing)/help/primo-scontrino/page.tsx,\
-  src/app/(marketing)/help/annullare-scontrino/page.tsx,\
-  src/app/(marketing)/help/regime-forfettario/page.tsx,\
-  src/app/(marketing)/help/prima-configurazione/page.tsx,\
-  src/app/(marketing)/help/errori-ade/page.tsx,\
-  src/app/(marketing)/help/sicurezza-credenziali/page.tsx,\
-  src/app/(marketing)/help/installare-app/page.tsx,\
-  src/app/(marketing)/help/chiusura-giornaliera/page.tsx,\
-  src/app/(marketing)/help/cassetto-fiscale/page.tsx,\
-  src/app/(marketing)/help/normativa-pos-2026/page.tsx,\
-  src/app/(marketing)/help/piani-e-prezzi/page.tsx,\
-  src/app/(marketing)/help/storico-ed-esportazione/page.tsx,\
-  src/app/(marketing)/help/analytics-e-report/page.tsx,\
-  src/app/(marketing)/help/aliquote-iva/page.tsx,\
-  src/app/(marketing)/help/cambio-piano/page.tsx,\
-  src/app/(marketing)/help/fatture-e-ricevute/page.tsx,\
-  src/app/(marketing)/help/contatto-assistenza/page.tsx,\
-  src/app/(marketing)/help/pos-rt-obbligo/page.tsx,\
-  src/app/(marketing)/help/intestazione-scontrino/page.tsx,\
-  src/app/(marketing)/help/stampare-scontrino-termica/page.tsx,\
-  src/app/(marketing)/help/registrare-pos-portale-ade/page.tsx,\
-  src/app/(marketing)/help/numero-documento-azzeramento/page.tsx,\
+  src/app/(marketing)/help/**/page.tsx,\
   src/app/(marketing)/termini/page.tsx,\
   src/app/(marketing)/cookie-policy/page.tsx,\
   src/app/(marketing)/cookie-policy/v01/page.tsx,\

--- a/src/app/(marketing)/help/aliquote-iva/page.tsx
+++ b/src/app/(marketing)/help/aliquote-iva/page.tsx
@@ -18,33 +18,29 @@ export default function AliquoteIvaPage() {
   return (
     <section className="px-4 py-16">
       <JsonLd
-        data={helpArticleBreadcrumb(
-          "aliquote-iva",
-          "Aliquote IVA, catalogo e pagamenti",
-        )}
+        data={helpArticleBreadcrumb("aliquote-iva", "Aliquote IVA e catalogo")}
       />
       <HelpArticleJsonLd slug="aliquote-iva" />
       <article className="mx-auto max-w-3xl">
         <Breadcrumbs
           items={helpArticleBreadcrumbItems(
             "aliquote-iva",
-            "Aliquote IVA, catalogo e pagamenti",
+            "Aliquote IVA e catalogo",
           )}
         />
 
         {/* ─── Intestazione ─── */}
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-3xl font-extrabold tracking-tight">
-            Come gestire aliquote IVA, catalogo e metodi di pagamento
+            Come gestire le aliquote IVA e il catalogo prodotti
           </h1>
           <Badge variant="secondary">Configurazione attività</Badge>
         </div>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           ScontrinoZero supporta tutte le aliquote IVA italiane (4%, 5%, 10%,
           22%) e i sei codici natura per le operazioni speciali. Questa guida
-          spiega come usarli in cassa, come pre-impostare prezzo e aliquota
-          tramite il catalogo prodotti, e quali metodi di pagamento sono
-          disponibili oggi.
+          spiega come usarli in cassa e come pre-impostare prezzo e aliquota
+          tramite il catalogo prodotti.
         </p>
         <HelpArticleUpdatedAt slug="aliquote-iva" />
         <figure className="mt-6">
@@ -253,23 +249,18 @@ export default function AliquoteIvaPage() {
         {/* ─── Metodi di pagamento ─── */}
         <h2 className="mt-10 text-xl font-semibold">Metodi di pagamento</h2>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          In cassa il selettore propone oggi due metodi:
-        </p>
-        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed">
-          <li>
-            <strong>Contanti</strong>
-          </li>
-          <li>
-            <strong>Carta</strong> (credito, debito, prepagata)
-          </li>
-        </ul>
-        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          Al momento dell&apos;emissione, seleziona il metodo usato dal cliente:
-          il dato viene trasmesso all&apos;AdE come parte del documento
-          commerciale. Il campo opzionale{" "}
-          <strong>codice lotteria scontrini</strong> compare solo quando scegli
-          pagamento con carta: alla Lotteria degli Scontrini partecipano
-          soltanto gli acquisti sopra 1 € pagati con strumenti elettronici.
+          In cassa il selettore propone due metodi, <strong>Contanti</strong> e{" "}
+          <strong>Carta</strong>, e ogni documento commerciale ne porta uno
+          solo. Quale scegliere a seconda di come hai incassato — bonifico,
+          assegno, carta o denaro — è spiegato con i riferimenti
+          dell&apos;Agenzia delle Entrate in{" "}
+          <Link
+            href="/help/metodi-di-pagamento"
+            className="text-primary hover:underline"
+          >
+            Bonifico e assegno sullo scontrino: quale metodo scegliere
+          </Link>
+          {"."}
         </p>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           Il tracciato AdE prevede ulteriori metodi (ticket / buono pasto,

--- a/src/app/(marketing)/help/metodi-di-pagamento/page.tsx
+++ b/src/app/(marketing)/help/metodi-di-pagamento/page.tsx
@@ -1,0 +1,233 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  JsonLd,
+  faqPageJsonLd,
+  helpArticleBreadcrumb,
+  helpArticleBreadcrumbItems,
+  type FaqItem,
+} from "@/components/json-ld";
+import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
+import { helpArticleMetadata } from "@/lib/help/metadata";
+import { HelpArticleJsonLd } from "@/components/help/article-json-ld";
+import { HelpArticleUpdatedAt } from "@/components/help/article-updated-at";
+import { RelatedHelpArticles } from "@/components/help/related-articles";
+
+export const metadata = helpArticleMetadata("metodi-di-pagamento");
+
+/**
+ * Mirror in testo piano della FAQ visibile a video: alimenta lo structured data
+ * FAQPage (rich result Google). Tenere allineato al contenuto renderizzato sotto.
+ */
+const faqItems: readonly FaqItem[] = [
+  {
+    question: "Ho incassato con un bonifico: quale metodo devo scegliere?",
+    answer:
+      "Scegli Carta. Il bonifico è una forma di pagamento elettronico, e la voce Carta di ScontrinoZero trasmette all'Agenzia delle Entrate proprio la modalità «pagamento elettronico». Lo chiarisce la FAQ n. 11 del documento «Collegamento POS-RT» dell'Agenzia, pubblicata il 19 febbraio 2026: se il pagamento avviene tramite bonifico, il documento commerciale deve indicare che si tratta di una forma di pagamento elettronico e il relativo ammontare.",
+  },
+  {
+    question: "E se il cliente paga con un assegno?",
+    answer:
+      "Scegli Contanti. Secondo la FAQ n. 27 dello stesso documento dell'Agenzia delle Entrate, pubblicata il 17 marzo 2026 e aggiornata il 25 marzo 2026, in caso di pagamento con assegno bancario o circolare il documento commerciale deve indicare che si tratta di una forma di pagamento contante.",
+  },
+  {
+    question:
+      "Posso dividere un pagamento tra contanti e carta sullo stesso scontrino?",
+    answer:
+      "No. ScontrinoZero associa un solo metodo di pagamento a ogni documento commerciale: scegli quello con cui il cliente ha saldato l'intero importo.",
+  },
+  {
+    question: "Il metodo scelto influisce sulla Lotteria degli Scontrini?",
+    answer:
+      "Sì. Il campo per il codice lotteria compare solo quando selezioni Carta, perché alla Lotteria degli Scontrini partecipano soltanto gli acquisti sopra 1 € pagati con strumenti elettronici. Con pagamento in contanti il codice non può essere trasmesso.",
+  },
+];
+
+export default function MetodiDiPagamentoPage() {
+  return (
+    <section className="px-4 py-16">
+      <JsonLd
+        data={helpArticleBreadcrumb(
+          "metodi-di-pagamento",
+          "Metodi di pagamento",
+        )}
+      />
+      <HelpArticleJsonLd slug="metodi-di-pagamento" />
+      <JsonLd data={faqPageJsonLd(faqItems)} />
+      <article className="mx-auto max-w-3xl">
+        <Breadcrumbs
+          items={helpArticleBreadcrumbItems(
+            "metodi-di-pagamento",
+            "Metodi di pagamento",
+          )}
+        />
+
+        {/* ─── Intestazione ─── */}
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Metodi di pagamento: bonifico, assegno, carta e contanti
+          </h1>
+          <Badge variant="secondary">Gestione scontrini</Badge>
+        </div>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          In cassa ScontrinoZero propone due metodi: <strong>Contanti</strong> e{" "}
+          <strong>Carta</strong>. Un incasso ricevuto con{" "}
+          <strong>bonifico</strong> va registrato come Carta, perché il bonifico
+          è a tutti gli effetti un pagamento elettronico; un{" "}
+          <strong>assegno</strong>, bancario o circolare, va invece registrato
+          come Contanti.
+        </p>
+        <HelpArticleUpdatedAt slug="metodi-di-pagamento" />
+
+        {/* ─── Cosa arriva davvero all'AdE ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Cosa viene trasmesso all&apos;Agenzia delle Entrate
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Le etichette che vedi in cassa sono una semplificazione: il tracciato
+          del documento commerciale non conosce la parola &laquo;carta&raquo;,
+          ma due forme di pagamento più ampie.
+        </p>
+        <div className="mt-3 overflow-x-auto">
+          <table className="text-muted-foreground w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left">
+                <th className="text-foreground pb-2 font-semibold">
+                  Voce in cassa
+                </th>
+                <th className="text-foreground pb-2 font-semibold">
+                  Forma trasmessa all&apos;AdE
+                </th>
+                <th className="text-foreground pb-2 font-semibold">
+                  Cosa comprende
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-border divide-y">
+              <tr>
+                <td className="text-foreground py-2 font-medium">Contanti</td>
+                <td className="py-2">Contante</td>
+                <td className="py-2">
+                  Denaro in banconote e monete, assegni bancari e circolari
+                </td>
+              </tr>
+              <tr>
+                <td className="text-foreground py-2 font-medium">Carta</td>
+                <td className="py-2">Pagamento elettronico</td>
+                <td className="py-2">
+                  Carte di credito, debito e prepagate, bancomat, app di
+                  pagamento, bonifici
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* ─── Bonifico ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Il bonifico è un pagamento elettronico
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Se incassi con bonifico, sul documento commerciale devi indicare il
+          pagamento elettronico: in ScontrinoZero significa selezionare{" "}
+          <strong>Carta</strong>. È il caso tipico di chi riceve accrediti
+          periodici da una piattaforma o da un committente invece di incassare
+          allo sportello.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il riferimento ufficiale è la <strong>FAQ n. 11</strong> del documento{" "}
+          <strong>&laquo;Collegamento POS-RT&raquo;</strong> pubblicato
+          dall&apos;Agenzia delle Entrate su{" "}
+          <strong>agenziaentrate.gov.it</strong> il{" "}
+          <strong>19 febbraio 2026</strong>, che risponde così alla domanda se
+          il bonifico debba essere collegato al registratore di cassa:
+        </p>
+        <blockquote className="border-border text-muted-foreground mt-3 border-l-2 pl-4 text-sm leading-relaxed italic">
+          {
+            "«No, il bonifico bancario non rientra tra gli strumenti di pagamento elettronico da collegare. In ogni caso se il pagamento avviene tramite bonifico il documento commerciale deve indicare che si tratta di una forma di pagamento elettronico e il relativo ammontare.»"
+          }
+        </blockquote>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Due indicazioni distinte, quindi: il bonifico <strong>non</strong> va
+          censito fra gli strumenti di pagamento da collegare — la sua
+          tracciabilità è già garantita dall&apos;estratto conto — ma sul
+          documento commerciale va comunque indicato come pagamento elettronico.
+        </p>
+
+        {/* ─── Assegno ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          L&apos;assegno è un pagamento in contanti
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          È il caso che sorprende più spesso: l&apos;assegno non è un pagamento
+          elettronico. Se il cliente salda con assegno, seleziona{" "}
+          <strong>Contanti</strong>.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Lo precisa la <strong>FAQ n. 27</strong> dello stesso documento
+          dell&apos;Agenzia delle Entrate, pubblicata il{" "}
+          <strong>17 marzo 2026</strong> e aggiornata il{" "}
+          <strong>25 marzo 2026</strong>: in caso di pagamento con assegno,
+          bancario o circolare, il documento commerciale deve indicare che si
+          tratta di una forma di pagamento contante.
+        </p>
+
+        {/* ─── Perché la scelta conta ─── */}
+        <h2 className="mt-10 text-xl font-semibold">
+          Perché la scelta del metodo conta
+        </h2>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          Il metodo non è un dettaglio estetico: viaggia dentro il documento
+          commerciale trasmesso all&apos;Agenzia e determina una cosa concreta
+          in cassa. Il campo <strong>codice Lotteria degli Scontrini</strong>{" "}
+          compare soltanto quando scegli Carta, perché alla Lotteria partecipano
+          solo gli acquisti sopra <strong>1 €</strong> pagati con strumenti
+          elettronici. Se registri come Contanti un incasso ricevuto con
+          bonifico, oltre a trasmettere un dato inesatto togli al cliente la
+          possibilità di partecipare.
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+          A ogni documento commerciale corrisponde{" "}
+          <strong>un solo metodo di pagamento</strong>: scegli quello con cui il
+          cliente ha saldato l&apos;intero importo dello scontrino. Per le
+          aliquote IVA e il catalogo prodotti, vedi{" "}
+          <Link
+            href="/help/aliquote-iva"
+            className="text-primary hover:underline"
+          >
+            Come gestire le aliquote IVA e il catalogo prodotti
+          </Link>
+          {"."}
+        </p>
+
+        {/* ─── FAQ (mirror di faqItems: tenere allineati) ─── */}
+        <h2 className="mt-10 text-xl font-semibold">Domande frequenti</h2>
+        <div className="mt-3 space-y-4">
+          {faqItems.map((faq) => (
+            <div key={faq.question}>
+              <p className="text-sm font-medium">{faq.question}</p>
+              <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+                {faq.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+        <RelatedHelpArticles slug="metodi-di-pagamento" />
+
+        {/* ─── Footer articolo ─── */}
+        <div className="border-border mt-12 border-t pt-6">
+          <p className="text-muted-foreground text-xs">
+            {"Hai trovato un errore in questa guida? "}
+            <a
+              href="mailto:info@scontrinozero.it"
+              className="text-primary hover:underline"
+            >
+              Segnalacelo
+            </a>
+            {"."}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -86,7 +86,7 @@ const helpCategories: HelpCategory[] = [
         href: "/help/regime-forfettario",
       },
       {
-        title: "Come gestire aliquote IVA, catalogo e metodi di pagamento",
+        title: "Come gestire le aliquote IVA e il catalogo prodotti",
         href: "/help/aliquote-iva",
       },
       {
@@ -138,6 +138,10 @@ const helpCategories: HelpCategory[] = [
       {
         title: "Come emettere il primo scontrino elettronico",
         href: "/help/primo-scontrino",
+      },
+      {
+        title: "Metodi di pagamento: bonifico, assegno, carta e contanti",
+        href: "/help/metodi-di-pagamento",
       },
       {
         title: "Annullare uno scontrino: quando si può e come fare",

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(85);
+    expect(result).toHaveLength(86);
 
     // Root
     expect(result[0]).toMatchObject({

--- a/src/lib/help/articles.test.ts
+++ b/src/lib/help/articles.test.ts
@@ -120,6 +120,47 @@ describe("analytics-e-report (KPI, grafici e gating Pro)", () => {
   });
 });
 
+describe("metodi-di-pagamento (bonifico e assegno sullo scontrino)", () => {
+  const article = helpArticles["metodi-di-pagamento"];
+
+  it("exists in the registry", () => {
+    expect(article).toBeDefined();
+  });
+
+  it("targets the 'bonifico' query in the metaTitle", () => {
+    expect(article.metaTitle.toLowerCase()).toContain("bonifico");
+  });
+
+  it("names both the bonifico and the assegno case in the description", () => {
+    const description = article.description.toLowerCase();
+    expect(description).toContain("bonifico");
+    expect(description).toContain("assegno");
+  });
+
+  it("links the payment cluster", () => {
+    expect(article.related).toContain("aliquote-iva");
+    expect(article.related).toContain("primo-scontrino");
+  });
+});
+
+describe("aliquote-iva does not cannibalise metodi-di-pagamento", () => {
+  const article = helpArticles["aliquote-iva"];
+
+  it("no longer claims the payment-methods intent in the metaTitle", () => {
+    expect(article.metaTitle.toLowerCase()).not.toContain(
+      "metodi di pagamento",
+    );
+  });
+
+  it("keeps the VAT intent in the metaTitle", () => {
+    expect(article.metaTitle.toLowerCase()).toContain("iva");
+  });
+
+  it("points at the dedicated payment article through related", () => {
+    expect(article.related).toContain("metodi-di-pagamento");
+  });
+});
+
 describe("per-article dates", () => {
   it("every article has datePublished and dateModified in ISO YYYY-MM-DD form", () => {
     for (const article of Object.values(helpArticles)) {

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -18,12 +18,12 @@ export const helpArticles: Record<string, HelpArticle> = {
   "aliquote-iva": {
     slug: "aliquote-iva",
     datePublished: "2026-04-17",
-    dateModified: "2026-08-02",
-    title: "Aliquote IVA, catalogo e metodi di pagamento",
-    metaTitle: "Come gestire aliquote IVA, catalogo e metodi di pagamento",
+    dateModified: "2026-08-04",
+    title: "Aliquote IVA e catalogo prodotti",
+    metaTitle: "Come gestire le aliquote IVA e il catalogo prodotti",
     description:
-      "Guida alla configurazione delle aliquote IVA (4%, 5%, 10%, 22% e nature speciali), del catalogo prodotti e dei metodi di pagamento in ScontrinoZero.",
-    related: ["regime-forfettario", "primo-scontrino", "annullare-scontrino"],
+      "Guida alla configurazione delle aliquote IVA (4%, 5%, 10%, 22% e nature speciali) e del catalogo prodotti in ScontrinoZero.",
+    related: ["regime-forfettario", "primo-scontrino", "metodi-di-pagamento"],
   },
   "annullare-scontrino": {
     slug: "annullare-scontrino",
@@ -176,6 +176,16 @@ export const helpArticles: Record<string, HelpArticle> = {
     description:
       "Come modificare la ragione sociale, l'indirizzo e i dati fiscali che appaiono sull'intestazione dello scontrino emesso da ScontrinoZero.",
     related: ["prima-configurazione", "come-collegare-ade", "primo-scontrino"],
+  },
+  "metodi-di-pagamento": {
+    slug: "metodi-di-pagamento",
+    datePublished: "2026-08-04",
+    dateModified: "2026-08-04",
+    title: "Metodi di pagamento: bonifico, assegno, carta e contanti",
+    metaTitle: "Bonifico e assegno sullo scontrino: quale metodo scegliere",
+    description:
+      "Quale metodo scegliere in cassa: il bonifico va indicato sul documento commerciale come pagamento elettronico, l'assegno come contante. Le regole dell'Agenzia delle Entrate e i riferimenti ufficiali.",
+    related: ["aliquote-iva", "primo-scontrino", "pos-rt-obbligo"],
   },
   "normativa-pos-2026": {
     slug: "normativa-pos-2026",

--- a/src/lib/per/categories.test.ts
+++ b/src/lib/per/categories.test.ts
@@ -162,6 +162,25 @@ describe("stabilimenti-balneari (riferimenti fiscali verificati)", () => {
   });
 });
 
+describe("b-and-b (incassi tramite portale di prenotazione)", () => {
+  const c = categories["b-and-b"];
+
+  // Il segmento incassa tipicamente via bonifico dal portale, non allo
+  // sportello: il bullet sul metodo di pagamento — presente su ambulanti,
+  // parrucchieri, eventi e lavanderie — qui mancava del tutto.
+  it("names the payment method among the benefits, like the other categories", () => {
+    const benefits = c.benefits.join(" ").toLowerCase();
+    expect(benefits).toContain("pagamento");
+    expect(benefits).toContain("bonifico");
+  });
+
+  // Il dettaglio (bonifico = elettronico, assegno = contante, con le FAQ AdE
+  // datate) vive nell'articolo help dedicato: la pagina /per ci rimanda.
+  it("points at the payment-methods help article", () => {
+    expect(c.relatedHelp).toContain("metodi-di-pagamento");
+  });
+});
+
 describe("getCategory", () => {
   it("returns the category for a known slug", () => {
     const c = getCategory("ambulanti");

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -219,6 +219,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
       "Configurazione una tantum di aliquota e voci ricorrenti (pernottamento, colazione, supplementi).",
       "Storico ordinato per stagione, utile per dichiarazione dei redditi e analisi.",
       "Funziona su qualsiasi smartphone o tablet, anche quello che già usi per ricevere gli ospiti.",
+      "Metodo di pagamento (contanti o carta) su ogni scontrino: gli accrediti ricevuti con bonifico da un portale di prenotazione si indicano come pagamento elettronico.",
     ],
     faq: [
       {
@@ -238,7 +239,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
           "Sì, purché tu sia titolare di partita IVA e abbia le credenziali AdE attive (Fisconline o CIE). L'obbligo di emissione del documento commerciale dipende dalla forma di esercizio: verifica con il commercialista se rientri nei casi obbligati.",
       },
     ],
-    relatedHelp: ["primo-scontrino", "aliquote-iva", "intestazione-scontrino"],
+    relatedHelp: ["primo-scontrino", "aliquote-iva", "metodi-di-pagamento"],
   },
   "regime-forfettario": {
     slug: "regime-forfettario",


### PR DESCRIPTION
Il bonifico va indicato sul documento commerciale come pagamento
elettronico e l'assegno come contante: due casi che oggi il centro
assistenza non copriva e che generano richieste di supporto.

- nuovo /help/metodi-di-pagamento con la tabella voce-in-cassa →
  forma trasmessa all'AdE, i riferimenti datati (FAQ n. 11 del
  19/02/2026 e FAQ n. 27 del 17/03/2026 aggiornata il 25/03/2026 del
  documento "Collegamento POS-RT") e 4 FAQ → FAQPage JSON-LD
- /help/aliquote-iva perde l'intent "metodi di pagamento" da titolo,
  metaTitle e description e rimanda alla nuova guida: i due articoli
  non si contendono più la stessa query
- l'hub /help linka il nuovo articolo e allinea il titolo di
  aliquote-iva, che era rimasto stale
- REVIEW #86: l'hub duplica a mano titoli e href del registry senza
  test di corrispondenza

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014NmSmnrR8YxWrddZmjP7Hi