### PR TITLE
fix(help): deriva titoli e link dell'hub dal registry articoli (#86)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -171,26 +171,6 @@ fatto che i payload sono statici, ma è un single point of failure.
 
 ## P3 — Bassa priorità
 
-### 86. Hub `/help`: titoli e link duplicati dal registry, senza guard test
-
-- **Categoria:** doppia scrittura contenuti · **Severità:** Low (contenuto stale / articolo orfano, nessun impatto runtime)
-- **File:** `src/app/(marketing)/help/page.tsx:37-231` (`featuredArticles` e `categories`), registry `src/lib/help/articles.ts`
-
-**Problema.** L'hub del centro assistenza ricopia a mano `title` e `href` di
-ogni articolo, mentre la fonte di verità è `helpArticles`. Due conseguenze
-osservate aggiungendo `metodi-di-pagamento`: (a) un articolo nuovo non compare
-nell'hub finché qualcuno non lo aggiunge a mano — resta raggiungibile solo da
-sitemap e link interni; (b) rinominando `aliquote-iva` il titolo nell'hub è
-rimasto stale, esattamente il pattern di doppia scrittura che la skill
-`marketing-content` vieta per date e prezzi. Nessun test copre la
-corrispondenza, quindi entrambe le derive passano la CI.
-
-**Fix proposto.** Estrarre `categories` in `src/lib/help/hub-categories.ts`
-tenendo solo lo slug (il titolo si legge da `helpArticles[slug].title`), e
-aggiungere un test che per ogni slug del registry esista una voce nell'hub
-(match `/help/<slug>` oppure `/help/<slug>#<ancora>`, come per `api`). Elimina
-sia l'orfano sia il titolo divergente.
-
 ### 81. Sweep GDPR: la query candidati aggrega l'intera tabella `commercial_documents` a ogni giro
 
 - **Categoria:** performance DB · **Severità:** Low (cresce col volume globale, non per-tenant)

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -4,6 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChevronRight } from "lucide-react";
 import { JsonLd, breadcrumbListJsonLd } from "@/components/json-ld";
 import { Breadcrumbs } from "@/components/marketing/breadcrumbs";
+import {
+  helpHubCategories,
+  helpHubFeaturedSlugs,
+  resolveHubArticle,
+} from "@/lib/help/hub-categories";
 
 const SITE_URL = "https://scontrinozero.it";
 const PAGE_URL = `${SITE_URL}/help`;
@@ -23,217 +28,14 @@ export const metadata: Metadata = {
   },
 };
 
-interface HelpArticle {
-  title: string;
-  href?: string;
-}
+const featuredArticles = helpHubFeaturedSlugs.map((slug) =>
+  resolveHubArticle({ slug }),
+);
 
-interface HelpCategory {
-  name: string;
-  description: string;
-  articles: readonly HelpArticle[];
-  categoryHref?: string;
-}
-
-const featuredArticles: HelpArticle[] = [
-  {
-    title: "Prima configurazione passo-passo (onboarding completo)",
-    href: "/help/prima-configurazione",
-  },
-  {
-    title: "Come collegare ScontrinoZero all'Agenzia delle Entrate",
-    href: "/help/come-collegare-ade",
-  },
-  {
-    title: "Credenziali Fisconline: dove trovarle e come verificarle",
-    href: "/help/credenziali-fisconline",
-  },
-  {
-    title: "Come emettere il primo scontrino elettronico",
-    href: "/help/primo-scontrino",
-  },
-  {
-    title: "Errori comuni di accesso AdE e come risolverli",
-    href: "/help/errori-ade",
-  },
-];
-
-const helpCategories: HelpCategory[] = [
-  {
-    name: "Partenza rapida",
-    description: "Per iniziare in meno di 30 minuti.",
-    articles: [
-      {
-        title: "Prima configurazione passo-passo (onboarding completo)",
-        href: "/help/prima-configurazione",
-      },
-      {
-        title: "Come emettere il primo scontrino elettronico",
-        href: "/help/primo-scontrino",
-      },
-      {
-        title: "Come installare ScontrinoZero come app sul tuo dispositivo",
-        href: "/help/installare-app",
-      },
-    ],
-  },
-  {
-    name: "Configurazione attività",
-    description: "Impostazioni fiscali e personalizzazioni.",
-    articles: [
-      {
-        title: "Regime forfettario: configurazione IVA corretta",
-        href: "/help/regime-forfettario",
-      },
-      {
-        title: "Come gestire le aliquote IVA e il catalogo prodotti",
-        href: "/help/aliquote-iva",
-      },
-      {
-        title: "Personalizzare intestazione e dati dello scontrino",
-        href: "/help/intestazione-scontrino",
-      },
-    ],
-  },
-  {
-    name: "Collegamento Agenzia Entrate",
-    description: "Credenziali Fisconline o CIE e troubleshooting accesso.",
-    articles: [
-      {
-        title: "Come collegare ScontrinoZero all'Agenzia delle Entrate",
-        href: "/help/come-collegare-ade",
-      },
-      {
-        title: "Collegare l'AdE con CIE (app CIE ID)",
-        href: "/help/collegare-ade-con-cie",
-      },
-      {
-        title: "Credenziali Fisconline: dove trovarle e come verificarle",
-        href: "/help/credenziali-fisconline",
-      },
-      {
-        title: "Errori comuni di accesso AdE e come risolverli",
-        href: "/help/errori-ade",
-      },
-    ],
-  },
-  {
-    name: "Sicurezza e cassetto fiscale",
-    description: "Verifica corrispettivi e protezione credenziali.",
-    articles: [
-      {
-        title: "Dove verificare i corrispettivi nel cassetto fiscale",
-        href: "/help/cassetto-fiscale",
-      },
-      {
-        title: "Sicurezza e privacy: come proteggiamo le tue credenziali",
-        href: "/help/sicurezza-credenziali",
-      },
-    ],
-  },
-  {
-    name: "Emissione e gestione scontrini",
-    description: "Operatività quotidiana in cassa.",
-    articles: [
-      {
-        title: "Come emettere il primo scontrino elettronico",
-        href: "/help/primo-scontrino",
-      },
-      {
-        title: "Metodi di pagamento: bonifico, assegno, carta e contanti",
-        href: "/help/metodi-di-pagamento",
-      },
-      {
-        title: "Annullare uno scontrino: quando si può e come fare",
-        href: "/help/annullare-scontrino",
-      },
-      {
-        title: "Chiusura giornaliera: è obbligatoria?",
-        href: "/help/chiusura-giornaliera",
-      },
-      {
-        title: "Storico scontrini: filtri, ricerca ed esportazione",
-        href: "/help/storico-ed-esportazione",
-      },
-      {
-        title: "Analytics e report: ricavi, scontrini e prodotti",
-        href: "/help/analytics-e-report",
-      },
-      {
-        title: "Come stampare lo scontrino su carta termica",
-        href: "/help/stampare-scontrino-termica",
-      },
-      {
-        title: "Numero documento e azzeramento sullo scontrino",
-        href: "/help/numero-documento-azzeramento",
-      },
-    ],
-  },
-  {
-    name: "Abbonamento, fatture e supporto",
-    description: "Piano, pagamenti e assistenza.",
-    articles: [
-      {
-        title: "Piani disponibili: Starter, Pro e versione gratuita",
-        href: "/help/piani-e-prezzi",
-      },
-      {
-        title: "Presenta un amico: come funziona il bonus referral",
-        href: "/help/presenta-un-amico",
-      },
-      {
-        title: "Come passare da mensile ad annuale",
-        href: "/help/cambio-piano",
-      },
-      {
-        title: "Dove trovare fatture e ricevute di pagamento",
-        href: "/help/fatture-e-ricevute",
-      },
-      {
-        title: "Come contattare l'assistenza",
-        href: "/help/contatto-assistenza",
-      },
-    ],
-  },
-  {
-    name: "POS e normativa",
-    description: "Obblighi 2026 e collegamento POS-RT.",
-    articles: [
-      {
-        title: "Collegamento POS-RT: chi è obbligato e scadenze",
-        href: "/help/pos-rt-obbligo",
-      },
-      {
-        title: "Come registrare un POS nel portale Fatture e Corrispettivi",
-        href: "/help/registrare-pos-portale-ade",
-      },
-      {
-        title: "Nuova normativa POS 2026: cosa cambia per gli esercenti",
-        href: "/help/normativa-pos-2026",
-      },
-    ],
-  },
-  {
-    name: "API per sviluppatori",
-    description:
-      "Solo per chi integra ScontrinoZero da un gestionale o un POS. Se sei un commerciante, parti da Partenza rapida.",
-    articles: [
-      {
-        title: "Autenticazione e gestione chiavi API",
-        href: "/help/api#autenticazione",
-      },
-      {
-        title: "Endpoint: emissione, stato e annullamento scontrino",
-        href: "/help/api#endpoint",
-      },
-      {
-        title: "Codici IVA, rate limit e gestione errori",
-        href: "/help/api#codici-iva",
-      },
-    ],
-    categoryHref: "/help/api",
-  },
-];
+const helpCategories = helpHubCategories.map((category) => ({
+  ...category,
+  articles: category.articles.map(resolveHubArticle),
+}));
 
 export default function HelpHomePage() {
   const crumbs = [
@@ -265,20 +67,14 @@ export default function HelpHomePage() {
           <h2 className="text-lg font-semibold">Articoli più letti</h2>
           <ul className="divide-border divide-y rounded-lg border">
             {featuredArticles.map((article) => (
-              <li key={article.title}>
-                {article.href ? (
-                  <Link
-                    href={article.href}
-                    className="hover:bg-muted/50 flex items-center justify-between px-4 py-3 text-sm transition-colors"
-                  >
-                    <span>{article.title}</span>
-                    <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
-                  </Link>
-                ) : (
-                  <span className="text-muted-foreground flex items-center justify-between px-4 py-3 text-sm">
-                    <span>{article.title}</span>
-                  </span>
-                )}
+              <li key={article.href}>
+                <Link
+                  href={article.href}
+                  className="hover:bg-muted/50 flex items-center justify-between px-4 py-3 text-sm transition-colors"
+                >
+                  <span>{article.title}</span>
+                  <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                </Link>
               </li>
             ))}
           </ul>
@@ -299,26 +95,14 @@ export default function HelpHomePage() {
                 <CardContent>
                   <ul className="space-y-2 text-sm leading-relaxed">
                     {category.articles.map((article) => (
-                      <li
-                        key={article.title}
-                        className="flex items-start gap-2"
-                      >
+                      <li key={article.href} className="flex items-start gap-2">
                         <span className="text-muted-foreground mt-0.5">›</span>
-                        {article.href ? (
-                          <Link
-                            href={article.href}
-                            className="text-primary hover:underline"
-                          >
-                            {article.title}
-                          </Link>
-                        ) : (
-                          <span className="text-muted-foreground inline-flex items-center gap-2">
-                            {article.title}
-                            <span className="bg-muted text-muted-foreground rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
-                              In arrivo
-                            </span>
-                          </span>
-                        )}
+                        <Link
+                          href={article.href}
+                          className="text-primary hover:underline"
+                        >
+                          {article.title}
+                        </Link>
                       </li>
                     ))}
                   </ul>

--- a/src/lib/help/articles.test.ts
+++ b/src/lib/help/articles.test.ts
@@ -161,6 +161,29 @@ describe("aliquote-iva does not cannibalise metodi-di-pagamento", () => {
   });
 });
 
+describe("normativa-pos-2026 non si confonde con pos-rt-obbligo", () => {
+  const normativa = helpArticles["normativa-pos-2026"];
+  const posRt = helpArticles["pos-rt-obbligo"];
+
+  it("keeps the 'normativa POS 2026' intent in the title (anchor text dell'hub)", () => {
+    expect(normativa.title.toLowerCase()).toContain("normativa pos 2026");
+  });
+
+  it("does not open with the same word as pos-rt-obbligo", () => {
+    // Le due voci sono adiacenti nella categoria "POS e normativa" dell'hub:
+    // con lo stesso incipit ("Collegamento POS-…") si leggono come lo stesso
+    // articolo scritto due volte.
+    expect(normativa.title).not.toBe(posRt.title);
+    const firstWord = (title: string) => title.split(" ")[0].toLowerCase();
+    expect(firstWord(normativa.title)).not.toBe(firstWord(posRt.title));
+  });
+
+  it("cross-links pos-rt-obbligo through related", () => {
+    expect(normativa.related).toContain("pos-rt-obbligo");
+    expect(posRt.related).toContain("normativa-pos-2026");
+  });
+});
+
 describe("per-article dates", () => {
   it("every article has datePublished and dateModified in ISO YYYY-MM-DD form", () => {
     for (const article of Object.values(helpArticles)) {

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -191,7 +191,7 @@ export const helpArticles: Record<string, HelpArticle> = {
     slug: "normativa-pos-2026",
     datePublished: "2026-04-17",
     dateModified: "2026-08-02",
-    title: "Collegamento POS-cassa 2026: cosa cambia",
+    title: "Normativa POS 2026: cosa cambia per gli esercenti",
     metaTitle: "Normativa POS 2026: obbligo, scadenze e sanzioni POS-cassa",
     description:
       "Normativa POS 2026 (Legge 207/2024): chi deve collegare POS e cassa, la scadenza del 20 aprile 2026 per la prima comunicazione, le sanzioni e come metterti in regola col Documento Commerciale Online.",

--- a/src/lib/help/hub-categories.test.ts
+++ b/src/lib/help/hub-categories.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { helpArticles, helpSlugs } from "./articles";
+import {
+  helpHubCategories,
+  helpHubFeaturedSlugs,
+  resolveHubArticle,
+} from "./hub-categories";
+
+const allRefs = helpHubCategories.flatMap((category) => category.articles);
+
+describe("helpHubCategories", () => {
+  it("references only slugs that exist in the registry", () => {
+    for (const ref of allRefs) {
+      expect(
+        helpArticles[ref.slug],
+        `slug sconosciuto: ${ref.slug}`,
+      ).toBeDefined();
+    }
+  });
+
+  it("covers every article of the registry (nessun orfano)", () => {
+    const covered = new Set(allRefs.map((ref) => ref.slug));
+    const missing = helpSlugs.filter((slug) => !covered.has(slug));
+    expect(
+      missing,
+      `articoli non raggiungibili dall'hub /help: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("has no duplicate entry inside the same category", () => {
+    for (const category of helpHubCategories) {
+      const hrefs = category.articles.map((ref) => resolveHubArticle(ref).href);
+      expect(new Set(hrefs).size, `duplicati in ${category.name}`).toBe(
+        hrefs.length,
+      );
+    }
+  });
+
+  it("gives every category a name and a description", () => {
+    for (const category of helpHubCategories) {
+      expect(category.name.trim().length).toBeGreaterThan(0);
+      expect(category.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("points categoryHref at an existing article when set", () => {
+    for (const category of helpHubCategories) {
+      if (category.categoryHref) {
+        expect(category.categoryHref).toMatch(/^\/help\/[a-z0-9-]+$/);
+        const slug = category.categoryHref.replace("/help/", "");
+        expect(helpArticles[slug]).toBeDefined();
+      }
+    }
+  });
+});
+
+describe("helpHubFeaturedSlugs", () => {
+  it("references only slugs that exist in the registry", () => {
+    for (const slug of helpHubFeaturedSlugs) {
+      expect(helpArticles[slug], `slug sconosciuto: ${slug}`).toBeDefined();
+    }
+  });
+
+  it("has no duplicates", () => {
+    expect(new Set(helpHubFeaturedSlugs).size).toBe(
+      helpHubFeaturedSlugs.length,
+    );
+  });
+});
+
+describe("resolveHubArticle", () => {
+  it("derives title and href from the registry", () => {
+    const article = helpArticles["aliquote-iva"];
+    expect(resolveHubArticle({ slug: "aliquote-iva" })).toEqual({
+      title: article.title,
+      href: "/help/aliquote-iva",
+    });
+  });
+
+  it("uses the section label and anchor for a sectioned entry", () => {
+    expect(
+      resolveHubArticle({
+        slug: "api",
+        section: { id: "endpoint", label: "Endpoint REST" },
+      }),
+    ).toEqual({
+      title: "Endpoint REST",
+      href: "/help/api#endpoint",
+    });
+  });
+
+  it("throws on a slug missing from the registry", () => {
+    expect(() => resolveHubArticle({ slug: "does-not-exist" })).toThrow(
+      /does-not-exist/,
+    );
+  });
+
+  it("never returns a stale title: ogni voce risolta combacia col registry", () => {
+    for (const ref of allRefs) {
+      const resolved = resolveHubArticle(ref);
+      if (!ref.section) {
+        expect(resolved.title).toBe(helpArticles[ref.slug].title);
+      }
+      expect(resolved.href.startsWith(`/help/${ref.slug}`)).toBe(true);
+    }
+  });
+});

--- a/src/lib/help/hub-categories.test.ts
+++ b/src/lib/help/hub-categories.test.ts
@@ -36,6 +36,18 @@ describe("helpHubCategories", () => {
     }
   });
 
+  it("has no two entries with the same label inside a category", () => {
+    for (const category of helpHubCategories) {
+      const titles = category.articles.map(
+        (ref) => resolveHubArticle(ref).title,
+      );
+      expect(
+        new Set(titles).size,
+        `etichette indistinguibili in ${category.name}: ${titles.join(" / ")}`,
+      ).toBe(titles.length);
+    }
+  });
+
   it("gives every category a name and a description", () => {
     for (const category of helpHubCategories) {
       expect(category.name.trim().length).toBeGreaterThan(0);

--- a/src/lib/help/hub-categories.ts
+++ b/src/lib/help/hub-categories.ts
@@ -1,0 +1,161 @@
+import { getHelpArticle } from "./articles";
+
+/**
+ * Sezione interna a un articolo: la voce dell'hub punta a un'ancora, non
+ * all'articolo intero, quindi porta la propria etichetta (id e label vivono
+ * insieme perché non hanno senso separati).
+ */
+export interface HubSection {
+  readonly id: string;
+  readonly label: string;
+}
+
+/**
+ * Riferimento a un articolo nell'hub `/help`. Contiene solo lo slug: titolo e
+ * href si derivano dal registry `helpArticles`, unica fonte di verità.
+ */
+export interface HubArticleRef {
+  readonly slug: string;
+  readonly section?: HubSection;
+}
+
+export interface HubCategory {
+  readonly name: string;
+  readonly description: string;
+  readonly articles: readonly HubArticleRef[];
+  /** Articolo "indice" della categoria, linkato in fondo alla card. */
+  readonly categoryHref?: string;
+}
+
+export interface HubArticleLink {
+  readonly title: string;
+  readonly href: string;
+}
+
+/**
+ * Risolve un riferimento in titolo + href leggendo il registry. Uno slug
+ * inesistente fa throw (`getHelpArticle`) e rompe il build della pagina: un
+ * refuso non arriva mai in produzione come link morto.
+ */
+export function resolveHubArticle(ref: HubArticleRef): HubArticleLink {
+  const article = getHelpArticle(ref.slug);
+  if (ref.section) {
+    return {
+      title: ref.section.label,
+      href: `/help/${article.slug}#${ref.section.id}`,
+    };
+  }
+  return { title: article.title, href: `/help/${article.slug}` };
+}
+
+/** Articoli in evidenza ("Articoli più letti") in cima all'hub. */
+export const helpHubFeaturedSlugs: readonly string[] = [
+  "prima-configurazione",
+  "come-collegare-ade",
+  "credenziali-fisconline",
+  "primo-scontrino",
+  "errori-ade",
+];
+
+/**
+ * Tassonomia dell'hub `/help`. Ogni slug del registry deve comparire qui:
+ * `hub-categories.test.ts` fallisce sull'articolo orfano.
+ */
+export const helpHubCategories: readonly HubCategory[] = [
+  {
+    name: "Partenza rapida",
+    description: "Per iniziare in meno di 30 minuti.",
+    articles: [
+      { slug: "prima-configurazione" },
+      { slug: "primo-scontrino" },
+      { slug: "installare-app" },
+    ],
+  },
+  {
+    name: "Configurazione attività",
+    description: "Impostazioni fiscali e personalizzazioni.",
+    articles: [
+      { slug: "regime-forfettario" },
+      { slug: "aliquote-iva" },
+      { slug: "intestazione-scontrino" },
+    ],
+  },
+  {
+    name: "Collegamento Agenzia Entrate",
+    description: "Credenziali Fisconline o CIE e troubleshooting accesso.",
+    articles: [
+      { slug: "come-collegare-ade" },
+      { slug: "collegare-ade-con-cie" },
+      { slug: "credenziali-fisconline" },
+      { slug: "errori-ade" },
+    ],
+  },
+  {
+    name: "Sicurezza e cassetto fiscale",
+    description: "Verifica corrispettivi e protezione credenziali.",
+    articles: [{ slug: "cassetto-fiscale" }, { slug: "sicurezza-credenziali" }],
+  },
+  {
+    name: "Emissione e gestione scontrini",
+    description: "Operatività quotidiana in cassa.",
+    articles: [
+      { slug: "primo-scontrino" },
+      { slug: "metodi-di-pagamento" },
+      { slug: "annullare-scontrino" },
+      { slug: "chiusura-giornaliera" },
+      { slug: "storico-ed-esportazione" },
+      { slug: "analytics-e-report" },
+      { slug: "stampare-scontrino-termica" },
+      { slug: "numero-documento-azzeramento" },
+    ],
+  },
+  {
+    name: "Abbonamento, fatture e supporto",
+    description: "Piano, pagamenti e assistenza.",
+    articles: [
+      { slug: "piani-e-prezzi" },
+      { slug: "presenta-un-amico" },
+      { slug: "cambio-piano" },
+      { slug: "fatture-e-ricevute" },
+      { slug: "contatto-assistenza" },
+    ],
+  },
+  {
+    name: "POS e normativa",
+    description: "Obblighi 2026 e collegamento POS-RT.",
+    articles: [
+      { slug: "pos-rt-obbligo" },
+      { slug: "registrare-pos-portale-ade" },
+      { slug: "normativa-pos-2026" },
+    ],
+  },
+  {
+    name: "API per sviluppatori",
+    description:
+      "Solo per chi integra ScontrinoZero da un gestionale o un POS. Se sei un commerciante, parti da Partenza rapida.",
+    articles: [
+      {
+        slug: "api",
+        section: {
+          id: "autenticazione",
+          label: "Autenticazione e gestione chiavi API",
+        },
+      },
+      {
+        slug: "api",
+        section: {
+          id: "endpoint",
+          label: "Endpoint: emissione, stato e annullamento scontrino",
+        },
+      },
+      {
+        slug: "api",
+        section: {
+          id: "codici-iva",
+          label: "Codici IVA, rate limit e gestione errori",
+        },
+      },
+    ],
+    categoryHref: "/help/api",
+  },
+];


### PR DESCRIPTION
L'hub /help ricopiava a mano title e href di ogni articolo mentre la
fonte di verità è `helpArticles`: un articolo nuovo restava orfano finché
qualcuno non lo aggiungeva a mano, e un rename del registry lasciava il
titolo stale nell'hub. Nessun test copriva la corrispondenza.

- nuovo `src/lib/help/hub-categories.ts`: la tassonomia tiene solo lo
  slug, `resolveHubArticle()` deriva titolo e href dal registry (throw su
  slug inesistente → il build fallisce invece di spedire un link morto);
  le voci ancorate (`/help/api#...`) portano la propria etichetta di
  sezione tramite `section: { id, label }`
- `page.tsx` consuma i dati derivati; rimosso il ramo "In arrivo" per le
  voci senza href, ora irraggiungibile (regola 28)
- guard test: ogni slug del registry compare nell'hub, ogni slug dell'hub
  esiste nel registry, nessun duplicato in categoria, `categoryHref`
  risolve a un articolo reale

Effetto collaterale voluto: le card mostrano ora il `title` breve del
registry invece della copia hardcoded (es. "Piani disponibili: Starter,
Pro e self-hosted" al posto di "…e versione gratuita", stale).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017nK3P2A9i6NFNm4egZhKTE