### PR TITLE
docs(help): /help/api documenta solo il formato d'errore attuale, niente storico

### DIFF
--- a/src/app/(marketing)/help/api/page.tsx
+++ b/src/app/(marketing)/help/api/page.tsx
@@ -806,16 +806,6 @@ const idempotencyKey = crypto.randomUUID();`}</code>
             }
           </li>
         </ul>
-        <div className="border-primary/40 bg-primary/5 mt-4 rounded-md border-l-4 p-4">
-          <p className="text-sm leading-relaxed font-medium">
-            Aggiornamento dell&apos;envelope d&apos;errore
-          </p>
-          <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-            {
-              "Fino alla versione 1.5.x gli errori usavano il campo error al posto di message, e il code era presente solo su alcune risposte. Dalla 1.6.0, se il tuo client legge body.error, spostalo su body.message (o meglio su body.code). Controlla anche la gestione del 503 ADE_UNAVAILABLE, descritto qui sotto: prima quel caso arrivava come 422."
-            }
-          </p>
-        </div>
         <p className="text-muted-foreground mt-4 text-sm leading-relaxed">
           {
             "Quando una risposta include l'header Retry-After, l'errore è temporaneo: attendi i secondi indicati e ripeti la richiesta "


### PR DESCRIPTION
Follow-up di #780 (envelope `{ code, message, requestId }`, già in `main`).

## Cosa cambia

Rimuove dalla pagina pubblica `/help/api` il box "Aggiornamento dell'envelope d'errore", che raccontava com'era il formato prima della 1.6.0.

Su una pagina di riferimento pubblica lo storico invecchia male e distrae chi sta integrando oggi: la pagina descrive il formato corrente e basta. La guida di migrazione (badge di versione + tabella prima/ora) resta in `DEVELOPER.md`, dove chi deve adeguare un client esistente la cerca apposta.

Diff: **1 file, 10 righe rimosse**. Nessun cambiamento di codice.

## Verifica

`npm run type-check` · `npm run lint` · `npx prettier --check src/` verdi; suite completa 4231 test verdi.

Verificato che non restino altri riferimenti storici nella pagina — la riga della tabella per `503 ADE_UNAVAILABLE` già spiegava il caso senza citare il vecchio `422`.

## Nota sul quality gate

SonarCloud riporta `0.0% Coverage on New Code`: è corretto e non è un'anomalia. L'unico file toccato è `src/app/(marketing)/help/api/page.tsx`, che sta in `sonar.coverage.exclusions`, quindi `new_lines_to_cover = 0` e la condizione passa a vuoto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uEfKgEiF3t5bnjr8sAa14