### PR TITLE
fix(pwa): impila il prompt d'installazione sopra la bottom nav (REVIEW #85)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -313,34 +313,6 @@ diventa rilevante con i piani Developer multi-key (10–50 chiavi/business, tabe
 
 ---
 
-### 85. Il banner d'installazione PWA copre interamente la bottom nav su mobile
-
-- **Categoria:** UX · **Severità:** Low — riguarda la sola sessione in browser, prima dell'installazione
-- **File:** `src/components/pwa/install-prompt.tsx`, `src/components/dashboard/bottom-nav.tsx`
-
-**Problema.** Entrambi i componenti sono `fixed bottom-0 left-0 right-0 z-50` e
-montano insieme nel dashboard layout. Il banner è alto quanto la nav o di più,
-quindi finché l'utente non installa (o non fa dismiss) le quattro voci
-Catalogo/Cassa/Storico/Analytics sono **inaccessibili** su mobile: restano
-raggiungibili solo via URL o dal contenuto della pagina. Il difetto è
-preesistente al PR che ha cablato `viewport-fit=cover` — quel PR ha allineato le
-safe-area dei due pannelli, non la loro sovrapposizione.
-
-**Fix (non ambiguo).**
-
-1. Impilare invece di sovrapporre: il banner si ancora **sopra** la nav su
-   viewport `< md` — `bottom-[calc(4rem_+_env(safe-area-inset-bottom))]` (4rem =
-   `h-16` della nav) e `md:bottom-0`, togliendo dal banner la sola
-   `pb-[calc(1rem_+_env(safe-area-inset-bottom))]` quando è impilato (la
-   compensazione la fa già la nav sotto di lui).
-2. Alzare di conseguenza il `pb` del `<main>` in `src/app/dashboard/layout.tsx`
-   **solo** mentre il banner è montato, o accettare che il banner copra l'ultima
-   riga di contenuto (è dismissibile: preferibile la seconda, più semplice).
-3. **Test:** in `install-prompt.test.tsx`, asserire la classe di offset sul
-   pannello; in `bottom-nav.test.tsx` nulla cambia.
-
----
-
 ### 24. Centralizzare policy retry/timeout sulle chiamate esterne
 
 - **Categoria:** architettura · **Severità:** Low — al prossimo provider esterno nuovo

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -127,12 +127,17 @@ export default async function DashboardLayout({
         </header>
 
         {/*
-          La bottom nav è alta h-16 e ora cresce della safe-area inset: senza
+          La bottom nav è alta h-16 e cresce della safe-area inset: senza
           sommarla qui il fondo del contenuto finirebbe sotto la nav esattamente
           sui telefoni con home indicator. Il 5rem è il vecchio pb-20 (64px di
           nav + 16px d'aria).
+
+          Da `md` la nav è nascosta, ma la inset va sommata lo stesso: con
+          viewport-fit=cover il layout arriva al bordo fisico anche su un iPad
+          installato come PWA, dove prima iOS riservava quella fascia da solo.
+          Con il solo `pb-6` l'ultima riga finirebbe a filo della home indicator.
         */}
-        <main className="container mx-auto flex-1 px-4 py-6 pb-[calc(5rem_+_env(safe-area-inset-bottom))] md:pb-6">
+        <main className="container mx-auto flex-1 px-4 py-6 pb-[calc(5rem_+_env(safe-area-inset-bottom))] md:pb-[calc(1.5rem_+_env(safe-area-inset-bottom))]">
           {children}
         </main>
 

--- a/src/components/pwa/install-prompt.test.tsx
+++ b/src/components/pwa/install-prompt.test.tsx
@@ -55,13 +55,38 @@ describe("PwaInstallPrompt", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("somma la safe-area al padding del pannello fisso", () => {
+  it("si impila sopra la bottom nav su mobile invece di coprirla", () => {
     setUserAgent(IOS_UA);
     const { container } = render(<PwaInstallPrompt />);
 
+    // 4rem = h-16 della nav; l'inset è quella che la nav aggiunge sotto di sé.
     const panel = container.querySelector("header");
     expect(panel?.className).toContain(
-      "pb-[calc(1rem_+_env(safe-area-inset-bottom))]",
+      "bottom-[calc(4rem_+_env(safe-area-inset-bottom))]",
+    );
+  });
+
+  it("torna a filo del bordo da md in su, dove la nav è nascosta", () => {
+    setUserAgent(IOS_UA);
+    const { container } = render(<PwaInstallPrompt />);
+
+    expect(container.querySelector("header")?.className).toContain(
+      "md:bottom-0",
+    );
+  });
+
+  it("compensa la safe-area solo da md, quando non c'è più la nav a farlo", () => {
+    setUserAgent(IOS_UA);
+    const { container } = render(<PwaInstallPrompt />);
+
+    // Impilato, sommarla di nuovo qui la conterebbe due volte: sotto il
+    // pannello c'è la nav, che il suo pb-[env(...)] ce l'ha già.
+    const panel = container.querySelector("header");
+    expect(panel?.className).toContain(
+      "md:pb-[calc(1rem_+_env(safe-area-inset-bottom))]",
+    );
+    expect(panel?.className).not.toContain(
+      " pb-[calc(1rem_+_env(safe-area-inset-bottom))]",
     );
   });
 

--- a/src/components/pwa/install-prompt.tsx
+++ b/src/components/pwa/install-prompt.tsx
@@ -12,16 +12,27 @@ const DISMISSED_KEY = "pwa-install-dismissed";
 
 // Pannello fisso in fondo, condiviso dalla variante iOS e da quella Android.
 //
-// Il padding sui tre lati esposti somma la safe-area alle vecchie 1rem (py-4 /
-// px-4): con il viewport-fit=cover dell'app shell il pannello arriva al bordo
-// fisico, quindi senza la somma i bottoni finirebbero sotto la home indicator.
-// Le inset valgono 0 fuori dai dispositivi con ritaglio, dove il padding torna
-// a essere esattamente 1rem.
+// **Si impila sopra la bottom nav, non ci si sovrappone** (REVIEW #85). Sotto
+// `md` entrambi erano `fixed bottom-0 z-50` e il pannello copriva le quattro
+// voci per intero: finché l'utente non faceva dismiss, la navigazione era
+// raggiungibile solo per URL. L'offset `4rem` è l'`h-16` della nav, più la
+// safe-area che la nav stessa aggiunge sotto di sé. Da `md` la nav è
+// `md:hidden`, quindi il pannello torna a filo del bordo.
+//
+// Di conseguenza la safe-area verticale la compensa **solo** la variante `md`:
+// quando è impilato ce l'ha già la nav sotto di lui, e sommarla qui la
+// conterebbe due volte. Le inset orizzontali valgono invece a ogni larghezza.
+// Fuori dai dispositivi con ritaglio ogni `env()` è 0 e il padding torna
+// esattamente 1rem.
+//
+// Resta acceso il fatto che il pannello copra l'ultima riga di contenuto: è
+// dismissibile, e alzare il `pb` del `<main>` solo mentre è montato costerebbe
+// uno stato condiviso fra due componenti per un banner che si chiude con un tap.
 //
 // Colori a token e non hardcoded: il prompt monta dentro il ThemeProvider del
 // dashboard, quindi con `bg-white` era una lastra bianca in dark mode.
 const PANEL_CLASS =
-  "bg-background border-border fixed right-0 bottom-0 left-0 z-50 border-t pt-4 pr-[calc(1rem_+_env(safe-area-inset-right))] pb-[calc(1rem_+_env(safe-area-inset-bottom))] pl-[calc(1rem_+_env(safe-area-inset-left))] shadow-lg";
+  "bg-background border-border fixed right-0 bottom-[calc(4rem_+_env(safe-area-inset-bottom))] left-0 z-50 border-t pt-4 pr-[calc(1rem_+_env(safe-area-inset-right))] pb-4 pl-[calc(1rem_+_env(safe-area-inset-left))] shadow-lg md:bottom-0 md:pb-[calc(1rem_+_env(safe-area-inset-bottom))]";
 
 function isIos(): boolean {
   return /iPad|iPhone|iPod/.test(navigator.userAgent);


### PR DESCRIPTION
Chiude **REVIEW #85** e il residuo iPad emerso verificando che #819 e #820 non avessero introdotto regressioni su tablet e desktop.

## Il banner copriva la navigazione

Sotto `md`, il prompt d'installazione e la bottom nav erano **entrambi** `fixed bottom-0 z-50`. Il pannello è più alto della nav, quindi la copriva per intero: finché l'utente non faceva dismiss, Catalogo, Cassa, Storico e Analytics erano raggiungibili **solo per URL**. Difetto preesistente, non introdotto dalle due PR precedenti — è emerso allineando le safe-area dei due pannelli fissi.

Il pannello si ancora ora a `4rem + env(safe-area-inset-bottom)`: l'`h-16` della nav più la inset che la nav stessa aggiunge sotto di sé. Da `md` torna a `bottom-0`, dove la nav è `md:hidden`.

Di conseguenza la safe-area **verticale** la compensa solo la variante `md`: quando è impilato ce l'ha già la nav sotto di lui, e sommarla anche nel pannello la conterebbe due volte, lasciando una fascia vuota. Le inset orizzontali restano invece a ogni larghezza.

**Trade-off tenuto acceso e documentato nel codice:** il pannello continua a coprire l'ultima riga di contenuto. Alzare il `pb` del `<main>` solo mentre il banner è montato richiederebbe uno stato condiviso fra due componenti per un elemento che si chiude con un tap — non vale il costo.

## Residuo iPad

Il `<main>` somma la safe-area anche da `md` in su, non solo sotto. Con `viewport-fit=cover` il layout arriva al bordo fisico anche su un **iPad installato come PWA**, dove prima iOS riservava quella fascia per conto suo: col solo `pb-6` l'ultima riga di contenuto finiva a filo della home indicator. Nessun contenuto era irraggiungibile — la pagina scorre — ma è l'unico punto in cui `cover` cambiava qualcosa su tablet.

## Verifica

L'ordine delle utility è stato controllato **sul CSS compilato**, non a ragionamento — è ciò da cui dipende tutta la correttezza di questo diff:

| utility | riga base | riga `md:` |
| --- | --- | --- |
| `bottom` | 341 | 2447 |
| `pb` (pannello) | 1497 | 2492 |
| `pb` (`<main>`) | 1509 | 2489 |

Le tre varianti `md:` cadono tutte dentro `@media (width >= 48rem)`, dopo le rispettive regole base: a pari specificità vince il breakpoint.

- `npm run lint` · `npm run type-check` · `npx prettier --check` · `npm run arch:check` verdi
- 4575 test su 261 file, tutti verdi

## Test aggiunti

Tre casi sul pannello: che si impili sopra la nav sotto `md`, che torni a filo del bordo da `md`, e che la compensazione della safe-area viva **solo** nella variante `md` — quest'ultimo è quello che impedisce di reintrodurre il doppio conteggio della inset se qualcuno "risistema" le classi.

## Cosa questo PR *non* fa

Come i due precedenti, serve la **verifica su hardware reale**: l'impilamento con la home indicator e la fascia dell'iPad non sono osservabili da Chromium headless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrY8p7toPnVKwHD59Jhm7i)_