### PR TITLE
build(deps): nanoid 3.3.18 per GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15137,9 +15137,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "fast-uri": "^3.1.5",
     "qs": "^6.15.2",
     "postcss": "^8.5.18",
+    "nanoid": "^3.3.17",
     "brace-expansion": "5.0.9",
     "micromatch": {
       "picomatch": "2.3.2"


### PR DESCRIPTION
Il job `audit` di CI fallisce su `high`: GHSA-2v37-7h3g-55p8 colpisce
nanoid `<3.3.17` (loop infinito nei generator custom con size zero),
tirato transitivamente da postcss (`nanoid: ^3.3.16`).

Non è una regressione di un branch: l'advisory fa fallire l'audit anche
su `main` (run 31243941753).

Aggiungo l'override `nanoid: ^3.3.17` accanto a quello di postcss, così
la versione vulnerabile non può rientrare da una futura ri-risoluzione,
coerentemente con come il repo tratta gli altri pin di sicurezza; il
lockfile risolve a 3.3.18. postcss è l'unico consumer e `^3.3.16` è
soddisfatto, quindi nessun cambio di major per nessuna dipendenza.

Verificato in locale con lo stesso comando della CI:
`npx audit-ci@7.1.0 --config audit-ci.json` → "Passed npm security
audit" (restano solo i moderate della catena esbuild, già in allowlist
come GHSA-67mh-4wv8-2f99).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Er7rthHugg3wyWxJ4uL3DC