### PR TITLE
fix(ui): niente scroll orizzontale con descrizioni lunghe

### DIFF
--- a/.claude/skills/react-patterns/SKILL.md
+++ b/.claude/skills/react-patterns/SKILL.md
@@ -323,6 +323,60 @@ l'ultima classe. Utile per override:
 
 ---
 
+## Scroll orizzontale da testo utente: `min-w-0` sul **contenitore**
+
+`truncate` (= `overflow:hidden` + `text-overflow:ellipsis` +
+`white-space:nowrap`) **taglia il testo ma non riduce la larghezza
+intrinseca**: con `nowrap` il min-content del blocco resta l'intera stringa.
+Se un antenato dimensiona sulla min-content, la vista si allarga lo stesso.
+
+Due amplificatori, entrambi presenti in `DialogContent`
+(`src/components/ui/dialog.tsx`):
+
+1. **grid item** → `min-width: auto` di default, quindi la sua automatic
+   minimum size è la min-content: il track cresce oltre `sm:max-w-lg`;
+2. **`overflow-y-auto`** → per spec `overflow-x: visible` calcola `auto`, così
+   lo sfioramento diventa una **barra di scorrimento orizzontale** dentro la
+   modale invece di un overflow invisibile.
+
+`min-w-0` sul flex item interno **non basta**: va messo sul figlio del grid
+(o del flex) che contiene il testo.
+
+```tsx
+// ❌ scrolla in orizzontale con descrizioni lunghe
+<DialogContent className="overflow-y-auto sm:max-w-lg">
+  <div className="divide-y rounded-md border">
+    <div className="flex justify-between">
+      <div className="min-w-0 flex-1">
+        <p className="truncate">{line.description}</p>
+
+// ✅ il track del grid non supera la modale
+<DialogContent className="overflow-y-auto sm:max-w-lg">
+  <div className="min-w-0 divide-y rounded-md border">
+    <div className="flex justify-between">
+      <div className="min-w-0 flex-1">
+        <p className="font-medium break-words">{line.description}</p>
+```
+
+Note operative:
+
+- Su una vista di **dettaglio** preferisci `break-words` a `truncate`: niente
+  `nowrap` (min-content = parola più lunga) e la descrizione resta leggibile
+  per intero. `break-words` da solo non abbassa la min-content sotto la parola
+  più lunga → serve comunque `min-w-0` sul contenitore.
+- Testo utente senza spazi (codici prenotazione, SKU) sfora anche **senza**
+  flex/grid: su ogni `<p>` che rende input utente in una card a larghezza
+  fissa serve `break-words` (es. `src/app/r/[documentId]/page.tsx`).
+- `DialogFooter` è `sm:flex-row` e i `Button` sono `shrink-0 whitespace-nowrap`:
+  oltre i 3 bottoni la somma supera i 512px di `sm:max-w-lg` → aggiungi
+  `flex-wrap`.
+- **jsdom non fa layout** (`scrollWidth` è sempre 0): i test presidiano le
+  classi, la misura vera si fa in Chromium headless
+  (`chrome --headless --dump-dom` con uno script che confronta `scrollWidth`
+  e `clientWidth`).
+
+---
+
 ## PWA / Serwist → skill `pwa-serwist`
 
 Service worker (`src/sw.ts`, gotcha `defaultCache`), race di

--- a/src/app/r/[documentId]/page.test.tsx
+++ b/src/app/r/[documentId]/page.test.tsx
@@ -138,3 +138,44 @@ describe("PublicReceiptPage rate limiting", () => {
     expect(mockFetchPublicReceipt).toHaveBeenCalledWith(VALID_DOC_ID);
   });
 });
+
+describe("PublicReceiptPage — descrizioni lunghe", () => {
+  let PublicReceiptPage: typeof import("./page").default;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue(
+      new Headers({ "cf-connecting-ip": "9.9.9.9" }),
+    );
+    vi.resetModules();
+    ({ default: PublicReceiptPage } = await import("./page"));
+  });
+
+  it("spezza le descrizioni senza spazi invece di sforare dalla card", async () => {
+    // Un codice prenotazione senza spazi non ha punti di a-capo: senza
+    // `break-words` il testo esce dalla card larga `max-w-md` e fa scrollare
+    // in orizzontale l'intera pagina pubblica (verificato in Chromium
+    // headless — jsdom non fa layout).
+    const description = "Pernottamento_Room2_MarioRossi_Booking45873_LONG_0001";
+    mockFetchPublicReceipt.mockResolvedValue({
+      ...MOCK_RECEIPT_DATA,
+      lines: [
+        {
+          id: "line-1",
+          description,
+          quantity: "1",
+          grossUnitPrice: "120.00",
+          vatCode: "10",
+        },
+      ],
+    });
+
+    render(
+      await PublicReceiptPage({
+        params: Promise.resolve({ documentId: VALID_DOC_ID }),
+      }),
+    );
+
+    expect(screen.getByText(description)).toHaveClass("break-words");
+  });
+});

--- a/src/app/r/[documentId]/page.tsx
+++ b/src/app/r/[documentId]/page.tsx
@@ -128,7 +128,10 @@ export default async function PublicReceiptPage({
                 return (
                   <div key={line.id} className="flex items-start gap-1 text-sm">
                     <div className="min-w-0 flex-1">
-                      <p className="leading-tight font-medium">
+                      {/* `break-words`: una descrizione senza spazi (es. un
+                          codice prenotazione lungo) sborderebbe dalla card e
+                          farebbe scrollare l'intera pagina in orizzontale. */}
+                      <p className="leading-tight font-medium break-words">
                         {line.description}
                       </p>
                       {qty !== 1 && (

--- a/src/components/storico/void-receipt-dialog.test.tsx
+++ b/src/components/storico/void-receipt-dialog.test.tsx
@@ -239,3 +239,58 @@ describe("VoidReceiptDialog — banner reauth CIE (REVIEW #54)", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("VoidReceiptDialog — descrizioni lunghe senza scroll orizzontale", () => {
+  // jsdom non fa layout (scrollWidth è sempre 0): la regressione si presidia
+  // sulle classi che governano la larghezza intrinseca, verificate a mano in
+  // Chromium headless. `DialogContent` è un `grid` con `overflow-y-auto` →
+  // `overflow-x` calcola `auto`, quindi ogni figlio che sfora apre una barra
+  // di scorrimento orizzontale dentro la modale.
+  const LONG_DESCRIPTION =
+    "Pernottamento Room 2 - Mario Rossi - Booking 45873 - soggiorno 3 notti";
+
+  const LONG_LINE_RECEIPT: ReceiptListItem = {
+    ...ACCEPTED_RECEIPT,
+    lines: [{ ...ACCEPTED_RECEIPT.lines[0], description: LONG_DESCRIPTION }],
+  };
+
+  function renderLongReceipt() {
+    renderWithQuery(
+      <VoidReceiptDialog {...defaultProps} receipt={LONG_LINE_RECEIPT} />,
+    );
+    return screen.getByText(LONG_DESCRIPTION);
+  }
+
+  it("manda a capo la descrizione invece di tenerla su una riga sola", () => {
+    const description = renderLongReceipt();
+
+    // `truncate` porta con sé `white-space: nowrap`: la larghezza min-content
+    // del blocco righe diventa l'intera stringa e il track del grid si allarga
+    // oltre la modale. Con il testo che va a capo la descrizione resta anche
+    // leggibile per intero — è la vista di dettaglio.
+    expect(description).not.toHaveClass("truncate");
+    expect(description).toHaveClass("break-words");
+  });
+
+  it("azzera la larghezza minima del blocco righe (grid item)", () => {
+    const description = renderLongReceipt();
+
+    // Il contenitore delle righe è un grid item di DialogContent: senza
+    // `min-w-0` la sua automatic minimum size resta il min-content (la parola
+    // più lunga della descrizione) e allarga la modale.
+    const linesContainer = description.closest("div.divide-y");
+    expect(linesContainer).toHaveClass("min-w-0");
+  });
+
+  it("manda a capo i bottoni del footer invece di farli sforare", () => {
+    renderLongReceipt();
+
+    // Cinque bottoni `shrink-0 whitespace-nowrap` misurano ~554px contro i
+    // 512px di `sm:max-w-lg`: senza `flex-wrap` il footer sfora da solo, a
+    // prescindere dalla lunghezza della descrizione.
+    const footer = screen
+      .getByRole("button", { name: "Chiudi" })
+      .closest('[data-slot="dialog-footer"]');
+    expect(footer).toHaveClass("flex-wrap");
+  });
+});

--- a/src/components/storico/void-receipt-dialog.tsx
+++ b/src/components/storico/void-receipt-dialog.tsx
@@ -227,14 +227,24 @@ export function VoidReceiptDialog({
             </DialogHeader>
 
             {/* Lines */}
-            <div className="divide-y rounded-md border">
+            {/* `min-w-0`: il blocco è un grid item di DialogContent, che ha
+                `overflow-y-auto` (quindi `overflow-x: auto` calcolato). Senza
+                azzerare la automatic minimum size il track del grid cresce fino
+                al min-content delle descrizioni e la modale scrolla in
+                orizzontale. */}
+            <div className="min-w-0 divide-y rounded-md border">
               {receipt.lines.map((line, index) => (
                 <div
                   key={`${receipt.id}-line-${index}`}
                   className="flex items-center justify-between px-3 py-2 text-sm"
                 >
                   <div className="min-w-0 flex-1 pr-2">
-                    <p className="truncate font-medium">{line.description}</p>
+                    {/* Niente `truncate` qui: è la vista di dettaglio, una
+                        descrizione lunga va letta per intero. `break-words`
+                        spezza anche i token senza spazi. */}
+                    <p className="font-medium break-words">
+                      {line.description}
+                    </p>
                     <p className="text-muted-foreground">
                       {Number.parseFloat(line.quantity).toLocaleString("it-IT")}{" "}
                       × {formatCurrency(line.grossUnitPrice)} —{" "}
@@ -256,7 +266,9 @@ export function VoidReceiptDialog({
             </div>
 
             {/* Bottoni: Annulla scontrino | Invia ricevuta | Chiudi */}
-            <DialogFooter className="gap-2">
+            {/* `flex-wrap`: i cinque bottoni sono `shrink-0 whitespace-nowrap`
+                e da soli superano i 512px di `sm:max-w-lg`. */}
+            <DialogFooter className="flex-wrap gap-2">
               {canVoid && (
                 <>
                   <Button


### PR DESCRIPTION
La modale di dettaglio dello storico scorreva in orizzontale quando la
descrizione di una riga era lunga. Tre cause distinte, tutte misurate in
Chromium headless (jsdom non fa layout):

1. `truncate` taglia il testo ma non la larghezza intrinseca: con
   `white-space: nowrap` il min-content del blocco righe resta l'intera
   stringa. Quel blocco è un grid item di `DialogContent` (`min-width: auto`
   di default) → il track cresce oltre `sm:max-w-lg`. Fix: `min-w-0` sul
   contenitore.
2. `DialogContent` ha `overflow-y-auto`, quindi `overflow-x` calcola `auto`:
   lo sfioramento diventa una barra di scorrimento visibile.
3. Il footer con cinque bottoni `shrink-0 whitespace-nowrap` misura ~554px
   contro i 512px della modale, a prescindere dalla descrizione. Fix:
   `flex-wrap`.

Nella vista di dettaglio `truncate` lascia il posto a `break-words`: la
descrizione va letta per intero ed è proprio lo scenario segnalato.

Stessa classe di problema sulla pagina pubblica `/r/[documentId]`: una
descrizione senza spazi (codice prenotazione) usciva dalla card e faceva
scorrere l'intera pagina. Aggiunto `break-words`.

Cassa e catalogo sono già a posto: stesso `truncate`, ma in flusso normale
(niente grid item né scroll container) — verificato, nessun overflow.

Lezione riusabile aggiunta alla skill react-patterns.