### PR TITLE
fix(seo): title assoluto su guide e help per non farli troncare in SERP

### DIFF
--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -136,6 +136,21 @@ al momento dell'analisi e non si poteva distinguere "drain rotto" da
 "rilasciato 40 minuti fa". Integrazione in CI rimandata: oggi è uno script
 da eseguire manualmente dopo `docker compose up -d`.
 
+## L'edge Cloudflare può scavalcare la config dell'app
+
+Stessa famiglia del "baked vs runtime": quello che leggi nel sorgente non è
+per forza quello che gira. Cloudflare inietta a livello di zona un blocco
+_Managed robots.txt_ **anteposto** all'output di `src/app/robots.ts`, e
+nessuna modifica al repo lo scavalca — si spegne solo dal dashboard. Ad
+agosto 2026 vietava `ClaudeBot`, `GPTBot`, `Google-Extended` e `CCBot`,
+rendendo `/llms.txt` e `/llms-full.txt` irraggiungibili dai crawler per cui
+erano stati scritti; scoperto curlando la produzione, invisibile nel repo.
+
+Il blocco WAF dei bot AI è un interruttore **separato** dal managed
+robots.txt (risponde 403, non `Disallow`): spegnerne uno non spegne l'altro,
+vanno verificati entrambi. Comandi di verifica e distinzioni fra i crawler →
+skill `marketing-content`, sezione "Verificare robots.txt servito".
+
 ## Procedura aggiornamento T&C
 
 1. Crea `src/app/(marketing)/termini/v*/page.tsx` (nuova versione vXX)

--- a/.claude/skills/marketing-content/SKILL.md
+++ b/.claude/skills/marketing-content/SKILL.md
@@ -139,6 +139,46 @@ guida/help/tool nuovo o revisionato rispetta:
 5. **Slug separati `/help` vs `/guide`** sulle keyword condivise (vedi sopra):
    help = operativo in-app, guide = educativo/reference. I `metaTitle` devono
    riflettere intent distinti per non cannibalizzarsi.
+6. **`metaTitle` ≤ 60 caratteri.** Guide e articoli help dichiarano un title
+   **assoluto** (`{ absolute: … }` in `guide/[slug]/page.tsx` e
+   `lib/help/metadata.ts`): bypassa il template root `"%s | ScontrinoZero"`,
+   che aggiungerebbe 16 caratteri e farebbe troncare la coda della keyword
+   senza nemmeno mostrare il brand — visibile comunque via site name
+   (`webSiteJsonLd`) e breadcrumb del dominio. L'invariante è testata nei due
+   registry; le pagine hub continuano a usare il template.
+7. **Il titolo riprende le parole della query e anticipa la risposta.** Non
+   "Registratore di cassa: prezzi e alternative" ma "Quanto costa un
+   registratore di cassa: 400-800 € + canone". Su GSC 2026-08 le pagine col
+   titolo che non riprende la query stavano a CTR 0,36-0,99% da posizione
+   9-10, cioè un ordine di grandezza sotto la norma per quelle posizioni.
+
+## Verificare robots.txt **servito**, non quello nel repo
+
+`src/app/robots.ts` non è l'ultima parola: Cloudflare può iniettare un blocco
+_Managed robots.txt_ a livello di zona che viene anteposto all'output
+dell'app, e nessuna modifica al repo lo scavalca. Ad agosto 2026 quel blocco
+vietava `ClaudeBot`, `GPTBot`, `Google-Extended`, `CCBot`, `Amazonbot`,
+`Applebot-Extended`, `Bytespider` e `meta-externalagent`: `/llms.txt` e
+`/llms-full.txt`, costruiti apposta per i crawler AI, erano irraggiungibili
+da metà dei crawler a cui parlano. Scoperto solo curlando la produzione.
+
+Quindi, ogni volta che si tocca GEO o si dà per acquisita la citabilità AI:
+
+```bash
+curl -sS https://scontrinozero.it/robots.txt          # cosa esce davvero
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -A 'ClaudeBot/1.0 (+https://www.anthropic.com/claude-bot)' \
+  https://scontrinozero.it/llms-full.txt              # 200, non 403
+```
+
+Il secondo comando serve perché il blocco WAF dei bot AI è un interruttore
+**separato** dal managed robots.txt: spegnerne uno non spegne l'altro, e
+l'enforcement WAF risponde 403 invece di un `Disallow`.
+
+Distinzioni da non confondere quando si valuta l'impatto: `Google-Extended`
+governa Gemini e il grounding Vertex, **non** le AI Overviews di Google (che
+dipendono da Googlebot); le citazioni in ChatGPT search passano da
+`OAI-SearchBot`, non da `GPTBot`, che copre il training.
 
 ## Vantaggio competitivo SEO
 

--- a/src/app/(marketing)/guide/[slug]/page.test.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { generateMetadata } from "./page";
+import { guideArticles, guideSlugs } from "@/lib/guide/articles";
+
+/**
+ * Il `<title>` di una guida deve arrivare in SERP intero. Il template root
+ * (`"%s | ScontrinoZero"` in `src/app/layout.tsx`) aggiungerebbe 16 caratteri
+ * di suffisso brand a un metaTitle già lungo fino a 60: il risultato viene
+ * troncato da Google intorno ai 60 caratteri, quindi il brand non si vede mai
+ * e la coda della keyword sparisce. Le guide dichiarano perciò un title
+ * `absolute`, che bypassa il template — il brand resta comunque visibile in
+ * SERP tramite il site name (`webSiteJsonLd`) e il breadcrumb del dominio.
+ */
+describe("generateMetadata (guida)", () => {
+  it("dichiara il metaTitle come title assoluto, senza suffisso brand", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "sanzioni-mancato-scontrino" }),
+    });
+    expect(meta.title).toEqual({
+      absolute: guideArticles["sanzioni-mancato-scontrino"].metaTitle,
+    });
+  });
+
+  it("usa la metaDescription del registry", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "codici-natura-iva" }),
+    });
+    expect(meta.description).toBe(
+      guideArticles["codici-natura-iva"].metaDescription,
+    );
+  });
+
+  it("imposta un canonical self-referential sotto /guide", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "codici-natura-iva" }),
+    });
+    expect(meta.alternates?.canonical).toBe(
+      "https://scontrinozero.it/guide/codici-natura-iva",
+    );
+  });
+
+  it("rispecchia title/description/url in Open Graph", async () => {
+    const article = guideArticles["registratore-di-cassa-prezzi"];
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "registratore-di-cassa-prezzi" }),
+    });
+    expect(meta.openGraph?.title).toBe(article.metaTitle);
+    expect(meta.openGraph?.description).toBe(article.metaDescription);
+    expect(meta.openGraph).toMatchObject({
+      url: "https://scontrinozero.it/guide/registratore-di-cassa-prezzi",
+      type: "article",
+    });
+  });
+
+  it("nessuno slug produce un title che riporta il suffisso brand", async () => {
+    for (const slug of guideSlugs) {
+      const meta = await generateMetadata({
+        params: Promise.resolve({ slug }),
+      });
+      expect(meta.title).toEqual({
+        absolute: guideArticles[slug].metaTitle,
+      });
+    }
+  });
+
+  // Il fallback era una stringa piana, quindi il template root ci appendeva un
+  // secondo suffisso: "Guida non trovata | ScontrinoZero | ScontrinoZero".
+  it("degrada su uno slug sconosciuto senza duplicare il suffisso brand", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "non-esiste" }),
+    });
+    expect(meta.title).toEqual({
+      absolute: "Guida non trovata | ScontrinoZero",
+    });
+  });
+});

--- a/src/app/(marketing)/guide/[slug]/page.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.tsx
@@ -20,6 +20,7 @@ import {
   isGuideSlug,
 } from "@/lib/guide/articles";
 import { AppScreenshot } from "@/components/marketing/app-screenshot";
+import { EditorialNote } from "@/components/marketing/editorial-note";
 import { helpArticles } from "@/lib/help/articles";
 import { isToolSlug, tools } from "@/lib/strumenti/tools";
 import { formatDate } from "@/lib/utils";
@@ -248,11 +249,7 @@ export default async function GuidePage({ params }: PageParams) {
             </>
           )}
 
-          <p className="text-muted-foreground mt-12 border-t pt-6 text-xs leading-relaxed">
-            {
-              "Informazione divulgativa, non sostituisce la consulenza del commercialista. Per situazioni specifiche verifica sempre la normativa aggiornata e il tuo codice ATECO."
-            }
-          </p>
+          <EditorialNote />
 
           <div className="bg-muted/40 border-border mt-10 rounded-lg border p-5 text-center">
             <p className="text-sm font-semibold">{"Pronto a provare?"}</p>

--- a/src/app/(marketing)/guide/[slug]/page.tsx
+++ b/src/app/(marketing)/guide/[slug]/page.tsx
@@ -39,11 +39,17 @@ export async function generateMetadata({
 }: PageParams): Promise<Metadata> {
   const { slug } = await params;
   if (!isGuideSlug(slug)) {
-    return { title: "Guida non trovata | ScontrinoZero" };
+    // Assoluto anche qui: da stringa piana il template root appenderebbe un
+    // secondo "| ScontrinoZero".
+    return { title: { absolute: "Guida non trovata | ScontrinoZero" } };
   }
   const g = guideArticles[slug];
   return {
-    title: g.metaTitle,
+    // Title assoluto: il template root ("%s | ScontrinoZero") aggiungerebbe 16
+    // caratteri a un metaTitle già vicino al troncamento SERP (~60), tagliando
+    // la coda della keyword senza nemmeno mostrare il brand. Il brand resta
+    // visibile via site name (webSiteJsonLd) e breadcrumb del dominio.
+    title: { absolute: g.metaTitle },
     description: g.metaDescription,
     openGraph: {
       title: g.metaTitle,

--- a/src/app/(marketing)/page.test.tsx
+++ b/src/app/(marketing)/page.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { HOME_COMPARISON_ROWS } from "./page";
+import { RT_COSTS } from "@/lib/marketing/rt-costs";
+
+/**
+ * La tabella comparativa della homepage è il claim sui costi del concorrente
+ * più letto del sito. Prima dichiarava un "Canone annuo €100–200" per il
+ * registratore telematico: quella cifra è un contratto di assistenza
+ * facoltativo, non un costo dovuto, e gonfiava di ~4x la spesa ricorrente.
+ * Le righe derivano ora da `src/lib/marketing/rt-costs.ts`.
+ */
+describe("HOME_COMPARISON_ROWS", () => {
+  const label = (l: string) => HOME_COMPARISON_ROWS.find((r) => r.label === l);
+
+  it("non dichiara più un canone annuo per il registratore telematico", () => {
+    for (const row of HOME_COMPARISON_ROWS) {
+      expect(row.label.toLowerCase()).not.toContain("canone annuo");
+      if (typeof row.competitor === "string") {
+        expect(row.competitor).not.toMatch(/100.?–.?200|100-200/);
+      }
+    }
+  });
+
+  it("deriva il costo hardware dalla fonte unica", () => {
+    const row = label("Costo acquisto hardware");
+    expect(row?.competitor).toBe(
+      `€${RT_COSTS.purchase.min}–${RT_COSTS.purchase.max}`,
+    );
+    expect(row?.ours).toBe("€0");
+  });
+
+  it("presenta la verificazione periodica come unico ricorrente obbligatorio", () => {
+    const row = label("Costi ricorrenti obbligatori");
+    expect(row).toBeDefined();
+    expect(row?.competitor).toContain(
+      `ogni ${RT_COSTS.periodicVerification.everyYears} anni`,
+    );
+    expect(row?.competitor).toContain(`${RT_COSTS.periodicVerification.min}`);
+  });
+
+  it("mantiene le righe booleane sui vincoli che l'RT impone", () => {
+    for (const l of ["Installazione tecnico", "Collaudo biennale"]) {
+      const row = label(l);
+      expect(row?.competitor, l).toBe(false);
+      expect(row?.ours, l).toBe(true);
+    }
+  });
+});

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -260,10 +260,10 @@ export default function Home() {
             </Link>
             {" · "}
             <Link
-              href="/guide/documento-commerciale-online"
+              href="/guide/sanzioni-mancato-scontrino"
               className="text-primary hover:underline"
             >
-              {"Documento commerciale online"}
+              {"Sanzioni mancato scontrino"}
             </Link>
             {" · "}
             <Link

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { JsonLd, faqPageJsonLd } from "@/components/json-ld";
 import { faqItems } from "@/components/marketing/faq-items";
 import { appHref } from "@/lib/marketing-to-app-href";
+import { RT_COSTS } from "@/lib/marketing/rt-costs";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -56,16 +57,19 @@ export const metadata: Metadata = {
   },
 };
 
-const HOME_COMPARISON_ROWS: readonly ComparisonRow[] = [
+export const HOME_COMPARISON_ROWS: readonly ComparisonRow[] = [
   {
     label: "Costo acquisto hardware",
-    competitor: "€400–800",
+    competitor: `€${RT_COSTS.purchase.min}–${RT_COSTS.purchase.max}`,
     ours: "€0",
   },
   {
-    label: "Canone annuo",
-    competitor: "€100–200",
-    ours: "da €29,99",
+    // Il costo ricorrente obbligatorio di un RT è la sola verificazione
+    // periodica: il "canone annuo €100-200" che stava qui è un contratto di
+    // assistenza facoltativo. Cifre da src/lib/marketing/rt-costs.ts.
+    label: "Costi ricorrenti obbligatori",
+    competitor: `€${RT_COSTS.periodicVerification.min}–${RT_COSTS.periodicVerification.max} ogni ${RT_COSTS.periodicVerification.everyYears} anni`,
+    ours: "da €29,99/anno",
   },
   {
     label: "Installazione tecnico",
@@ -175,8 +179,9 @@ export default function Home() {
             <div>
               <h2 className="text-2xl font-bold">Il problema</h2>
               <p className="text-muted-foreground mt-4 leading-relaxed">
-                I registratori telematici costano centinaia di euro, hanno
-                canoni annuali di manutenzione e occupano spazio sul bancone.
+                I registratori telematici costano centinaia di euro, richiedono
+                l&apos;installazione di un tecnico abilitato e una verificazione
+                periodica ogni due anni, e occupano spazio sul bancone.
                 <br />
                 <br />
                 Per un ambulante, un artigiano o una micro-attività è un costo

--- a/src/app/(marketing)/per/[slug]/page.test.tsx
+++ b/src/app/(marketing)/per/[slug]/page.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { generateMetadata } from "./page";
+import { categories, categorySlugs } from "@/lib/per/categories";
+
+/**
+ * Stessa ragione delle guide e degli articoli help: il template root
+ * ("%s | ScontrinoZero") aggiungerebbe 16 caratteri a un metaTitle già vicino
+ * al limite di troncamento SERP, tagliando la coda della keyword senza
+ * nemmeno mostrare il brand — visibile comunque via site name e breadcrumb.
+ */
+describe("generateMetadata (categoria /per)", () => {
+  it("dichiara il metaTitle come title assoluto su ogni categoria", async () => {
+    for (const slug of categorySlugs) {
+      const meta = await generateMetadata({
+        params: Promise.resolve({ slug }),
+      });
+      expect(meta.title).toEqual({ absolute: categories[slug].metaTitle });
+    }
+  });
+
+  it("imposta un canonical self-referential sotto /per", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "regime-forfettario" }),
+    });
+    expect(meta.alternates?.canonical).toBe(
+      "https://scontrinozero.it/per/regime-forfettario",
+    );
+  });
+
+  it("degrada su uno slug sconosciuto senza duplicare il suffisso brand", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "non-esiste" }),
+    });
+    expect(meta.title).toEqual({
+      absolute: "Categoria non trovata | ScontrinoZero",
+    });
+  });
+});

--- a/src/app/(marketing)/per/[slug]/page.tsx
+++ b/src/app/(marketing)/per/[slug]/page.tsx
@@ -33,11 +33,16 @@ export async function generateMetadata({
 }: PageParams): Promise<Metadata> {
   const { slug } = await params;
   if (!isCategorySlug(slug)) {
-    return { title: "Categoria non trovata | ScontrinoZero" };
+    // Assoluto: da stringa piana il template root appenderebbe un secondo
+    // "| ScontrinoZero".
+    return { title: { absolute: "Categoria non trovata | ScontrinoZero" } };
   }
   const category = categories[slug];
   return {
-    title: category.metaTitle,
+    // Title assoluto: il template root ("%s | ScontrinoZero") aggiungerebbe 16
+    // caratteri a un metaTitle già vicino al troncamento SERP (~60), tagliando
+    // la coda della keyword senza nemmeno mostrare il brand.
+    title: { absolute: category.metaTitle },
     description: category.metaDescription,
     openGraph: {
       title: category.metaTitle,

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
     const { default: sitemap } = await import("./sitemap");
     const result = sitemap();
 
-    expect(result).toHaveLength(86);
+    expect(result).toHaveLength(85);
 
     // Root
     expect(result[0]).toMatchObject({
@@ -111,7 +111,6 @@ describe("sitemap", () => {
     // Guide hub + articles
     expect(allUrls).toContain("https://scontrinozero.it/guide");
     const expectedGuideUrls = [
-      "https://scontrinozero.it/guide/documento-commerciale-online",
       "https://scontrinozero.it/guide/scontrino-senza-registratore-di-cassa",
       "https://scontrinozero.it/guide/differenza-scontrino-ricevuta-fattura",
       "https://scontrinozero.it/guide/pos-rt-obbligo-2026",
@@ -204,7 +203,7 @@ describe("sitemap", () => {
       "/strumenti",
       "/strumenti/scorporo-iva",
       "/guide",
-      "/guide/documento-commerciale-online",
+      "/guide/scontrino-senza-registratore-di-cassa",
       "/privacy",
       "/help",
     ]) {

--- a/src/components/help/related-articles.tsx
+++ b/src/components/help/related-articles.tsx
@@ -3,6 +3,7 @@ import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getRelatedArticles } from "@/lib/help/articles";
 import { appHref } from "@/lib/marketing-to-app-href";
+import { EditorialNote } from "@/components/marketing/editorial-note";
 
 interface RelatedHelpArticlesProps {
   readonly slug: string;
@@ -38,6 +39,8 @@ export function RelatedHelpArticles({ slug }: RelatedHelpArticlesProps) {
           </a>
         </Button>
       </div>
+
+      <EditorialNote />
     </>
   );
 }

--- a/src/components/json-ld.test.tsx
+++ b/src/components/json-ld.test.tsx
@@ -168,6 +168,23 @@ describe("organizationJsonLd", () => {
     expect(organizationJsonLd["@type"]).toBe("Organization");
   });
 
+  /**
+   * `knowsAbout` dichiara i domini di competenza dell'entità: è il segnale che
+   * i sistemi AI usano per decidere SU COSA questo sito è citabile. Costa nulla
+   * e non promette nulla di non spedito — descrive argomenti, non funzionalità.
+   */
+  it("dichiara i domini di competenza per l'entità", () => {
+    const topics = organizationJsonLd.knowsAbout.map((t) => t.toLowerCase());
+    expect(topics).toContain("documento commerciale online");
+    expect(topics).toContain("corrispettivi telematici");
+    expect(topics).toContain("regime forfettario");
+    expect(organizationJsonLd.knowsAbout.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("limita l'ambito geografico all'Italia (prodotto Italy-only)", () => {
+    expect(organizationJsonLd.areaServed).toBe("IT");
+  });
+
   it("has name ScontrinoZero", () => {
     expect(organizationJsonLd.name).toBe("ScontrinoZero");
   });

--- a/src/components/json-ld.test.tsx
+++ b/src/components/json-ld.test.tsx
@@ -469,13 +469,13 @@ describe("webApplicationJsonLd", () => {
 describe("guideArticleBreadcrumb", () => {
   it("produces a 3-level breadcrumb (Home → Guide → article)", () => {
     const ld = guideArticleBreadcrumb(
-      "documento-commerciale-online",
-      "Doc commerciale",
+      "scontrino-senza-registratore-di-cassa",
+      "Scontrino senza cassa",
     );
     expect(ld.itemListElement).toHaveLength(3);
     expect(ld.itemListElement[0].name).toBe("Home");
     expect(ld.itemListElement[1].name).toBe("Guide");
-    expect(ld.itemListElement[2].name).toBe("Doc commerciale");
+    expect(ld.itemListElement[2].name).toBe("Scontrino senza cassa");
   });
 
   it("article URL contains the slug under /guide", () => {

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -103,6 +103,25 @@ export const organizationJsonLd = {
   url: SITE_URL,
   logo: `${SITE_URL}/logo.png`,
   sameAs: ["https://github.com/dstmrk"],
+  // Ambito geografico: il prodotto copre solo la normativa fiscale italiana.
+  areaServed: "IT",
+  /**
+   * Domini di competenza dell'entità: è il segnale che i motori e i sistemi
+   * AI usano per stabilire SU COSA questo sito è una fonte pertinente, e
+   * quindi su quali domande è candidato a essere citato. Elenca argomenti su
+   * cui il sito ha contenuto editoriale reale — non funzionalità di prodotto,
+   * che vivono in `softwareApplicationJsonLd.featureList`.
+   */
+  knowsAbout: [
+    "Documento commerciale online",
+    "Scontrino elettronico",
+    "Corrispettivi telematici",
+    "Registratore telematico",
+    "Regime forfettario",
+    "Lotteria degli scontrini",
+    "Codici natura IVA",
+    "Agenzia delle Entrate - Fatture e Corrispettivi",
+  ],
   contactPoint: {
     "@type": "ContactPoint",
     contactType: "customer support",

--- a/src/components/marketing/breadcrumbs.test.tsx
+++ b/src/components/marketing/breadcrumbs.test.tsx
@@ -8,7 +8,7 @@ const ITEMS = [
   { name: "Guide", url: "https://scontrinozero.it/guide" },
   {
     name: "Documento commerciale online",
-    url: "https://scontrinozero.it/guide/documento-commerciale-online",
+    url: "https://scontrinozero.it/guide/scontrino-senza-registratore-di-cassa",
   },
 ];
 

--- a/src/components/marketing/editorial-note.test.tsx
+++ b/src/components/marketing/editorial-note.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EditorialNote } from "./editorial-note";
+import { CONTACT_EMAIL } from "@/lib/contact";
+
+describe("EditorialNote", () => {
+  it("dichiara che le norme sono citate con estremo e data", () => {
+    render(<EditorialNote />);
+    expect(screen.getByText(/estremo e data/i)).toBeInTheDocument();
+  });
+
+  it("mantiene il disclaimer di non sostituzione del commercialista", () => {
+    render(<EditorialNote />);
+    expect(screen.getByText(/non sostituisce/i)).toBeInTheDocument();
+    expect(screen.getByText(/commercialista/i)).toBeInTheDocument();
+  });
+
+  it("offre un canale per segnalare imprecisioni", () => {
+    render(<EditorialNote />);
+    const link = screen.getByRole("link", { name: CONTACT_EMAIL });
+    expect(link).toHaveAttribute("href", `mailto:${CONTACT_EMAIL}`);
+  });
+
+  /**
+   * Guard anti-overpromising. Un blocco di trasparenza che rivendica processi
+   * inesistenti — revisione di un professionista, cadenze di aggiornamento,
+   * certificazioni — è peggio di nessun blocco: è una promessa falsa su
+   * contenuto fiscale. Qui si dichiara solo ciò che è verificabile dal testo
+   * stesso (le norme citate con estremo e data) e ciò che è realmente offerto
+   * (un indirizzo a cui scrivere).
+   */
+  it("non rivendica processi editoriali che non esistono", () => {
+    const { container } = render(<EditorialNote />);
+    const testo = container.textContent ?? "";
+    for (const claim of [
+      /verificat[oa] da un (commercialista|professionista|esperto)/i,
+      /revisionat[oa] da/i,
+      /aggiornat[oa] (ogni|mensilmente|settimanalmente|trimestralmente)/i,
+      /certificat/i,
+      /garantiamo/i,
+      /rispondiamo entro/i,
+    ]) {
+      expect(testo, `claim non sostenibile: ${claim.source}`).not.toMatch(
+        claim,
+      );
+    }
+  });
+});

--- a/src/components/marketing/editorial-note.tsx
+++ b/src/components/marketing/editorial-note.tsx
@@ -1,0 +1,37 @@
+import { CONTACT_EMAIL } from "@/lib/contact";
+
+/**
+ * Nota di trasparenza in fondo ai contenuti editoriali (guide e articoli
+ * /help).
+ *
+ * **Perché esiste.** Su contenuto fiscale la fiducia è metà del valore: sia
+ * per i lettori, sia per i motori e i sistemi AI che devono decidere se
+ * citarci. Prima questa nota viveva inline solo nelle guide, mentre nessuno
+ * dei 28 articoli /help ne aveva una — pur trattando normativa (regime
+ * forfettario, obbligo POS 2026, aliquote IVA).
+ *
+ * **Cosa NON dice, deliberatamente.** Nessuna rivendicazione di revisione da
+ * parte di un professionista, nessuna cadenza di aggiornamento promessa,
+ * nessuna certificazione, nessun impegno sui tempi di risposta: sono processi
+ * che non esistono, e dichiararli su materia fiscale sarebbe una promessa
+ * falsa — peggio del non avere la nota. Qui si afferma solo ciò che è
+ * verificabile leggendo la pagina (le norme citate con estremo e data) e ciò
+ * che è realmente offerto (un indirizzo a cui segnalare errori). Un test
+ * presidia l'assenza di quelle rivendicazioni.
+ *
+ * La data di ultimo aggiornamento non è ripetuta qui: guide e articoli /help
+ * la mostrano già in testa, derivata dal registry.
+ */
+export function EditorialNote() {
+  return (
+    <p className="text-muted-foreground mt-12 border-t pt-6 text-xs leading-relaxed">
+      {
+        "Quando citiamo una norma indichiamo estremo e data, così puoi verificarla alla fonte. Informazione divulgativa: non sostituisce la consulenza del commercialista, e per situazioni specifiche vanno sempre verificati la normativa aggiornata e il tuo codice ATECO. Hai trovato un'imprecisione? Segnalacela a "
+      }
+      <a href={`mailto:${CONTACT_EMAIL}`} className="hover:underline">
+        {CONTACT_EMAIL}
+      </a>
+      {"."}
+    </p>
+  );
+}

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -9,14 +9,13 @@ import {
 } from "./articles";
 
 describe("guideSlugs", () => {
-  it("contains exactly 18 slugs", () => {
-    expect(guideSlugs).toHaveLength(18);
+  it("contains exactly 17 slugs", () => {
+    expect(guideSlugs).toHaveLength(17);
   });
 
   it("contains the expected slugs", () => {
     expect(guideSlugs).toEqual(
       expect.arrayContaining([
-        "documento-commerciale-online",
         "scontrino-senza-registratore-di-cassa",
         "differenza-scontrino-ricevuta-fattura",
         "pos-rt-obbligo-2026",
@@ -188,7 +187,7 @@ describe("guide inline screenshots", () => {
     readonly src: string;
   }> = [
     {
-      slug: "documento-commerciale-online",
+      slug: "scontrino-senza-registratore-di-cassa",
       src: "/screenshots/documento-commerciale.png",
     },
     {
@@ -521,8 +520,8 @@ describe("registratore-telematico-vs-documento-commerciale-online", () => {
 
 describe("getGuide", () => {
   it("returns the guide for a known slug", () => {
-    const a = getGuide("documento-commerciale-online");
-    expect(a.slug).toBe("documento-commerciale-online");
+    const a = getGuide("scontrino-senza-registratore-di-cassa");
+    expect(a.slug).toBe("scontrino-senza-registratore-di-cassa");
   });
 
   it("throws for an unknown slug", () => {
@@ -691,5 +690,62 @@ describe("costi RT: nessun claim di canone annuo obbligatorio", () => {
     const prezzi = prosa(guideArticles["registratore-di-cassa-prezzi"]);
     expect(prezzi).toMatch(/verificazione/i);
     expect(prezzi).toMatch(/ogni 2 anni/i);
+  });
+});
+
+/**
+ * `/guide/documento-commerciale-online` è stata fusa in
+ * `scontrino-senza-registratore-di-cassa` (agosto 2026). Le due guide
+ * coprivano lo stesso argomento e Google le teneva **entrambe** fuori
+ * dall'indice, lasciando le 454 impressioni del cluster "senza cassa" alla
+ * homepage, che le serviva a posizione 40. Il termine istituzionale "documento
+ * commerciale online" valeva 9 impressioni contro 454: la superstite è quella
+ * che parla la lingua di chi cerca, ma deve possedere anche il termine
+ * ufficiale, altrimenti la fusione ha perso contenuto.
+ */
+describe("fusione del cluster documento commerciale online", () => {
+  it("lo slug fuso non esiste più", () => {
+    expect(guideSlugs).not.toContain("documento-commerciale-online");
+  });
+
+  it("nessuna guida punta più allo slug rimosso", () => {
+    for (const slug of guideSlugs) {
+      expect(guideArticles[slug].relatedGuides, `guida ${slug}`).not.toContain(
+        "documento-commerciale-online",
+      );
+    }
+  });
+
+  const survivor = () => guideArticles["scontrino-senza-registratore-di-cassa"];
+
+  it("la superstite definisce il termine istituzionale e la sigla DCO", () => {
+    const testo = survivor()
+      .sections.map((s) => `${s.heading} ${s.body}`)
+      .join(" ");
+    expect(testo).toMatch(/documento commerciale online/i);
+    expect(testo).toMatch(/\bDCO\b/);
+  });
+
+  it("la superstite eredita il contenuto obbligatorio del documento", () => {
+    const testo = survivor()
+      .sections.map((s) => `${s.heading} ${s.body}`)
+      .join(" ");
+    expect(testo).toMatch(/numero progressivo/i);
+    expect(testo).toMatch(/codice lotteria/i);
+  });
+
+  it("la superstite eredita la base normativa datata", () => {
+    const testo = survivor()
+      .sections.map((s) => s.body)
+      .join(" ");
+    expect(testo).toContain("D.Lgs. 127/2015");
+    expect(testo).toContain("28 ottobre 2016");
+  });
+
+  it("la superstite eredita l'equivalenza fiscale con l'RT nelle FAQ", () => {
+    const faq = survivor()
+      .faq.map((f) => `${f.question} ${f.answer}`)
+      .join(" ");
+    expect(faq).toMatch(/stesso valore|fiscalmente equivalent/i);
   });
 });

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  type GuideSlug,
   getGuide,
   guideArticles,
   guideImageFrame,
@@ -645,5 +646,50 @@ describe("metaTitle allineati all'intento di ricerca (dati GSC 2026-08-05)", () 
     const t = guideArticles["scontrino-regime-forfettario"].metaTitle;
     expect(t.toLowerCase()).toContain("forfettario");
     expect(t.toLowerCase()).toContain("obbligatorio");
+  });
+});
+
+/**
+ * Il costo del registratore telematico è prosa in una decina di punti, quindi
+ * non è importabile da `src/lib/marketing/rt-costs.ts` come un dato
+ * strutturato. Questo guard è la versione applicabile della regola "doppia
+ * scrittura vietata": il framing sbagliato non può rientrare in silenzio.
+ *
+ * Da ritirare: il "canone annuo di manutenzione 100-200 €". Quella cifra è un
+ * contratto di assistenza FACOLTATIVO; il solo costo ricorrente obbligatorio è
+ * la verificazione periodica, 50-100 € ogni 2 anni. Presentarlo come canone
+ * dovuto gonfia di ~4x la spesa ricorrente del concorrente.
+ */
+describe("costi RT: nessun claim di canone annuo obbligatorio", () => {
+  const prosa = (a: (typeof guideArticles)[GuideSlug]) =>
+    [
+      a.heroIntro,
+      a.metaDescription,
+      ...a.sections.flatMap((s) => [s.body, ...(s.table?.rows.flat() ?? [])]),
+      ...a.faq.map((f) => f.answer),
+    ].join(" ");
+
+  const VIETATI = [
+    /canone annuo di manutenzione/i,
+    /100-200 € l'anno/i,
+    /€100-200 l'anno/i,
+    /100-200 €\/anno/i,
+  ];
+
+  for (const slug of guideSlugs) {
+    it(`${slug} non presenta i 100-200 € come canone annuo`, () => {
+      const testo = prosa(guideArticles[slug]);
+      for (const pattern of VIETATI) {
+        expect(testo, `guida ${slug}: "${pattern.source}"`).not.toMatch(
+          pattern,
+        );
+      }
+    });
+  }
+
+  it("la guida prezzi resta la sola a enumerare le voci di costo", () => {
+    const prezzi = prosa(guideArticles["registratore-di-cassa-prezzi"]);
+    expect(prezzi).toMatch(/verificazione/i);
+    expect(prezzi).toMatch(/ogni 2 anni/i);
   });
 });

--- a/src/lib/guide/articles.test.ts
+++ b/src/lib/guide/articles.test.ts
@@ -65,9 +65,12 @@ describe("guideArticles dictionary", () => {
         expect(a.title.length).toBeLessThanOrEqual(70);
       });
 
-      it("has metaTitle 30-70 chars", () => {
+      // 60 è il budget che Google rende in SERP prima di troncare. Il title è
+      // assoluto (nessun suffisso brand aggiunto dal template root), quindi il
+      // metaTitle è per intero ciò che l'utente legge nel risultato.
+      it("has metaTitle 30-60 chars (budget SERP)", () => {
         expect(a.metaTitle.length).toBeGreaterThanOrEqual(30);
-        expect(a.metaTitle.length).toBeLessThanOrEqual(70);
+        expect(a.metaTitle.length).toBeLessThanOrEqual(60);
       });
 
       it("has metaDescription 80-170 chars", () => {
@@ -592,5 +595,55 @@ describe("relatedTools slugs point to real tools", () => {
     expect(
       guideArticles["scontrino-regime-forfettario"].relatedTools,
     ).toContain("dicitura-regime-forfettario");
+  });
+});
+
+/**
+ * Le query di Search Console mostrano un divario netto fra posizione e CTR su
+ * alcune guide: il titolo non riprende le parole con cui l'utente cerca, o non
+ * anticipa la risposta. Questi test bloccano l'intento nel metaTitle, così una
+ * riscrittura futura non lo perde per strada.
+ */
+describe("metaTitle allineati all'intento di ricerca (dati GSC 2026-08-05)", () => {
+  // "quanto costa un registratore di cassa" (pos 13,7) e "registratori
+  // telematici costo" (pos 16,7): la domanda è un prezzo, il titolo risponde.
+  it("registratore-di-cassa-prezzi riprende la query e mostra la cifra", () => {
+    const t = guideArticles["registratore-di-cassa-prezzi"].metaTitle;
+    expect(t.toLowerCase()).toContain("quanto costa");
+    expect(t).toMatch(/\d/);
+  });
+
+  // "codice n2.2", "n2.2 iva", "codice iva n2.2": il codice esatto va in testa.
+  it("codici-natura-iva apre con il codice cercato", () => {
+    expect(guideArticles["codici-natura-iva"].metaTitle).toMatch(
+      /^Codice natura IVA N2\.2/,
+    );
+  });
+
+  // "differenza tra fattura e scontrino" (pos 11,9): mancava la parola chiave.
+  it("differenza-scontrino-ricevuta-fattura nomina la differenza", () => {
+    expect(
+      guideArticles[
+        "differenza-scontrino-ricevuta-fattura"
+      ].metaTitle.toLowerCase(),
+    ).toContain("differenza");
+  });
+
+  // "dove trovo gli scontrini nel cassetto fiscale" (pos 7,2, CTR 0%).
+  it("cassetto-fiscale-dove-trovare-scontrini riprende la formulazione della query", () => {
+    const t =
+      guideArticles[
+        "cassetto-fiscale-dove-trovare-scontrini"
+      ].metaTitle.toLowerCase();
+    expect(t).toContain("scontrini");
+    expect(t).toContain("cassetto fiscale");
+  });
+
+  // Il cluster forfettario vale 437 impressioni con 0 clic: il titolo deve
+  // rispondere "sì, è obbligatorio" invece di rimandare al contenuto.
+  it("scontrino-regime-forfettario anticipa la risposta nel titolo", () => {
+    const t = guideArticles["scontrino-regime-forfettario"].metaTitle;
+    expect(t.toLowerCase()).toContain("forfettario");
+    expect(t.toLowerCase()).toContain("obbligatorio");
   });
 });

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -1,5 +1,4 @@
 export const guideSlugs = [
-  "documento-commerciale-online",
   "scontrino-senza-registratore-di-cassa",
   "differenza-scontrino-ricevuta-fattura",
   "pos-rt-obbligo-2026",
@@ -77,81 +76,6 @@ export interface GuideArticle {
 }
 
 export const guideArticles: Record<GuideSlug, GuideArticle> = {
-  "documento-commerciale-online": {
-    slug: "documento-commerciale-online",
-    title: "Documento commerciale online: cos'è e come funziona",
-    metaTitle: "Documento commerciale online: cos'è e a cosa serve",
-    metaDescription:
-      "Cos'è il documento commerciale online (DCO), come si emette dal portale Fatture e Corrispettivi, base normativa e differenze rispetto al registratore telematico.",
-    heroIntro:
-      'Il documento commerciale online (DCO) è la versione digitale dello scontrino: lo si emette dal portale Agenzia delle Entrate "Fatture e Corrispettivi" senza bisogno di un registratore telematico fisico. È fiscalmente equivalente allo scontrino stampato e trasmette i corrispettivi all\'AdE in tempo reale.',
-    publishedAt: "2026-05-14",
-    updatedAt: "2026-05-14",
-    readingMinutes: 6,
-    sections: [
-      {
-        heading: "Cos'è il documento commerciale online",
-        body: 'Il documento commerciale online (DCO) è uno scontrino elettronico emesso direttamente dal portale "Fatture e Corrispettivi" dell\'Agenzia delle Entrate o da un software collegato. Sostituisce lo scontrino emesso da un registratore telematico, ed è fiscalmente equivalente a tutti gli effetti. Contiene gli stessi dati: progressivo, data e ora, dettaglio articoli, aliquote IVA, totale e – se richiesto – il codice lotteria del cliente.',
-      },
-      {
-        heading: "Base normativa",
-        body: "Il DCO è disciplinato dal Provvedimento dell'Agenzia delle Entrate del 28 ottobre 2016 n. 182017 e successive modifiche, e dall'articolo 2 del D.Lgs. 127/2015 che ha introdotto l'obbligo della memorizzazione e trasmissione telematica dei corrispettivi. L'Interpello AdE n. 956-1523/2020 ha confermato che l'uso di software di terze parti come \"velocizzatori\" della procedura web è ammesso, purché rispetti le prescrizioni normative.",
-      },
-      {
-        heading: "Quando si emette",
-        body: "Va emesso al momento del pagamento per ogni vendita al consumatore finale (B2C). Non sostituisce la fattura elettronica B2B verso altre partite IVA: in quel caso si emette comunque fattura tramite SDI. Per le vendite occasionali o le prestazioni di servizio rese al pubblico, il DCO è il documento corretto.",
-      },
-      {
-        heading: "Cosa contiene",
-        body: "Un DCO riporta obbligatoriamente: ragione sociale e partita IVA dell'esercente, data e ora di emissione, numero progressivo annuale, descrizione dei beni o servizi venduti, prezzo unitario, quantità, aliquota IVA per riga, totale corrispettivo, eventuale codice lotteria del cliente. La trasmissione all'AdE avviene istantaneamente al momento della conferma di emissione.",
-        image: {
-          src: "/screenshots/documento-commerciale.png",
-          alt: "Documento commerciale online con identificativo AdE, dettaglio articoli, aliquote IVA e totale",
-          width: 661,
-          height: 1188,
-          caption:
-            "Sul documento compaiono l'identificativo AdE, gli articoli con le aliquote IVA e il totale.",
-        },
-      },
-      {
-        heading: "Come si emette con ScontrinoZero",
-        body: "ScontrinoZero replica in automatico la procedura ufficiale del portale dell'Agenzia delle Entrate: inserisci gli articoli nel carrello, scegli il metodo di pagamento, opzionalmente aggiungi il codice lotteria del cliente, e tocca \"Emetti\". Il documento viene generato, firmato con le tue credenziali dell'Agenzia delle Entrate, trasmesso al portale AdE e archiviato nel tuo storico digitale. Tutto in 3-5 secondi.",
-      },
-      {
-        heading: "Vantaggi rispetto al registratore telematico",
-        body: "Il DCO emesso da software elimina i costi hardware iniziali (400-800 € per un RT), l'installazione da tecnico abilitato (100-200 € una tantum) e la verificazione periodica obbligatoria ogni 2 anni (50-100 € a intervento). In compenso richiede una connessione internet stabile e non è ottimale per attività con coda alla cassa: il vantaggio è massimo per attività mobili, stagionali o con volumi bassi/medi.",
-      },
-    ],
-    faq: [
-      {
-        question:
-          "Il documento commerciale online ha lo stesso valore dello scontrino del registratore telematico?",
-        answer:
-          "Sì. Sono fiscalmente equivalenti: stesso valore probatorio, stessi adempimenti di trasmissione, stessi diritti del cliente (garanzia, reso, lotteria). La differenza è solo nel mezzo di emissione: software vs hardware certificato.",
-      },
-      {
-        question:
-          "Serve ancora avere un registratore telematico se uso il DCO?",
-        answer:
-          "No, sono alternative. Se emetti tutti i corrispettivi tramite DCO da software, il registratore telematico non è necessario. Puoi tenerne uno fisico e affiancare il DCO per la mobilità, ma legalmente uno dei due basta.",
-      },
-      {
-        question: "Posso emettere DCO anche in regime forfettario?",
-        answer:
-          "Sì. Il regime forfettario non esonera dall'obbligo di emettere il documento commerciale per le vendite B2C. Sul documento va indicata la natura N2 (operazione non soggetta IVA, art. 1 c. 54-89 L. 190/2014) al posto dell'aliquota — il codice granulare N2.2 vale solo per la fattura elettronica — ma lo scontrino va comunque emesso e trasmesso.",
-      },
-    ],
-    relatedHelp: [
-      "primo-scontrino",
-      "come-collegare-ade",
-      "regime-forfettario",
-    ],
-    relatedGuides: [
-      "scontrino-senza-registratore-di-cassa",
-      "differenza-scontrino-ricevuta-fattura",
-    ],
-  },
-
   "scontrino-senza-registratore-di-cassa": {
     slug: "scontrino-senza-registratore-di-cassa",
     title: "Emettere scontrino senza registratore di cassa: si può?",
@@ -161,24 +85,20 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     heroIntro:
       "Sì, si può: da gennaio 2020 qualunque partita IVA può emettere lo scontrino elettronico senza registratore di cassa fisico, gratis dal portale \"Fatture e Corrispettivi\" dell'Agenzia delle Entrate oppure in pochi secondi con un'app dal telefono. Vediamo cosa serve, quanto costa e come scegliere l'app giusta.",
     publishedAt: "2026-05-14",
-    updatedAt: "2026-08-02",
+    updatedAt: "2026-08-05",
     readingMinutes: 8,
     sections: [
       {
         heading: "La premessa normativa",
-        body: "Il D.Lgs. 127/2015 e il Provvedimento AdE del 28 ottobre 2016 hanno introdotto la possibilità di emettere e memorizzare i corrispettivi senza un registratore telematico, usando una procedura web messa a disposizione dall'Agenzia delle Entrate. La trasmissione avviene direttamente al portale e ha lo stesso valore fiscale dello scontrino tradizionale.",
+        body: "Lo scontrino che emetti senza registratore di cassa si chiama, nel linguaggio dell'Agenzia delle Entrate, **documento commerciale online** (DCO): è uno scontrino elettronico emesso dal portale \"Fatture e Corrispettivi\" o da un software collegato, e sostituisce a tutti gli effetti quello del registratore telematico. La base normativa è l'articolo 2 del D.Lgs. 127/2015, che ha introdotto la memorizzazione e trasmissione telematica dei corrispettivi, e il Provvedimento AdE del 28 ottobre 2016 n. 182017. L'Interpello AdE n. 956-1523/2020 ha confermato che usare software di terze parti per velocizzare la procedura web è ammesso, purché ne rispetti le prescrizioni.",
       },
       {
         heading: "Cosa serve",
         body: "Serve una partita IVA attiva, credenziali Fisconline o SPID per accedere al portale AdE, una connessione internet stabile e un dispositivo (smartphone, tablet o PC). Non occorre hardware certificato, non occorre installazione da tecnico abilitato, non occorre alcun collaudo periodico.",
       },
       {
-        heading: "Procedura passo-passo dal portale AdE",
-        body: 'Accedi a Fatture e Corrispettivi con SPID o credenziali Fisconline. Nella sezione "Corrispettivi" scegli "Documento commerciale online". Inserisci gli articoli, le quantità e le aliquote IVA. Conferma il pagamento. Il documento viene generato, trasmesso e ti puoi stampare o inviare via email/QR al cliente. Tempo medio per emissione: 30-60 secondi.',
-      },
-      {
-        heading: "Procedura con un'app dedicata",
-        body: 'App come ScontrinoZero automatizzano la procedura: salvi il catalogo prodotti una volta, e in fase di emissione basta toccare gli articoli, scegliere il pagamento e premere "Emetti". L\'app si occupa di autenticarsi su AdE con le tue credenziali, di trasmettere il documento e di archiviarlo. Tempo medio: 5-10 secondi per scontrino.',
+        heading: "Come si emette: dal portale AdE o da un'app",
+        body: 'Dal portale è gratis ma lento. Accedi a Fatture e Corrispettivi con SPID o credenziali Fisconline, nella sezione "Corrispettivi" scegli "Documento commerciale online", inserisci articoli, quantità e aliquote IVA, conferma il pagamento: il documento viene generato, trasmesso e puoi stamparlo o inviarlo via email/QR al cliente. Tempo medio 30-60 secondi a scontrino. Un\'app dedicata automatizza gli stessi passaggi: app come ScontrinoZero salvano il catalogo prodotti una volta, poi in emissione basta toccare gli articoli, scegliere il pagamento e premere "Emetti" — l\'app si autentica su AdE con le tue credenziali, trasmette il documento e lo archivia. Tempo medio 5-10 secondi. La procedura fiscale è identica: cambia solo quanto tempo ci metti.',
         image: {
           src: "/screenshots/cassa-tastierino.png",
           alt: "Schermata Cassa di ScontrinoZero: tastierino per l'importo, quantità e aliquota IVA della riga",
@@ -191,6 +111,18 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         heading: "Quale app scegliere per lo scontrino elettronico",
         body: "La risposta secca: un'app che trasmetta il documento commerciale direttamente all'Agenzia delle Entrate con le tue credenziali, senza hardware aggiuntivo, con prezzo trasparente e prova gratuita. I criteri che contano nella scelta sono cinque: velocità di emissione (al banco contano i secondi, non i minuti), costo chiaro senza vincoli di durata né hardware da comprare, storico consultabile con i totali giornalieri, annullo dello scontrino direttamente dall'app, e assistenza raggiungibile quando qualcosa non va. ScontrinoZero è costruita esattamente su questi criteri: catalogo prodotti, emissione in pochi secondi, annullo e storico inclusi, da €29,99 l'anno con 30 giorni di prova senza carta. Per una checklist completa dei criteri vedi la guida alla scelta del software, linkata in fondo.",
+      },
+      {
+        heading: "Cosa contiene il documento commerciale",
+        body: "Un DCO riporta obbligatoriamente: ragione sociale e partita IVA dell'esercente, data e ora di emissione, numero progressivo annuale, descrizione dei beni o servizi venduti, prezzo unitario, quantità, aliquota IVA per riga, totale corrispettivo ed eventuale codice lotteria del cliente. La trasmissione all'Agenzia delle Entrate avviene nel momento in cui confermi l'emissione. Va emesso al pagamento per ogni vendita al consumatore finale: non sostituisce la fattura elettronica verso altre partite IVA, che continua a passare dal Sistema di Interscambio.",
+        image: {
+          src: "/screenshots/documento-commerciale.png",
+          alt: "Documento commerciale online emesso da ScontrinoZero, con progressivo, dettaglio delle righe, aliquote IVA e totale",
+          width: 900,
+          height: 1272,
+          caption:
+            "Il documento commerciale come lo riceve il cliente: progressivo, righe, aliquote e totale.",
+        },
       },
       {
         heading: "Quanto costa emettere scontrini senza registratore di cassa",
@@ -247,6 +179,18 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         question:
+          "Il documento commerciale online ha lo stesso valore dello scontrino del registratore telematico?",
+        answer:
+          "Sì. Sono fiscalmente equivalenti: stesso valore probatorio, stessi adempimenti di trasmissione, stessi diritti del cliente su garanzia, reso e lotteria. La differenza sta solo nel mezzo di emissione, software invece di hardware certificato.",
+      },
+      {
+        question:
+          "Serve ancora avere un registratore telematico se uso il DCO?",
+        answer:
+          "No, sono alternative. Se emetti tutti i corrispettivi tramite documento commerciale online da software, il registratore telematico non è necessario. Puoi tenerne uno fisico e affiancare il DCO per la mobilità, ma legalmente uno dei due basta.",
+      },
+      {
+        question:
           "Qual è la migliore app per fare scontrini senza registratore di cassa?",
         answer:
           "Quella che trasmette direttamente all'AdE con le tue credenziali, ha un prezzo trasparente e ti fa emettere in pochi secondi. Valuta velocità, costo annuo, storico e annullo inclusi, e la possibilità di provare gratis. ScontrinoZero copre tutti questi punti e si prova 30 giorni senza carta di credito.",
@@ -259,7 +203,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     ],
     relatedHelp: ["primo-scontrino", "credenziali-fisconline", "errori-ade"],
     relatedGuides: [
-      "documento-commerciale-online",
+      "differenza-scontrino-ricevuta-fattura",
       "scegliere-software-scontrini-elettronici",
       "scontrino-regime-forfettario",
     ],
@@ -325,7 +269,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "regime-forfettario",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
       "scontrino-regime-forfettario",
     ],
   },
@@ -388,8 +332,8 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     ],
     relatedHelp: ["pos-rt-obbligo", "normativa-pos-2026", "primo-scontrino"],
     relatedGuides: [
-      "documento-commerciale-online",
       "scontrino-senza-registratore-di-cassa",
+      "obbligo-scontrino-elettronico-2026",
     ],
   },
 
@@ -462,7 +406,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     ],
     relatedHelp: ["regime-forfettario", "aliquote-iva", "primo-scontrino"],
     relatedGuides: [
-      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
       "differenza-scontrino-ricevuta-fattura",
       "codici-natura-iva",
     ],
@@ -531,7 +475,6 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "pos-rt-obbligo",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
       "scontrino-senza-registratore-di-cassa",
       "pos-rt-obbligo-2026",
     ],
@@ -596,8 +539,8 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "cassetto-fiscale",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
       "scontrino-senza-registratore-di-cassa",
+      "annullare-scontrino-elettronico",
     ],
   },
 
@@ -687,7 +630,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "primo-scontrino",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
       "differenza-scontrino-ricevuta-fattura",
     ],
   },
@@ -761,7 +704,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "regime-forfettario",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
       "scontrino-regime-forfettario",
     ],
   },
@@ -828,7 +771,6 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "sicurezza-credenziali",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
       "scontrino-senza-registratore-di-cassa",
       "pos-rt-obbligo-2026",
     ],
@@ -1154,8 +1096,8 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       "come-collegare-ade",
     ],
     relatedGuides: [
-      "documento-commerciale-online",
       "scontrino-senza-registratore-di-cassa",
+      "scegliere-software-scontrini-elettronici",
     ],
   },
 
@@ -1223,7 +1165,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     ],
     relatedHelp: ["cassetto-fiscale", "storico-ed-esportazione", "errori-ade"],
     relatedGuides: [
-      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
       "chiusura-giornaliera-corrispettivi",
       "annullare-scontrino-elettronico",
     ],
@@ -1559,7 +1501,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     ],
     relatedHelp: ["pos-rt-obbligo", "chiusura-giornaliera", "primo-scontrino"],
     relatedGuides: [
-      "documento-commerciale-online",
+      "scontrino-senza-registratore-di-cassa",
       "migrare-da-registratore-telematico-a-software",
       "registratore-di-cassa-prezzi",
     ],

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -119,7 +119,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Vantaggi rispetto al registratore telematico",
-        body: "Il DCO emesso da software elimina i costi hardware iniziali (€400-800 per un RT), il canone annuo di manutenzione (€100-200), il collaudo biennale obbligatorio e l'installazione da tecnico abilitato. In compenso richiede una connessione internet stabile e non è ottimale per attività con coda alla cassa: il vantaggio è massimo per attività mobili, stagionali o con volumi bassi/medi.",
+        body: "Il DCO emesso da software elimina i costi hardware iniziali (400-800 € per un RT), l'installazione da tecnico abilitato (100-200 € una tantum) e la verificazione periodica obbligatoria ogni 2 anni (50-100 € a intervento). In compenso richiede una connessione internet stabile e non è ottimale per attività con coda alla cassa: il vantaggio è massimo per attività mobili, stagionali o con volumi bassi/medi.",
       },
     ],
     faq: [
@@ -194,7 +194,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Quanto costa emettere scontrini senza registratore di cassa",
-        body: "Da zero a poche decine di euro l'anno. Il portale Fatture e Corrispettivi dell'Agenzia delle Entrate è gratuito ma lento (30-60 secondi a scontrino); le app dedicate costano in genere 30-100 € l'anno e riducono l'emissione a pochi secondi. Il confronto con il registratore telematico fisico è netto: un RT costa 400-800 € di acquisto più 100-200 € l'anno di manutenzione e il collaudo biennale. La regola pratica: sotto le poche centinaia di scontrini al giorno, o se lavori in mobilità, lo scontrino senza cassa conviene quasi sempre; il registratore fisico resta più rapido solo al banco con code e alti volumi.",
+        body: "Da zero a poche decine di euro l'anno. Il portale Fatture e Corrispettivi dell'Agenzia delle Entrate è gratuito ma lento (30-60 secondi a scontrino); le app dedicate costano in genere 30-100 € l'anno e riducono l'emissione a pochi secondi. Il confronto con il registratore telematico fisico è netto: un RT costa 400-800 € di acquisto, più 100-200 € una tantum di installazione da tecnico abilitato e 50-100 € di verificazione periodica ogni 2 anni, cioè 550-1.100 € sul primo triennio. La regola pratica: sotto le poche centinaia di scontrini al giorno, o se lavori in mobilità, lo scontrino senza cassa conviene quasi sempre; il registratore fisico resta più rapido solo al banco con code e alti volumi.",
         table: {
           headers: [
             "Soluzione",
@@ -212,8 +212,8 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
             ],
             [
               "Registratore telematico",
-              "€400-800 + installazione",
-              "100-200 € + collaudo biennale",
+              "€400-800 + 100-200 € installazione",
+              "50-100 € ogni 2 anni (verificazione)",
               "istantaneo al banco",
             ],
           ],
@@ -254,7 +254,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Quanto costa fare scontrini senza registratore di cassa?",
         answer:
-          "Da zero: il portale Fatture e Corrispettivi dell'AdE è gratuito, ma richiede 30-60 secondi a scontrino. Un'app dedicata costa in genere 30-100 € l'anno (ScontrinoZero parte da €29,99) ed emette in pochi secondi. Un registratore telematico fisico costa invece 400-800 € di acquisto più 100-200 € l'anno.",
+          "Da zero: il portale Fatture e Corrispettivi dell'AdE è gratuito, ma richiede 30-60 secondi a scontrino. Un'app dedicata costa in genere 30-100 € l'anno (ScontrinoZero parte da €29,99) ed emette in pochi secondi. Un registratore telematico fisico costa invece 400-800 € di acquisto, più 100-200 € di installazione e 50-100 € di verificazione ogni 2 anni.",
       },
     ],
     relatedHelp: ["primo-scontrino", "credenziali-fisconline", "errori-ade"],
@@ -483,7 +483,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     sections: [
       {
         heading: "Perché valutare la migrazione",
-        body: "Un registratore telematico medio costa €400-800 di acquisto, €100-200 di canone annuo di manutenzione, una visita di collaudo biennale obbligatoria a pagamento e l'installazione iniziale da tecnico abilitato. Il documento commerciale online via software elimina hardware, canoni e collaudi. Per attività con volumi medi o bassi, oppure mobili (ambulanti, B&B, servizi a domicilio), il risparmio annuo è significativo e l'operatività diventa più flessibile.",
+        body: "Un registratore telematico medio costa 400-800 € di acquisto, 100-200 € di installazione iniziale da tecnico abilitato e una verificazione periodica obbligatoria ogni 2 anni (50-100 € a intervento); a questi si aggiunge, se lo sottoscrivi, un contratto di assistenza facoltativo. Il documento commerciale online via software elimina hardware, installazione e verificazioni. Per attività con volumi medi o bassi, oppure mobili (ambulanti, B&B, servizi a domicilio), il risparmio annuo è significativo e l'operatività diventa più flessibile.",
       },
       {
         heading: "Quando NON conviene migrare",
@@ -994,7 +994,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     sections: [
       {
         heading: "Serve una stampante fiscale? No",
-        body: "Con il documento commerciale online lo scontrino ha già valore fiscale nel momento in cui viene trasmesso all'Agenzia delle Entrate: la stampa su carta è solo una copia di cortesia per il cliente, nemmeno obbligatoria (puoi mostrare lo scontrino a schermo o inviarlo via email). Per questo non serve un registratore telematico omologato (400-800 € di hardware più 100-200 € l'anno di manutenzione), né va dichiarato nulla all'AdE: una qualsiasi stampante termica generica, la stessa usata per le ricevute dei POS bancari, fa il lavoro. È la differenza di costo più grande rispetto alla cassa tradizionale.",
+        body: "Con il documento commerciale online lo scontrino ha già valore fiscale nel momento in cui viene trasmesso all'Agenzia delle Entrate: la stampa su carta è solo una copia di cortesia per il cliente, nemmeno obbligatoria (puoi mostrare lo scontrino a schermo o inviarlo via email). Per questo non serve un registratore telematico omologato (400-800 € di hardware, più installazione e verificazione periodica ogni 2 anni), né va dichiarato nulla all'AdE: una qualsiasi stampante termica generica, la stessa usata per le ricevute dei POS bancari, fa il lavoro. È la differenza di costo più grande rispetto alla cassa tradizionale.",
       },
       {
         heading: "WiFi, Bluetooth o USB: il confronto",
@@ -1312,7 +1312,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
     metaDescription:
       "Un registratore telematico costa 400-800 € di acquisto, più 100-200 € di installazione e 50-100 € di verificazione ogni 2 anni. Le alternative software partono da 0 €.",
     heroIntro:
-      "Un registratore di cassa telematico costa 400-800 € di acquisto, più l'installazione del tecnico abilitato e la verificazione periodica biennale: sui 3 anni la spesa reale supera facilmente i 1.000 €. L'alternativa software (documento commerciale online) parte da 0 € col portale AdE o da pochi euro al mese con un'app. Vediamo tutte le voci di costo e quando conviene l'una o l'altra strada.",
+      "Un registratore di cassa telematico costa 400-800 € di acquisto, più l'installazione del tecnico abilitato e la verificazione periodica biennale: sui 3 anni la spesa reale sta fra 550 e 1.100 €. L'alternativa software (documento commerciale online) parte da 0 € col portale AdE o da pochi euro al mese con un'app. Vediamo tutte le voci di costo e quando conviene l'una o l'altra strada.",
     publishedAt: "2026-07-22",
     updatedAt: "2026-07-22",
     readingMinutes: 6,
@@ -1323,7 +1323,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       },
       {
         heading: "Il costo reale su 3 anni",
-        body: "Mettendo insieme le voci, un RT da 600 € con installazione a 150 € e una verificazione biennale a 80 € porta la spesa del primo triennio a circa 900-1.000 €, senza contare carta, eventuali riparazioni fuori garanzia e il tempo per gli adempimenti tecnici. È il numero da confrontare con le alternative software, che su 3 anni costano da 0 € (portale AdE) a circa 90-150 € (app in abbonamento).",
+        body: "Mettendo insieme le voci, un RT da 600 € con installazione a 150 € e una verificazione biennale a 80 € porta la spesa del primo triennio a 830 €, senza contare carta, eventuali riparazioni fuori garanzia e il tempo per gli adempimenti tecnici. La forbice tipica va da 550 € (modello base, installazione economica) a 1.100 € (fascia alta), a cui si aggiunge un contratto di assistenza solo se scegli di sottoscriverlo. È il numero da confrontare con le alternative software, che su 3 anni costano da 0 € (portale AdE) a circa 90-150 € (app in abbonamento).",
         table: {
           headers: ["Soluzione", "Costo iniziale", "Costo 3 anni (indicativo)"],
           rows: [
@@ -1362,7 +1362,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
       {
         question: "Quanto costa un registratore di cassa telematico?",
         answer:
-          "I modelli da banco più comuni costano 400-800 € di acquisto, a cui aggiungere 100-200 € di installazione da tecnico abilitato e 50-100 € di verificazione ogni 2 anni. Sui 3 anni la spesa complessiva è tipicamente di 900-1.200 €.",
+          "I modelli da banco più comuni costano 400-800 € di acquisto, a cui aggiungere 100-200 € di installazione da tecnico abilitato e 50-100 € di verificazione ogni 2 anni. Sui 3 anni la spesa complessiva è tipicamente di 550-1.100 €, contratto di assistenza facoltativo escluso.",
       },
       {
         question: "È obbligatorio comprare il registratore di cassa?",

--- a/src/lib/guide/articles.ts
+++ b/src/lib/guide/articles.ts
@@ -155,8 +155,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "scontrino-senza-registratore-di-cassa": {
     slug: "scontrino-senza-registratore-di-cassa",
     title: "Emettere scontrino senza registratore di cassa: si può?",
-    metaTitle:
-      "Scontrino senza cassa: come emetterlo senza registratore (2026)",
+    metaTitle: "Scontrino senza cassa: si può, ecco come farlo (2026)",
     metaDescription:
       "Sì, si può: dal 2020 emetti lo scontrino senza cassa né registratore telematico, dal portale AdE o con un'app dal telefono. Cosa serve, costi e come iniziare.",
     heroIntro:
@@ -269,7 +268,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "differenza-scontrino-ricevuta-fattura": {
     slug: "differenza-scontrino-ricevuta-fattura",
     title: "Differenza fra scontrino, ricevuta fiscale e fattura",
-    metaTitle: "Scontrino, ricevuta fiscale o fattura: quale emettere?",
+    metaTitle: "Differenza tra scontrino, ricevuta fiscale e fattura",
     metaDescription:
       "Le differenze pratiche fra scontrino elettronico, ricevuta fiscale e fattura: quando si usa cosa, esempi tipici per commercianti, artigiani e professionisti.",
     heroIntro:
@@ -397,8 +396,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "scontrino-regime-forfettario": {
     slug: "scontrino-regime-forfettario",
     title: "Scontrino in regime forfettario: cosa devi sapere",
-    metaTitle:
-      "Scontrino regime forfettario 2026: quando è obbligatorio e come",
+    metaTitle: "Scontrino regime forfettario: sì, è obbligatorio (2026)",
     metaDescription:
       "Sì, anche in regime forfettario lo scontrino ai privati è obbligatorio: si emette senza IVA con natura N2, anche senza registratore di cassa. Errori tipici e lotteria.",
     heroIntro:
@@ -838,8 +836,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "codici-natura-iva": {
     slug: "codici-natura-iva",
     title: "Codici natura IVA: cosa sono e quando si usano",
-    metaTitle:
-      "Codice natura IVA N2.2: significato, forfettario e tabella N1-N7",
+    metaTitle: "Codice natura IVA N2.2: cosa significa e tabella N1-N7",
     metaDescription:
       'N2.2 significa "operazione non soggetta a IVA - altri casi": il codice del forfettario in fattura elettronica. Tabella N1-N7, differenza con N2 e dicitura.',
     heroIntro:
@@ -1165,7 +1162,7 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "cassetto-fiscale-dove-trovare-scontrini": {
     slug: "cassetto-fiscale-dove-trovare-scontrini",
     title: "Dove trovare gli scontrini emessi nel portale AdE",
-    metaTitle: "Dove trovare gli scontrini nel cassetto fiscale (portale AdE)",
+    metaTitle: "Dove trovo gli scontrini nel cassetto fiscale: percorso",
     metaDescription:
       "Gli scontrini emessi non stanno nel cassetto fiscale ma in Fatture e Corrispettivi: il percorso per trovarli, verificarli e cosa vede il privato.",
     heroIntro:
@@ -1311,9 +1308,9 @@ export const guideArticles: Record<GuideSlug, GuideArticle> = {
   "registratore-di-cassa-prezzi": {
     slug: "registratore-di-cassa-prezzi",
     title: "Quanto costa un registratore di cassa nel 2026",
-    metaTitle: "Registratore di cassa: prezzi 2026 e alternative senza costi",
+    metaTitle: "Quanto costa un registratore di cassa: 400-800 € + canone",
     metaDescription:
-      "Un registratore telematico costa 400-800 € più 50-100 €/anno di gestione. Le alternative software partono da 0 €: tutti i prezzi a confronto e quando conviene cosa.",
+      "Un registratore telematico costa 400-800 € di acquisto, più 100-200 € di installazione e 50-100 € di verificazione ogni 2 anni. Le alternative software partono da 0 €.",
     heroIntro:
       "Un registratore di cassa telematico costa 400-800 € di acquisto, più l'installazione del tecnico abilitato e la verificazione periodica biennale: sui 3 anni la spesa reale supera facilmente i 1.000 €. L'alternativa software (documento commerciale online) parte da 0 € col portale AdE o da pochi euro al mese con un'app. Vediamo tutte le voci di costo e quando conviene l'una o l'altra strada.",
     publishedAt: "2026-07-22",

--- a/src/lib/help/articles.test.ts
+++ b/src/lib/help/articles.test.ts
@@ -42,6 +42,18 @@ describe("helpArticles registry", () => {
     }
   });
 
+  // Il title degli articoli help è assoluto (helpArticleMetadata), quindi il
+  // metaTitle è per intero ciò che Google rende: oltre i ~60 caratteri viene
+  // troncato e la coda della keyword si perde.
+  it("each metaTitle fits the SERP budget (≤ 60 chars)", () => {
+    for (const article of Object.values(helpArticles)) {
+      expect(
+        article.metaTitle.length,
+        `help ${article.slug}: "${article.metaTitle}"`,
+      ).toBeLessThanOrEqual(60);
+    }
+  });
+
   it("each title fits the Article headline limit (≤ 110 chars)", () => {
     for (const article of Object.values(helpArticles)) {
       expect(article.title.length).toBeLessThanOrEqual(110);

--- a/src/lib/help/articles.ts
+++ b/src/lib/help/articles.ts
@@ -246,8 +246,7 @@ export const helpArticles: Record<string, HelpArticle> = {
     datePublished: "2026-06-26",
     dateModified: "2026-07-13",
     title: "Presenta un amico: come funziona il bonus referral",
-    metaTitle:
-      "Presenta un amico: bonus referral e quando arriva il mese gratis",
+    metaTitle: "Presenta un amico: bonus referral e mese gratis",
     description:
       "Come funziona Presenta un amico: il presentato ottiene subito 1 mese di prova in più, il presentatore 1 mese sul piano quando l'invitato collega la P.IVA. Dove trovare e condividere il codice.",
     related: ["piani-e-prezzi", "cambio-piano", "contatto-assistenza"],

--- a/src/lib/help/metadata.test.ts
+++ b/src/lib/help/metadata.test.ts
@@ -3,10 +3,23 @@ import { helpArticleMetadata } from "./metadata";
 import { getHelpArticle, helpSlugs } from "./articles";
 
 describe("helpArticleMetadata", () => {
-  it("uses the article metaTitle as document title", () => {
+  it("uses the article metaTitle as absolute document title", () => {
     const article = getHelpArticle("regime-forfettario");
     const meta = helpArticleMetadata("regime-forfettario");
-    expect(meta.title).toBe(article.metaTitle);
+    expect(meta.title).toEqual({ absolute: article.metaTitle });
+  });
+
+  // Il template root aggiungerebbe "| ScontrinoZero" (16 caratteri) a un
+  // metaTitle già vicino al limite di troncamento SERP (~60): il brand non
+  // verrebbe comunque mostrato e la coda della keyword sparirebbe. Il title
+  // assoluto protegge il budget di caratteri su ogni articolo.
+  it("nessuno slug riporta il suffisso brand nel title", () => {
+    for (const slug of helpSlugs) {
+      const meta = helpArticleMetadata(slug);
+      expect(meta.title).toEqual({
+        absolute: getHelpArticle(slug).metaTitle,
+      });
+    }
   });
 
   it("uses the article description", () => {

--- a/src/lib/help/metadata.ts
+++ b/src/lib/help/metadata.ts
@@ -6,7 +6,14 @@ const SITE_URL = "https://scontrinozero.it";
 /**
  * Costruisce i metadata SEO di una pagina del centro assistenza dal registry
  * `helpArticles` (unica fonte di verità): titolo SEO, descrizione, canonical e
- * Open Graph. Il template root aggiunge il suffisso "| ScontrinoZero" al title.
+ * Open Graph.
+ *
+ * Il title è **assoluto**: bypassa il template root ("%s | ScontrinoZero"),
+ * che aggiungerebbe 16 caratteri di suffisso a un metaTitle già vicino al
+ * limite di troncamento della SERP (~60 caratteri). Con il suffisso il brand
+ * non verrebbe comunque mostrato e a essere tagliata sarebbe la coda della
+ * keyword; il brand resta visibile in SERP tramite il site name dichiarato in
+ * `webSiteJsonLd` e tramite il breadcrumb del dominio.
  *
  * Tenere i metadata qui evita la duplicazione tra il registry e i 23 file di
  * pagina e garantisce che canonical/OG siano presenti e coerenti ovunque.
@@ -15,7 +22,7 @@ export function helpArticleMetadata(slug: string): Metadata {
   const article = getHelpArticle(slug);
   const url = `${SITE_URL}/help/${slug}`;
   return {
-    title: article.metaTitle,
+    title: { absolute: article.metaTitle },
     description: article.description,
     openGraph: {
       title: article.metaTitle,

--- a/src/lib/marketing/rt-costs.test.ts
+++ b/src/lib/marketing/rt-costs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { RT_COSTS, rtThreeYearTotalRange, formatRtCostRange } from "./rt-costs";
+
+describe("RT_COSTS", () => {
+  it("tiene l'acquisto hardware nella fascia dei modelli da banco", () => {
+    expect(RT_COSTS.purchase.min).toBe(400);
+    expect(RT_COSTS.purchase.max).toBe(800);
+  });
+
+  it("tratta l'installazione come una tantum, non ricorrente", () => {
+    expect(RT_COSTS.installation.recurring).toBe(false);
+  });
+
+  // Il costo ricorrente OBBLIGATORIO è la verificazione periodica, ogni 2
+  // anni: è la voce che il copy presentava come "canone annuo €100-200",
+  // gonfiando di ~4x la spesa ricorrente del concorrente.
+  it("modella la verificazione come biennale, non annuale", () => {
+    expect(RT_COSTS.periodicVerification.everyYears).toBe(2);
+    expect(RT_COSTS.periodicVerification.min).toBe(50);
+    expect(RT_COSTS.periodicVerification.max).toBe(100);
+  });
+
+  it("marca il contratto di assistenza come facoltativo", () => {
+    expect(RT_COSTS.assistanceContract.optional).toBe(true);
+  });
+});
+
+describe("rtThreeYearTotalRange", () => {
+  // 400 + 100 + 50 = 550 · 800 + 200 + 100 = 1100, con una sola
+  // verificazione dentro il triennio (al 24° mese).
+  it("somma acquisto, installazione e una verificazione", () => {
+    expect(rtThreeYearTotalRange()).toEqual({ min: 550, max: 1100 });
+  });
+
+  it("resta ampiamente sopra il triennio di un abbonamento software", () => {
+    const { min } = rtThreeYearTotalRange();
+    const proTriennio = 49.99 * 3;
+    expect(min).toBeGreaterThan(proTriennio * 3);
+  });
+});
+
+describe("formatRtCostRange", () => {
+  it("formatta una fascia in euro con il separatore di migliaia italiano", () => {
+    expect(formatRtCostRange({ min: 550, max: 1100 })).toBe("550-1.100 €");
+  });
+
+  it("formatta senza separatore sotto il migliaio", () => {
+    expect(formatRtCostRange({ min: 400, max: 800 })).toBe("400-800 €");
+  });
+});

--- a/src/lib/marketing/rt-costs.ts
+++ b/src/lib/marketing/rt-costs.ts
@@ -1,0 +1,67 @@
+/**
+ * Costi del registratore telematico (RT) — fonte unica per tutto il marketing.
+ *
+ * Regola "doppia scrittura vietata" (skill `marketing-content`): questi numeri
+ * comparivano a mano in otto punti fra guide, categorie e tabella comparativa
+ * della homepage, e avevano già divergito. Chi cita un costo RT importa da qui.
+ *
+ * **Cosa è obbligatorio e cosa no.** Il costo ricorrente imposto dalla norma è
+ * la sola verificazione periodica, **ogni 2 anni**. Il "canone annuo di
+ * manutenzione" da 100-200 € che si legge in giro è un contratto di assistenza
+ * **facoltativo**: esiste sul mercato, ma non è dovuto, e presentarlo come
+ * ricorrente obbligatorio gonfia di circa 4x la spesa annua del concorrente.
+ * Il confronto con ScontrinoZero regge senza gonfiarlo — 550-1.100 € sul
+ * triennio contro ~90-150 € — quindi si usa la versione difendibile.
+ */
+
+export interface CostRange {
+  readonly min: number;
+  readonly max: number;
+}
+
+export const RT_COSTS = {
+  /** Acquisto del dispositivo: modelli da banco più comuni. */
+  purchase: { min: 400, max: 800, recurring: false },
+  /** Installazione e attivazione da tecnico abilitato: una tantum. */
+  installation: { min: 100, max: 200, recurring: false },
+  /** Verificazione periodica obbligatoria: unico costo ricorrente imposto. */
+  periodicVerification: { min: 50, max: 100, everyYears: 2, recurring: true },
+  /** Contratto di assistenza: diffuso ma non dovuto. Mai come "canone annuo". */
+  assistanceContract: { min: 100, max: 200, optional: true },
+} as const;
+
+/** Orizzonte su cui si confronta l'RT con un abbonamento software. */
+export const RT_COMPARISON_YEARS = 3;
+
+/**
+ * Spesa del primo triennio **senza** contratto di assistenza: acquisto +
+ * installazione + una verificazione (cade al 24° mese, quindi una sola dentro
+ * i 3 anni).
+ */
+export function rtThreeYearTotalRange(): CostRange {
+  const verifications = Math.floor(
+    RT_COMPARISON_YEARS / RT_COSTS.periodicVerification.everyYears,
+  );
+  return {
+    min:
+      RT_COSTS.purchase.min +
+      RT_COSTS.installation.min +
+      RT_COSTS.periodicVerification.min * verifications,
+    max:
+      RT_COSTS.purchase.max +
+      RT_COSTS.installation.max +
+      RT_COSTS.periodicVerification.max * verifications,
+  };
+}
+
+/**
+ * Formatta una fascia come "550-1.100 €".
+ *
+ * `useGrouping: true` è esplicito: il default ICU per l'italiano è "min2",
+ * che NON raggruppa i numeri di 4 cifre (1100 → "1100" invece di "1.100").
+ */
+export function formatRtCostRange(range: CostRange): string {
+  const fmt = (n: number) =>
+    n.toLocaleString("it-IT", { useGrouping: true } as const);
+  return `${fmt(range.min)}-${fmt(range.max)} €`;
+}

--- a/src/lib/per/categories.test.ts
+++ b/src/lib/per/categories.test.ts
@@ -59,9 +59,14 @@ describe("categories dictionary", () => {
         expect(c.title.length).toBeLessThanOrEqual(70);
       });
 
-      it("has metaTitle 30–70 chars", () => {
+      // Budget SERP: il title delle /per è assoluto (nessun suffisso brand dal
+      // template root), quindi il metaTitle è per intero ciò che Google rende.
+      it("has metaTitle 30–60 chars (budget SERP)", () => {
         expect(c.metaTitle.length).toBeGreaterThanOrEqual(30);
-        expect(c.metaTitle.length).toBeLessThanOrEqual(70);
+        expect(
+          c.metaTitle.length,
+          `per ${c.slug}: "${c.metaTitle}"`,
+        ).toBeLessThanOrEqual(60);
       });
 
       it("has metaDescription 80–170 chars", () => {
@@ -235,5 +240,27 @@ describe("relatedHelp slugs point to real help articles", () => {
         ).toContain(helpSlug);
       }
     }
+  });
+});
+
+/**
+ * `/per/regime-forfettario` e `/guide/scontrino-regime-forfettario` coprono lo
+ * stesso pubblico e per un periodo hanno avuto titoli quasi identici: la /per
+ * è finita fuori indice. Non è però un duplicato da rimuovere — è la landing
+ * commerciale del segmento (prezzo, benefici, obblighi) mentre la guida è
+ * quella educativa, ed è una delle card della griglia in homepage. La
+ * separazione si fa sull'intento del titolo: la guida risponde "devo?", la
+ * /per risponde "con cosa?".
+ */
+describe("separazione di intento sul cluster forfettario", () => {
+  it("la /per punta alla soluzione, non all'obbligo", async () => {
+    const { guideArticles } = await import("@/lib/guide/articles");
+    const perTitle = categories["regime-forfettario"].metaTitle;
+    const guideTitle = guideArticles["scontrino-regime-forfettario"].metaTitle;
+
+    expect(perTitle).not.toBe(guideTitle);
+    expect(perTitle.toLowerCase()).toMatch(/app|soluzione/);
+    expect(perTitle.toLowerCase()).not.toContain("obbligatorio");
+    expect(guideTitle.toLowerCase()).toContain("obbligatorio");
   });
 });

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -616,7 +616,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
     audience:
       "chioschi, bar e attività di ristorazione stagionali, asporto e delivery, piccole somministrazioni a basso volume",
     useCase:
-      "Siamo onesti: se hai un bar o un ristorante con fila alla cassa e decine di battute l'ora, il registratore telematico fisico resta più ergonomico — l'emissione del Documento Commerciale Online richiede qualche secondo per scontrino e non è pensata per il bancone ad alto flusso. ScontrinoZero è invece la scelta giusta per il segmento a basso volume della ristorazione: il chiosco estivo, il bar stagionale, l'asporto e il delivery, il food service a eventi. Lì elimini l'hardware (400-800 € più canoni) e fai tutto dallo smartphone.",
+      "Siamo onesti: se hai un bar o un ristorante con fila alla cassa e decine di battute l'ora, il registratore telematico fisico resta più ergonomico — l'emissione del Documento Commerciale Online richiede qualche secondo per scontrino e non è pensata per il bancone ad alto flusso. ScontrinoZero è invece la scelta giusta per il segmento a basso volume della ristorazione: il chiosco estivo, il bar stagionale, l'asporto e il delivery, il food service a eventi. Lì elimini l'hardware (400-800 €, più installazione e verificazioni periodiche) e fai tutto dallo smartphone.",
     obligations: [
       "Emissione del Documento Commerciale Online per ogni vendita o somministrazione B2C (art. 22 DPR 633/72).",
       "Aliquota IVA corretta: 10% per la somministrazione di alimenti e bevande, 22% per alcune vendite accessorie.",

--- a/src/lib/per/categories.ts
+++ b/src/lib/per/categories.ts
@@ -244,7 +244,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   "regime-forfettario": {
     slug: "regime-forfettario",
     title: "Scontrino elettronico in regime forfettario",
-    metaTitle: "Scontrino elettronico in regime forfettario",
+    metaTitle: "App per scontrini in regime forfettario",
     metaDescription:
       "Sei in regime forfettario? Emetti scontrini verso privati senza IVA e senza registratore fisico. Soluzione più economica del mercato, da €2,50/mese.",
     heroSubtitle:
@@ -651,8 +651,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   negozi: {
     slug: "negozi",
     title: "Scontrino elettronico per piccoli negozi al dettaglio",
-    metaTitle:
-      "Scontrino elettronico per negozi al dettaglio senza registratore",
+    metaTitle: "Scontrino elettronico per negozi al dettaglio",
     metaDescription:
       "Piccolo negozio, atelier o showroom: emetti scontrini elettronici senza registratore telematico, da smartphone o tablet. Da €2,50/mese, prova gratis.",
     heroSubtitle:
@@ -739,7 +738,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   fioristi: {
     slug: "fioristi",
     title: "Scontrino elettronico per fioristi e garden",
-    metaTitle: "Scontrino elettronico per fioristi senza registratore di cassa",
+    metaTitle: "Scontrino elettronico per fioristi e vivai",
     metaDescription:
       "Fioreria o banco fiori: emetti scontrini elettronici dallo smartphone, anche a domicilio o al mercato, senza registratore telematico. Da €2,50/mese.",
     heroSubtitle:
@@ -873,8 +872,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   fotografi: {
     slug: "fotografi",
     title: "Scontrino elettronico per fotografi",
-    metaTitle:
-      "Scontrino elettronico per fotografi senza registratore di cassa",
+    metaTitle: "Scontrino elettronico per fotografi e studi foto",
     metaDescription:
       "Servizi fotografici, stampe ed eventi: emetti lo scontrino elettronico dallo smartphone al momento dell'incasso, senza registratore. Da €2,50/mese.",
     heroSubtitle:
@@ -917,8 +915,7 @@ export const categories: Record<CategorySlug, CategoryContent> = {
   toelettatura: {
     slug: "toelettatura",
     title: "Scontrino elettronico per toelettature e pet service",
-    metaTitle:
-      "Scontrino elettronico per toelettatura cani e gatti senza cassa",
+    metaTitle: "Scontrino elettronico per toelettatura animali",
     metaDescription:
       "Toelettatura, pet sitting e servizi per animali: scontrini elettronici senza registratore, con listino servizi nel catalogo. Da €2,50/mese, prova gratis.",
     heroSubtitle:


### PR DESCRIPTION
Il template root ("%s | ScontrinoZero") aggiungeva 16 caratteri di suffisso
brand a metaTitle già lunghi 54-64: il <title> reale arrivava a 70-80
caratteri contro i ~60 che Google mostra. Risultato: la coda della keyword
veniva tagliata e il brand non compariva comunque.

Il report Search Console del 5 agosto mostra l'effetto su pagine ben
posizionate ma con CTR fuori scala: /guide/registratore-di-cassa-prezzi
0,36% a posizione 9,1 · /guide/codici-natura-iva 0,49% a 10,6 ·
/guide/cassetto-fiscale-dove-trovare-scontrini 0,77% a 8,8.

Guide e articoli help dichiarano ora un title `absolute`, che bypassa il
template e libera il budget di caratteri per la keyword. Il brand resta
visibile in SERP tramite il site name (webSiteJsonLd) e il breadcrumb del
dominio; le pagine hub continuano a usare il template.

Corretto anche il fallback dello slug sconosciuto: da stringa piana il
template appendeva un secondo suffisso ("Guida non trovata | ScontrinoZero
| ScontrinoZero").

Aggiunto src/app/(marketing)/guide/[slug]/page.test.tsx, prima suite sul
generateMetadata delle guide.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Cv2KvG76ozJXw2unHMfRJ