### PR TITLE
fix(business): normalizza la provincia in maiuscolo prima di scriverla

### DIFF
--- a/.claude/skills/ade-integration/SKILL.md
+++ b/.claude/skills/ade-integration/SKILL.md
@@ -116,6 +116,31 @@ frontend: la response `text/x-component` contiene il JSON `{ error }` — da lì
 si risale al messaggio in `error-messages.ts` e quindi alla classe d'errore
 esatta, prima ancora di aprire i log server.
 
+### Failure mode noto: dato del cedente non normalizzato (`EF0`)
+
+`{"esito": false, "errori": [{"codice": "EF0", "descrizione": "'<Campo>' non valido"}]}`
+= l'AdE ha rifiutato un campo del cedente/prestatore, non il documento. È un
+errore d'**input utente** (regola 20: `warn`, non issue Sentry), ma permanente:
+ogni emissione continua a fallire finché il dato in DB non viene corretto.
+
+`buildCedenteFromBusiness` (`src/lib/ade/mapper.ts`) inoltra i campi di
+`businesses` **verbatim**, quindi l'AdE valida ciò che abbiamo salvato. Caso
+reale: `province = "na"` minuscolo → `EF0 'Provincia' non valido` su tutti gli
+scontrini di un'attività, per settimane, senza che nulla nel codice fosse
+rotto. L'AdE vuole la sigla maiuscola.
+
+Regola generale: **ogni campo che finisce verbatim in un payload AdE va
+normalizzato alla scrittura**, non a read-time nel mapper. Il mapper resta
+puro (un solo punto di verità: quello che c'è in DB è già nel formato AdE);
+normalizzano le server action che scrivono `businesses` — `saveBusiness`
+(onboarding) e `updateBusiness` (settings), entrambe via `normalizeProvince`
+in `src/lib/validation.ts`. Aggiungendo un campo al cedente, chiedersi
+sempre: che formato pretende l'AdE, e chi lo garantisce alla scrittura?
+
+Diagnosi: la risposta AdE è persistita in `commercial_documents.ade_response`,
+quindi un `SELECT` sui documenti `REJECTED` di un business dà il codice e il
+campo esatti senza toccare i log.
+
 ---
 
 ## HAR analysis: completezza, non solo ordine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,6 +1478,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1494,6 +1495,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1510,6 +1512,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1526,6 +1529,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1542,6 +1546,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1558,6 +1563,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1574,6 +1580,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,6 +1597,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,6 +1614,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1622,6 +1631,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1638,6 +1648,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1654,6 +1665,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,6 +1682,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1686,6 +1699,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1702,6 +1716,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1718,6 +1733,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1734,6 +1750,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1750,6 +1767,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1766,6 +1784,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1782,6 +1801,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1798,6 +1818,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1814,6 +1835,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1830,6 +1852,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1846,6 +1869,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1862,6 +1886,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1878,6 +1903,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11433,7 +11459,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -14113,9 +14139,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",
     "vite": "^8.0.5",
     "yaml": ">=2.8.3",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "sharp": "^0.35.0",
     "picomatch": "4.0.4",
     "express-rate-limit": "^8.5.1",

--- a/src/app/(marketing)/help/prima-configurazione/page.tsx
+++ b/src/app/(marketing)/help/prima-configurazione/page.tsx
@@ -137,8 +137,9 @@ export default function PrimaConfigurazioneePage() {
           </li>
           <li>
             <strong>Indirizzo sede operativa</strong> — indirizzo, numero
-            civico, CAP (5 cifre), città e provincia. L&apos;indirizzo è
-            obbligatorio e apparirà nell&apos;intestazione degli scontrini.
+            civico, CAP (5 cifre), città e provincia (sigla di 2 lettere, es.
+            RM). L&apos;indirizzo è obbligatorio e apparirà
+            nell&apos;intestazione degli scontrini.
           </li>
         </ul>
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">

--- a/src/app/onboarding/onboarding-form.tsx
+++ b/src/app/onboarding/onboarding-form.tsx
@@ -5,7 +5,11 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
-import { adePinSchema, italianZipCodeSchema } from "@/lib/validation";
+import {
+  adePinSchema,
+  italianProvinceSchema,
+  italianZipCodeSchema,
+} from "@/lib/validation";
 import { objectToFormData } from "@/lib/form-utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -45,7 +49,7 @@ const step1Schema = z.object({
   streetNumber: z.string().optional(),
   zipCode: italianZipCodeSchema,
   city: z.string().optional(),
-  province: z.string().optional(),
+  province: italianProvinceSchema.optional(),
   preferredVatCode: z.string().optional(),
 });
 

--- a/src/components/settings/edit-business-section.test.tsx
+++ b/src/components/settings/edit-business-section.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { EditBusinessSection } from "./edit-business-section";
+import { ITALIAN_PROVINCE_MESSAGE } from "@/lib/validation";
+
+const mockUpdateBusiness = vi.fn();
+vi.mock("@/server/profile-actions", () => ({
+  updateBusiness: (fd: FormData) => mockUpdateBusiness(fd),
+}));
+
+const mockRouterRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateBusiness.mockResolvedValue({});
+});
+
+function renderSection(province: string | null = "NA") {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <EditBusinessSection
+        businessId="biz-1"
+        businessName="Bar Centrale"
+        address="Via Roma"
+        streetNumber="1"
+        city="Napoli"
+        province={province}
+        zipCode="80100"
+        preferredVatCode="22"
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function openDialog() {
+  fireEvent.click(screen.getByRole("button", { name: "Modifica attività" }));
+}
+
+function setProvince(value: string) {
+  fireEvent.change(screen.getByLabelText("Prov."), { target: { value } });
+}
+
+function submit() {
+  fireEvent.click(screen.getByRole("button", { name: "Salva" }));
+}
+
+describe("EditBusinessSection", () => {
+  it("precompila la provincia dai dati dell'attività", () => {
+    renderSection();
+    openDialog();
+
+    expect(screen.getByLabelText("Prov.")).toHaveValue("NA");
+  });
+
+  // Il guard client esiste per NON far scoprire l'errore all'utente dopo
+  // l'emissione: senza, l'AdE rigetta lo scontrino con
+  // `EF0 — 'Provincia' non valido` e la vendita non viene registrata.
+  it("blocca il submit quando la provincia non è una sigla di 2 lettere", async () => {
+    renderSection();
+    openDialog();
+    setProvince("ROMA");
+    submit();
+
+    expect(await screen.findByText(ITALIAN_PROVINCE_MESSAGE)).toBeVisible();
+    expect(mockUpdateBusiness).not.toHaveBeenCalled();
+  });
+
+  it("blocca il submit su una sigla di una sola lettera", async () => {
+    renderSection();
+    openDialog();
+    setProvince("N");
+    submit();
+
+    expect(await screen.findByText(ITALIAN_PROVINCE_MESSAGE)).toBeVisible();
+    expect(mockUpdateBusiness).not.toHaveBeenCalled();
+  });
+
+  // Il maiuscolo lo impone il server (`normalizeProvince`): il client accetta
+  // il minuscolo senza infastidire l'utente con un errore evitabile.
+  it("accetta una sigla minuscola e la invia alla server action", async () => {
+    renderSection();
+    openDialog();
+    setProvince("na");
+    submit();
+
+    await waitFor(() => expect(mockUpdateBusiness).toHaveBeenCalled());
+    const fd = mockUpdateBusiness.mock.calls[0][0] as FormData;
+    expect(fd.get("province")).toBe("na");
+  });
+
+  it("accetta la provincia vuota (campo opzionale)", async () => {
+    renderSection(null);
+    openDialog();
+    setProvince("");
+    submit();
+
+    await waitFor(() => expect(mockUpdateBusiness).toHaveBeenCalled());
+    const fd = mockUpdateBusiness.mock.calls[0][0] as FormData;
+    expect(fd.get("province")).toBe("");
+  });
+
+  it("limita il campo a 2 caratteri", () => {
+    renderSection();
+    openDialog();
+
+    expect(screen.getByLabelText("Prov.")).toHaveAttribute("maxLength", "2");
+  });
+});

--- a/src/components/settings/edit-business-section.tsx
+++ b/src/components/settings/edit-business-section.tsx
@@ -24,7 +24,10 @@ import {
 } from "@/components/ui/select";
 import { updateBusiness } from "@/server/profile-actions";
 import { ERROR_MESSAGES } from "@/lib/error-messages";
-import { BUSINESS_PROFILE_LIMITS } from "@/lib/validation";
+import {
+  BUSINESS_PROFILE_LIMITS,
+  italianProvinceSchema,
+} from "@/lib/validation";
 import {
   isValidPreferredVatCode,
   VAT_CODES,
@@ -69,14 +72,7 @@ const editBusinessSchema = z.object({
     )
     .optional()
     .or(z.literal("")),
-  province: z
-    .string()
-    .max(
-      BUSINESS_PROFILE_LIMITS.province,
-      `La provincia non può superare ${BUSINESS_PROFILE_LIMITS.province} caratteri.`,
-    )
-    .optional()
-    .or(z.literal("")),
+  province: italianProvinceSchema.optional(),
   zipCode: z.string().regex(/^\d{5}$/, "CAP non valido (5 cifre numeriche)."),
   preferredVatCode: z.enum(VAT_CODES).or(z.literal("")).optional(),
 });
@@ -267,6 +263,8 @@ export function EditBusinessSection({
             control={form.control}
             name="province"
             label="Prov."
+            placeholder="RM…"
+            maxLength={2}
             autoComplete="address-level1"
             disabled={mutation.isPending}
           />

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -5,10 +5,14 @@ import {
   isValidEmail,
   isStrongPassword,
   isValidLotteryCode,
+  isValidItalianProvince,
   isValidItalianZipCode,
   isSafeRelativeRedirect,
+  italianProvinceSchema,
   italianZipCodeSchema,
   normalizeEmail,
+  normalizeProvince,
+  ITALIAN_PROVINCE_MESSAGE,
   ITALIAN_ZIP_MESSAGE,
 } from "./validation";
 
@@ -16,6 +20,8 @@ describe("BUSINESS_PROFILE_LIMITS", () => {
   // Snapshot dei valori canonici: cambiarli qui (con motivazione) si propaga
   // a server actions, Zod schema client e label UI senza drift.
   it("definisce i limiti attuali per ogni campo", () => {
+    // `province` NON è qui: non ha un limite di lunghezza ma un formato
+    // esatto (sigla di 2 lettere) — vedi `italianProvinceSchema`.
     expect(BUSINESS_PROFILE_LIMITS).toEqual({
       firstName: 80,
       lastName: 80,
@@ -23,7 +29,6 @@ describe("BUSINESS_PROFILE_LIMITS", () => {
       address: 150,
       streetNumber: 20,
       city: 80,
-      province: 3,
     });
   });
 
@@ -276,5 +281,88 @@ describe("italianZipCodeSchema", () => {
     const result = italianZipCodeSchema.safeParse("12");
     expect(result.success).toBe(false);
     expect(result.error?.issues[0]?.message).toBe(ITALIAN_ZIP_MESSAGE);
+  });
+});
+
+describe("normalizeProvince", () => {
+  // Regressione prod: una sigla salvata minuscola ("na") viene rifiutata
+  // dall'AdE con EF0 "'Provincia' non valido", perché il mapper la inoltra
+  // verbatim nel cedente. La sigla va normalizzata maiuscola alla scrittura.
+  it("porta la sigla in maiuscolo", () => {
+    expect(normalizeProvince("na")).toBe("NA");
+  });
+
+  it("normalizza anche il case misto", () => {
+    expect(normalizeProvince("Na")).toBe("NA");
+  });
+
+  it("rimuove gli spazi attorno alla sigla", () => {
+    expect(normalizeProvince("  na  ")).toBe("NA");
+  });
+
+  it("è idempotente su una sigla già normalizzata", () => {
+    expect(normalizeProvince("NA")).toBe("NA");
+  });
+
+  it("restituisce null su stringa vuota", () => {
+    expect(normalizeProvince("")).toBeNull();
+  });
+
+  it("restituisce null su soli spazi", () => {
+    expect(normalizeProvince("   ")).toBeNull();
+  });
+
+  it("restituisce null su null (campo opzionale non compilato)", () => {
+    expect(normalizeProvince(null)).toBeNull();
+  });
+});
+
+describe("isValidItalianProvince", () => {
+  it("accetta una sigla maiuscola", () => {
+    expect(isValidItalianProvince("NA")).toBe(true);
+  });
+
+  it("accetta una sigla minuscola (la normalizzazione avviene a monte)", () => {
+    expect(isValidItalianProvince("na")).toBe(true);
+  });
+
+  it("rifiuta una sigla di una sola lettera", () => {
+    expect(isValidItalianProvince("N")).toBe(false);
+  });
+
+  it("rifiuta il nome esteso della provincia", () => {
+    expect(isValidItalianProvince("ROMA")).toBe(false);
+  });
+
+  it("rifiuta sigle di 3 lettere (nessuna provincia italiana le usa)", () => {
+    expect(isValidItalianProvince("NAP")).toBe(false);
+  });
+
+  it("rifiuta cifre", () => {
+    expect(isValidItalianProvince("N1")).toBe(false);
+  });
+
+  it("rifiuta lettere accentate", () => {
+    expect(isValidItalianProvince("NÀ")).toBe(false);
+  });
+
+  it("rifiuta la stringa vuota", () => {
+    expect(isValidItalianProvince("")).toBe(false);
+  });
+});
+
+describe("italianProvinceSchema", () => {
+  it("accetta una sigla valida", () => {
+    expect(italianProvinceSchema.safeParse("NA").success).toBe(true);
+  });
+
+  it("accetta la stringa vuota (campo opzionale)", () => {
+    expect(italianProvinceSchema.safeParse("").success).toBe(true);
+  });
+
+  it("rifiuta input invalido con il messaggio canonico", () => {
+    const result = italianProvinceSchema.safeParse("ROMA");
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(ITALIAN_PROVINCE_MESSAGE);
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -101,10 +101,54 @@ export const italianZipCodeSchema = z
   .regex(ITALIAN_ZIP_REGEX, ITALIAN_ZIP_MESSAGE);
 
 /**
+ * Sigla della provincia italiana: esattamente 2 lettere.
+ *
+ * L'AdE la vuole **maiuscola** nel cedente/prestatore del Documento
+ * Commerciale: una sigla minuscola fa fallire l'emissione con
+ * `EF0 — 'Provincia' non valido`. Il case è accettato in input (la
+ * normalizzazione avviene alla scrittura, vedi `normalizeProvince`) ma il
+ * formato no: nessuna provincia italiana ha una sigla di 1 o 3 lettere.
+ */
+const ITALIAN_PROVINCE_REGEX = /^[A-Za-z]{2}$/;
+export const ITALIAN_PROVINCE_MESSAGE =
+  "Provincia non valida: usa la sigla di 2 lettere (es. NA).";
+
+export function isValidItalianProvince(province: string): boolean {
+  return ITALIAN_PROVINCE_REGEX.test(province);
+}
+
+/**
+ * Normalizza la sigla della provincia: trim + maiuscolo, `null` se vuota.
+ *
+ * Va applicata in **ogni** scrittura di `businesses.province` (onboarding e
+ * modifica attività) prima della validazione e dell'UPDATE: è l'unico punto
+ * che garantisce l'invariante "in DB la sigla è sempre maiuscola", su cui si
+ * appoggia `buildCedenteFromBusiness` che inoltra il valore verbatim all'AdE.
+ */
+export function normalizeProvince(raw: string | null): string | null {
+  const normalized = raw?.trim().toUpperCase() ?? "";
+  return normalized === "" ? null : normalized;
+}
+
+/**
+ * Zod schema riusabile per la sigla della provincia (client). Accetta la
+ * stringa vuota: il campo è opzionale. Il maiuscolo lo impone il server via
+ * `normalizeProvince` — qui serve solo a dare un errore leggibile invece di
+ * far rigettare lo scontrino dall'AdE dopo l'emissione.
+ */
+export const italianProvinceSchema = z
+  .string()
+  .regex(ITALIAN_PROVINCE_REGEX, ITALIAN_PROVINCE_MESSAGE)
+  .or(z.literal(""));
+
+/**
  * Limiti di lunghezza (in caratteri) per i campi di business + profilo.
  * Sorgente unica di verità: usare queste costanti in Zod schema, server-side
  * validation e qualsiasi label "max N caratteri" lato UI. Aggiornandone una
  * qui si propaga ovunque.
+ *
+ * `province` non compare: non ha un limite di lunghezza ma un formato esatto
+ * (vedi `ITALIAN_PROVINCE_REGEX`).
  */
 export const BUSINESS_PROFILE_LIMITS = {
   firstName: 80,
@@ -113,19 +157,19 @@ export const BUSINESS_PROFILE_LIMITS = {
   address: 150,
   streetNumber: 20,
   city: 80,
-  province: 3,
 } as const;
 
 /**
- * Valida la lunghezza dei campi indirizzo opzionali di un business
- * (`businessName`, `streetNumber`, `city`, `province`). Restituisce il messaggio
- * d'errore del primo campo troppo lungo, o `null` se sono tutti validi.
+ * Valida i campi indirizzo opzionali di un business: la lunghezza di
+ * `businessName`/`streetNumber`/`city` e il **formato** di `province` (sigla
+ * di 2 lettere, non una lunghezza massima). Restituisce il messaggio d'errore
+ * del primo campo invalido, o `null` se sono tutti validi.
  *
  * Estratto e condiviso tra `saveBusiness` (onboarding) e `updateBusiness`
  * (settings) per evitare drift e tenere la Cognitive Complexity dei due
  * caller sotto la soglia SonarCloud S3776 (15).
  */
-export function validateBusinessOptionalFieldLengths(fields: {
+export function validateBusinessOptionalFields(fields: {
   businessName: string | null;
   streetNumber: string | null;
   city: string | null;
@@ -143,12 +187,13 @@ export function validateBusinessOptionalFieldLengths(fields: {
       "Il numero civico",
     ],
     [fields.city, BUSINESS_PROFILE_LIMITS.city, "Il comune"],
-    [fields.province, BUSINESS_PROFILE_LIMITS.province, "La provincia"],
   ];
   for (const [value, limit, label] of checks) {
     if (value && value.length > limit)
       return `${label} non può superare ${limit} caratteri.`;
   }
+  if (fields.province && !isValidItalianProvince(fields.province))
+    return ITALIAN_PROVINCE_MESSAGE;
   return null;
 }
 

--- a/src/server/onboarding-actions.test.ts
+++ b/src/server/onboarding-actions.test.ts
@@ -413,12 +413,58 @@ describe("onboarding-actions", () => {
       expect(result.error).toContain("80");
     });
 
-    it("returns error when province exceeds 3 characters", async () => {
+    it("returns error when province is not a 2-letter code", async () => {
       const { saveBusiness } = await import("./onboarding-actions");
       const result = await saveBusiness(
         formData({ ...VALID_DATA, province: "ROMA" }),
       );
-      expect(result.error).toContain("3");
+      expect(result.error).toMatch(/provincia/i);
+    });
+
+    // Regressione prod: una sigla minuscola arriva verbatim all'AdE, che
+    // rigetta l'emissione con `EF0 — 'Provincia' non valido`.
+    it("normalizza la provincia in maiuscolo sull'INSERT", async () => {
+      mockLimit.mockResolvedValueOnce([FAKE_PROFILE]);
+      mockLimit.mockResolvedValueOnce([]);
+      mockReturning.mockResolvedValueOnce([{ id: "new-biz-id" }]);
+
+      const { saveBusiness } = await import("./onboarding-actions");
+      const result = await saveBusiness(
+        formData({ ...VALID_DATA, province: "na" }),
+      );
+      expect(result.error).toBeUndefined();
+      expect(mockInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ province: "NA" }),
+      );
+    });
+
+    it("normalizza la provincia in maiuscolo sull'UPDATE", async () => {
+      mockLimit.mockResolvedValueOnce([FAKE_PROFILE]);
+      mockLimit.mockResolvedValueOnce([FAKE_BUSINESS]);
+
+      const { saveBusiness } = await import("./onboarding-actions");
+      const result = await saveBusiness(
+        formData({ ...VALID_DATA, province: " na " }),
+      );
+      expect(result.error).toBeUndefined();
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({ province: "NA" }),
+      );
+    });
+
+    it("salva null quando la provincia è vuota (campo opzionale)", async () => {
+      mockLimit.mockResolvedValueOnce([FAKE_PROFILE]);
+      mockLimit.mockResolvedValueOnce([]);
+      mockReturning.mockResolvedValueOnce([{ id: "new-biz-id" }]);
+
+      const { saveBusiness } = await import("./onboarding-actions");
+      const result = await saveBusiness(
+        formData({ ...VALID_DATA, province: "" }),
+      );
+      expect(result.error).toBeUndefined();
+      expect(mockInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ province: null }),
+      );
     });
 
     it("preserva preferredVatCode esistente quando il field è assente dal form (UPDATE)", async () => {

--- a/src/server/onboarding-actions.ts
+++ b/src/server/onboarding-actions.ts
@@ -51,7 +51,8 @@ import {
   BUSINESS_PROFILE_LIMITS,
   isValidItalianZipCode,
   ITALIAN_ZIP_MESSAGE,
-  validateBusinessOptionalFieldLengths,
+  normalizeProvince,
+  validateBusinessOptionalFields,
 } from "@/lib/validation";
 import { isInvalidPreferredVatCode } from "@/types/cassa";
 import { ERROR_MESSAGES } from "@/lib/error-messages";
@@ -156,7 +157,7 @@ function validateSaveBusinessInput(input: SaveBusinessInput): string | null {
   if (!input.address) return "L'indirizzo è obbligatorio.";
   if (input.address.length > BUSINESS_PROFILE_LIMITS.address)
     return `L'indirizzo non può superare ${BUSINESS_PROFILE_LIMITS.address} caratteri.`;
-  const optionalError = validateBusinessOptionalFieldLengths(input);
+  const optionalError = validateBusinessOptionalFields(input);
   if (optionalError) return optionalError;
   if (!isValidItalianZipCode(input.zipCode)) return ITALIAN_ZIP_MESSAGE;
   if (
@@ -185,7 +186,9 @@ export async function saveBusiness(
   const streetNumber = getFormStringOrNull(formData, "streetNumber");
   const zipCode = getFormString(formData, "zipCode");
   const city = getFormStringOrNull(formData, "city");
-  const province = getFormStringOrNull(formData, "province");
+  // Maiuscolo alla scrittura: l'AdE rifiuta una sigla minuscola con
+  // `EF0 — 'Provincia' non valido` al momento dell'emissione (regola 9).
+  const province = normalizeProvince(getFormStringOrNull(formData, "province"));
 
   // Distinguish "field absent" (don't touch existing preference on UPDATE)
   // from "field present and empty" (clear it). `getFormStringOrNull` collapses

--- a/src/server/profile-actions.test.ts
+++ b/src/server/profile-actions.test.ts
@@ -269,12 +269,36 @@ describe("profile-actions", () => {
       expect(result.error).toMatch(/120/);
     });
 
-    it("returns error when province exceeds 3 chars", async () => {
+    it("returns error when province is not a 2-letter code", async () => {
       const { updateBusiness } = await import("./profile-actions");
       const result = await updateBusiness(
-        formData({ ...VALID, province: "XXXX" }),
+        formData({ ...VALID, province: "ROMA" }),
       );
       expect(result.error).toMatch(/provincia/i);
+    });
+
+    // Regressione prod: una sigla minuscola arriva verbatim all'AdE, che
+    // rigetta l'emissione con `EF0 — 'Provincia' non valido`.
+    it("normalizza la provincia in maiuscolo prima dell'UPDATE", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, province: "na" }),
+      );
+      expect(result.error).toBeUndefined();
+      expect(mockDbUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({ province: "NA" }),
+      );
+    });
+
+    it("salva null quando la provincia è vuota (campo opzionale)", async () => {
+      const { updateBusiness } = await import("./profile-actions");
+      const result = await updateBusiness(
+        formData({ ...VALID, province: "  " }),
+      );
+      expect(result.error).toBeUndefined();
+      expect(mockDbUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({ province: null }),
+      );
     });
 
     it("returns ownership error when checkBusinessOwnership fails", async () => {

--- a/src/server/profile-actions.ts
+++ b/src/server/profile-actions.ts
@@ -17,7 +17,8 @@ import {
   isStrongPassword,
   isValidItalianZipCode,
   ITALIAN_ZIP_MESSAGE,
-  validateBusinessOptionalFieldLengths,
+  normalizeProvince,
+  validateBusinessOptionalFields,
 } from "@/lib/validation";
 import { isInvalidPreferredVatCode } from "@/types/cassa";
 import { getClientIp } from "@/lib/get-client-ip";
@@ -183,7 +184,9 @@ export async function updateBusiness(
   const address = getFormString(formData, "address");
   const streetNumber = getFormStringOrNull(formData, "streetNumber");
   const city = getFormStringOrNull(formData, "city");
-  const province = getFormStringOrNull(formData, "province");
+  // Maiuscolo alla scrittura: l'AdE rifiuta una sigla minuscola con
+  // `EF0 — 'Provincia' non valido` al momento dell'emissione (regola 9).
+  const province = normalizeProvince(getFormStringOrNull(formData, "province"));
   const zipCode = getFormString(formData, "zipCode");
 
   // Distinguish "field absent" (don't touch) from "field present and empty"
@@ -199,7 +202,7 @@ export async function updateBusiness(
     return {
       error: `L'indirizzo non può superare ${BUSINESS_PROFILE_LIMITS.address} caratteri.`,
     };
-  const optionalError = validateBusinessOptionalFieldLengths({
+  const optionalError = validateBusinessOptionalFields({
     businessName,
     streetNumber,
     city,

--- a/tests/unit/server-onboarding-actions.test.ts
+++ b/tests/unit/server-onboarding-actions.test.ts
@@ -136,9 +136,14 @@ vi.mock("@/lib/validation", () => ({
     address: 150,
     streetNumber: 20,
     city: 80,
-    province: 3,
   },
-  validateBusinessOptionalFieldLengths: vi.fn().mockReturnValue(null),
+  // Riproduce il contratto reale (trim + maiuscolo, null se vuota): la
+  // provincia finisce nel payload di INSERT/UPDATE asserito da questi test.
+  normalizeProvince: vi.fn((raw: string | null) => {
+    const normalized = raw?.trim().toUpperCase() ?? "";
+    return normalized === "" ? null : normalized;
+  }),
+  validateBusinessOptionalFields: vi.fn().mockReturnValue(null),
 }));
 
 vi.mock("@/types/cassa", () => {

--- a/tests/unit/server-profile-actions.test.ts
+++ b/tests/unit/server-profile-actions.test.ts
@@ -85,9 +85,14 @@ vi.mock("@/lib/validation", () => ({
     address: 150,
     streetNumber: 20,
     city: 80,
-    province: 3,
   },
-  validateBusinessOptionalFieldLengths: vi.fn().mockReturnValue(null),
+  // Riproduce il contratto reale (trim + maiuscolo, null se vuota): la
+  // provincia finisce nel payload dell'UPDATE asserito da questi test.
+  normalizeProvince: vi.fn((raw: string | null) => {
+    const normalized = raw?.trim().toUpperCase() ?? "";
+    return normalized === "" ? null : normalized;
+  }),
+  validateBusinessOptionalFields: vi.fn().mockReturnValue(null),
 }));
 
 vi.mock("@/types/cassa", () => {


### PR DESCRIPTION
L'AdE rifiuta il Documento Commerciale con `EF0 — 'Provincia' non valido`
quando la sigla del cedente non è maiuscola. `buildCedenteFromBusiness`
inoltra `businesses.province` verbatim, quindi una sigla salvata minuscola
blocca ogni emissione dell'attività finché il dato non viene corretto: in
produzione un'attività ha accumulato 7 scontrini REJECTED per questo.

Nessun punto del percorso normalizzava il campo — né gli schemi Zod dei
form, né le server action, né il mapper.

- `normalizeProvince()` (trim + maiuscolo, null se vuota) applicata in
  `saveBusiness` e `updateBusiness`: è la scrittura a garantire l'invariante
  "in DB la sigla è sempre maiuscola", così il mapper resta puro.
- `italianProvinceSchema` valida il formato (2 lettere) nei due form, per
  dare un errore leggibile invece di far scoprire il problema all'utente
  solo dopo il rigetto AdE. Il case resta libero lato client.
- `validateBusinessOptionalFieldLengths` → `validateBusinessOptionalFields`:
  per la provincia il vincolo è di formato, non di lunghezza. Cade quindi
  `BUSINESS_PROFILE_LIMITS.province`, che non aveva più un uso.

Nota: i record già in DB non sono toccati dal fix — vanno normalizzati a
parte con `UPDATE businesses SET province = upper(trim(province))`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AkkvE1B69Dj96dTZUn8di7